### PR TITLE
Fix capnp and ruff binary resolution for cross-machine builds

### DIFF
--- a/crates/config-internal/src/encoding/facade.rs
+++ b/crates/config-internal/src/encoding/facade.rs
@@ -135,14 +135,22 @@ impl CapnpFacade {
     }
 
     fn resolve_capnp_binary() -> Result<PathBuf> {
+        // 1. Runtime env var takes precedence (hard error if explicitly set but missing).
         if let Some(path) = env::var_os("CAPNP_BINARY_PATH") {
             return Self::validate_path(PathBuf::from(path));
         }
 
+        // 2. Compile-time path: only use if it still exists on disk.
+        //    When the binary was built on a different machine, this path is stale.
         if let Some(path) = option_env!("CAPNP_BINARY_PATH") {
-            return Self::validate_path(PathBuf::from(path));
+            let p = PathBuf::from(path);
+            if p.is_file() {
+                return Self::validate_path(p);
+            }
+            // Stale compile-time path — fall through to bundled binary.
         }
 
+        // 3. Embedded/bundled binary (the production path for distributed builds).
         Self::validate_path(Self::bundled_capnp_binary()?)
     }
 

--- a/crates/generator-internal/Cargo.toml
+++ b/crates/generator-internal/Cargo.toml
@@ -21,6 +21,7 @@ rust-embed = { version = "8", features = ["include-exclude"] }
 
 [dev-dependencies]
 bytes = "1"
+config = { path = "../config-internal", features = ["test_helpers"] }
 serde_json5 = "0.2.1"
 tempfile = "3.10"
 peppylib = { path = "../peppylib" }

--- a/crates/generator-internal/build.rs
+++ b/crates/generator-internal/build.rs
@@ -106,9 +106,6 @@ mod ruff_build {
             // Clean up build directory
             std::fs::remove_dir_all(&build_dir).ok();
         }
-
-        // Set environment variable for runtime to find the ruff binary
-        println!("cargo:rustc-env=RUFF_BINARY_PATH={}", ruff_binary_path);
     }
 }
 
@@ -199,7 +196,31 @@ mod peppylib_build {
     }
 }
 
+/// Generates `embedded_ruff.rs` in OUT_DIR that embeds the ruff binary via `include_bytes!`.
+/// This allows the binary to be extracted at runtime on any machine, rather than relying
+/// on a stale compile-time filesystem path.
+fn embed_ruff_binary() {
+    use std::io::Write;
+
+    let out_dir = std::path::PathBuf::from(std::env::var("OUT_DIR").unwrap());
+    let ruff_binary_path = out_dir.join("ruff");
+    let generated = out_dir.join("embedded_ruff.rs");
+
+    let mut file = std::fs::File::create(&generated).unwrap();
+    if ruff_binary_path.exists() {
+        writeln!(
+            file,
+            r#"pub const RUFF_BINARY: Option<&[u8]> = Some(include_bytes!("{}"));"#,
+            ruff_binary_path.display()
+        )
+        .unwrap();
+    } else {
+        writeln!(file, r#"pub const RUFF_BINARY: Option<&[u8]> = None;"#).unwrap();
+    }
+}
+
 fn main() {
     ruff_build::run();
+    embed_ruff_binary();
     peppylib_build::run();
 }

--- a/crates/generator-internal/src/generator/python/ruff/facade.rs
+++ b/crates/generator-internal/src/generator/python/ruff/facade.rs
@@ -1,35 +1,26 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
-
-/// Path to the ruff binary, injected at compile time by `build.rs`.
-const RUFF_BINARY_PATH: Option<&str> = option_env!("RUFF_BINARY_PATH");
 
 /// Facade for the `ruff` Python linter/formatter binary.
 ///
-/// Uses the ruff binary built from source by `build.rs`. No runtime filesystem
-/// discovery is performed — the binary path is baked in at compile time, making
-/// the result fully portable.
+/// The ruff binary is embedded into the peppy binary at compile time via `build.rs`
+/// and extracted to a temp file at runtime, making the result fully portable across
+/// machines.
 #[derive(Debug)]
 pub struct RuffFacade {
-    ruff_path: &'static str,
+    ruff_path: PathBuf,
 }
 
 impl RuffFacade {
-    /// Creates a new `RuffFacade`, returning an error if the ruff binary was
-    /// not embedded at compile time by `build.rs`.
+    /// Creates a new `RuffFacade`, extracting the embedded ruff binary if needed.
     pub fn new() -> std::io::Result<Self> {
-        let ruff_path = RUFF_BINARY_PATH.ok_or_else(|| {
-            std::io::Error::new(
-                std::io::ErrorKind::NotFound,
-                "ruff binary not found. The build script (build.rs) should have built it from source.",
-            )
-        })?;
+        let ruff_path = Self::resolve_ruff_binary()?;
         Ok(Self { ruff_path })
     }
 
     /// Formats Python files at the given path using `ruff format`.
     pub fn format(&self, path: &Path) -> std::io::Result<()> {
-        let output = Command::new(self.ruff_path)
+        let output = Command::new(&self.ruff_path)
             .args(["format", "--quiet"])
             .arg(path)
             .output()?;
@@ -46,7 +37,7 @@ impl RuffFacade {
 
     /// Lints and auto-fixes Python files at the given path using `ruff check --fix`.
     pub fn check_and_fix(&self, path: &Path) -> std::io::Result<()> {
-        let output = Command::new(self.ruff_path)
+        let output = Command::new(&self.ruff_path)
             .args(["check", "--fix", "--quiet"])
             .arg(path)
             .output()?;
@@ -60,6 +51,53 @@ impl RuffFacade {
 
         Ok(())
     }
+
+    fn resolve_ruff_binary() -> std::io::Result<PathBuf> {
+        // 1. Runtime env var override (for development / testing).
+        if let Some(path) = std::env::var_os("RUFF_BINARY_PATH") {
+            let p = PathBuf::from(path);
+            if p.is_file() {
+                return Ok(p);
+            }
+        }
+
+        // 2. Extract from embedded bytes (production path).
+        Self::bundled_ruff_binary()
+    }
+
+    fn bundled_ruff_binary() -> std::io::Result<PathBuf> {
+        mod embedded {
+            include!(concat!(env!("OUT_DIR"), "/embedded_ruff.rs"));
+        }
+
+        let binary_bytes = embedded::RUFF_BINARY.ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                format!(
+                    "no bundled ruff binary available for {}/{}",
+                    std::env::consts::OS,
+                    std::env::consts::ARCH
+                ),
+            )
+        })?;
+
+        let temp_dir = std::env::temp_dir();
+        let binary_path = temp_dir.join("peppy_ruff_binary");
+
+        if !binary_path.exists() {
+            std::fs::write(&binary_path, binary_bytes)?;
+
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let mut perms = std::fs::metadata(&binary_path)?.permissions();
+                perms.set_mode(0o755);
+                std::fs::set_permissions(&binary_path, perms)?;
+            }
+        }
+
+        Ok(binary_path)
+    }
 }
 
 #[cfg(test)]
