### PR TITLE
Support arrays of objects in message format schemas

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,11 @@
 {
-  "rust-analyzer.checkOnSave": false,
+  "rust-analyzer.checkOnSave": true,
+  "rust-analyzer.check.overrideCommand": [
+    "cargo",
+    "check",
+    "--workspace",
+    "--message-format=json"
+  ],
   "python.defaultInterpreterPath": "${workspaceFolder}/crates/peppylib-py/.pixi/envs/default/bin/python",
   "python.testing.pytestEnabled": true,
   "python.testing.pytestArgs": [

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+  "rust-analyzer.checkOnSave": false,
   "python.defaultInterpreterPath": "${workspaceFolder}/crates/peppylib-py/.pixi/envs/default/bin/python",
   "python.testing.pytestEnabled": true,
   "python.testing.pytestArgs": [

--- a/crates/config-internal/src/encoding.rs
+++ b/crates/config-internal/src/encoding.rs
@@ -126,9 +126,9 @@ impl MessageFormatMapper {
                         for (field_name, field_schema) in &object.fields {
                             let sanitized = sanitize_field_name(field_name);
                             let next_key = if current_key.is_empty() {
-                                sanitized
+                                format!("[].{sanitized}")
                             } else {
-                                format!("{current_key}.{sanitized}")
+                                format!("{current_key}[].{sanitized}")
                             };
                             override_array_types(&next_key, field_schema, mapping);
                         }
@@ -951,6 +951,45 @@ mod tests {
         assert!(
             capnp_module_content.contains("pub mod frame_capnp;"),
             "capnp.rs should contain 'pub mod frame_capnp;'"
+        );
+    }
+
+    #[test]
+    fn test_override_array_types_for_nested_object_arrays() {
+        let msg_format: MessageFormat = serde_json5::from_str(
+            r#"
+            {
+              points: {
+                $type: "array",
+                $items: {
+                  $type: "object",
+                  coords: {
+                    $type: "array",
+                    $items: "f32",
+                    $length: 3
+                  },
+                  label: "string"
+                }
+              }
+            }
+            "#,
+        )
+        .expect("valid format");
+
+        let artifacts = MessageFormatMapper::new("test_nested_object_array", msg_format)
+            .map_message_format_to_capnpn()
+            .expect("artifacts generation succeeds");
+
+        let canonical_type_map = artifacts
+            .type_mapping()
+            .iter()
+            .map(|(key, value)| (key.clone(), canonicalize_literal(value)))
+            .collect::<std::collections::HashMap<_, _>>();
+
+        assert_eq!(
+            canonical_type_map.get("points[].coords"),
+            Some(&canonicalize_literal("[f32; 3]")),
+            "coords inside array-of-objects should be overridden to a fixed-size array via the [] key path"
         );
     }
 }

--- a/crates/config-internal/src/encoding.rs
+++ b/crates/config-internal/src/encoding.rs
@@ -122,6 +122,17 @@ impl MessageFormatMapper {
                     {
                         *entry = rendered;
                     }
+                    if let SchemaType::Object(object) = array.items.as_ref() {
+                        for (field_name, field_schema) in &object.fields {
+                            let sanitized = sanitize_field_name(field_name);
+                            let next_key = if current_key.is_empty() {
+                                sanitized
+                            } else {
+                                format!("{current_key}.{sanitized}")
+                            };
+                            override_array_types(&next_key, field_schema, mapping);
+                        }
+                    }
                 }
                 SchemaType::Object(object) => {
                     for (field_name, field_schema) in &object.fields {

--- a/crates/config-internal/src/lib.rs
+++ b/crates/config-internal/src/lib.rs
@@ -66,10 +66,10 @@ pub mod node {
         ConsumedService, ConsumedTopic, ContainerConfig, DEFAULT_VARIANT_NAME, DependsOn,
         EmittedTopic, Execution, ExposedAction, ExposedService, ExternalConsumedTopic,
         InterfaceKind, Interfaces, LinkedConsumedTopic, Manifest, MergedVariant, MessageFormat,
-        Name, NodeConfig, NodeConfigCreator, NodeConfigParser, NodeDependency, ParsedNodeConfig,
-        PeppyNodeConfig, PeppygenLanguage, PrimitiveSchema, QoSProfile, SchemaType,
-        ServiceInterfaces, Toolchain, TopicInterfaces, TypeToken, Variant, VariantConfig,
-        VariantConfigParser, extract_parameter_refs, is_blocked_mount_source,
+        Name, NodeConfig, NodeConfigCreator, NodeConfigParser, NodeDependency, ObjectKind,
+        ObjectSchema, ParsedNodeConfig, PeppyNodeConfig, PeppygenLanguage, PrimitiveSchema,
+        QoSProfile, SchemaType, ServiceInterfaces, Toolchain, TopicInterfaces, TypeToken, Variant,
+        VariantConfig, VariantConfigParser, extract_parameter_refs, is_blocked_mount_source,
     };
 }
 

--- a/crates/config-internal/src/node.rs
+++ b/crates/config-internal/src/node.rs
@@ -10,7 +10,7 @@ pub use types::{
     ConsumedTopic, ContainerConfig, DEFAULT_VARIANT_NAME, DependsOn, EmittedTopic, Execution,
     ExposedAction, ExposedService, ExternalConsumedTopic, InterfaceKind, Interfaces,
     LinkedConsumedTopic, Manifest, MergedVariant, MessageFormat, Name, NodeConfig, NodeDependency,
-    ParsedNodeConfig, PeppyNodeConfig, PeppygenLanguage, PrimitiveSchema, QoSProfile, SchemaType,
-    ServiceInterfaces, Toolchain, TopicInterfaces, TypeToken, Variant, VariantConfig,
-    extract_parameter_refs, is_blocked_mount_source,
+    ObjectKind, ObjectSchema, ParsedNodeConfig, PeppyNodeConfig, PeppygenLanguage, PrimitiveSchema,
+    QoSProfile, SchemaType, ServiceInterfaces, Toolchain, TopicInterfaces, TypeToken, Variant,
+    VariantConfig, extract_parameter_refs, is_blocked_mount_source,
 };

--- a/crates/config-internal/src/node/types.rs
+++ b/crates/config-internal/src/node/types.rs
@@ -419,7 +419,7 @@ pub struct PrimitiveSchema {
 pub struct ArraySchema {
     #[serde(rename = "$type")]
     pub kind: ArrayKind,
-    #[serde(rename = "$items")]
+    #[serde(rename = "$items", deserialize_with = "deserialize_array_items")]
     pub items: Box<SchemaType>,
     #[serde(rename = "$length", default, skip_serializing_if = "Option::is_none")]
     pub length: Option<usize>,
@@ -447,6 +447,19 @@ pub struct ObjectSchema {
 #[serde(rename_all = "lowercase")]
 pub enum ObjectKind {
     Object,
+}
+
+fn deserialize_array_items<'de, D>(deserializer: D) -> Result<Box<SchemaType>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let schema = SchemaType::deserialize(deserializer)?;
+    if schema.is_optional() {
+        return Err(de::Error::custom(
+            "`$optional` is not supported on array items",
+        ));
+    }
+    Ok(Box::new(schema))
 }
 
 impl<'de> Deserialize<'de> for ObjectSchema {
@@ -489,11 +502,13 @@ impl<'de> Visitor<'de> for ObjectSchemaVisitor {
                 }
                 _ => {
                     let value: SchemaType = map.next_value()?;
-                    if fields.insert(key.clone(), value).is_some() {
+                    if value.is_optional() {
                         return Err(de::Error::custom(format!(
-                            "duplicate object field `{}`",
-                            key
+                            "`$optional` is not supported on nested field `{key}`"
                         )));
+                    }
+                    if fields.insert(key.clone(), value).is_some() {
+                        return Err(de::Error::custom(format!("duplicate object field `{key}`")));
                     }
                 }
             }
@@ -1587,6 +1602,64 @@ mod tests {
         let serialized = serde_json5::to_string(&parsed).expect("should serialize");
         let reparsed: MessageFormat = serde_json5::from_str(&serialized).expect("should re-parse");
         assert_eq!(parsed, reparsed);
+    }
+
+    #[test]
+    fn root_level_optional_is_accepted() {
+        let json5 = r#"{
+            error_msg: { $type: "string", $optional: true },
+            code: "u32"
+        }"#;
+
+        let parsed: MessageFormat = serde_json5::from_str(json5).expect("should parse");
+        assert!(parsed.0["error_msg"].is_optional());
+        assert!(!parsed.0["code"].is_optional());
+    }
+
+    #[test]
+    fn object_field_rejects_optional() {
+        let json5 = r#"{
+            header: {
+                $type: "object",
+                debug: { $type: "string", $optional: true }
+            }
+        }"#;
+
+        let parsed: Result<MessageFormat, _> = serde_json5::from_str(json5);
+        assert!(
+            parsed.is_err(),
+            "optional on nested object field should fail"
+        );
+    }
+
+    #[test]
+    fn array_items_rejects_optional() {
+        let json5 = r#"{
+            values: { $type: "array", $items: { $type: "u8", $optional: true } }
+        }"#;
+
+        let parsed: Result<MessageFormat, _> = serde_json5::from_str(json5);
+        assert!(parsed.is_err(), "optional on array items should fail");
+    }
+
+    #[test]
+    fn deeply_nested_rejects_optional() {
+        let json5 = r#"{
+            frames: {
+                $type: "array",
+                $items: {
+                    $type: "object",
+                    name: "string",
+                    debug: { $type: "string", $optional: true }
+                }
+            }
+        }"#;
+
+        let parsed: Result<MessageFormat, _> = serde_json5::from_str(json5);
+        assert!(
+            parsed.is_err(),
+            "optional on field inside array-of-objects should fail"
+        );
     }
 
     #[test]

--- a/crates/config-internal/src/node/types.rs
+++ b/crates/config-internal/src/node/types.rs
@@ -459,6 +459,11 @@ where
             "`$optional` is not supported on array items",
         ));
     }
+    if matches!(schema, SchemaType::Array(_)) {
+        return Err(de::Error::custom(
+            "nested arrays (arrays of arrays) are not supported as array items",
+        ));
+    }
     Ok(Box::new(schema))
 }
 
@@ -1640,6 +1645,19 @@ mod tests {
 
         let parsed: Result<MessageFormat, _> = serde_json5::from_str(json5);
         assert!(parsed.is_err(), "optional on array items should fail");
+    }
+
+    #[test]
+    fn array_items_rejects_nested_arrays() {
+        let json5 = r#"{
+            data: { $type: "array", $items: { $type: "array", $items: "u8" } }
+        }"#;
+
+        let result: Result<MessageFormat, _> = serde_json5::from_str(json5);
+        assert!(
+            result.is_err(),
+            "nested arrays (arrays of arrays) should fail"
+        );
     }
 
     #[test]

--- a/crates/config-internal/src/node/types.rs
+++ b/crates/config-internal/src/node/types.rs
@@ -1649,6 +1649,8 @@ mod tests {
     }
 
     #[test]