@@ -70,6 +108,28 @@ mod tests {
     fn new_succeeds() {
         let facade = RuffFacade::new();
         assert!(facade.is_ok(), "ruff binary should be built by build.rs");
+    }
+
+    #[test]
+    fn bundled_ruff_binary_exists_and_is_executable() {
+        let facade = RuffFacade::new().expect("ruff binary should be available");
+        assert!(
+            facade.ruff_path.exists(),
+            "ruff binary should exist at {}",
+            facade.ruff_path.display()
+        );
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let perms = std::fs::metadata(&facade.ruff_path)
+                .expect("should read metadata")
+                .permissions();
+            assert!(
+                perms.mode() & 0o111 != 0,
+                "ruff binary should be executable"
+            );
+        }
     }
 
     #[test]

--- a/crates/peppy/tests/node_sync.rs
+++ b/crates/peppy/tests/node_sync.rs
@@ -1,10 +1,11 @@
 use peppy::test_support::{LogCapture, ServeCommandEmulation};
 use std::path::Path;
 use std::sync::Arc;
+use std::time::Duration;
 
 use config::node::{ExposedTopic, MessageFormat, NodeConfigParser, QoSProfile, Toolchain};
 use peppy::commands::Command;
-use peppy::commands::node::{NodeCommand, NodeCommands, NodeName};
+use peppy::commands::node::{NodeCommand, NodeCommands, NodeInitBuilder, NodeName};
 use peppy::context::AppContext;
 
 fn add_exposed_topic(peppy_json5: &Path) {
@@ -143,5 +144,121 @@ async fn node_sync_rust_command_succeeds() {
     assert!(
         goodbye_world_contents.contains("goodbye_world"),
         "goodbye_world.rs should contain topic name"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn node_sync_python_command_succeeds() {
+    let serve = ServeCommandEmulation::with_mock()
+        .await
+        .expect("failed to create serve emulation");
+    let shared_messenger = serve.messenger();
+    assert!(
+        !serve.daemon_node_name().is_empty(),
+        "daemon_node_name should not be empty"
+    );
+
+    // Create a temp directory for the node
+    let node_dir = tempfile::tempdir().expect("failed to create temp dir for node");
+    let node_name = "test_sync_python_node";
+
+    // Create AppContext pointing to the temp directory
+    let node_ctx = Arc::new(
+        AppContext::with_messenger(node_dir.path(), Arc::clone(&shared_messenger))
+            .with_daemon_state_file(serve.daemon_state_path()),
+    );
+
+    // Set up logging
+    let log_capture = LogCapture::new();
+    let subscriber = tracing_subscriber::fmt()
+        .with_ansi(false)
+        .without_time()
+        .with_writer(log_capture.clone())
+        .finish();
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    // Create a Python node using NodeInitBuilder with no timeout to avoid CI flakiness
+    NodeInitBuilder::new(
+        &node_ctx,
+        NodeName::new(node_name).expect("valid node name"),
+        Toolchain::Uv,
+    )
+    .with_timeout(None::<Duration>)
+    .build()
+    .expect("node init command should succeed");
+
+    let node_path = node_dir.path().join(node_name);
+    let peppy_json5_path = node_path.join("peppy.json5");
+    assert!(
+        peppy_json5_path.exists(),
+        "peppy.json5 should exist at {}",
+        peppy_json5_path.display()
+    );
+
+    let old_fingerprint = config::fingerprint::read_codegen_fingerprint(
+        &peppy_json5_path,
+        config::consts::PEPPYGEN_OUTPUT_PATH,
+    )
+    .expect("fingerprint should be readable");
+    assert!(
+        !old_fingerprint.is_empty(),
+        "fingerprint should not be empty"
+    );
+
+    // Change peppy.json5 to force a new fingerprint.
+    add_exposed_topic(&peppy_json5_path);
+
+    let expected_fingerprint =
+        config::runtime::RuntimeConfig::generate_peppy_config_fingerprint(&peppy_json5_path)
+            .expect("peppy.json5 fingerprint should generate");
+    assert_ne!(
+        expected_fingerprint, old_fingerprint,
+        "fingerprint should change after modifying peppy.json5"
+    );
+
+    // Run sync from inside the node directory
+    let sync_ctx = Arc::new(
+        AppContext::with_messenger(&node_path, Arc::clone(&shared_messenger))
+            .with_daemon_state_file(serve.daemon_state_path()),
+    );
+    NodeCommand {
+        command: NodeCommands::Sync {},
+    }
+    .execute(&sync_ctx)
+    .expect("node sync command should succeed");
+
+    let new_fingerprint = config::fingerprint::read_codegen_fingerprint(
+        &peppy_json5_path,
+        config::consts::PEPPYGEN_OUTPUT_PATH,
+    )
+    .expect("updated fingerprint should be readable");
+    assert_eq!(
+        new_fingerprint, expected_fingerprint,
+        "fingerprint file should be updated by sync"
+    );
+
+    let logs = log_capture.logs();
+    assert!(
+        logs.contains("Synced node interfaces successfully"),
+        "logs should contain sync success message. Logs:\n{}",
+        logs
+    );
+
+    // Verify that the `goodbye_world` topic Python code was generated
+    let goodbye_world_topic_path = node_path
+        .join(config::consts::PEPPYGEN_OUTPUT_PATH)
+        .join("peppygen/exposed_topics/goodbye_world.py");
+    assert!(
+        goodbye_world_topic_path.exists(),
+        "goodbye_world topic should be generated at {}",
+        goodbye_world_topic_path.display()
+    );
+
+    // Verify the generated file has expected content
+    let goodbye_world_contents = std::fs::read_to_string(&goodbye_world_topic_path)
+        .expect("goodbye_world.py should be readable");
+    assert!(
+        goodbye_world_contents.contains("goodbye_world"),
+        "goodbye_world.py should contain topic name"
     );
 }

--- a/crates/peppylib-py/src/runtime.rs
+++ b/crates/peppylib-py/src/runtime.rs
@@ -424,10 +424,10 @@ impl PyNodeBuilder {
                                     let result = future_ref.bind(py).call_method0("result")?;
                                     // Store the return value to prevent GC of
                                     // returned tasks.
-                                    if !result.is_none() {
-                                        if let Ok(mut guard) = setup_return.lock() {
-                                            *guard = Some(result.unbind());
-                                        }
+                                    if !result.is_none()
+                                        && let Ok(mut guard) = setup_return.lock()
+                                    {
+                                        *guard = Some(result.unbind());
                                     }
                                     Ok(())
                                 }) {


### PR DESCRIPTION
Handle stale compile-time paths when binaries are built on different machines by falling back to bundled binaries. Embed ruff binary at compile-time and extract at runtime to temp directory for portability. Add Python node sync test and minor code cleanup.