+    /// Verifies that a nested schema (array of objects containing a fixed-length array)
+    /// survives a serialize → deserialize roundtrip without data loss.
     fn nested_schema_roundtrip() {
         let json5 = r#"{
             frames: {
@@ -1670,7 +1672,10 @@ mod tests {
     #[test]
     fn root_level_optional_is_accepted() {
         let json5 = r#"{
-            error_msg: { $type: "string", $optional: true },
+            error_msg: { 
+              $type: "string", 
+              $optional: true 
+            },
             code: "u32"
         }"#;
 
@@ -1684,7 +1689,10 @@ mod tests {
         let json5 = r#"{
             header: {
                 $type: "object",
-                debug: { $type: "string", $optional: true }
+                debug: { 
+                  $type: "string", 
+                  $optional: true 
+                }
             }
         }"#;
 
@@ -1698,7 +1706,13 @@ mod tests {
     #[test]
     fn array_items_rejects_optional() {
         let json5 = r#"{
-            values: { $type: "array", $items: { $type: "u8", $optional: true } }
+            values: { 
+              $type: "array", 
+              $items: { 
+                $type: "u8", 
+                $optional: true 
+              }
+            }
         }"#;
 
         let parsed: Result<MessageFormat, _> = serde_json5::from_str(json5);
@@ -1708,7 +1722,13 @@ mod tests {
     #[test]
     fn array_items_rejects_nested_arrays() {
         let json5 = r#"{
-            data: { $type: "array", $items: { $type: "array", $items: "u8" } }
+            data: {
+              $type: "array", 
+              $items: {
+                $type: "array", 
+                $items: "u8" 
+              }
+            }
         }"#;
 
         let result: Result<MessageFormat, _> = serde_json5::from_str(json5);
@@ -1726,7 +1746,10 @@ mod tests {
                 $items: {
                     $type: "object",
                     name: "string",
-                    debug: { $type: "string", $optional: true }
+                    debug: {
+                      $type: "string",
+                      $optional: true 
+                    }
                 }
             }
         }"#;

--- a/crates/config-internal/src/node/types.rs
+++ b/crates/config-internal/src/node/types.rs
@@ -519,7 +519,7 @@ impl<'de> Visitor<'de> for ObjectSchemaVisitor {
             }
         }
 
-        let kind = kind.ok_or_else(|| de::Error::missing_field("$type"))?;
+        let kind = kind.unwrap_or(ObjectKind::Object);
         Ok(ObjectSchema {
             kind,
             fields,
@@ -1478,13 +1478,17 @@ mod tests {
     }
 
     #[test]
-    fn object_schema_requires_type_field() {
+    fn object_schema_implies_type_when_omitted() {
         let json5 = r#"{
             header: { stamp: "time", frame_id: "u32" }
         }"#;
 
-        let parsed: Result<MessageFormat, _> = serde_json5::from_str(json5);
-        assert!(parsed.is_err(), "object without type should fail parsing");
+        let parsed: MessageFormat = serde_json5::from_str(json5).expect("should parse");
+        let SchemaType::Object(obj) = &parsed.0["header"] else {
+            panic!("expected Object");
+        };
+        assert_eq!(obj.fields["stamp"], SchemaType::Type(TypeToken::Time));
+        assert_eq!(obj.fields["frame_id"], SchemaType::Type(TypeToken::U32));
     }
 
     #[test]
@@ -1543,6 +1547,60 @@ mod tests {
                 $type: "array",
                 $items: {
                     $type: "object",
+                    name: "string",
+                    parent: "string",
+                    position: {
+                        $type: "array",
+                        $items: "i32",
+                        $length: 3
+                    },
+                    orientation: {
+                        $type: "array",
+                        $items: "i32",
+                        $length: 4
+                    },
+                },
+            }
+        }"#;
+
+        let parsed: MessageFormat = serde_json5::from_str(json5).expect("should parse");
+        let SchemaType::Array(frames_arr) = &parsed.0["frames"] else {
+            panic!("expected Array");
+        };
+        assert!(frames_arr.length.is_none());
+
+        let SchemaType::Object(frame_obj) = frames_arr.items.as_ref() else {
+            panic!("expected Object items");
+        };
+        assert_eq!(
+            frame_obj.fields["name"],
+            SchemaType::Type(TypeToken::String)
+        );
+        assert_eq!(
+            frame_obj.fields["parent"],
+            SchemaType::Type(TypeToken::String)
+        );
+
+        let SchemaType::Array(pos) = &frame_obj.fields["position"] else {
+            panic!("expected Array for position");
+        };
+        assert_eq!(*pos.items, SchemaType::Type(TypeToken::I32));
+        assert_eq!(pos.length, Some(3));
+
+        let SchemaType::Array(orient) = &frame_obj.fields["orientation"] else {
+            panic!("expected Array for orientation");
+        };
+        assert_eq!(*orient.items, SchemaType::Type(TypeToken::I32));
+        assert_eq!(orient.length, Some(4));
+    }
+
+    #[test]
+    fn array_items_can_be_objects_without_object_type() {
+        let json5 = r#"{
+            frames: {
+                $type: "array",
+                $items: {
+                    // $type: "object", This one is optional here since it's automatically implied
                     name: "string",
                     parent: "string",
                     position: {

--- a/crates/config-internal/src/node/types.rs
+++ b/crates/config-internal/src/node/types.rs
@@ -419,7 +419,7 @@ pub struct PrimitiveSchema {
 pub struct ArraySchema {
     #[serde(rename = "$type")]
     pub kind: ArrayKind,
-    #[serde(rename = "$items", deserialize_with = "deserialize_array_items")]
+    #[serde(rename = "$items")]
     pub items: Box<SchemaType>,
     #[serde(rename = "$length", default, skip_serializing_if = "Option::is_none")]
     pub length: Option<usize>,
@@ -449,19 +449,6 @@ pub enum ObjectKind {
     Object,
 }
 
-fn deserialize_array_items<'de, D>(deserializer: D) -> Result<Box<SchemaType>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let schema = SchemaType::deserialize(deserializer)?;
-    match schema {
-        SchemaType::Type(_) | SchemaType::Primitive(_) => Ok(Box::new(schema)),
-        SchemaType::Array(_) | SchemaType::Object(_) => Err(de::Error::custom(
-            "nested arrays or objects are not supported inside array schemas",
-        )),
-    }
-}
-
 impl<'de> Deserialize<'de> for ObjectSchema {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -477,7 +464,7 @@ impl<'de> Visitor<'de> for ObjectSchemaVisitor {
     type Value = ObjectSchema;
 
     fn expecting(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
-        formatter.write_str("an object schema definition with a $type and primitive fields")
+        formatter.write_str("an object schema definition with a $type and typed fields")
     }
 
     fn visit_map<M>(self, mut map: M) -> Result<Self::Value, M::Error>
@@ -502,21 +489,11 @@ impl<'de> Visitor<'de> for ObjectSchemaVisitor {
                 }
                 _ => {
                     let value: SchemaType = map.next_value()?;
-                    match value {
-                        SchemaType::Type(_) | SchemaType::Primitive(_) => {
-                            if fields.insert(key.clone(), value).is_some() {
-                                return Err(de::Error::custom(format!(
-                                    "duplicate object field `{}`",
-                                    key
-                                )));
-                            }
-                        }
-                        SchemaType::Array(_) | SchemaType::Object(_) => {
-                            return Err(de::Error::custom(format!(
-                                "nested arrays or objects are not supported for field `{}`",
-                                key
-                            )));
-                        }
+                    if fields.insert(key.clone(), value).is_some() {
+                        return Err(de::Error::custom(format!(
+                            "duplicate object field `{}`",
+                            key
+                        )));
                     }
                 }
             }
@@ -1501,49 +1478,115 @@ mod tests {
     }
 
     #[test]
-    fn object_schema_rejects_nested_array() {
+    fn object_fields_can_be_arrays() {
         let json5 = r#"{
             header: {
                 $type: "object",
-                nested: { $type: "array", $items: "u8" }
+                data: { $type: "array", $items: "u8" }
             }
         }"#;
 
-        let parsed: Result<MessageFormat, _> = serde_json5::from_str(json5);
-        assert!(parsed.is_err(), "object fields cannot contain arrays");
+        let parsed: MessageFormat = serde_json5::from_str(json5).expect("should parse");
+        let header = &parsed.0["header"];
+        let SchemaType::Object(obj) = header else {
+            panic!("expected Object");
+        };
+        let SchemaType::Array(arr) = &obj.fields["data"] else {
+            panic!("expected Array");
+        };
+        assert_eq!(*arr.items, SchemaType::Type(TypeToken::U8));
     }
 
     #[test]
-    fn object_schema_rejects_nested_object() {
+    fn object_fields_can_be_objects() {
         let json5 = r#"{
-            header: {
+            outer: {
                 $type: "object",
-                nested: { $type: "object", field: "u8" }
+                inner: { $type: "object", value: "u32" }
             }
         }"#;
 
-        let parsed: Result<MessageFormat, _> = serde_json5::from_str(json5);
-        assert!(parsed.is_err(), "object fields cannot contain objects");
+        let parsed: MessageFormat = serde_json5::from_str(json5).expect("should parse");
+        let SchemaType::Object(outer) = &parsed.0["outer"] else {
+            panic!("expected Object");
+        };
+        let SchemaType::Object(inner) = &outer.fields["inner"] else {
+            panic!("expected nested Object");
+        };
+        assert_eq!(inner.fields["value"], SchemaType::Type(TypeToken::U32));
     }
 
     #[test]
-    fn array_schema_rejects_nested_object() {
+    fn array_items_can_be_objects() {
         let json5 = r#"{
-            image: { $type: "array", $items: { $type: "object", field: "u8" } }
+            frames: {
+                $type: "array",
+                $items: {
+                    $type: "object",
+                    name: "string",
+                    parent: "string",
+                    position: {
+                        $type: "array",
+                        $items: "i32",
+                        $length: 3
+                    },
+                    orientation: {
+                        $type: "array",
+                        $items: "i32",
+                        $length: 4
+                    },
+                },
+            }
         }"#;
 
-        let parsed: Result<MessageFormat, _> = serde_json5::from_str(json5);
-        assert!(parsed.is_err(), "array items cannot contain objects");
+        let parsed: MessageFormat = serde_json5::from_str(json5).expect("should parse");
+        let SchemaType::Array(frames_arr) = &parsed.0["frames"] else {
+            panic!("expected Array");
+        };
+        assert!(frames_arr.length.is_none());
+
+        let SchemaType::Object(frame_obj) = frames_arr.items.as_ref() else {
+            panic!("expected Object items");
+        };
+        assert_eq!(
+            frame_obj.fields["name"],
+            SchemaType::Type(TypeToken::String)
+        );
+        assert_eq!(
+            frame_obj.fields["parent"],
+            SchemaType::Type(TypeToken::String)
+        );
+
+        let SchemaType::Array(pos) = &frame_obj.fields["position"] else {
+            panic!("expected Array for position");
+        };
+        assert_eq!(*pos.items, SchemaType::Type(TypeToken::I32));
+        assert_eq!(pos.length, Some(3));
+
+        let SchemaType::Array(orient) = &frame_obj.fields["orientation"] else {
+            panic!("expected Array for orientation");
+        };
+        assert_eq!(*orient.items, SchemaType::Type(TypeToken::I32));
+        assert_eq!(orient.length, Some(4));
     }
 
     #[test]
-    fn array_schema_rejects_nested_array() {
+    fn nested_schema_roundtrip() {
         let json5 = r#"{
-            image: { $type: "array", $items: { $type: "array", $items: "u8" } }
+            frames: {
+                $type: "array",
+                $items: {
+                    $type: "object",
+                    name: "string",
+                    position: { $type: "array", $items: "f32", $length: 3 }
+                }
+            }
         }"#;
 
-        let parsed: Result<MessageFormat, _> = serde_json5::from_str(json5);
-        assert!(parsed.is_err(), "array items cannot contain arrays");
+        let parsed: MessageFormat = serde_json5::from_str(json5).expect("should parse");
+        let serialized = serde_json5::to_string(&parsed).expect("should serialize");
+        let reparsed: MessageFormat = serde_json5::from_str(&serialized).expect("should re-parse");
+        assert_eq!(parsed, reparsed);
     }
 
     #[test]

--- a/crates/generator-internal/src/error.rs
+++ b/crates/generator-internal/src/error.rs
@@ -59,14 +59,8 @@ This field name is reserved by peppy transport metadata and cannot be used insid
     UnsupportedArrayItemSchema { field: String },
     #[error("internal generator invariant violated: {context}")]
     InvariantViolation { context: String },
-    #[error(
-        "unsupported fixed-length array item type `{item}` in field `{field}` for `{language:?}` generator"
-    )]
-    UnsupportedFixedArrayItemType {
-        language: PeppygenLanguage,
-        field: String,
-        item: &'static str,
-    },
+    #[error("unsupported fixed-length array item type `{item}` in field `{field}`")]
+    UnsupportedFixedArrayItemType { field: String, item: &'static str },
     #[error(
         "unsupported optional scalar type `{item}` in field `{field}` for `{language:?}` generator"
     )]

--- a/crates/generator-internal/src/error.rs
+++ b/crates/generator-internal/src/error.rs
@@ -76,6 +76,16 @@ This field name is reserved by peppy transport metadata and cannot be used insid
         item: &'static str,
     },
     #[error(
+        "generated type name collision in `{context}`: fields `{first_field}` and `{second_field}` \
+both produce the type name `{type_name}`"
+    )]
+    GeneratedTypeNameCollision {
+        context: String,
+        type_name: String,
+        first_field: String,
+        second_field: String,
+    },
+    #[error(
         "field name normalization collision in `{context}` for `{language:?}` generator: \
 `{first_field}` and `{second_field}` both normalize to `{normalized}` as `{normalization}`"
     )]

--- a/crates/generator-internal/src/generator/naming.rs
+++ b/crates/generator-internal/src/generator/naming.rs
@@ -114,6 +114,21 @@ pub fn module_name_from_components(node: &str, name: &str) -> String {
     }
 }
 
+/// Returns the intermediate field name used when generating a struct for
+/// array-of-objects items.  E.g. `"frames"` → `"frames_item"`.
+pub(crate) fn array_item_field_name(field_name: &str) -> String {
+    format!("{field_name}_item")
+}
+
+/// Returns the full CamelCase type/class name for an array-of-objects item struct.
+/// E.g. `("Message", "frames")` → `"MessageFramesItem"`.
+pub(crate) fn array_item_type_name(struct_prefix: &str, field_name: &str) -> String {
+    format!(
+        "{struct_prefix}{}",
+        to_camel_case(&array_item_field_name(field_name))
+    )
+}
+
 /// Converts a snake_case or raw string to CamelCase.
 pub(crate) fn to_camel_case(raw: &str) -> String {
     let sanitized = sanitize_component(raw);
@@ -242,6 +257,24 @@ pub fn unique_module_name(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn array_item_field_name_appends_item_suffix() {
+        assert_eq!(array_item_field_name("frames"), "frames_item");
+        assert_eq!(array_item_field_name("data"), "data_item");
+    }
+
+    #[test]
+    fn array_item_type_name_produces_camel_case() {
+        assert_eq!(
+            array_item_type_name("Message", "frames"),
+            "MessageFramesItem"
+        );
+        assert_eq!(
+            array_item_type_name("MessageHeader", "points"),
+            "MessageHeaderPointsItem"
+        );
+    }
 
     #[test]
     fn capnp_field_name_camel_cases() {

--- a/crates/generator-internal/src/generator/python.rs
+++ b/crates/generator-internal/src/generator/python.rs
@@ -17,7 +17,7 @@ use super::naming::{module_name_from_components, resolve_schema_file_stem, to_ca
 use super::types::{
     CapnpSchema, ConsumedActionMessage, InterfaceArtifact, InterfaceKind, LanguageGenerator,
     cancel_action_response_format, non_empty_message_format, validate_fixed_length_array_items,
-    validate_message_format_field_names,
+    validate_generated_type_name_collisions, validate_message_format_field_names,
 };
 use crate::error::{Error, Result};
 use config::encoding::MessageFormatMapper;
@@ -81,6 +81,7 @@ impl PythonGenerator {
     ) -> Result<PythonSchemaInfo> {
         validate_message_format_field_names(format, schema_key)?;
         validate_fixed_length_array_items(format, PeppygenLanguage::Python)?;
+        validate_generated_type_name_collisions(format, "Message")?;
 
         let artifacts = MessageFormatMapper::new(schema_key, format.clone())
             .map_message_format_to_capnpn()

--- a/crates/generator-internal/src/generator/python.rs
+++ b/crates/generator-internal/src/generator/python.rs
@@ -23,7 +23,7 @@ use crate::error::{Error, Result};
 use config::encoding::MessageFormatMapper;
 use config::node::{
     ConsumedAction, ConsumedService, ConsumedTopic, EmittedTopic, ExposedAction, ExposedService,
-    MessageFormat, PeppygenLanguage,
+    MessageFormat,
 };
 use std::collections::HashMap;
 use std::path::Path;
@@ -80,7 +80,7 @@ impl PythonGenerator {
         format: &MessageFormat,
     ) -> Result<PythonSchemaInfo> {
         validate_message_format_field_names(format, schema_key)?;
-        validate_fixed_length_array_items(format, PeppygenLanguage::Python)?;
+        validate_fixed_length_array_items(format)?;
         validate_generated_type_name_collisions(format, "Message")?;
 
         let artifacts = MessageFormatMapper::new(schema_key, format.clone())

--- a/crates/generator-internal/src/generator/python/deserialization.rs
+++ b/crates/generator-internal/src/generator/python/deserialization.rs
@@ -1,7 +1,7 @@
 use super::PythonSchemaInfo;
 use super::code_builder::PythonCodeBuilder;
 use super::identifiers::{is_python_keyword, sanitize_python_identifier};
-use crate::generator::naming::{sanitize_capnp_field_name, to_camel_case};
+use crate::generator::naming::{array_item_type_name, sanitize_capnp_field_name, to_camel_case};
 use config::node::{MessageFormat, SchemaType, TypeToken};
 use indexmap::IndexMap;
 
@@ -268,8 +268,7 @@ fn generate_object_array_reader(
     let capnp_name = sanitize_capnp_field_name(field_name);
     let python_name = sanitize_python_identifier(field_name);
 
-    let item_field = format!("{field_name}_item");
-    let nested_prefix = format!("{struct_prefix}{}", to_camel_case(&item_field));
+    let nested_prefix = array_item_type_name(struct_prefix, field_name);
 
     let list_idx = *counter;
     *counter += 1;

--- a/crates/generator-internal/src/generator/python/deserialization.rs
+++ b/crates/generator-internal/src/generator/python/deserialization.rs
@@ -43,6 +43,7 @@ pub fn generate_field_reader_statements(
                 &object.fields,
                 struct_prefix,
                 counter,
+                array.length,
             ),
             _ => {
                 let is_u8 = matches!(array.items.as_ref().as_type_token(), Some(TypeToken::U8));
@@ -262,6 +263,7 @@ fn generate_object_array_reader(
     fields: &IndexMap<String, SchemaType>,
     struct_prefix: &str,
     counter: &mut u32,
+    length: Option<usize>,
 ) -> String {
     let capnp_name = sanitize_capnp_field_name(field_name);
     let python_name = sanitize_python_identifier(field_name);
@@ -311,5 +313,61 @@ fn generate_object_array_reader(
     ));
 
     builder.dedent();
+
+    if let Some(len) = length {
+        builder.line(&format!("if len({result_var}) != {len}:"));
+        builder.indent();
+        builder.line(&format!(
+            "raise ValueError(\"invalid fixed list length for field '{field_name}': expected {len}, got \" + str(len({result_var})))"
+        ));
+        builder.dedent();
+    }
+
     result_var
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn call_object_array_reader(length: Option<usize>) -> String {
+        let mut builder = PythonCodeBuilder::new();
+        let mut counter = 0u32;
+        let mut fields = IndexMap::new();
+        fields.insert("x".to_string(), SchemaType::Type(TypeToken::I32));
+
+        generate_object_array_reader(
+            &mut builder,
+            "reader",
+            "frames",
+            &fields,
+            "Test",
+            &mut counter,
+            length,
+        );
+
+        builder.build()
+    }
+
+    #[test]
+    fn object_array_reader_emits_length_check() {
+        let code = call_object_array_reader(Some(3));
+        assert!(
+            code.contains("raise ValueError"),
+            "fixed-length path must raise ValueError, got:\n{code}"
+        );
+        assert!(
+            code.contains("expected 3"),
+            "error message must mention expected length, got:\n{code}"
+        );
+    }
+
+    #[test]
+    fn object_array_reader_no_length_check_when_dynamic() {
+        let code = call_object_array_reader(None);
+        assert!(
+            !code.contains("raise ValueError"),
+            "dynamic-length path must not raise ValueError, got:\n{code}"
+        );
+    }
 }

--- a/crates/generator-internal/src/generator/python/deserialization.rs
+++ b/crates/generator-internal/src/generator/python/deserialization.rs
@@ -35,10 +35,20 @@ pub fn generate_field_reader_statements(
         SchemaType::Type(_) | SchemaType::Primitive(_) => {
             generate_primitive_reader(builder, reader_var, field_name, counter)
         }
-        SchemaType::Array(array) => {
-            let is_u8 = matches!(array.items.as_ref().as_type_token(), Some(TypeToken::U8));
-            generate_array_reader(builder, reader_var, field_name, is_u8, counter)
-        }
+        SchemaType::Array(array) => match array.items.as_ref() {
+            SchemaType::Object(object) => generate_object_array_reader(
+                builder,
+                reader_var,
+                field_name,
+                &object.fields,
+                struct_prefix,
+                counter,
+            ),
+            _ => {
+                let is_u8 = matches!(array.items.as_ref().as_type_token(), Some(TypeToken::U8));
+                generate_array_reader(builder, reader_var, field_name, is_u8, counter)
+            }
+        },
         SchemaType::Object(object) => generate_object_reader(
             builder,
             reader_var,
@@ -242,5 +252,64 @@ fn generate_object_reader(
         .collect();
     let kwargs_str = kwargs.join(", ");
     builder.line(&format!("{result_var} = {nested_prefix}({kwargs_str})"));
+    result_var
+}
+
+fn generate_object_array_reader(
+    builder: &mut PythonCodeBuilder,
+    reader_var: &str,
+    field_name: &str,
+    fields: &IndexMap<String, SchemaType>,
+    struct_prefix: &str,
+    counter: &mut u32,
+) -> String {
+    let capnp_name = sanitize_capnp_field_name(field_name);
+    let python_name = sanitize_python_identifier(field_name);
+
+    let item_field = format!("{field_name}_item");
+    let nested_prefix = format!("{struct_prefix}{}", to_camel_case(&item_field));
+
+    let list_idx = *counter;
+    *counter += 1;
+    let list_var = format!("list_{list_idx}");
+    builder.line(&format!(
+        "{list_var} = {}",
+        capnp_read_expr(reader_var, &capnp_name)
+    ));
+
+    let result_idx = *counter;
+    *counter += 1;
+    let result_var = format!("{python_name}_{result_idx}");
+    builder.line(&format!("{result_var} = []"));
+
+    let elem_idx = *counter;
+    *counter += 1;
+    let elem_var = format!("elem_{elem_idx}");
+    builder.line(&format!("for {elem_var} in {list_var}:"));
+    builder.indent();
+
+    let mut nested_bindings = Vec::new();
+    for (nested_name, nested_schema) in fields {
+        let nested_var = generate_field_reader_statements(
+            builder,
+            &elem_var,
+            nested_name,
+            nested_schema,
+            &nested_prefix,
+            counter,
+        );
+        nested_bindings.push((sanitize_python_identifier(nested_name), nested_var));
+    }
+
+    let kwargs: Vec<String> = nested_bindings
+        .iter()
+        .map(|(name, var)| format!("{name}={var}"))
+        .collect();
+    let kwargs_str = kwargs.join(", ");
+    builder.line(&format!(
+        "{result_var}.append({nested_prefix}({kwargs_str}))"
+    ));
+
+    builder.dedent();
     result_var
 }

--- a/crates/generator-internal/src/generator/python/serialization.rs
+++ b/crates/generator-internal/src/generator/python/serialization.rs
@@ -70,9 +70,40 @@ fn emit_field_assignment(
         SchemaType::Type(_) | SchemaType::Primitive(_) => {
             builder.line(&capnp_assignment_stmt(builder_var, &capnp_name, value_expr));
         }
-        SchemaType::Array(_) => {
-            builder.line(&capnp_assignment_stmt(builder_var, &capnp_name, value_expr));
-        }
+        SchemaType::Array(array) => match array.items.as_ref() {
+            SchemaType::Object(object) => {
+                let idx = *counter;
+                *counter += 1;
+                let list_builder = format!("list_{idx}");
+                builder.line(&format!(
+                    "{list_builder} = {builder_var}.init(\"{capnp_name}\", len({value_expr}))"
+                ));
+                let loop_idx = format!("i_{idx}");
+                let loop_elem = format!("elem_{idx}");
+                builder.line(&format!(
+                    "for {loop_idx}, {loop_elem} in enumerate({value_expr}):"
+                ));
+                builder.indent();
+                let elem_builder = format!("eb_{idx}");
+                builder.line(&format!("{elem_builder} = {list_builder}[{loop_idx}]"));
+                for (nested_name, nested_schema) in &object.fields {
+                    let nested_python = sanitize_python_identifier(nested_name);
+                    let nested_value = format!("{loop_elem}.{nested_python}");
+                    emit_field_assignment(
+                        builder,
+                        &elem_builder,
+                        nested_name,
+                        nested_schema,
+                        &nested_value,
+                        counter,
+                    );
+                }
+                builder.dedent();
+            }
+            _ => {
+                builder.line(&capnp_assignment_stmt(builder_var, &capnp_name, value_expr));
+            }
+        },
         SchemaType::Object(object) => {
             let idx = *counter;
             *counter += 1;

--- a/crates/generator-internal/src/generator/python/serialization.rs
+++ b/crates/generator-internal/src/generator/python/serialization.rs
@@ -75,8 +75,19 @@ fn emit_field_assignment(
                 let idx = *counter;
                 *counter += 1;
                 let list_builder = format!("list_{idx}");
+                let length_expr = if let Some(len) = array.length {
+                    builder.line(&format!("if len({value_expr}) != {len}:"));
+                    builder.indent();
+                    builder.line(&format!(
+                        "raise ValueError(\"invalid fixed list length for field '{field_name}': expected {len}, got \" + str(len({value_expr})))"
+                    ));
+                    builder.dedent();
+                    format!("{len}")
+                } else {
+                    format!("len({value_expr})")
+                };
                 builder.line(&format!(
-                    "{list_builder} = {builder_var}.init(\"{capnp_name}\", len({value_expr}))"
+                    "{list_builder} = {builder_var}.init(\"{capnp_name}\", {length_expr})"
                 ));
                 let loop_idx = format!("i_{idx}");
                 let loop_elem = format!("elem_{idx}");
@@ -154,4 +165,73 @@ fn emit_time_assignment(
     ));
     builder.line(&format!("{ts_builder}.sec = {ts_var}.sec"));
     builder.line(&format!("{ts_builder}.nsec = {ts_var}.nsec"));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use config::node::{ArrayKind, ArraySchema, ObjectKind, ObjectSchema};
+    use indexmap::IndexMap;
+
+    fn emit_object_array(length: Option<usize>) -> String {
+        let mut fields = IndexMap::new();
+        fields.insert("x".to_string(), SchemaType::Type(TypeToken::I32));
+
+        let schema = SchemaType::Array(ArraySchema {
+            kind: ArrayKind::Array,
+            items: Box::new(SchemaType::Object(ObjectSchema {
+                kind: ObjectKind::Object,
+                fields,
+                optional: false,
+            })),
+            length,
+            optional: false,
+        });
+
+        let mut builder = PythonCodeBuilder::new();
+        let mut counter = 0u32;
+        emit_field_assignment(
+            &mut builder,
+            "msg",
+            "frames",
+            &schema,
+            "self.frames",
+            &mut counter,
+        );
+        builder.build()
+    }
+
+    #[test]
+    fn object_array_serialization_uses_fixed_length_and_validates() {
+        let code = emit_object_array(Some(4));
+        assert!(
+            code.contains("raise ValueError"),
+            "fixed-length path must validate with ValueError, got:\n{code}"
+        );
+        assert!(
+            code.contains("!= 4"),
+            "must check len against declared length 4, got:\n{code}"
+        );
+        assert!(
+            code.contains("init(\"frames\", 4)"),
+            "must pass fixed literal 4 to init, got:\n{code}"
+        );
+        assert!(
+            !code.contains("init(\"frames\", len("),
+            "fixed-length path must not use len() in init, got:\n{code}"
+        );
+    }
+
+    #[test]
+    fn object_array_serialization_uses_runtime_len_when_dynamic() {
+        let code = emit_object_array(None);
+        assert!(
+            !code.contains("raise ValueError"),
+            "dynamic-length path must not raise ValueError, got:\n{code}"
+        );
+        assert!(
+            code.contains("init(\"frames\", len(self.frames))"),
+            "dynamic-length path must use len(value_expr) in init, got:\n{code}"
+        );
+    }
 }

--- a/crates/generator-internal/src/generator/python/tests/actions.rs
+++ b/crates/generator-internal/src/generator/python/tests/actions.rs
@@ -87,10 +87,7 @@ const EXPOSED_ACTION_WITH_NESTED_FEEDBACK_EXAMPLE: &str = r#"
       state: {
         $type: "object",
         position: "i32",
-        note: {
-          $type: "string",
-          $optional: true
-        }
+        note: "string"
       }
     }
   }
@@ -465,10 +462,9 @@ fn exposed_action_feedback_emits_nested_types() {
     assert_contains_all(
         &rendered,
         &[
-            "from typing import Optional",
             "class FeedbackState:",
             "position: int",
-            "note: Optional[str]",
+            "note: str",
             "async def emit_feedback(self, state: FeedbackState):",
         ],
     );

--- a/crates/generator-internal/src/generator/python/tests/topics.rs
+++ b/crates/generator-internal/src/generator/python/tests/topics.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::error::Error;
 use config::node::{ConsumedTopic, EmittedTopic, MessageFormat, PeppygenLanguage};
 
 const EMITTED_TOPIC_EXAMPLE: &str = r#"
@@ -42,78 +43,6 @@ const EMITTED_TOPIC_EXAMPLE2: &str = r#"
 }
 "#;
 
-const EMITTED_TOPIC_WITH_PYTHON_KEYWORD_FIELDS: &str = r#"
-{
-  name: "keyword_topic",
-  qos_profile: "standard",
-  message_format: {
-    "class": "u32",
-    "from": "string"
-  }
-}
-"#;
-
-const EMITTED_TOPIC_RESERVED_FIELD_EXAMPLE: &str = r#"
-{
-  name: "robot_state",
-  qos_profile: "standard",
-  message_format: {
-    instance_id: "string",
-    status: "u8"
-  }
-}
-"#;
-
-const EMITTED_TOPIC_FIXED_STRING_ARRAY_EXAMPLE: &str = r#"
-{
-  name: "labels",
-  qos_profile: "standard",
-  message_format: {
-    labels: {
-      $type: "array",
-      $items: "string",
-      $length: 3
-    }
-  }
-}
-"#;
-
-const EMITTED_TOPIC_FIXED_OBJECT_ARRAY_EXAMPLE: &str = r#"
-{
-  name: "detections",
-  qos_profile: "sensor_data",
-  message_format: {
-    objects: {
-      $type: "array",
-      $items: {
-        $type: "object",
-        x: "f32",
-        y: "f32"
-      },
-      $length: 4
-    }
-  }
-}
-"#;
-
-const EMITTED_TOPIC_DYNAMIC_OBJECT_ARRAY_EXAMPLE: &str = r#"
-{
-  name: "detections",
-  qos_profile: "sensor_data",
-  message_format: {
-    objects: {
-      $type: "array",
-      $items: {
-        $type: "object",
-        x: "f32",
-        y: "f32",
-        label: "string"
-      }
-    }
-  }
-}
-"#;
-
 const SUBSCRIBED_TOPIC_EXAMPLE1: &str = r#"
 {
     local_node_id: "uvc_camera",
@@ -145,13 +74,6 @@ const SUBSCRIBED_TOPIC_EXAMPLE2: &str = r#"
 }
 "#;
 
-const SUBSCRIBED_TOPIC_EXAMPLE_KEYWORDS: &str = r#"
-{
-    local_node_id: "keyword_source",
-    name: "keyword_topic",
-}
-"#;
-
 const SUBSCRIBED_TOPIC_FORMAT_EXAMPLE2: &str = r#"
 {
   header: {
@@ -167,13 +89,6 @@ const SUBSCRIBED_TOPIC_FORMAT_EXAMPLE2: &str = r#"
     $type: "array",
     $items: "u8",
   }
-}
-"#;
-
-const SUBSCRIBED_TOPIC_FORMAT_EXAMPLE_KEYWORDS: &str = r#"
-{
-    "class": "u32",
-    "from": "string"
 }
 "#;
 
@@ -342,7 +257,18 @@ fn emit_two_topics() {
 
 #[test]
 fn emit_topic_escapes_python_keyword_fields() {
-    let topic = parse_emitted_topic(EMITTED_TOPIC_WITH_PYTHON_KEYWORD_FIELDS);
+    let emitted_topic_with_python_keyword_fields: &str = r#"
+    {
+      name: "keyword_topic",
+      qos_profile: "standard",
+      message_format: {
+        "class": "u32",
+        "from": "string"
+      }
+    }
+    "#;
+
+    let topic = parse_emitted_topic(emitted_topic_with_python_keyword_fields);
 
     let mut generator = PythonGenerator::new();
     generator.add_emitted_topic(&topic).unwrap();
@@ -365,9 +291,17 @@ fn emit_topic_escapes_python_keyword_fields() {
 
 #[test]
 fn emit_topic_rejects_reserved_message_field_name() {
-    use crate::error::Error;
-
-    let topic = parse_emitted_topic(EMITTED_TOPIC_RESERVED_FIELD_EXAMPLE);
+    let emitted_topic_reserved_field_example: &str = r#"
+    {
+      name: "robot_state",
+      qos_profile: "standard",
+      message_format: {
+        instance_id: "string",
+        status: "u8"
+      }
+    }
+    "#;
+    let topic = parse_emitted_topic(emitted_topic_reserved_field_example);
 
     let mut generator = PythonGenerator::new();
     let err = generator.add_emitted_topic(&topic).unwrap_err();
@@ -388,9 +322,21 @@ fn emit_topic_rejects_reserved_message_field_name() {
 
 #[test]
 fn emit_topic_rejects_fixed_string_array() {
-    use crate::error::Error;
+    let emitted_topic_fixed_string_array_example: &str = r#"
+    {
+      name: "labels",
+      qos_profile: "standard",
+      message_format: {
+        labels: {
+          $type: "array",
+          $items: "string",
+          $length: 3
+        }
+      }
+    }
+    "#;
 
-    let topic = parse_emitted_topic(EMITTED_TOPIC_FIXED_STRING_ARRAY_EXAMPLE);
+    let topic = parse_emitted_topic(emitted_topic_fixed_string_array_example);
 
     let mut generator = PythonGenerator::new();
     let err = generator.add_emitted_topic(&topic).unwrap_err();
@@ -411,9 +357,25 @@ fn emit_topic_rejects_fixed_string_array() {
 
 #[test]
 fn emit_topic_rejects_fixed_object_array() {
-    use crate::error::Error;
+    let emitted_topic_fixed_object_array_example = r#"
+    {
+      name: "detections",
+      qos_profile: "sensor_data",
+      message_format: {
+        objects: {
+          $type: "array",
+          $length: 4,
+          $items: {
+            $type: "object",
+            x: "f32",
+            y: "f32"
+          },
+        }
+      }
+    }
+    "#;
 
-    let topic = parse_emitted_topic(EMITTED_TOPIC_FIXED_OBJECT_ARRAY_EXAMPLE);
+    let topic = parse_emitted_topic(emitted_topic_fixed_object_array_example);
 
     let mut generator = PythonGenerator::new();
     let err = generator.add_emitted_topic(&topic).unwrap_err();
@@ -434,7 +396,23 @@ fn emit_topic_rejects_fixed_object_array() {
 
 #[test]
 fn emit_topic_with_dynamic_object_array() {
-    let topic = parse_emitted_topic(EMITTED_TOPIC_DYNAMIC_OBJECT_ARRAY_EXAMPLE);
+    let emitted_topic_dynamic_object_array_example: &str = r#"
+    {
+      name: "detections",
+      qos_profile: "sensor_data",
+      message_format: {
+        objects: {
+          $type: "array",
+          $items: {
+            x: "f32",
+            y: "f32",
+            label: "string"
+          }
+        }
+      }
+    }
+    "#;
+    let topic = parse_emitted_topic(emitted_topic_dynamic_object_array_example);
 
     let mut generator = PythonGenerator::new();
     generator.add_emitted_topic(&topic).unwrap();
@@ -578,8 +556,22 @@ fn consumed_topic() {
 
 #[test]
 fn consumed_topic_escapes_python_keyword_fields() {
-    let topic = parse_consumed_topic(SUBSCRIBED_TOPIC_EXAMPLE_KEYWORDS);
-    let format = parse_message_format(SUBSCRIBED_TOPIC_FORMAT_EXAMPLE_KEYWORDS);
+    let subscribed_topic_example_keywords: &str = r#"
+    {
+        local_node_id: "keyword_source",
+        name: "keyword_topic",
+    }
+    "#;
+
+    let topic = parse_consumed_topic(subscribed_topic_example_keywords);
+    let subscribed_topic_format_example_keywords: &str = r#"
+    {
+        "class": "u32",
+        "from": "string"
+    }
+    "#;
+
+    let format = parse_message_format(subscribed_topic_format_example_keywords);
 
     let mut generator = PythonGenerator::new();
     generator

--- a/crates/generator-internal/src/generator/python/tests/topics.rs
+++ b/crates/generator-internal/src/generator/python/tests/topics.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::error::Error;
-use config::node::{ConsumedTopic, EmittedTopic, MessageFormat, PeppygenLanguage};
+use config::node::{ConsumedTopic, EmittedTopic, MessageFormat};
 
 const EMITTED_TOPIC_EXAMPLE: &str = r#"
 {
@@ -342,12 +342,7 @@ fn emit_topic_rejects_fixed_string_array() {
     let err = generator.add_emitted_topic(&topic).unwrap_err();
 
     match err {
-        Error::UnsupportedFixedArrayItemType {
-            language,
-            field,
-            item,
-        } => {
-            assert_eq!(language, PeppygenLanguage::Python);
+        Error::UnsupportedFixedArrayItemType { field, item } => {
             assert_eq!(field, "labels");
             assert_eq!(item, "string");
         }
@@ -381,12 +376,7 @@ fn emit_topic_rejects_fixed_object_array() {
     let err = generator.add_emitted_topic(&topic).unwrap_err();
 
     match err {
-        Error::UnsupportedFixedArrayItemType {
-            language,
-            field,
-            item,
-        } => {
-            assert_eq!(language, PeppygenLanguage::Python);
+        Error::UnsupportedFixedArrayItemType { field, item } => {
             assert_eq!(field, "objects");
             assert_eq!(item, "object");
         }

--- a/crates/generator-internal/src/generator/python/tests/topics.rs
+++ b/crates/generator-internal/src/generator/python/tests/topics.rs
@@ -78,6 +78,42 @@ const EMITTED_TOPIC_FIXED_STRING_ARRAY_EXAMPLE: &str = r#"
 }
 "#;
 
+const EMITTED_TOPIC_FIXED_OBJECT_ARRAY_EXAMPLE: &str = r#"
+{
+  name: "detections",
+  qos_profile: "sensor_data",
+  message_format: {
+    objects: {
+      $type: "array",
+      $items: {
+        $type: "object",
+        x: "f32",
+        y: "f32"
+      },
+      $length: 4
+    }
+  }
+}
+"#;
+
+const EMITTED_TOPIC_DYNAMIC_OBJECT_ARRAY_EXAMPLE: &str = r#"
+{
+  name: "detections",
+  qos_profile: "sensor_data",
+  message_format: {
+    objects: {
+      $type: "array",
+      $items: {
+        $type: "object",
+        x: "f32",
+        y: "f32",
+        label: "string"
+      }
+    }
+  }
+}
+"#;
+
 const SUBSCRIBED_TOPIC_EXAMPLE1: &str = r#"
 {
     local_node_id: "uvc_camera",
@@ -371,6 +407,54 @@ fn emit_topic_rejects_fixed_string_array() {
         }
         other => panic!("expected UnsupportedFixedArrayItemType, got: {other:?}"),
     }
+}
+
+#[test]
+fn emit_topic_rejects_fixed_object_array() {
+    use crate::error::Error;
+
+    let topic = parse_emitted_topic(EMITTED_TOPIC_FIXED_OBJECT_ARRAY_EXAMPLE);
+
+    let mut generator = PythonGenerator::new();
+    let err = generator.add_emitted_topic(&topic).unwrap_err();
+
+    match err {
+        Error::UnsupportedFixedArrayItemType {
+            language,
+            field,
+            item,
+        } => {
+            assert_eq!(language, PeppygenLanguage::Python);
+            assert_eq!(field, "objects");
+            assert_eq!(item, "object");
+        }
+        other => panic!("expected UnsupportedFixedArrayItemType, got: {other:?}"),
+    }
+}
+
+#[test]
+fn emit_topic_with_dynamic_object_array() {
+    let topic = parse_emitted_topic(EMITTED_TOPIC_DYNAMIC_OBJECT_ARRAY_EXAMPLE);
+
+    let mut generator = PythonGenerator::new();
+    generator.add_emitted_topic(&topic).unwrap();
+    let artifacts = render_artifacts(generator.into_artifacts());
+    assert_eq!(
+        artifacts.len(),
+        1,
+        "expected a single generated artifact, got {}",
+        artifacts.len()
+    );
+    let rendered = artifacts.into_iter().next().expect("artifact is present");
+
+    // Object array serialization: list init with runtime length and element iteration
+    assert_contains_all(&rendered, &[".init(\"objects\", len(", "in enumerate("]);
+
+    // Dynamic-length path must not emit a fixed-length guard
+    assert!(
+        !rendered.contains("raise ValueError"),
+        "dynamic object array must not emit a length check"
+    );
 }
 
 /// In the case of a topic, a "subscribed" topic is an entity that expects to receive messages

--- a/crates/generator-internal/src/generator/python/type_mapping.rs
+++ b/crates/generator-internal/src/generator/python/type_mapping.rs
@@ -1,6 +1,6 @@
 use super::identifiers::sanitize_python_identifier;
 use crate::error::{Error, Result};
-use crate::generator::naming::to_camel_case;
+use crate::generator::naming::{array_item_type_name, to_camel_case};
 use config::node::{PeppygenLanguage, QoSProfile, SchemaType, TypeToken};
 use std::collections::HashMap;
 
@@ -49,8 +49,7 @@ pub fn schema_type_to_python(
         SchemaType::Primitive(primitive) => primitive_type_str(&primitive.kind).to_string(),
         SchemaType::Array(array) => match array.items.as_ref() {
             SchemaType::Object(object) => {
-                let item_field = format!("{field_name}_item");
-                let class_name = format!("{struct_prefix}{}", to_camel_case(&item_field));
+                let class_name = array_item_type_name(struct_prefix, field_name);
                 validate_python_identifier_collisions(object.fields.keys(), &class_name)?;
                 let mut fields = Vec::new();
                 for (nested_name, nested_schema) in &object.fields {

--- a/crates/generator-internal/src/generator/python/type_mapping.rs
+++ b/crates/generator-internal/src/generator/python/type_mapping.rs
@@ -47,18 +47,44 @@ pub fn schema_type_to_python(
     let base_type = match schema {
         SchemaType::Type(token) => primitive_type_str(token).to_string(),
         SchemaType::Primitive(primitive) => primitive_type_str(&primitive.kind).to_string(),
-        SchemaType::Array(array) => {
-            let item_type = match array.items.as_ref().as_type_token() {
-                Some(TypeToken::U8) => return Ok(wrap_optional(schema, "bytes".to_string())),
-                Some(token) => primitive_type_str(token),
-                None => {
-                    return Err(Error::UnsupportedArrayItemSchema {
-                        field: field_name.to_string(),
+        SchemaType::Array(array) => match array.items.as_ref() {
+            SchemaType::Object(object) => {
+                let item_field = format!("{field_name}_item");
+                let class_name = format!("{struct_prefix}{}", to_camel_case(&item_field));
+                validate_python_identifier_collisions(object.fields.keys(), &class_name)?;
+                let mut fields = Vec::new();
+                for (nested_name, nested_schema) in &object.fields {
+                    let field_type = schema_type_to_python(
+                        nested_schema,
+                        &class_name,
+                        nested_name,
+                        nested_classes,
+                    )?;
+                    fields.push(PythonField {
+                        name: sanitize_python_identifier(nested_name),
+                        type_str: field_type,
+                        is_optional: nested_schema.is_optional(),
                     });
                 }
-            };
-            format!("list[{item_type}]")
-        }
+                nested_classes.push(NestedDataclass {
+                    name: class_name.clone(),
+                    fields,
+                });
+                format!("list[{class_name}]")
+            }
+            _ => {
+                let item_type = match array.items.as_ref().as_type_token() {
+                    Some(TypeToken::U8) => return Ok(wrap_optional(schema, "bytes".to_string())),
+                    Some(token) => primitive_type_str(token),
+                    None => {
+                        return Err(Error::UnsupportedArrayItemSchema {
+                            field: field_name.to_string(),
+                        });
+                    }
+                };
+                format!("list[{item_type}]")
+            }
+        },
         SchemaType::Object(object) => {
             let class_name = format!("{struct_prefix}{}", to_camel_case(field_name));
             validate_python_identifier_collisions(object.fields.keys(), &class_name)?;

--- a/crates/generator-internal/src/generator/rust/context.rs
+++ b/crates/generator-internal/src/generator/rust/context.rs
@@ -3,7 +3,8 @@ use super::type_mapping::schema_type_to_tokens;
 use crate::error::{Error, Result};
 use crate::generator::naming::sanitize_capnp_field_name;
 use crate::generator::types::{
-    validate_fixed_length_array_items, validate_message_format_field_names,
+    validate_fixed_length_array_items, validate_generated_type_name_collisions,
+    validate_message_format_field_names,
 };
 use config::encoding::{CapnpSchemaArtifacts, FunctionParam, MessageFormatMapper};
 use config::node::{MessageFormat, PeppygenLanguage, SchemaType, TypeToken};
@@ -100,6 +101,7 @@ pub fn map_message_format(
             validate_normalized_field_names_for_rust(format)?;
             validate_message_format_field_names(format, "message_format")?;
             validate_fixed_length_array_items(format, PeppygenLanguage::Rust)?;
+            validate_generated_type_name_collisions(format, "Message")?;
             validate_optional_scalar_fields_for_rust(format)?;
             MessageFormatMapper::new(schema_name, format.clone())
                 .map_message_format_to_capnpn()

--- a/crates/generator-internal/src/generator/rust/context.rs
+++ b/crates/generator-internal/src/generator/rust/context.rs
@@ -100,7 +100,7 @@ pub fn map_message_format(
         Some(format) => {
             validate_normalized_field_names_for_rust(format)?;
             validate_message_format_field_names(format, "message_format")?;
-            validate_fixed_length_array_items(format, PeppygenLanguage::Rust)?;
+            validate_fixed_length_array_items(format)?;
             validate_generated_type_name_collisions(format, "Message")?;
             validate_optional_scalar_fields_for_rust(format)?;
             MessageFormatMapper::new(schema_name, format.clone())

--- a/crates/generator-internal/src/generator/rust/context.rs
+++ b/crates/generator-internal/src/generator/rust/context.rs
@@ -406,8 +406,10 @@ mod tests {
     }
 
     #[test]
-    fn reject_optional_nested_scalar_for_rust() {
-        let format: MessageFormat = serde_json5::from_str(
+    fn reject_optional_nested_scalar_at_parse_time() {
+        // `$optional` on nested object fields is rejected at deserialization
+        // time by the ObjectSchema visitor, not at generator validation time.
+        let result: std::result::Result<MessageFormat, _> = serde_json5::from_str(
             r#"
             {
                 status: {
@@ -419,17 +421,11 @@ mod tests {
                 }
             }
             "#,
-        )
-        .unwrap();
-
-        let err = validate_optional_scalar_fields_for_rust(&format).unwrap_err();
-        match err {
-            Error::UnsupportedOptionalScalarType { field, item, .. } => {
-                assert_eq!(field, "status.healthy");
-                assert_eq!(item, "bool");
-            }
-            other => panic!("expected UnsupportedOptionalScalarType, got: {other:?}"),
-        }
+        );
+        assert!(
+            result.is_err(),
+            "optional on nested object field should be rejected at parse time"
+        );
     }
 
     #[test]

--- a/crates/generator-internal/src/generator/rust/deserialization.rs
+++ b/crates/generator-internal/src/generator/rust/deserialization.rs
@@ -2,7 +2,7 @@ use super::identifiers::sanitize_rust_identifier;
 use super::serialization::NameGenerator;
 use super::type_mapping::primitive_type_token;
 use crate::error::{Error, Result};
-use crate::generator::naming::{sanitize_component, to_camel_case};
+use crate::generator::naming::{array_item_type_name, sanitize_component, to_camel_case};
 use config::node::{ArraySchema, MessageFormat, SchemaType, TypeToken};
 use indexmap::IndexMap;
 use proc_macro2::{Ident, Literal, Span, TokenStream};
@@ -556,8 +556,7 @@ fn generate_object_array_reader(
     let value_ident = names.next(field_name);
     let field_literal = Literal::string(field_name);
 
-    let item_field_name = format!("{field_name}_item");
-    let nested_prefix = format!("{struct_prefix}{}", to_camel_case(&item_field_name));
+    let nested_prefix = array_item_type_name(struct_prefix, field_name);
     let struct_ident = Ident::new(&nested_prefix, Span::call_site());
 
     let element_ident = names.next("element");

--- a/crates/generator-internal/src/generator/rust/deserialization.rs
+++ b/crates/generator-internal/src/generator/rust/deserialization.rs
@@ -180,9 +180,14 @@ fn generate_field_reader_statements_inner(
             context_expr,
             names,
         )),
-        SchemaType::Array(array) => {
-            generate_array_reader(reader_expr, field_name, array, context_expr, names)
-        }
+        SchemaType::Array(array) => generate_array_reader(
+            reader_expr,
+            field_name,
+            array,
+            struct_prefix,
+            context_expr,
+            names,
+        ),
         SchemaType::Object(object) => generate_object_reader(
             reader_expr,
             field_name,
@@ -323,6 +328,7 @@ fn generate_array_reader(
     reader_expr: &TokenStream,
     field_name: &str,
     array: &ArraySchema,
+    struct_prefix: &str,
     context_expr: &TokenStream,
     names: &mut NameGenerator,
 ) -> Result<(Vec<TokenStream>, Ident)> {
@@ -330,27 +336,38 @@ fn generate_array_reader(
         &format!("get_{}", sanitize_component(field_name)),
         Span::call_site(),
     );
-    match array.items.as_ref().as_type_token() {
-        Some(TypeToken::U8) => Ok(generate_u8_array_reader(
+    match array.items.as_ref() {
+        SchemaType::Object(object) => generate_object_array_reader(
             reader_expr,
             field_name,
             &method_ident,
-            array.length,
+            &object.fields,
+            struct_prefix,
             context_expr,
             names,
-        )),
-        Some(token) => Ok(generate_primitive_array_reader(
-            reader_expr,
-            field_name,
-            token,
-            &method_ident,
-            array.length,
-            context_expr,
-            names,
-        )),
-        None => Err(Error::UnsupportedArrayItemSchema {
-            field: field_name.to_string(),
-        }),
+        ),
+        _ => match array.items.as_ref().as_type_token() {
+            Some(TypeToken::U8) => Ok(generate_u8_array_reader(
+                reader_expr,
+                field_name,
+                &method_ident,
+                array.length,
+                context_expr,
+                names,
+            )),
+            Some(token) => Ok(generate_primitive_array_reader(
+                reader_expr,
+                field_name,
+                token,
+                &method_ident,
+                array.length,
+                context_expr,
+                names,
+            )),
+            None => Err(Error::UnsupportedArrayItemSchema {
+                field: field_name.to_string(),
+            }),
+        },
     }
 }
 
@@ -516,6 +533,69 @@ fn generate_object_reader(
         let #value_ident = #struct_ident {
             #( #field_inits ),*
         };
+    });
+
+    Ok((statements, value_ident))
+}
+
+fn generate_object_array_reader(
+    reader_expr: &TokenStream,
+    field_name: &str,
+    method_ident: &Ident,
+    fields: &IndexMap<String, SchemaType>,
+    struct_prefix: &str,
+    context_expr: &TokenStream,
+    names: &mut NameGenerator,
+) -> Result<(Vec<TokenStream>, Ident)> {
+    let list_ident = names.next("list");
+    let result_ident = names.next("result");
+    let value_ident = names.next(field_name);
+    let field_literal = Literal::string(field_name);
+
+    let item_field_name = format!("{field_name}_item");
+    let nested_prefix = format!("{struct_prefix}{}", to_camel_case(&item_field_name));
+    let struct_ident = Ident::new(&nested_prefix, Span::call_site());
+
+    let element_ident = names.next("element");
+    let mut field_statements = Vec::new();
+    let mut field_inits = Vec::new();
+
+    for (nested_name, nested_schema) in fields {
+        let (mut nested_statements, nested_value_ident) = generate_field_reader_statements(
+            &quote!(#element_ident),
+            nested_name.as_str(),
+            nested_schema,
+            &nested_prefix,
+            context_expr,
+            names,
+        )?;
+        field_statements.append(&mut nested_statements);
+        let field_ident = Ident::new(&sanitize_rust_identifier(nested_name), Span::call_site());
+        field_inits.push(quote!(#field_ident: #nested_value_ident));
+    }
+
+    let mut statements = vec![quote! {
+        let #list_ident = #reader_expr
+            .reborrow()
+            .#method_ident()
+            .map_err(|source| {
+                #[allow(clippy::all)]
+                let context = #context_expr;
+                crate::Error::Deserialization(
+                    format!("field '{}' in {}: {}", #field_literal, context, source)
+                )
+            })?;
+    }];
+
+    statements.push(quote! {
+        let mut #result_ident = Vec::with_capacity(#list_ident.len() as usize);
+        for #element_ident in #list_ident.iter() {
+            #( #field_statements )*
+            #result_ident.push(#struct_ident {
+                #( #field_inits ),*
+            });
+        }
+        let #value_ident = #result_ident;
     });
 
     Ok((statements, value_ident))

--- a/crates/generator-internal/src/generator/rust/deserialization.rs
+++ b/crates/generator-internal/src/generator/rust/deserialization.rs
@@ -340,11 +340,11 @@ fn generate_array_reader(
         SchemaType::Object(object) => generate_object_array_reader(
             reader_expr,
             field_name,
-            &method_ident,
             &object.fields,
             struct_prefix,
             context_expr,
             names,
+            array.length,
         ),
         _ => match array.items.as_ref().as_type_token() {
             Some(TypeToken::U8) => Ok(generate_u8_array_reader(
@@ -541,12 +541,16 @@ fn generate_object_reader(
 fn generate_object_array_reader(
     reader_expr: &TokenStream,
     field_name: &str,
-    method_ident: &Ident,
     fields: &IndexMap<String, SchemaType>,
     struct_prefix: &str,
     context_expr: &TokenStream,
     names: &mut NameGenerator,
+    length: Option<usize>,
 ) -> Result<(Vec<TokenStream>, Ident)> {
+    let method_ident = Ident::new(
+        &format!("get_{}", sanitize_component(field_name)),
+        Span::call_site(),
+    );
     let list_ident = names.next("list");
     let result_ident = names.next("result");
     let value_ident = names.next(field_name);
@@ -587,16 +591,91 @@ fn generate_object_array_reader(
             })?;
     }];
 
-    statements.push(quote! {
-        let mut #result_ident = Vec::with_capacity(#list_ident.len() as usize);
-        for #element_ident in #list_ident.iter() {
-            #( #field_statements )*
-            #result_ident.push(#struct_ident {
-                #( #field_inits ),*
-            });
-        }
-        let #value_ident = #result_ident;
-    });
+    if let Some(len) = length {
+        let len_lit = Literal::usize_unsuffixed(len);
+        statements.push(quote! {
+            let mut #result_ident = Vec::with_capacity(#len_lit);
+            for #element_ident in #list_ident.iter() {
+                #( #field_statements )*
+                #result_ident.push(#struct_ident {
+                    #( #field_inits ),*
+                });
+            }
+            let #value_ident: [#struct_ident; #len_lit] = #result_ident.try_into().map_err(|v: Vec<_>| {
+                crate::Error::Deserialization(
+                    format!("invalid fixed list length for field '{}': expected {}, got {}", #field_literal, #len_lit, v.len())
+                )
+            })?;
+        });
+    } else {
+        statements.push(quote! {
+            let mut #result_ident = Vec::with_capacity(#list_ident.len() as usize);
+            for #element_ident in #list_ident.iter() {
+                #( #field_statements )*
+                #result_ident.push(#struct_ident {
+                    #( #field_inits ),*
+                });
+            }
+            let #value_ident = #result_ident;
+        });
+    }
 
     Ok((statements, value_ident))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn call_object_array_reader(length: Option<usize>) -> String {
+        let reader_expr = quote!(reader);
+        let mut fields = IndexMap::new();
+        fields.insert("x".to_string(), SchemaType::Type(TypeToken::I32));
+        let context_expr = quote!("TestMsg");
+        let mut names = NameGenerator::new();
+
+        let (statements, _) = generate_object_array_reader(
+            &reader_expr,
+            "frames",
+            &fields,
+            "Test",
+            &context_expr,
+            &mut names,
+            length,
+        )
+        .unwrap();
+
+        let combined = quote! { #( #statements )* };
+        combined.to_string()
+    }
+
+    #[test]
+    fn object_array_reader_fixed_length_uses_try_into() {
+        let code = call_object_array_reader(Some(4));
+        assert!(
+            code.contains("try_into"),
+            "fixed-length path must use try_into, got: {code}"
+        );
+        assert!(
+            code.contains("Vec :: with_capacity (4"),
+            "expected fixed literal 4 in Vec::with_capacity, got: {code}"
+        );
+        assert!(
+            code.contains(r#""frames" , 4 , v . len ()"#),
+            "error message must reference field name and expected length, got: {code}"
+        );
+    }
+
+    #[test]
+    fn object_array_reader_dynamic_length_uses_vec() {
+        let code = call_object_array_reader(None);
+        assert!(
+            !code.contains("try_into"),
+            "dynamic-length path must not use try_into, got: {code}"
+        );
+        assert!(
+            code.contains("Vec :: with_capacity"),
+            "dynamic-length path must use Vec::with_capacity, got: {code}"
+        );
+    }
 }

--- a/crates/generator-internal/src/generator/rust/deserialization.rs
+++ b/crates/generator-internal/src/generator/rust/deserialization.rs
@@ -592,18 +592,19 @@ fn generate_object_array_reader(
 
     if let Some(len) = length {
         let len_lit = Literal::usize_unsuffixed(len);
+        let idx_ident = names.next("idx");
         statements.push(quote! {
-            let mut #result_ident = Vec::with_capacity(#len_lit);
-            for #element_ident in #list_ident.iter() {
-                #( #field_statements )*
-                #result_ident.push(#struct_ident {
-                    #( #field_inits ),*
-                });
+            if #list_ident.len() != #len_lit as u32 {
+                return Err(crate::Error::Deserialization(
+                    format!("invalid fixed list length for field '{}': expected {}, got {}", #field_literal, #len_lit, #list_ident.len())
+                ));
             }
-            let #value_ident: [#struct_ident; #len_lit] = #result_ident.try_into().map_err(|v: Vec<_>| {
-                crate::Error::Deserialization(
-                    format!("invalid fixed list length for field '{}': expected {}, got {}", #field_literal, #len_lit, v.len())
-                )
+            let #value_ident: [#struct_ident; #len_lit] = core::array::try_from_fn(|#idx_ident| {
+                let #element_ident = #list_ident.get(#idx_ident as u32);
+                #( #field_statements )*
+                Ok::<_, crate::Error>(#struct_ident {
+                    #( #field_inits ),*
+                })
             })?;
         });
     } else {
@@ -649,18 +650,18 @@ mod tests {
     }
 
     #[test]
-    fn object_array_reader_fixed_length_uses_try_into() {
+    fn object_array_reader_fixed_length_uses_array() {
         let code = call_object_array_reader(Some(4));
         assert!(
-            code.contains("try_into"),
-            "fixed-length path must use try_into, got: {code}"
+            code.contains("[TestFramesItem ; 4]"),
+            "fixed-length path must produce a [T; N] array, got: {code}"
         );
         assert!(
-            code.contains("Vec :: with_capacity (4"),
-            "expected fixed literal 4 in Vec::with_capacity, got: {code}"
+            code.contains("try_from_fn"),
+            "fixed-length path must use core::array::try_from_fn, got: {code}"
         );
         assert!(
-            code.contains(r#""frames" , 4 , v . len ()"#),
+            code.contains(r#""frames" , 4"#),
             "error message must reference field name and expected length, got: {code}"
         );
     }

--- a/crates/generator-internal/src/generator/rust/serialization.rs
+++ b/crates/generator-internal/src/generator/rust/serialization.rs
@@ -189,14 +189,18 @@ fn generate_field_assignment_inner(
             &primitive.kind,
         )),
         SchemaType::Array(array) => match array.items.as_ref() {
-            SchemaType::Object(object) => generate_object_list_assignment(
-                builder_expr,
-                &init_method,
-                value_expr,
-                &object.fields,
-                names,
-                value_is_ref,
-            ),
+            SchemaType::Object(object) => {
+                let length_expr = make_length_expr(array.length, value_expr, field_name)?;
+                generate_object_list_assignment(
+                    builder_expr,
+                    &init_method,
+                    value_expr,
+                    &object.fields,
+                    names,
+                    value_is_ref,
+                    &length_expr,
+                )
+            }
             _ => {
                 let item_token = array.items.as_ref().as_type_token();
                 if matches!(item_token, Some(TypeToken::U8)) {
@@ -291,6 +295,26 @@ fn generate_time_assignment(
     }
 }
 
+fn make_length_expr(
+    length: Option<usize>,
+    value_expr: &TokenStream,
+    field_name: &str,
+) -> Result<TokenStream> {
+    match length {
+        Some(len) => {
+            let len_lit = Literal::u32_unsuffixed(u32::try_from(len).map_err(|_| {
+                Error::InvariantViolation {
+                    context: format!("list length {len} for field `{field_name}` exceeds u32::MAX"),
+                }
+            })?);
+            Ok(quote!(#len_lit))
+        }
+        None => Ok(quote!(
+            u32::try_from((#value_expr).len()).expect("list length exceeds u32::MAX")
+        )),
+    }
+}
+
 fn generate_list_assignment(
     builder_expr: &TokenStream,
     init_method: &Ident,
@@ -304,17 +328,7 @@ fn generate_list_assignment(
     let idx_ident = names.next("idx");
     let element_ident = names.next("value");
 
-    let length_expr = match length {
-        Some(len) => {
-            let len_lit = Literal::u32_unsuffixed(u32::try_from(len).map_err(|_| {
-                Error::InvariantViolation {
-                    context: format!("list length {len} for field `{field_name}` exceeds u32::MAX"),
-                }
-            })?);
-            quote!(#len_lit)
-        }
-        None => quote!(u32::try_from((#value_expr).len()).expect("list length exceeds u32::MAX")),
-    };
+    let length_expr = make_length_expr(length, value_expr, field_name)?;
 
     let element_setter = match token {
         TypeToken::String => quote!(#list_ident.set(#idx_ident as u32, #element_ident.as_str());),
@@ -390,13 +404,11 @@ fn generate_object_list_assignment(
     fields: &IndexMap<String, SchemaType>,
     names: &mut NameGenerator,
     value_is_ref: bool,
+    length_expr: &TokenStream,
 ) -> Result<TokenStream> {
     let list_ident = names.next("list");
     let idx_ident = names.next("idx");
     let element_ident = names.next("element");
-
-    let length_expr =
-        quote!(u32::try_from((#value_expr).len()).expect("list length exceeds u32::MAX"));
 
     let element_builder_ident = names.next("builder");
     let mut nested = Vec::with_capacity(fields.len());
@@ -465,4 +477,74 @@ pub fn build_serialize_payload(
         })?;
         peppylib::Payload::from(buffer)
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// When `length` is `Some`, the generated code must use the fixed literal
+    /// instead of a runtime `.len()` call.
+    #[test]
+    fn object_list_assignment_uses_fixed_length_literal() {
+        let builder = quote!(root);
+        let init = Ident::new("init_frames", Span::call_site());
+        let value = quote!(self.frames);
+        let mut fields = IndexMap::new();
+        fields.insert("x".to_string(), SchemaType::Type(TypeToken::I32));
+        let mut names = NameGenerator::new();
+
+        let length_expr = make_length_expr(Some(4), &value, "frames").unwrap();
+        let tokens = generate_object_list_assignment(
+            &builder,
+            &init,
+            &value,
+            &fields,
+            &mut names,
+            true,
+            &length_expr,
+        )
+        .unwrap();
+
+        let code = tokens.to_string();
+        // Must use the literal 4, not a runtime .len() call.
+        assert!(
+            code.contains("init_frames (4"),
+            "expected fixed literal 4 in generated code, got: {code}"
+        );
+        assert!(
+            !code.contains("len"),
+            "fixed-length path must not use .len(), got: {code}"
+        );
+    }
+
+    /// When `length` is `None`, the generated code must fall back to runtime
+    /// `.len()`.
+    #[test]
+    fn object_list_assignment_uses_runtime_len_when_no_fixed_length() {
+        let builder = quote!(root);
+        let init = Ident::new("init_frames", Span::call_site());
+        let value = quote!(self.frames);
+        let mut fields = IndexMap::new();
+        fields.insert("x".to_string(), SchemaType::Type(TypeToken::I32));
+        let mut names = NameGenerator::new();
+
+        let length_expr = make_length_expr(None, &value, "frames").unwrap();
+        let tokens = generate_object_list_assignment(
+            &builder,
+            &init,
+            &value,
+            &fields,
+            &mut names,
+            true,
+            &length_expr,
+        )
+        .unwrap();
+
+        let code = tokens.to_string();
+        assert!(
+            code.contains("len"),
+            "dynamic-length path must use .len(), got: {code}"
+        );
+    }
 }

--- a/crates/generator-internal/src/generator/rust/serialization.rs
+++ b/crates/generator-internal/src/generator/rust/serialization.rs
@@ -190,7 +190,7 @@ fn generate_field_assignment_inner(
         )),
         SchemaType::Array(array) => match array.items.as_ref() {
             SchemaType::Object(object) => {
-                let list_length = ObjectListLength::new(array.length, value_expr, field_name)?;
+                let length_expr = make_length_expr(array.length, value_expr, field_name)?;
                 generate_object_list_assignment(
                     builder_expr,
                     &init_method,
@@ -198,7 +198,7 @@ fn generate_field_assignment_inner(
                     &object.fields,
                     names,
                     value_is_ref,
-                    &list_length,
+                    &length_expr,
                 )
             }
             _ => {
@@ -316,35 +316,6 @@ fn make_length_expr(
 }
 
 /// Pre-computed length tokens for object list serialization.
-struct ObjectListLength {
-    /// Expression passed to `init_method` (either a literal or runtime `.len()`).
-    init_expr: TokenStream,
-    /// Optional runtime assertion that the slice length matches the schema
-    /// (non-empty only for fixed-length arrays).
-    check: TokenStream,
-}
-
-impl ObjectListLength {
-    fn new(length: Option<usize>, value_expr: &TokenStream, field_name: &str) -> Result<Self> {
-        let init_expr = make_length_expr(length, value_expr, field_name)?;
-        let check = if let Some(len) = length {
-            let len_lit = Literal::usize_unsuffixed(len);
-            let field_literal = Literal::string(field_name);
-            quote! {
-                assert_eq!(
-                    (#value_expr).len(),
-                    #len_lit,
-                    "object array length mismatch for field `{}`: expected {}, got {}",
-                    #field_literal, #len_lit, (#value_expr).len(),
-                );
-            }
-        } else {
-            quote!()
-        };
-        Ok(Self { init_expr, check })
-    }
-}
-
 fn generate_list_assignment(
     builder_expr: &TokenStream,
     init_method: &Ident,
@@ -434,11 +405,8 @@ fn generate_object_list_assignment(
     fields: &IndexMap<String, SchemaType>,
     names: &mut NameGenerator,
     value_is_ref: bool,
-    list_length: &ObjectListLength,
+    length_expr: &TokenStream,
 ) -> Result<TokenStream> {
-    let length_expr = &list_length.init_expr;
-    let length_check = &list_length.check;
-
     let list_ident = names.next("list");
     let idx_ident = names.next("idx");
     let element_ident = names.next("element");
@@ -467,7 +435,6 @@ fn generate_object_list_assignment(
     }
 
     Ok(quote! {
-        #length_check
         let mut #list_ident = #builder_expr.reborrow().#init_method(#length_expr);
         for (#idx_ident, #element_ident) in (#value_expr).iter().enumerate() {
             let mut #element_builder_ident = #list_ident.reborrow().get(#idx_ident as u32);
@@ -528,7 +495,7 @@ mod tests {
         fields.insert("x".to_string(), SchemaType::Type(TypeToken::I32));
         let mut names = NameGenerator::new();
 
-        let list_length = ObjectListLength::new(Some(4), &value, "frames").unwrap();
+        let length_expr = make_length_expr(Some(4), &value, "frames").unwrap();
         let tokens = generate_object_list_assignment(
             &builder,
             &init,
@@ -536,7 +503,7 @@ mod tests {
             &fields,
             &mut names,
             true,
-            &list_length,
+            &length_expr,
         )
         .unwrap();
 
@@ -546,10 +513,9 @@ mod tests {
             code.contains("init_frames (4"),
             "expected fixed literal 4 in generated code, got: {code}"
         );
-        // Must emit a length check for the fixed-length path.
         assert!(
-            code.contains("assert_eq"),
-            "fixed-length path must emit a length check, got: {code}"
+            !code.contains("assert_eq"),
+            "fixed-length path must not emit a runtime length check, got: {code}"
         );
     }
 
@@ -564,7 +530,7 @@ mod tests {
         fields.insert("x".to_string(), SchemaType::Type(TypeToken::I32));
         let mut names = NameGenerator::new();
 
-        let list_length = ObjectListLength::new(None, &value, "frames").unwrap();
+        let length_expr = make_length_expr(None, &value, "frames").unwrap();
         let tokens = generate_object_list_assignment(
             &builder,
             &init,
@@ -572,7 +538,7 @@ mod tests {
             &fields,
             &mut names,
             true,
-            &list_length,
+            &length_expr,
         )
         .unwrap();
 
@@ -580,79 +546,6 @@ mod tests {
         assert!(
             code.contains("len"),
             "dynamic-length path must use .len(), got: {code}"
-        );
-        assert!(
-            !code.contains("assert_eq"),
-            "dynamic-length path must not emit a length check, got: {code}"
-        );
-    }
-
-    /// When `length` is `Some`, the `assert_eq!` length check must appear
-    /// before the list init call, and include the field name for diagnostics.
-    #[test]
-    fn object_list_assignment_emits_length_check_for_fixed_length() {
-        let builder = quote!(root);
-        let init = Ident::new("init_frames", Span::call_site());
-        let value = quote!(self.frames);
-        let mut fields = IndexMap::new();
-        fields.insert("x".to_string(), SchemaType::Type(TypeToken::I32));
-        let mut names = NameGenerator::new();
-
-        let list_length = ObjectListLength::new(Some(4), &value, "frames").unwrap();
-        let tokens = generate_object_list_assignment(
-            &builder,
-            &init,
-            &value,
-            &fields,
-            &mut names,
-            true,
-            &list_length,
-        )
-        .unwrap();
-
-        let code = tokens.to_string();
-        let assert_pos = code
-            .find("assert_eq")
-            .expect("expected assert_eq in generated code");
-        let init_pos = code
-            .find("init_frames")
-            .expect("expected init_frames in generated code");
-        assert!(
-            assert_pos < init_pos,
-            "length check must appear before list init, got: {code}"
-        );
-        assert!(
-            code.contains("frames"),
-            "length check must include field name, got: {code}"
-        );
-    }
-
-    /// When `length` is `None`, no `assert_eq!` length check should be emitted.
-    #[test]
-    fn object_list_assignment_no_length_check_for_dynamic() {
-        let builder = quote!(root);
-        let init = Ident::new("init_frames", Span::call_site());
-        let value = quote!(self.frames);
-        let mut fields = IndexMap::new();
-        fields.insert("x".to_string(), SchemaType::Type(TypeToken::I32));
-        let mut names = NameGenerator::new();
-
-        let list_length = ObjectListLength::new(None, &value, "frames").unwrap();
-        let tokens = generate_object_list_assignment(
-            &builder,
-            &init,
-            &value,
-            &fields,
-            &mut names,
-            true,
-            &list_length,
-        )
-        .unwrap();
-
-        let code = tokens.to_string();
-        assert!(
-            !code.contains("assert_eq"),
-            "dynamic-length path must not emit assert_eq, got: {code}"
         );
     }
 }

--- a/crates/generator-internal/src/generator/rust/serialization.rs
+++ b/crates/generator-internal/src/generator/rust/serialization.rs
@@ -188,26 +188,36 @@ fn generate_field_assignment_inner(
             value_is_ref,
             &primitive.kind,
         )),
-        SchemaType::Array(array) => {
-            let item_token = array.items.as_ref().as_type_token();
-            if matches!(item_token, Some(TypeToken::U8)) {
-                Ok(quote!(#builder_expr.#set_method(#value_expr.as_ref());))
-            } else if let Some(token) = item_token {
-                generate_list_assignment(
-                    builder_expr,
-                    &init_method,
-                    value_expr,
-                    field_name,
-                    array.length,
-                    token,
-                    names,
-                )
-            } else {
-                Err(Error::UnsupportedArrayItemSchema {
-                    field: field_name.to_string(),
-                })
+        SchemaType::Array(array) => match array.items.as_ref() {
+            SchemaType::Object(object) => generate_object_list_assignment(
+                builder_expr,
+                &init_method,
+                value_expr,
+                &object.fields,
+                names,
+                value_is_ref,
+            ),
+            _ => {
+                let item_token = array.items.as_ref().as_type_token();
+                if matches!(item_token, Some(TypeToken::U8)) {
+                    Ok(quote!(#builder_expr.#set_method(#value_expr.as_ref());))
+                } else if let Some(token) = item_token {
+                    generate_list_assignment(
+                        builder_expr,
+                        &init_method,
+                        value_expr,
+                        field_name,
+                        array.length,
+                        token,
+                        names,
+                    )
+                } else {
+                    Err(Error::UnsupportedArrayItemSchema {
+                        field: field_name.to_string(),
+                    })
+                }
             }
-        }
+        },
         SchemaType::Object(object) => generate_object_assignment(
             builder_expr,
             &init_method,
@@ -370,6 +380,53 @@ fn generate_object_assignment(
     Ok(quote! {
         let mut #builder_ident = #builder_expr.reborrow().#init_method();
         #(#nested)*
+    })
+}
+
+fn generate_object_list_assignment(
+    builder_expr: &TokenStream,
+    init_method: &Ident,
+    value_expr: &TokenStream,
+    fields: &IndexMap<String, SchemaType>,
+    names: &mut NameGenerator,
+    value_is_ref: bool,
+) -> Result<TokenStream> {
+    let list_ident = names.next("list");
+    let idx_ident = names.next("idx");
+    let element_ident = names.next("element");
+
+    let length_expr =
+        quote!(u32::try_from((#value_expr).len()).expect("list length exceeds u32::MAX"));
+
+    let element_builder_ident = names.next("builder");
+    let mut nested = Vec::with_capacity(fields.len());
+    for (nested_name, nested_schema) in fields {
+        let nested_ident = Ident::new(
+            &sanitize_rust_identifier(nested_name.as_str()),
+            Span::call_site(),
+        );
+        let nested_value_expr = if value_is_ref {
+            quote!(&#element_ident.#nested_ident)
+        } else {
+            quote!(#element_ident.#nested_ident)
+        };
+        nested.push(generate_field_assignment_inner(
+            &quote!(#element_builder_ident),
+            nested_name,
+            nested_schema,
+            &nested_value_expr,
+            names,
+            true,
+            value_is_ref,
+        )?);
+    }
+
+    Ok(quote! {
+        let mut #list_ident = #builder_expr.reborrow().#init_method(#length_expr);
+        for (#idx_ident, #element_ident) in (#value_expr).iter().enumerate() {
+            let mut #element_builder_ident = #list_ident.reborrow().get(#idx_ident as u32);
+            #(#nested)*
+        }
     })
 }
 

--- a/crates/generator-internal/src/generator/rust/serialization.rs
+++ b/crates/generator-internal/src/generator/rust/serialization.rs
@@ -190,7 +190,7 @@ fn generate_field_assignment_inner(
         )),
         SchemaType::Array(array) => match array.items.as_ref() {
             SchemaType::Object(object) => {
-                let length_expr = make_length_expr(array.length, value_expr, field_name)?;
+                let list_length = ObjectListLength::new(array.length, value_expr, field_name)?;
                 generate_object_list_assignment(
                     builder_expr,
                     &init_method,
@@ -198,7 +198,7 @@ fn generate_field_assignment_inner(
                     &object.fields,
                     names,
                     value_is_ref,
-                    &length_expr,
+                    &list_length,
                 )
             }
             _ => {
@@ -315,6 +315,36 @@ fn make_length_expr(
     }
 }
 
+/// Pre-computed length tokens for object list serialization.
+struct ObjectListLength {
+    /// Expression passed to `init_method` (either a literal or runtime `.len()`).
+    init_expr: TokenStream,
+    /// Optional runtime assertion that the slice length matches the schema
+    /// (non-empty only for fixed-length arrays).
+    check: TokenStream,
+}
+
+impl ObjectListLength {
+    fn new(length: Option<usize>, value_expr: &TokenStream, field_name: &str) -> Result<Self> {
+        let init_expr = make_length_expr(length, value_expr, field_name)?;
+        let check = if let Some(len) = length {
+            let len_lit = Literal::usize_unsuffixed(len);
+            let field_literal = Literal::string(field_name);
+            quote! {
+                assert_eq!(
+                    (#value_expr).len(),
+                    #len_lit,
+                    "object array length mismatch for field `{}`: expected {}, got {}",
+                    #field_literal, #len_lit, (#value_expr).len(),
+                );
+            }
+        } else {
+            quote!()
+        };
+        Ok(Self { init_expr, check })
+    }
+}
+
 fn generate_list_assignment(
     builder_expr: &TokenStream,
     init_method: &Ident,
@@ -404,8 +434,11 @@ fn generate_object_list_assignment(
     fields: &IndexMap<String, SchemaType>,
     names: &mut NameGenerator,
     value_is_ref: bool,
-    length_expr: &TokenStream,
+    list_length: &ObjectListLength,
 ) -> Result<TokenStream> {
+    let length_expr = &list_length.init_expr;
+    let length_check = &list_length.check;
+
     let list_ident = names.next("list");
     let idx_ident = names.next("idx");
     let element_ident = names.next("element");
@@ -434,6 +467,7 @@ fn generate_object_list_assignment(
     }
 
     Ok(quote! {
+        #length_check
         let mut #list_ident = #builder_expr.reborrow().#init_method(#length_expr);
         for (#idx_ident, #element_ident) in (#value_expr).iter().enumerate() {
             let mut #element_builder_ident = #list_ident.reborrow().get(#idx_ident as u32);
@@ -494,7 +528,7 @@ mod tests {
         fields.insert("x".to_string(), SchemaType::Type(TypeToken::I32));
         let mut names = NameGenerator::new();
 
-        let length_expr = make_length_expr(Some(4), &value, "frames").unwrap();
+        let list_length = ObjectListLength::new(Some(4), &value, "frames").unwrap();
         let tokens = generate_object_list_assignment(
             &builder,
             &init,
@@ -502,7 +536,7 @@ mod tests {
             &fields,
             &mut names,
             true,
-            &length_expr,
+            &list_length,
         )
         .unwrap();
 
@@ -512,9 +546,10 @@ mod tests {
             code.contains("init_frames (4"),
             "expected fixed literal 4 in generated code, got: {code}"
         );
+        // Must emit a length check for the fixed-length path.
         assert!(
-            !code.contains("len"),
-            "fixed-length path must not use .len(), got: {code}"
+            code.contains("assert_eq"),
+            "fixed-length path must emit a length check, got: {code}"
         );
     }
 
@@ -529,7 +564,7 @@ mod tests {
         fields.insert("x".to_string(), SchemaType::Type(TypeToken::I32));
         let mut names = NameGenerator::new();
 
-        let length_expr = make_length_expr(None, &value, "frames").unwrap();
+        let list_length = ObjectListLength::new(None, &value, "frames").unwrap();
         let tokens = generate_object_list_assignment(
             &builder,
             &init,
@@ -537,7 +572,7 @@ mod tests {
             &fields,
             &mut names,
             true,
-            &length_expr,
+            &list_length,
         )
         .unwrap();
 
@@ -545,6 +580,79 @@ mod tests {
         assert!(
             code.contains("len"),
             "dynamic-length path must use .len(), got: {code}"
+        );
+        assert!(
+            !code.contains("assert_eq"),
+            "dynamic-length path must not emit a length check, got: {code}"
+        );
+    }
+
+    /// When `length` is `Some`, the `assert_eq!` length check must appear
+    /// before the list init call, and include the field name for diagnostics.
+    #[test]
+    fn object_list_assignment_emits_length_check_for_fixed_length() {
+        let builder = quote!(root);
+        let init = Ident::new("init_frames", Span::call_site());
+        let value = quote!(self.frames);
+        let mut fields = IndexMap::new();
+        fields.insert("x".to_string(), SchemaType::Type(TypeToken::I32));
+        let mut names = NameGenerator::new();
+
+        let list_length = ObjectListLength::new(Some(4), &value, "frames").unwrap();
+        let tokens = generate_object_list_assignment(
+            &builder,
+            &init,
+            &value,
+            &fields,
+            &mut names,
+            true,
+            &list_length,
+        )
+        .unwrap();
+
+        let code = tokens.to_string();
+        let assert_pos = code
+            .find("assert_eq")
+            .expect("expected assert_eq in generated code");
+        let init_pos = code
+            .find("init_frames")
+            .expect("expected init_frames in generated code");
+        assert!(
+            assert_pos < init_pos,
+            "length check must appear before list init, got: {code}"
+        );
+        assert!(
+            code.contains("frames"),
+            "length check must include field name, got: {code}"
+        );
+    }
+
+    /// When `length` is `None`, no `assert_eq!` length check should be emitted.
+    #[test]
+    fn object_list_assignment_no_length_check_for_dynamic() {
+        let builder = quote!(root);
+        let init = Ident::new("init_frames", Span::call_site());
+        let value = quote!(self.frames);
+        let mut fields = IndexMap::new();
+        fields.insert("x".to_string(), SchemaType::Type(TypeToken::I32));
+        let mut names = NameGenerator::new();
+
+        let list_length = ObjectListLength::new(None, &value, "frames").unwrap();
+        let tokens = generate_object_list_assignment(
+            &builder,
+            &init,
+            &value,
+            &fields,
+            &mut names,
+            true,
+            &list_length,
+        )
+        .unwrap();
+
+        let code = tokens.to_string();
+        assert!(
+            !code.contains("assert_eq"),
+            "dynamic-length path must not emit assert_eq, got: {code}"
         );
     }
 }

--- a/crates/generator-internal/src/generator/rust/tests/topics.rs
+++ b/crates/generator-internal/src/generator/rust/tests/topics.rs
@@ -86,6 +86,42 @@ const EMITTED_TOPIC_FIXED_STRING_ARRAY_EXAMPLE: &str = r#"
 }
 "#;
 
+const EMITTED_TOPIC_FIXED_OBJECT_ARRAY_EXAMPLE: &str = r#"
+{
+  name: "detections",
+  qos_profile: "sensor_data",
+  message_format: {
+    objects: {
+      $type: "array",
+      $items: {
+        $type: "object",
+        x: "f32",
+        y: "f32"
+      },
+      $length: 4
+    }
+  }
+}
+"#;
+
+const EMITTED_TOPIC_DYNAMIC_OBJECT_ARRAY_EXAMPLE: &str = r#"
+{
+  name: "detections",
+  qos_profile: "sensor_data",
+  message_format: {
+    objects: {
+      $type: "array",
+      $items: {
+        $type: "object",
+        x: "f32",
+        y: "f32",
+        label: "string"
+      }
+    }
+  }
+}
+"#;
+
 const SUBSCRIBED_TOPIC_EXAMPLE1: &str = r#"
 {
     local_node_id: "uvc_camera",
@@ -306,6 +342,54 @@ fn emit_topic_rejects_fixed_string_array() {
         }
         other => panic!("expected UnsupportedFixedArrayItemType, got: {other:?}"),
     }
+}
+
+#[test]
+fn emit_topic_rejects_fixed_object_array() {
+    use crate::error::Error;
+
+    let topic = parse_emitted_topic(EMITTED_TOPIC_FIXED_OBJECT_ARRAY_EXAMPLE);
+    let mut generator = RustGenerator::new();
+
+    let err = generator.add_emitted_topic(&topic).unwrap_err();
+
+    match err {
+        Error::UnsupportedFixedArrayItemType {
+            language,
+            field,
+            item,
+        } => {
+            assert_eq!(language, PeppygenLanguage::Rust);
+            assert_eq!(field, "objects");
+            assert_eq!(item, "object");
+        }
+        other => panic!("expected UnsupportedFixedArrayItemType, got: {other:?}"),
+    }
+}
+
+#[test]
+fn emit_topic_with_dynamic_object_array() {
+    let topic = parse_emitted_topic(EMITTED_TOPIC_DYNAMIC_OBJECT_ARRAY_EXAMPLE);
+
+    let mut generator = RustGenerator::new();
+    generator.add_emitted_topic(&topic).unwrap();
+    let artifacts = render_artifacts(generator.into_artifacts());
+    assert_eq!(
+        artifacts.len(),
+        1,
+        "expected a single generated artifact, got {}",
+        artifacts.len()
+    );
+    let rendered = artifacts.into_iter().next().expect("artifact is present");
+
+    // Object array serialization: list init and element access
+    assert_contains_all(&rendered, &["init_objects(", ".reborrow().get(", ".len()"]);
+
+    // Dynamic-length path must not emit a fixed-length guard
+    assert!(
+        !rendered.contains("assert_eq"),
+        "dynamic object array must not emit a length check"
+    );
 }
 
 /// In the case of a topic, a "subscribed" topic is an entity expects to receive messages from another entity

--- a/crates/generator-internal/src/generator/rust/tests/topics.rs
+++ b/crates/generator-internal/src/generator/rust/tests/topics.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::error::Error;
-use config::node::{ConsumedTopic, EmittedTopic, MessageFormat, PeppygenLanguage};
+use config::node::{ConsumedTopic, EmittedTopic, MessageFormat};
 
 const EMITTED_TOPIC_EXAMPLE: &str = r#"
 {
@@ -267,12 +267,7 @@ fn emit_topic_rejects_fixed_string_array() {
     let err = generator.add_emitted_topic(&topic).unwrap_err();
 
     match err {
-        Error::UnsupportedFixedArrayItemType {
-            language,
-            field,
-            item,
-        } => {
-            assert_eq!(language, PeppygenLanguage::Rust);
+        Error::UnsupportedFixedArrayItemType { field, item } => {
             assert_eq!(field, "labels");
             assert_eq!(item, "string");
         }
@@ -306,12 +301,7 @@ fn emit_topic_rejects_fixed_object_array() {
     let err = generator.add_emitted_topic(&topic).unwrap_err();
 
     match err {
-        Error::UnsupportedFixedArrayItemType {
-            language,
-            field,
-            item,
-        } => {
-            assert_eq!(language, PeppygenLanguage::Rust);
+        Error::UnsupportedFixedArrayItemType { field, item } => {
             assert_eq!(field, "objects");
             assert_eq!(item, "object");
         }

--- a/crates/generator-internal/src/generator/rust/tests/topics.rs
+++ b/crates/generator-internal/src/generator/rust/tests/topics.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::error::Error;
 use config::node::{ConsumedTopic, EmittedTopic, MessageFormat, PeppygenLanguage};
 
 const EMITTED_TOPIC_EXAMPLE: &str = r#"
@@ -22,14 +23,6 @@ const EMITTED_TOPIC_EXAMPLE: &str = r#"
 }
 "#;
 
-const EMITTED_TOPIC_EXAMPLE_EMPTY_FORMAT: &str = r#"
-{
-  name: "video_stream",
-  qos_profile: "sensor_data",
-  message_format: {}
-}
-"#;
-
 const EMITTED_TOPIC_EXAMPLE2: &str = r#"
 {
   name: "push_lidar_object", // The name of the topic inside the `lidar_sensor` node
@@ -47,78 +40,6 @@ const EMITTED_TOPIC_EXAMPLE2: &str = r#"
     return_type: "u8", // e.g. first return, last return
     classification: "u8", // type of object detected
   },
-}
-"#;
-
-const EMITTED_TOPIC_KEYWORD_FIELDS_EXAMPLE: &str = r#"
-{
-  name: "keyword_topic",
-  qos_profile: "standard",
-  message_format: {
-    "type": "u32",
-    "match": "string"
-  }
-}
-"#;
-
-const EMITTED_TOPIC_RESERVED_FIELD_EXAMPLE: &str = r#"
-{
-  name: "robot_state",
-  qos_profile: "standard",
-  message_format: {
-    instance_id: "string",
-    status: "u8"
-  }
-}
-"#;
-
-const EMITTED_TOPIC_FIXED_STRING_ARRAY_EXAMPLE: &str = r#"
-{
-  name: "labels",
-  qos_profile: "standard",
-  message_format: {
-    labels: {
-      $type: "array",
-      $items: "string",
-      $length: 3
-    }
-  }
-}
-"#;
-
-const EMITTED_TOPIC_FIXED_OBJECT_ARRAY_EXAMPLE: &str = r#"
-{
-  name: "detections",
-  qos_profile: "sensor_data",
-  message_format: {
-    objects: {
-      $type: "array",
-      $items: {
-        $type: "object",
-        x: "f32",
-        y: "f32"
-      },
-      $length: 4
-    }
-  }
-}
-"#;
-
-const EMITTED_TOPIC_DYNAMIC_OBJECT_ARRAY_EXAMPLE: &str = r#"
-{
-  name: "detections",
-  qos_profile: "sensor_data",
-  message_format: {
-    objects: {
-      $type: "array",
-      $items: {
-        $type: "object",
-        x: "f32",
-        y: "f32",
-        label: "string"
-      }
-    }
-  }
 }
 "#;
 
@@ -153,13 +74,6 @@ const SUBSCRIBED_TOPIC_EXAMPLE2: &str = r#"
 }
 "#;
 
-const SUBSCRIBED_TOPIC_EXAMPLE_KEYWORDS: &str = r#"
-{
-    local_node_id: "keyword_source",
-    name: "keyword_topic",
-}
-"#;
-
 const SUBSCRIBED_TOPIC_FORMAT_EXAMPLE2: &str = r#"
 {
   header: {
@@ -175,13 +89,6 @@ const SUBSCRIBED_TOPIC_FORMAT_EXAMPLE2: &str = r#"
     $type: "array",
     $items: "u8",              // raw bytes; interpret per 'encoding'
   }
-}
-"#;
-
-const SUBSCRIBED_TOPIC_FORMAT_EXAMPLE_KEYWORDS: &str = r#"
-{
-    "type": "u32",
-    "match": "string"
 }
 "#;
 
@@ -277,7 +184,17 @@ fn emit_two_topics() {
 
 #[test]
 fn emit_topic_escapes_rust_keyword_fields() {
-    let topic = parse_emitted_topic(EMITTED_TOPIC_KEYWORD_FIELDS_EXAMPLE);
+    let emitted_topic_keyword_fields_example: &str = r#"
+    {
+      name: "keyword_topic",
+      qos_profile: "standard",
+      message_format: {
+        "type": "u32",
+        "match": "string"
+      }
+    }
+    "#;
+    let topic = parse_emitted_topic(emitted_topic_keyword_fields_example);
 
     let mut generator = RustGenerator::new();
     generator.add_emitted_topic(&topic).unwrap();
@@ -300,9 +217,17 @@ fn emit_topic_escapes_rust_keyword_fields() {
 
 #[test]
 fn emit_topic_rejects_reserved_message_field_name() {
-    use crate::error::Error;
-
-    let topic = parse_emitted_topic(EMITTED_TOPIC_RESERVED_FIELD_EXAMPLE);
+    let emitted_topic_reserved_field_example: &str = r#"
+    {
+      name: "robot_state",
+      qos_profile: "standard",
+      message_format: {
+        instance_id: "string",
+        status: "u8"
+      }
+    }
+    "#;
+    let topic = parse_emitted_topic(emitted_topic_reserved_field_example);
     let mut generator = RustGenerator::new();
 
     let err = generator.add_emitted_topic(&topic).unwrap_err();
@@ -323,9 +248,20 @@ fn emit_topic_rejects_reserved_message_field_name() {
 
 #[test]
 fn emit_topic_rejects_fixed_string_array() {
-    use crate::error::Error;
-
-    let topic = parse_emitted_topic(EMITTED_TOPIC_FIXED_STRING_ARRAY_EXAMPLE);
+    let emitted_topic_fixed_string_array_example: &str = r#"
+    {
+      name: "labels",
+      qos_profile: "standard",
+      message_format: {
+        labels: {
+          $type: "array",
+          $items: "string",
+          $length: 3
+        }
+      }
+    }
+    "#;
+    let topic = parse_emitted_topic(emitted_topic_fixed_string_array_example);
     let mut generator = RustGenerator::new();
 
     let err = generator.add_emitted_topic(&topic).unwrap_err();
@@ -346,9 +282,25 @@ fn emit_topic_rejects_fixed_string_array() {
 
 #[test]
 fn emit_topic_rejects_fixed_object_array() {
-    use crate::error::Error;
+    let emitted_topic_fixed_object_array_example: &str = r#"
+    {
+      name: "detections",
+      qos_profile: "sensor_data",
+      message_format: {
+        objects: {
+          $type: "array",
+          $items: {
+            $type: "object",
+              x: "f32",
+              y: "f32"
+          },
+          $length: 4
+        }
+      }
+    }
+    "#;
 
-    let topic = parse_emitted_topic(EMITTED_TOPIC_FIXED_OBJECT_ARRAY_EXAMPLE);
+    let topic = parse_emitted_topic(emitted_topic_fixed_object_array_example);
     let mut generator = RustGenerator::new();
 
     let err = generator.add_emitted_topic(&topic).unwrap_err();
@@ -369,7 +321,24 @@ fn emit_topic_rejects_fixed_object_array() {
 
 #[test]
 fn emit_topic_with_dynamic_object_array() {
-    let topic = parse_emitted_topic(EMITTED_TOPIC_DYNAMIC_OBJECT_ARRAY_EXAMPLE);
+    let emitted_topic_dynamic_object_array_example: &str = r#"
+    {
+      name: "detections",
+      qos_profile: "sensor_data",
+      message_format: {
+        objects: {
+          $type: "array",
+          $items: {
+            $type: "object",
+              x: "f32",
+              y: "f32",
+              label: "string"
+          }
+        }
+      }
+    }
+    "#;
+    let topic = parse_emitted_topic(emitted_topic_dynamic_object_array_example);
 
     let mut generator = RustGenerator::new();
     generator.add_emitted_topic(&topic).unwrap();
@@ -460,8 +429,20 @@ fn consumed_topic() {
 
 #[test]
 fn consumed_topic_escapes_rust_keyword_fields() {
-    let topic = parse_consumed_topic(SUBSCRIBED_TOPIC_EXAMPLE_KEYWORDS);
-    let format = parse_message_format(SUBSCRIBED_TOPIC_FORMAT_EXAMPLE_KEYWORDS);
+    let subscribed_topic_example_keywords: &str = r#"
+    {
+        local_node_id: "keyword_source",
+        name: "keyword_topic",
+    }
+    "#;
+    let topic = parse_consumed_topic(subscribed_topic_example_keywords);
+    let subscribed_topic_format_example_keywords: &str = r#"
+    {
+        "type": "u32",
+        "match": "string"
+    }
+    "#;
+    let format = parse_message_format(subscribed_topic_format_example_keywords);
 
     let mut generator = RustGenerator::new();
     generator
@@ -595,7 +576,14 @@ fn external_consumed_topic() {
 #[test]
 fn clippy_single_emitted_topic_empty_format() {
     let temp_dir = TempDir::new().unwrap();
-    let emitted_topic = parse_emitted_topic(EMITTED_TOPIC_EXAMPLE_EMPTY_FORMAT);
+    let emitted_topic_example_empty_format: &str = r#"
+    {
+      name: "video_stream",
+      qos_profile: "sensor_data",
+      message_format: {}
+    }
+    "#;
+    let emitted_topic = parse_emitted_topic(emitted_topic_example_empty_format);
 
     let consumed_action1: ConsumedAction = serde_json5::from_str(
         r#"

--- a/crates/generator-internal/src/generator/rust/type_mapping.rs
+++ b/crates/generator-internal/src/generator/rust/type_mapping.rs
@@ -1,7 +1,7 @@
 use super::context::GenerationContext;
 use super::identifiers::sanitize_rust_identifier;
 use crate::error::{Error, Result};
-use crate::generator::naming::to_camel_case;
+use crate::generator::naming::{array_item_field_name, to_camel_case};
 use config::encoding::FunctionParam;
 use config::node::{SchemaType, TypeToken};
 use proc_macro2::{Ident, Literal, Span, TokenStream};
@@ -20,7 +20,7 @@ pub fn schema_type_to_tokens(
         SchemaType::Array(array) => {
             let item_ty = match array.items.as_ref() {
                 SchemaType::Object(_) => {
-                    let item_field = format!("{field_name}_item");
+                    let item_field = array_item_field_name(field_name);
                     schema_type_to_tokens(
                         array.items.as_ref(),
                         struct_prefix,

--- a/crates/generator-internal/src/generator/rust/type_mapping.rs
+++ b/crates/generator-internal/src/generator/rust/type_mapping.rs
@@ -18,12 +18,24 @@ pub fn schema_type_to_tokens(
         SchemaType::Type(token) => primitive_type_token(token),
         SchemaType::Primitive(primitive) => primitive_type_token(&primitive.kind),
         SchemaType::Array(array) => {
-            let item_ty = match array.items.as_ref().as_type_token() {
-                Some(token) => primitive_type_token(token),
-                None => {
-                    return Err(Error::UnsupportedArrayItemSchema {
-                        field: field_name.to_string(),
-                    });
+            let item_ty = match array.items.as_ref() {
+                SchemaType::Object(_) => {
+                    let item_field = format!("{field_name}_item");
+                    schema_type_to_tokens(
+                        array.items.as_ref(),
+                        struct_prefix,
+                        &item_field,
+                        context,
+                    )?
+                }
+                other => {
+                    let token =
+                        other
+                            .as_type_token()
+                            .ok_or_else(|| Error::UnsupportedArrayItemSchema {
+                                field: field_name.to_string(),
+                            })?;
+                    primitive_type_token(token)
                 }
             };
 

--- a/crates/generator-internal/src/generator/types.rs
+++ b/crates/generator-internal/src/generator/types.rs
@@ -415,18 +415,17 @@ mod tests {
 
         let err = validate_message_format_field_names(&format, "test.topic").unwrap_err();
 
-        match err {
-            Error::UnauthorizedMessageFieldName {
-                field,
-                path,
-                context,
-            } => {
-                assert_eq!(field, "instance_id");
-                assert_eq!(path, "instance_id");
-                assert_eq!(context, "test.topic");
-            }
-            other => panic!("expected UnauthorizedMessageFieldName, got: {other:?}"),
-        }
+        let Error::UnauthorizedMessageFieldName {
+            field,
+            path,
+            context,
+        } = err
+        else {
+            panic!("expected UnauthorizedMessageFieldName, got: {err:?}");
+        };
+        assert_eq!(field, "instance_id");
+        assert_eq!(path, "instance_id");
+        assert_eq!(context, "test.topic");
     }
 
     #[test]
@@ -445,13 +444,11 @@ mod tests {
 
         let err = validate_message_format_field_names(&format, "test.topic").unwrap_err();
 
-        match err {
-            Error::UnauthorizedMessageFieldName { field, path, .. } => {
-                assert_eq!(field, "instance_id");
-                assert_eq!(path, "header.instance_id");
-            }
-            other => panic!("expected UnauthorizedMessageFieldName, got: {other:?}"),
-        }
+        let Error::UnauthorizedMessageFieldName { field, path, .. } = err else {
+            panic!("expected UnauthorizedMessageFieldName, got: {err:?}");
+        };
+        assert_eq!(field, "instance_id");
+        assert_eq!(path, "header.instance_id");
     }
 
     #[test]
@@ -470,18 +467,17 @@ mod tests {
         .unwrap();
 
         let err = validate_fixed_length_array_items(&format, PeppygenLanguage::Rust).unwrap_err();
-        match err {
-            Error::UnsupportedFixedArrayItemType {
-                language,
-                field,
-                item,
-            } => {
-                assert_eq!(language, PeppygenLanguage::Rust);
-                assert_eq!(field, "labels");
-                assert_eq!(item, "string");
-            }
-            other => panic!("expected UnsupportedFixedArrayItemType, got: {other:?}"),
-        }
+        let Error::UnsupportedFixedArrayItemType {
+            language,
+            field,
+            item,
+        } = err
+        else {
+            panic!("expected UnsupportedFixedArrayItemType, got: {err:?}");
+        };
+        assert_eq!(language, PeppygenLanguage::Rust);
+        assert_eq!(field, "labels");
+        assert_eq!(item, "string");
     }
 
     #[test]
@@ -503,18 +499,17 @@ mod tests {
         .unwrap();
 
         let err = validate_fixed_length_array_items(&format, PeppygenLanguage::Rust).unwrap_err();
-        match err {
-            Error::UnsupportedFixedArrayItemType {
-                language,
-                field,
-                item,
-            } => {
-                assert_eq!(language, PeppygenLanguage::Rust);
-                assert_eq!(field, "frames");
-                assert_eq!(item, "object");
-            }
-            other => panic!("expected UnsupportedFixedArrayItemType, got: {other:?}"),
-        }
+        let Error::UnsupportedFixedArrayItemType {
+            language,
+            field,
+            item,
+        } = err
+        else {
+            panic!("expected UnsupportedFixedArrayItemType, got: {err:?}");
+        };
+        assert_eq!(language, PeppygenLanguage::Rust);
+        assert_eq!(field, "frames");
+        assert_eq!(item, "object");
     }
 
     #[test]
@@ -559,20 +554,19 @@ mod tests {
         .unwrap();
 
         let err = validate_generated_type_name_collisions(&format, "Message").unwrap_err();
-        match err {
-            Error::GeneratedTypeNameCollision {
-                context,
-                type_name,
-                first_field,
-                second_field,
-            } => {
-                assert_eq!(context, "Message");
-                assert_eq!(type_name, "MessageFramesItem");
-                assert_eq!(first_field, "frames");
-                assert_eq!(second_field, "frames_item");
-            }
-            other => panic!("expected GeneratedTypeNameCollision, got: {other:?}"),
-        }
+        let Error::GeneratedTypeNameCollision {
+            context,
+            type_name,
+            first_field,
+            second_field,
+        } = err
+        else {
+            panic!("expected GeneratedTypeNameCollision, got: {err:?}");
+        };
+        assert_eq!(context, "Message");
+        assert_eq!(type_name, "MessageFramesItem");
+        assert_eq!(first_field, "frames");
+        assert_eq!(second_field, "frames_item");
     }
 
     #[test]
@@ -625,20 +619,19 @@ mod tests {
         .unwrap();
 
         let err = validate_generated_type_name_collisions(&format, "Message").unwrap_err();
-        match err {
-            Error::GeneratedTypeNameCollision {
-                context,
-                type_name,
-                first_field,
-                second_field,
-            } => {
-                assert_eq!(context, "MessageOuter");
-                assert_eq!(type_name, "MessageOuterFramesItem");
-                assert_eq!(first_field, "frames");
-                assert_eq!(second_field, "frames_item");
-            }
-            other => panic!("expected GeneratedTypeNameCollision, got: {other:?}"),
-        }
+        let Error::GeneratedTypeNameCollision {
+            context,
+            type_name,
+            first_field,
+            second_field,
+        } = err
+        else {
+            panic!("expected GeneratedTypeNameCollision, got: {err:?}");
+        };
+        assert_eq!(context, "MessageOuter");
+        assert_eq!(type_name, "MessageOuterFramesItem");
+        assert_eq!(first_field, "frames");
+        assert_eq!(second_field, "frames_item");
     }
 }
 

--- a/crates/generator-internal/src/generator/types.rs
+++ b/crates/generator-internal/src/generator/types.rs
@@ -4,7 +4,7 @@ use crate::generator::naming::{array_item_type_name, to_camel_case};
 use config::consts::PeppyDirs;
 use config::node::{
     ConsumedAction, ConsumedService, ConsumedTopic, EmittedTopic, ExposedAction, ExposedService,
-    MessageFormat, PeppygenLanguage, PrimitiveSchema, SchemaType, TypeToken,
+    MessageFormat, PrimitiveSchema, SchemaType, TypeToken,
 };
 use indexmap::IndexMap;
 use std::collections::HashMap;
@@ -223,17 +223,12 @@ fn is_fixed_array_item_copy_primitive(token: &TypeToken) -> bool {
     )
 }
 
-fn validate_fixed_array_schema(
-    schema: &SchemaType,
-    path: &str,
-    language: PeppygenLanguage,
-) -> Result<()> {
+fn validate_fixed_array_schema(schema: &SchemaType, path: &str) -> Result<()> {
     match schema {
         SchemaType::Array(array) => {
             if array.length.is_some() {
                 if matches!(array.items.as_ref(), SchemaType::Object(_)) {
                     return Err(Error::UnsupportedFixedArrayItemType {
-                        language,
                         field: path.to_string(),
                         item: "object",
                     });
@@ -245,19 +240,18 @@ fn validate_fixed_array_schema(
                 })?;
                 if !is_fixed_array_item_copy_primitive(token) {
                     return Err(Error::UnsupportedFixedArrayItemType {
-                        language,
                         field: path.to_string(),
                         item: type_token_name(token),
                     });
                 }
             }
 
-            validate_fixed_array_schema(array.items.as_ref(), path, language)
+            validate_fixed_array_schema(array.items.as_ref(), path)
         }
         SchemaType::Object(object) => {
             for (field_name, nested) in &object.fields {
                 let nested_path = format!("{path}.{field_name}");
-                validate_fixed_array_schema(nested, &nested_path, language)?;
+                validate_fixed_array_schema(nested, &nested_path)?;
             }
             Ok(())
         }
@@ -265,12 +259,9 @@ fn validate_fixed_array_schema(
     }
 }
 
-pub fn validate_fixed_length_array_items(
-    format: &MessageFormat,
-    language: PeppygenLanguage,
-) -> Result<()> {
+pub fn validate_fixed_length_array_items(format: &MessageFormat) -> Result<()> {
     for (field_name, schema) in &format.0 {
-        validate_fixed_array_schema(schema, field_name, language)?;
+        validate_fixed_array_schema(schema, field_name)?;
     }
     Ok(())
 }
@@ -452,7 +443,7 @@ mod tests {
     }
 
     #[test]
-    fn reject_fixed_string_array_for_rust() {
+    fn reject_fixed_string_array() {
         let format: MessageFormat = serde_json5::from_str(
             r#"
             {
@@ -466,16 +457,10 @@ mod tests {
         )
         .unwrap();
 
-        let err = validate_fixed_length_array_items(&format, PeppygenLanguage::Rust).unwrap_err();
-        let Error::UnsupportedFixedArrayItemType {
-            language,
-            field,
-            item,
-        } = err
-        else {
+        let err = validate_fixed_length_array_items(&format).unwrap_err();
+        let Error::UnsupportedFixedArrayItemType { field, item } = err else {
             panic!("expected UnsupportedFixedArrayItemType, got: {err:?}");
         };
-        assert_eq!(language, PeppygenLanguage::Rust);
         assert_eq!(field, "labels");
         assert_eq!(item, "string");
     }
@@ -498,22 +483,16 @@ mod tests {
         )
         .unwrap();
 
-        let err = validate_fixed_length_array_items(&format, PeppygenLanguage::Rust).unwrap_err();
-        let Error::UnsupportedFixedArrayItemType {
-            language,
-            field,
-            item,
-        } = err
-        else {
+        let err = validate_fixed_length_array_items(&format).unwrap_err();
+        let Error::UnsupportedFixedArrayItemType { field, item } = err else {
             panic!("expected UnsupportedFixedArrayItemType, got: {err:?}");
         };
-        assert_eq!(language, PeppygenLanguage::Rust);
         assert_eq!(field, "frames");
         assert_eq!(item, "object");
     }
 
     #[test]
-    fn allow_fixed_i32_array_for_rust() {
+    fn allow_fixed_i32_array() {
         let format: MessageFormat = serde_json5::from_str(
             r#"
             {
@@ -527,8 +506,7 @@ mod tests {
         )
         .unwrap();
 
-        validate_fixed_length_array_items(&format, PeppygenLanguage::Rust)
-            .expect("fixed i32 arrays are supported");
+        validate_fixed_length_array_items(&format).expect("fixed i32 arrays are supported");
     }
 
     #[test]

--- a/crates/generator-internal/src/generator/types.rs
+++ b/crates/generator-internal/src/generator/types.rs
@@ -229,6 +229,13 @@ fn validate_fixed_array_schema(
     match schema {
         SchemaType::Array(array) => {
             if array.length.is_some() {
+                if matches!(array.items.as_ref(), SchemaType::Object(_)) {
+                    return Err(Error::UnsupportedFixedArrayItemType {
+                        language,
+                        field: path.to_string(),
+                        item: "object",
+                    });
+                }
                 let token = array.items.as_ref().as_type_token().ok_or_else(|| {
                     Error::UnsupportedArrayItemSchema {
                         field: path.to_string(),
@@ -411,6 +418,39 @@ mod tests {
                 assert_eq!(language, PeppygenLanguage::Rust);
                 assert_eq!(field, "labels");
                 assert_eq!(item, "string");
+            }
+            other => panic!("expected UnsupportedFixedArrayItemType, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn reject_fixed_object_array() {
+        let format: MessageFormat = serde_json5::from_str(
+            r#"
+            {
+                frames: {
+                    $type: "array",
+                    $items: {
+                        $type: "object",
+                        name: "string"
+                    },
+                    $length: 4
+                }
+            }
+            "#,
+        )
+        .unwrap();
+
+        let err = validate_fixed_length_array_items(&format, PeppygenLanguage::Rust).unwrap_err();
+        match err {
+            Error::UnsupportedFixedArrayItemType {
+                language,
+                field,
+                item,
+            } => {
+                assert_eq!(language, PeppygenLanguage::Rust);
+                assert_eq!(field, "frames");
+                assert_eq!(item, "object");
             }
             other => panic!("expected UnsupportedFixedArrayItemType, got: {other:?}"),
         }

--- a/crates/generator-internal/src/generator/types.rs
+++ b/crates/generator-internal/src/generator/types.rs
@@ -1,11 +1,13 @@
 use crate::error::{Error, Result};
 use crate::generator::common::CrateDeployMode;
+use crate::generator::naming::{array_item_type_name, to_camel_case};
 use config::consts::PeppyDirs;
 use config::node::{
     ConsumedAction, ConsumedService, ConsumedTopic, EmittedTopic, ExposedAction, ExposedService,
     MessageFormat, PeppygenLanguage, PrimitiveSchema, SchemaType, TypeToken,
 };
 use indexmap::IndexMap;
+use std::collections::HashMap;
 use std::path::Path;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -336,6 +338,65 @@ pub fn cancel_action_response_format() -> MessageFormat {
     MessageFormat(fields)
 }
 
+/// Validates that generated type names for nested objects and array-of-object items
+/// do not collide within the same message format.
+///
+/// For example, a field `frames` (array of objects) generates `{prefix}FramesItem`,
+/// while a sibling field `frames_item` (object) also generates `{prefix}FramesItem`.
+/// This function detects such collisions and returns an error.
+pub fn validate_generated_type_name_collisions(
+    format: &MessageFormat,
+    struct_prefix: &str,
+) -> Result<()> {
+    validate_sibling_type_name_collisions(&format.0, struct_prefix)
+}
+
+fn validate_sibling_type_name_collisions(
+    fields: &IndexMap<String, SchemaType>,
+    struct_prefix: &str,
+) -> Result<()> {
+    let mut seen: HashMap<String, String> = HashMap::new();
+
+    for (field_name, schema) in fields {
+        let generated_name = match schema {
+            SchemaType::Object(_) => Some(format!("{struct_prefix}{}", to_camel_case(field_name))),
+            SchemaType::Array(array) if matches!(array.items.as_ref(), SchemaType::Object(_)) => {
+                Some(array_item_type_name(struct_prefix, field_name))
+            }
+            _ => None,
+        };
+
+        if let Some(name) = generated_name {
+            if let Some(previous_field) = seen.get(&name) {
+                return Err(Error::GeneratedTypeNameCollision {
+                    context: struct_prefix.to_string(),
+                    type_name: name,
+                    first_field: previous_field.clone(),
+                    second_field: field_name.clone(),
+                });
+            }
+            seen.insert(name, field_name.clone());
+        }
+
+        // Recurse into nested objects and array items.
+        match schema {
+            SchemaType::Object(object) => {
+                let nested_prefix = format!("{struct_prefix}{}", to_camel_case(field_name));
+                validate_sibling_type_name_collisions(&object.fields, &nested_prefix)?;
+            }
+            SchemaType::Array(array) => {
+                if let SchemaType::Object(object) = array.items.as_ref() {
+                    let nested_prefix = array_item_type_name(struct_prefix, field_name);
+                    validate_sibling_type_name_collisions(&object.fields, &nested_prefix)?;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -473,6 +534,111 @@ mod tests {
 
         validate_fixed_length_array_items(&format, PeppygenLanguage::Rust)
             .expect("fixed i32 arrays are supported");
+    }
+
+    #[test]
+    fn reject_array_item_type_name_collision() {
+        let format: MessageFormat = serde_json5::from_str(
+            r#"
+            {
+                frames: {
+                    $type: "array",
+                    $items: {
+                        $type: "object",
+                        x: "i32",
+                        y: "i32"
+                    }
+                },
+                frames_item: {
+                    $type: "object",
+                    id: "u16"
+                }
+            }
+            "#,
+        )
+        .unwrap();
+
+        let err = validate_generated_type_name_collisions(&format, "Message").unwrap_err();
+        match err {
+            Error::GeneratedTypeNameCollision {
+                context,
+                type_name,
+                first_field,
+                second_field,
+            } => {
+                assert_eq!(context, "Message");
+                assert_eq!(type_name, "MessageFramesItem");
+                assert_eq!(first_field, "frames");
+                assert_eq!(second_field, "frames_item");
+            }
+            other => panic!("expected GeneratedTypeNameCollision, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn allow_non_colliding_array_and_object_fields() {
+        let format: MessageFormat = serde_json5::from_str(
+            r#"
+            {
+                frames: {
+                    $type: "array",
+                    $items: {
+                        $type: "object",
+                        x: "i32"
+                    }
+                },
+                metadata: {
+                    $type: "object",
+                    id: "u16"
+                }
+            }
+            "#,
+        )
+        .unwrap();
+
+        validate_generated_type_name_collisions(&format, "Message")
+            .expect("non-colliding fields should pass");
+    }
+
+    #[test]
+    fn reject_nested_array_item_type_name_collision() {
+        let format: MessageFormat = serde_json5::from_str(
+            r#"
+            {
+                outer: {
+                    $type: "object",
+                    frames: {
+                        $type: "array",
+                        $items: {
+                            $type: "object",
+                            x: "i32"
+                        }
+                    },
+                    frames_item: {
+                        $type: "object",
+                        id: "u16"
+                    }
+                }
+            }
+            "#,
+        )
+        .unwrap();
+
+        let err = validate_generated_type_name_collisions(&format, "Message").unwrap_err();
+        match err {
+            Error::GeneratedTypeNameCollision {
+                context,
+                type_name,
+                first_field,
+                second_field,
+            } => {
+                assert_eq!(context, "MessageOuter");
+                assert_eq!(type_name, "MessageOuterFramesItem");
+                assert_eq!(first_field, "frames");
+                assert_eq!(second_field, "frames_item");
+            }
+            other => panic!("expected GeneratedTypeNameCollision, got: {other:?}"),
+        }
     }
 }
 

--- a/crates/generator-internal/tests/helpers.rs
+++ b/crates/generator-internal/tests/helpers.rs
@@ -25,10 +25,13 @@ pub fn test_peppy_dirs() -> PeppyDirs {
 
 pub const STUB_NODE_CONFIG: &str = r#"{
   schema_version: 1,
-  manifest: { name: "generated_node",
-    tag: "0.1.0" },
+  manifest: {
+    name: "generated_node",
+    tag: "0.1.0"
+  },
 
-  execution: { language: "rust",
+  execution: {
+    language: "rust",
     start_cmd: ["./target/release/generated_node"]
   }
 }

--- a/crates/generator-internal/tests/python/generate_lib.rs
+++ b/crates/generator-internal/tests/python/generate_lib.rs
@@ -10,8 +10,10 @@ use tempfile::TempDir;
 
 const PEPPY_JSON5_CONFIG: &str = r#"{
   schema_version: 1,
-  manifest: { name: "test_node",
-    tag: "0.1.0" },
+  manifest: {
+    name: "test_node",
+    tag: "0.1.0"
+  },
   interfaces: {
     topics: {
       emits: [

--- a/crates/generator-internal/tests/rust/generate_lib.rs
+++ b/crates/generator-internal/tests/rust/generate_lib.rs
@@ -11,8 +11,10 @@ use crate::helpers;
 
 const PEPPY_JSON5_CONFIG: &str = r#"{
   schema_version: 1,
-  manifest: { name: "test_node",
-    tag: "0.1.0" },
+  manifest: {
+    name: "test_node",
+    tag: "0.1.0"
+  },
   interfaces: {
     topics: {
       emits: [
@@ -42,7 +44,8 @@ const PEPPY_JSON5_CONFIG: &str = r#"{
     }
   },
 
-  execution: { language: "rust",
+  execution: {
+    language: "rust",
     start_cmd: ["./target/release/test_node"]
   },
 }"#;
@@ -55,10 +58,13 @@ fn generate_peppygen_lib_minimal_config() {
     // Minimal config with no interfaces
     let minimal_config = r#"{
       schema_version: 1,
-      manifest: { name: "minimal_node",
-        tag: "0.1.0" },
+      manifest: {
+        name: "minimal_node",
+        tag: "0.1.0"
+      },
 
-      execution: { language: "rust",
+      execution: {
+        language: "rust",
         start_cmd: ["./target/debug/minimal_node"]
       }
     }"#;

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -256,21 +256,24 @@
       }
     },
     "node_modules/@clack/core": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.1.0.tgz",
-      "integrity": "sha512-SVcm4Dqm2ukn64/8Gub2wnlA5nS2iWJyCkdNHcvNHPIeBTGojpdJ+9cZKwLfmqy7irD4N5qLteSilJlE0WLAtA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.2.0.tgz",
+      "integrity": "sha512-qfxof/3T3t9DPU/Rj3OmcFyZInceqj/NVtO9rwIuJqCUgh32gwPjpFQQp/ben07qKlhpwq7GzfWpST4qdJ5Drg==",
       "license": "MIT",
       "dependencies": {
+        "fast-wrap-ansi": "^0.1.3",
         "sisteransi": "^1.0.5"
       }
     },
     "node_modules/@clack/prompts": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.1.0.tgz",
-      "integrity": "sha512-pkqbPGtohJAvm4Dphs2M8xE29ggupihHdy1x84HNojZuMtFsHiUlRvqD24tM2+XmI+61LlfNceM3Wr7U5QES5g==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.2.0.tgz",
+      "integrity": "sha512-4jmztR9fMqPMjz6H/UZXj0zEmE43ha1euENwkckKKel4XpSfokExPo5AiVStdHSAlHekz4d0CA/r45Ok1E4D3w==",
       "license": "MIT",
       "dependencies": {
-        "@clack/core": "1.1.0",
+        "@clack/core": "1.2.0",
+        "fast-string-width": "^1.1.0",
+        "fast-wrap-ansi": "^0.1.3",
         "sisteransi": "^1.0.5"
       }
     },
@@ -284,9 +287,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
-      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -294,9 +297,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
-      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
       "cpu": [
         "ppc64"
       ],
@@ -310,9 +313,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
-      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
       "cpu": [
         "arm"
       ],
@@ -326,9 +329,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
-      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
       "cpu": [
         "arm64"
       ],
@@ -342,9 +345,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
-      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
       "cpu": [
         "x64"
       ],
@@ -358,9 +361,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
-      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
       "cpu": [
         "arm64"
       ],
@@ -374,9 +377,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
-      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
       "cpu": [
         "x64"
       ],
@@ -390,9 +393,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
       "cpu": [
         "arm64"
       ],
@@ -406,9 +409,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
-      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
       "cpu": [
         "x64"
       ],
@@ -422,9 +425,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
-      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
       "cpu": [
         "arm"
       ],
@@ -438,9 +441,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
-      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
       "cpu": [
         "arm64"
       ],
@@ -454,9 +457,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
-      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
       "cpu": [
         "ia32"
       ],
@@ -470,9 +473,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
-      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
       "cpu": [
         "loong64"
       ],
@@ -486,9 +489,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
-      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
       "cpu": [
         "mips64el"
       ],
@@ -502,9 +505,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
-      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
       "cpu": [
         "ppc64"
       ],
@@ -518,9 +521,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
-      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
       "cpu": [
         "riscv64"
       ],
@@ -534,9 +537,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
-      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
       "cpu": [
         "s390x"
       ],
@@ -550,9 +553,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
-      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
       "cpu": [
         "x64"
       ],
@@ -566,9 +569,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
       "cpu": [
         "arm64"
       ],
@@ -582,9 +585,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
-      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
       "cpu": [
         "x64"
       ],
@@ -598,9 +601,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
       "cpu": [
         "arm64"
       ],
@@ -614,9 +617,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
-      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
       "cpu": [
         "x64"
       ],
@@ -630,9 +633,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
-      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
       "cpu": [
         "arm64"
       ],
@@ -646,9 +649,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
-      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
       "cpu": [
         "x64"
       ],
@@ -662,9 +665,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
-      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
       "cpu": [
         "arm64"
       ],
@@ -678,9 +681,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
-      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
       "cpu": [
         "ia32"
       ],
@@ -694,9 +697,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
-      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
       "cpu": [
         "x64"
       ],
@@ -1458,9 +1461,9 @@
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.0.tgz",
-      "integrity": "sha512-WOhNW9K8bR3kf4zLxbfg6Pxu2ybOUbB2AjMDHSQx86LIF4rH4Ft7vmMwNt0loO0eonglSNy4cpD3MKXXKQu0/A==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
+      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
       "cpu": [
         "arm"
       ],
@@ -1471,9 +1474,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.0.tgz",
-      "integrity": "sha512-u6JHLll5QKRvjciE78bQXDmqRqNs5M/3GVqZeMwvmjaNODJih/WIrJlFVEihvV0MiYFmd+ZyPr9wxOVbPAG2Iw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
+      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
       "cpu": [
         "arm64"
       ],
@@ -1484,9 +1487,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.0.tgz",
-      "integrity": "sha512-qEF7CsKKzSRc20Ciu2Zw1wRrBz4g56F7r/vRwY430UPp/nt1x21Q/fpJ9N5l47WWvJlkNCPJz3QRVw008fi7yA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
+      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
       "cpu": [
         "arm64"
       ],
@@ -1497,9 +1500,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.0.tgz",
-      "integrity": "sha512-WADYozJ4QCnXCH4wPB+3FuGmDPoFseVCUrANmA5LWwGmC6FL14BWC7pcq+FstOZv3baGX65tZ378uT6WG8ynTw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
+      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
       "cpu": [
         "x64"
       ],
@@ -1510,9 +1513,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.0.tgz",
-      "integrity": "sha512-6b8wGHJlDrGeSE3aH5mGNHBjA0TTkxdoNHik5EkvPHCt351XnigA4pS7Wsj/Eo9Y8RBU6f35cjN9SYmCFBtzxw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
+      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
       "cpu": [
         "arm64"
       ],
@@ -1523,9 +1526,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.0.tgz",
-      "integrity": "sha512-h25Ga0t4jaylMB8M/JKAyrvvfxGRjnPQIR8lnCayyzEjEOx2EJIlIiMbhpWxDRKGKF8jbNH01NnN663dH638mA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
+      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
       "cpu": [
         "x64"
       ],
@@ -1536,9 +1539,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.0.tgz",
-      "integrity": "sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
+      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
       "cpu": [
         "arm"
       ],
@@ -1549,9 +1552,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.0.tgz",
-      "integrity": "sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
+      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
       "cpu": [
         "arm"
       ],
@@ -1562,9 +1565,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.0.tgz",
-      "integrity": "sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
+      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
       "cpu": [
         "arm64"
       ],
@@ -1575,9 +1578,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.0.tgz",
-      "integrity": "sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
+      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
       "cpu": [
         "arm64"
       ],
@@ -1588,9 +1591,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.0.tgz",
-      "integrity": "sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
+      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
       "cpu": [
         "loong64"
       ],
@@ -1601,9 +1604,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.0.tgz",
-      "integrity": "sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
+      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
       "cpu": [
         "loong64"
       ],
@@ -1614,9 +1617,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.0.tgz",
-      "integrity": "sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
+      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
       "cpu": [
         "ppc64"
       ],
@@ -1627,9 +1630,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.0.tgz",
-      "integrity": "sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
+      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
       "cpu": [
         "ppc64"
       ],
@@ -1640,9 +1643,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.0.tgz",
-      "integrity": "sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
+      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
       "cpu": [
         "riscv64"
       ],
@@ -1653,9 +1656,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.0.tgz",
-      "integrity": "sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
+      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
       "cpu": [
         "riscv64"
       ],
@@ -1666,9 +1669,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.0.tgz",
-      "integrity": "sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
+      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
       "cpu": [
         "s390x"
       ],
@@ -1679,9 +1682,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.0.tgz",
-      "integrity": "sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
       "cpu": [
         "x64"
       ],
@@ -1692,9 +1695,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.0.tgz",
-      "integrity": "sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
+      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
       "cpu": [
         "x64"
       ],
@@ -1705,9 +1708,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.0.tgz",
-      "integrity": "sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
+      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
       "cpu": [
         "x64"
       ],
@@ -1718,9 +1721,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.0.tgz",
-      "integrity": "sha512-pESDkos/PDzYwtyzB5p/UoNU/8fJo68vcXM9ZW2V0kjYayj1KaaUfi1NmTUTUpMn4UhU4gTuK8gIaFO4UGuMbA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
+      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
       "cpu": [
         "arm64"
       ],
@@ -1731,9 +1734,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.0.tgz",
-      "integrity": "sha512-hj1wFStD7B1YBeYmvY+lWXZ7ey73YGPcViMShYikqKT1GtstIKQAtfUI6yrzPjAy/O7pO0VLXGmUVWXQMaYgTQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
+      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
       "cpu": [
         "arm64"
       ],
@@ -1744,9 +1747,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.0.tgz",
-      "integrity": "sha512-SyaIPFoxmUPlNDq5EHkTbiKzmSEmq/gOYFI/3HHJ8iS/v1mbugVa7dXUzcJGQfoytp9DJFLhHH4U3/eTy2Bq4w==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
+      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
       "cpu": [
         "ia32"
       ],
@@ -1757,9 +1760,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.0.tgz",
-      "integrity": "sha512-RdcryEfzZr+lAr5kRm2ucN9aVlCCa2QNq4hXelZxb8GG0NJSazq44Z3PCCc8wISRuCVnGs0lQJVX5Vp6fKA+IA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
       "cpu": [
         "x64"
       ],
@@ -1770,9 +1773,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.0.tgz",
-      "integrity": "sha512-PrsWNQ8BuE00O3Xsx3ALh2Df8fAj9+cvvX9AIA6o4KpATR98c9mud4XtDWVvsEuyia5U4tVSTKygawyJkjm60w==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
+      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
       "cpu": [
         "x64"
       ],
@@ -1967,9 +1970,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "25.5.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
-      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "version": "25.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
+      "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
@@ -2083,9 +2086,9 @@
       }
     },
     "node_modules/astro": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-6.1.1.tgz",
-      "integrity": "sha512-vq8sHpu1JsY1fWAunn+tdKNbVDmLQNiVdyuGsVT2csgITdFGXXVAyEXFWc1DzkMN0ehElPeiHnqItyQOJK+GqA==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-6.1.3.tgz",
+      "integrity": "sha512-FUKbBYOdYYrRNZwDd9I5CVSfR6Nj9aZeNzcjcvh1FgHwR0uXawkYFR3HiGxmdmAB2m8fs0iIkDdsiUfwGeO8qA==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler": "^3.0.1",
@@ -2375,9 +2378,9 @@
       }
     },
     "node_modules/cookie-es": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.2.tgz",
-      "integrity": "sha512-+W7VmiVINB+ywl1HGXJXmrqkOhpKrIiVZV6tQuV54ZyQC7MMuBt81Vc336GMLoHBq5hV/F9eXgt5Mnx0Rha5Fg==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.3.tgz",
+      "integrity": "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==",
       "license": "MIT"
     },
     "node_modules/crossws": {
@@ -2522,9 +2525,9 @@
       }
     },
     "node_modules/defu": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
-      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.6.tgz",
+      "integrity": "sha512-f8mefEW4WIVg4LckePx3mALjQSPQgFlg9U8yaPdlsbdYcHQyj9n2zL2LJEA52smeYxOvmd/nB7TpMtHGMTHcug==",
       "license": "MIT"
     },
     "node_modules/dequal": {
@@ -2725,9 +2728,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
-      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -2737,32 +2740,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.4",
-        "@esbuild/android-arm": "0.27.4",
-        "@esbuild/android-arm64": "0.27.4",
-        "@esbuild/android-x64": "0.27.4",
-        "@esbuild/darwin-arm64": "0.27.4",
-        "@esbuild/darwin-x64": "0.27.4",
-        "@esbuild/freebsd-arm64": "0.27.4",
-        "@esbuild/freebsd-x64": "0.27.4",
-        "@esbuild/linux-arm": "0.27.4",
-        "@esbuild/linux-arm64": "0.27.4",
-        "@esbuild/linux-ia32": "0.27.4",
-        "@esbuild/linux-loong64": "0.27.4",
-        "@esbuild/linux-mips64el": "0.27.4",
-        "@esbuild/linux-ppc64": "0.27.4",
-        "@esbuild/linux-riscv64": "0.27.4",
-        "@esbuild/linux-s390x": "0.27.4",
-        "@esbuild/linux-x64": "0.27.4",
-        "@esbuild/netbsd-arm64": "0.27.4",
-        "@esbuild/netbsd-x64": "0.27.4",
-        "@esbuild/openbsd-arm64": "0.27.4",
-        "@esbuild/openbsd-x64": "0.27.4",
-        "@esbuild/openharmony-arm64": "0.27.4",
-        "@esbuild/sunos-x64": "0.27.4",
-        "@esbuild/win32-arm64": "0.27.4",
-        "@esbuild/win32-ia32": "0.27.4",
-        "@esbuild/win32-x64": "0.27.4"
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -2892,6 +2895,30 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
+    "node_modules/fast-string-truncated-width": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-1.2.1.tgz",
+      "integrity": "sha512-Q9acT/+Uu3GwGj+5w/zsGuQjh9O1TyywhIwAxHudtWrgF09nHOPrvTLhQevPbttcxjr/SNN7mJmfOw/B1bXgow==",
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-1.1.0.tgz",
+      "integrity": "sha512-O3fwIVIH5gKB38QNbdg+3760ZmGz0SZMgvwJbA1b2TGXceKE6A2cOlfogh1iw8lr049zPyd7YADHy+B7U4W9bQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^1.2.0"
+      }
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.1.6.tgz",
+      "integrity": "sha512-HlUwET7a5gqjURj70D5jl7aC3Zmy4weA1SHUfM0JFI0Ptq987NH2TwbBFLoERhfwk+E+eaq4EK3jXoT+R3yp3w==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^1.1.0"
+      }
+    },
     "node_modules/fast-xml-builder": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
@@ -3006,14 +3033,14 @@
       "license": "ISC"
     },
     "node_modules/h3": {
-      "version": "1.15.10",
-      "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.10.tgz",
-      "integrity": "sha512-YzJeWSkDZxAhvmp8dexjRK5hxziRO7I9m0N53WhvYL5NiWfkUkzssVzY9jvGu0HBoLFW6+duYmNSn6MaZBCCtg==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.11.tgz",
+      "integrity": "sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==",
       "license": "MIT",
       "dependencies": {
-        "cookie-es": "^1.2.2",
+        "cookie-es": "^1.2.3",
         "crossws": "^0.3.5",
-        "defu": "^6.1.4",
+        "defu": "^6.1.6",
         "destr": "^2.0.5",
         "iron-webcrypto": "^1.2.1",
         "node-mock-http": "^1.0.4",
@@ -4928,9 +4955,9 @@
       }
     },
     "node_modules/p-queue": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.1.0.tgz",
-      "integrity": "sha512-O/ZPaXuQV29uSLbxWBGGZO1mCQXV2BLIwUr59JUU9SoH76mnYvtms7aafH/isNSNGwuEfP6W/4xD0/TJXxrizw==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.1.1.tgz",
+      "integrity": "sha512-yQS1vV2V7Q14MQrgD8jMNY5owPuGgVHVdSK8NqmKpOVajnjbaeMa6uLOzTALPtvJ7Vo4bw0BGsw7qfUT8z24Ig==",
       "license": "MIT",
       "dependencies": {
         "eventemitter3": "^5.0.1",
@@ -5046,9 +5073,9 @@
       }
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
-      "integrity": "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.1.tgz",
+      "integrity": "sha512-d7gQQmLvAKXKXE2GeP9apIGbMYKz88zWdsn/BN2HRWVQsDFdUY36WSLTY0Jvd4HWi7Fb30gQ62oAOzdgJA6fZw==",
       "funding": [
         {
           "type": "github",
@@ -5582,9 +5609,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.0.tgz",
-      "integrity": "sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
+      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -5597,31 +5624,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.60.0",
-        "@rollup/rollup-android-arm64": "4.60.0",
-        "@rollup/rollup-darwin-arm64": "4.60.0",
-        "@rollup/rollup-darwin-x64": "4.60.0",
-        "@rollup/rollup-freebsd-arm64": "4.60.0",
-        "@rollup/rollup-freebsd-x64": "4.60.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.60.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.60.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.60.0",
-        "@rollup/rollup-linux-arm64-musl": "4.60.0",
-        "@rollup/rollup-linux-loong64-gnu": "4.60.0",
-        "@rollup/rollup-linux-loong64-musl": "4.60.0",
-        "@rollup/rollup-linux-ppc64-gnu": "4.60.0",
-        "@rollup/rollup-linux-ppc64-musl": "4.60.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.60.0",
-        "@rollup/rollup-linux-riscv64-musl": "4.60.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.60.0",
-        "@rollup/rollup-linux-x64-gnu": "4.60.0",
-        "@rollup/rollup-linux-x64-musl": "4.60.0",
-        "@rollup/rollup-openbsd-x64": "4.60.0",
-        "@rollup/rollup-openharmony-arm64": "4.60.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.60.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.60.0",
-        "@rollup/rollup-win32-x64-gnu": "4.60.0",
-        "@rollup/rollup-win32-x64-msvc": "4.60.0",
+        "@rollup/rollup-android-arm-eabi": "4.60.1",
+        "@rollup/rollup-android-arm64": "4.60.1",
+        "@rollup/rollup-darwin-arm64": "4.60.1",
+        "@rollup/rollup-darwin-x64": "4.60.1",
+        "@rollup/rollup-freebsd-arm64": "4.60.1",
+        "@rollup/rollup-freebsd-x64": "4.60.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
+        "@rollup/rollup-linux-arm64-musl": "4.60.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
+        "@rollup/rollup-linux-loong64-musl": "4.60.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-musl": "4.60.1",
+        "@rollup/rollup-openbsd-x64": "4.60.1",
+        "@rollup/rollup-openharmony-arm64": "4.60.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
+        "@rollup/rollup-win32-x64-gnu": "4.60.1",
+        "@rollup/rollup-win32-x64-msvc": "4.60.1",
         "fsevents": "~2.3.2"
       }
     },
@@ -6412,9 +6439,9 @@
       }
     },
     "node_modules/vitefu": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.2.tgz",
-      "integrity": "sha512-zpKATdUbzbsycPFBN71nS2uzBUQiVnFoOrr2rvqv34S1lcAgMKKkjWleLGeiJlZ8lwCXvtWaRn7R3ZC16SYRuw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.3.tgz",
+      "integrity": "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==",
       "license": "MIT",
       "workspaces": [
         "tests/deps/*",
@@ -6422,7 +6449,7 @@
         "tests/projects/workspace/packages/*"
       ],
       "peerDependencies": {
-        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-beta.0"
+        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "vite": {

--- a/docs/src/content/docs/reference/message_format.mdx
+++ b/docs/src/content/docs/reference/message_format.mdx
@@ -227,9 +227,9 @@ A full `peppy.json5` topic using multiple schema types:
     name: "arm_controller",
     tag: "0.1.0"
   },
-  execution: {
+ execution: {
     language: "rust",
-    start_cmd: "cargo run"
+    start_cmd: ["cargo", "run"]
   },
   interfaces: {
     topics: {

--- a/docs/src/content/docs/reference/message_format.mdx
+++ b/docs/src/content/docs/reference/message_format.mdx
@@ -1,0 +1,254 @@
+---
+title: Message Format
+description: Reference for all message format field types used in topics, services, and actions
+sidebar:
+  order: 2
+---
+
+The `message_format` defines the structure of messages exchanged between nodes through [topics](/advanced_guides/topics/), [services](/advanced_guides/services/), and [actions](/advanced_guides/actions/).
+It is a map of field names to schema types, declared inline in `peppy.json5`.
+
+```json5
+message_format: {
+  temperature: "f32",
+  label: "string",
+}
+```
+
+Each field value is a **schema type** — either a bare type token, or a structured schema with modifiers.
+
+---
+
+## Primitive types
+
+A bare type string is the simplest form. These map directly to language-native types.
+
+| Type       | Alias      | Rust type               | Python type |
+|------------|------------|-------------------------|-------------|
+| `"bool"`   |            | `bool`                  | `bool`      |
+| `"u8"`     |            | `u8`                    | `int`       |
+| `"u16"`    |            | `u16`                   | `int`       |
+| `"u32"`    |            | `u32`                   | `int`       |
+| `"u64"`    |            | `u64`                   | `int`       |
+| `"i8"`     |            | `i8`                    | `int`       |
+| `"i16"`    |            | `i16`                   | `int`       |
+| `"i32"`    |            | `i32`                   | `int`       |
+| `"i64"`    |            | `i64`                   | `int`       |
+| `"f32"`    | `"float"`  | `f32`                   | `float`     |
+| `"f64"`    | `"double"` | `f64`                   | `float`     |
+| `"string"` | `"str"`    | `String`                | `str`       |
+| `"bytes"`  |            | `Vec<u8>`               | `bytes`     |
+| `"time"`   |            | `std::time::SystemTime` | `float`     |
+
+Aliases can be used interchangeably with their canonical name (e.g. `"float"` is equivalent to `"f32"`).
+
+---
+
+## Optional modifier
+
+Any primitive type can be made optional by using the structured form with `$optional`:
+
+```json5
+error_msg: {
+  $type: "string",
+  $optional: true
+}
+```
+
+| Field       | Required | Description                            |
+|-------------|----------|----------------------------------------|
+| `$type`     | Yes      | Any primitive type token               |
+| `$optional` | No       | When `true`, the field may be absent. Defaults to `false` |
+
+:::note
+`$optional` is typically used on **service and action response fields** where a value may or may not be present depending on the outcome — for example, an `error_msg` that is only set when the operation fails. Topic messages are usually complete, so `$optional` is rarely needed there.
+:::
+
+---
+
+## Object
+
+An object groups related fields into a nested structure. It generates a nested struct in Rust and a dataclass in Python.
+
+```json5
+header: {
+  $type: "object",
+  stamp: "time",
+  frame_id: "u32"
+}
+```
+
+| Field       | Required | Description                                   |
+|-------------|----------|-----------------------------------------------|
+| `$type`     | Yes      | Must be `"object"`                            |
+| `$optional` | No       | When `true`, the entire object may be absent  |
+| *other keys*| No       | Each additional key is a field with its own schema type |
+
+Object fields can be any schema type, including arrays and nested objects:
+
+```json5
+sensor_reading: {
+  $type: "object",
+  header: {
+    $type: "object",
+    stamp: "time",
+    frame_id: "u32"
+  },
+  samples: {
+    $type: "array",
+    $items: "f32"
+  }
+}
+```
+
+---
+
+## Array
+
+An array represents a list of items of the same type.
+
+```json5
+distances: {
+  $type: "array",
+  $items: "f32"
+}
+```
+
+| Field       | Required | Description                                         |
+|-------------|----------|-----------------------------------------------------|
+| `$type`     | Yes      | Must be `"array"`                                   |
+| `$items`    | Yes      | The schema type of each element                     |
+| `$length`   | No       | Fixed number of elements. Omit for variable-length  |
+| `$optional` | No       | When `true`, the entire array may be absent          |
+
+### Fixed-length array
+
+When `$length` is provided, the array has an exact number of elements:
+
+```json5
+position: {
+  $type: "array",
+  $items: "f32",
+  $length: 3
+}
+```
+
+This maps to `[f32; 3]` in Rust and `list[float]` in Python.
+
+### Variable-length array
+
+Without `$length`, the array can contain any number of elements:
+
+```json5
+frame: {
+  $type: "array",
+  $items: "u8"
+}
+```
+
+This maps to `Vec<u8>` in Rust and `bytes` in Python (for `u8` items) or `list[T]` for other types.
+
+### Array of objects
+
+`$items` can be an object, allowing arrays of structured records:
+
+```json5
+frames: {
+  $type: "array",
+  $items: {
+    $type: "object",
+    name: "string",
+    parent: "string",
+    position: {
+      $type: "array",
+      $items: "i32",
+      $length: 3
+    },
+    orientation: {
+      $type: "array",
+      $items: "i32",
+      $length: 4
+    }
+  }
+}
+```
+
+This accepts messages like:
+
+```json
+{
+  "frames": [
+    { "name": "link1", "parent": "world", "position": [0, 0, 1], "orientation": [1, 0, 0, 0] },
+    { "name": "link2", "parent": "link1", "position": [0, 1, 0], "orientation": [1, 0, 0, 0] }
+  ]
+}
+```
+
+---
+
+## Nesting rules
+
+Schema types can be nested arbitrarily:
+
+- **Object fields** can be primitives, arrays, or other objects
+- **Array items** can be primitives, objects, or other arrays
+
+This enables complex hierarchical message structures. For example, a robotics transform tree:
+
+```json5
+message_format: {
+  timestamp: "time",
+  root_frame: "string",
+  transforms: {
+    $type: "array",
+    $items: {
+      $type: "object",
+      name: "string",
+      parent: "string",
+      translation: { $type: "array", $items: "f64", $length: 3 },
+      rotation: { $type: "array", $items: "f64", $length: 4 }
+    }
+  }
+}
+```
+
+---
+
+## Complete example
+
+A full `peppy.json5` topic using multiple schema types:
+
+```json5
+{
+  schema_version: 1,
+  manifest: {
+    name: "arm_controller",
+    tag: "0.1.0"
+  },
+  execution: {
+    language: "rust",
+    start_cmd: "cargo run"
+  },
+  interfaces: {
+    topics: {
+      emits: [
+        {
+          name: "arm_state",
+          qos_profile: "sensor_data",
+          message_format: {
+            timestamp: "time",
+            joint_positions: { $type: "array", $items: "f64", $length: 6 },
+            joint_velocities: { $type: "array", $items: "f64", $length: 6 },
+            end_effector: {
+              $type: "object",
+              position: { $type: "array", $items: "f64", $length: 3 },
+              orientation: { $type: "array", $items: "f64", $length: 4 },
+              gripper_open: "bool"
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+```

--- a/docs/src/content/docs/reference/message_format.mdx
+++ b/docs/src/content/docs/reference/message_format.mdx
@@ -61,7 +61,9 @@ error_msg: {
 | `$optional` | No       | When `true`, the field may be absent. Defaults to `false` |
 
 :::note
-`$optional` is typically used on **service and action response fields** where a value may or may not be present depending on the outcome — for example, an `error_msg` that is only set when the operation fails. Topic messages are usually complete, so `$optional` is rarely needed there.
+`$optional` can only be used on **root-level fields** of a `message_format` — direct children, not fields nested inside objects or array items. If a parent structure is present, all its fields must be present too.
+
+In practice, this is used on **service and action response fields** where a value may or may not be present depending on the outcome — for example, an `error_msg` that is only set when the operation fails.
 :::
 
 ---

--- a/docs/src/content/docs/reference/message_format.mdx
+++ b/docs/src/content/docs/reference/message_format.mdx
@@ -74,7 +74,6 @@ An object groups related fields into a nested structure. It generates a nested s
 
 ```json5
 header: {
-  $type: "object",
   stamp: "time",
   frame_id: "u32"
 }
@@ -82,7 +81,7 @@ header: {
 
 | Field       | Required | Description                                   |
 |-------------|----------|-----------------------------------------------|
-| `$type`     | Yes      | Must be `"object"`                            |
+| `$type`     | No       | Only valid value is `"object"`. Can be omitted since the parser infers it from the structure |
 | `$optional` | No       | When `true`, the entire object may be absent  |
 | *other keys*| No       | Each additional key is a field with its own schema type |
 
@@ -119,8 +118,8 @@ distances: {
 | Field       | Required | Description                                         |
 |-------------|----------|-----------------------------------------------------|
 | `$type`     | Yes      | Must be `"array"`                                   |
-| `$items`    | Yes      | The schema type of each element                     |
-| `$length`   | No       | Fixed number of elements. Omit for variable-length  |
+| `$items`    | Yes      | A primitive type or an object schema. Nested arrays (arrays of arrays) are not supported |
+| `$length`   | No       | Fixed number of elements. Only supported when `$items` is a numeric or boolean primitive — not supported for `string`, `time`, or object items. Omit for variable-length |
 | `$optional` | No       | When `true`, the entire array may be absent          |
 
 ### Fixed-length array

--- a/docs/src/content/docs/reference/message_format.mdx
+++ b/docs/src/content/docs/reference/message_format.mdx
@@ -229,7 +229,7 @@ A full `peppy.json5` topic using multiple schema types:
   },
  execution: {
     language: "rust",
-    start_cmd: ["cargo", "run"]
+    start_cmd: ["./target/release/uvc_camera"],
   },
   interfaces: {
     topics: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Generators now handle arrays-of-objects, emitting per-item nested types/structs and runtime vs fixed-length checks.

* **Bug Fixes / Validation**
  * Reject `$optional` on nested fields and array items; reject fixed-length arrays whose items are objects; added detection for generated type-name collisions.

* **Documentation**
  * Added a comprehensive message_format reference with examples.

* **Tests**
  * Added/updated tests for nested schemas, object-array codegen, serialization/deserialization, and validation cases.

* **Chores**
  * Re-exported object schema types in the public API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->