### PR TITLE
Core node name is now fixed across reboot/reinstallation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -671,7 +671,7 @@ dependencies = [
  "rust-embed",
  "serde_json",
  "serde_json5",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "sysinfo",
  "tar",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -662,6 +662,7 @@ dependencies = [
  "hostname",
  "httptest",
  "libc",
+ "machine-uid",
  "names-generator2",
  "node-stack",
  "peppylib",
@@ -2226,6 +2227,17 @@ name = "mac-addr"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3d25b0e0b648a86960ac23b7ad4abb9717601dec6f66c165f5b037f3f03065f"
+
+[[package]]
+name = "machine-uid"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d7217d573cdb141d6da43113b098172e057d39915d79c4bdedbc3aacd46bd96"
+dependencies = [
+ "libc",
+ "windows-registry",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "matchers"
@@ -5188,6 +5200,17 @@ checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
  "windows-core",
  "windows-link",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]

--- a/crates/core-node-internal/Cargo.toml
+++ b/crates/core-node-internal/Cargo.toml
@@ -14,6 +14,7 @@ containers = { path = "../containers-internal" }
 bytes = "1.10"
 chrono = "0.4"
 hostname = "0.4"
+machine-uid = "0.5"
 capnp = "0.25"
 futures = "0.3"
 names-generator2 = "0.2.1"

--- a/crates/core-node-internal/Cargo.toml
+++ b/crates/core-node-internal/Cargo.toml
@@ -40,7 +40,7 @@ ureq = "3.1"
 tar = "0.4"
 zstd = "0.13.3"
 tempfile = "3.10"
-sha2 = "0.10"
+sha2 = "0.11"
 
 [build-dependencies]
 build-helpers = { path = "../build-helpers-internal" }

--- a/crates/core-node-internal/src/services.rs
+++ b/crates/core-node-internal/src/services.rs
@@ -25,7 +25,10 @@ use std::time::{Duration, Instant};
 use tokio::sync::{Mutex, oneshot};
 use tracing::info;
 
-const CORE_NODE_TAG: &str = "core-node";
+const CORE_NODE_TAG: &str = match option_env!("PEPPY_GIT_TAG") {
+    Some(tag) => tag,
+    None => "unknown",
+};
 
 #[cfg(test)]
 mod tests;
@@ -93,7 +96,20 @@ impl CoreNode {
     ) -> Self {
         let manifest_name = match node_name {
             Some(name) => Name::new(name).unwrap(),
-            None => Name::new(get_random(rng())).unwrap(),
+            None => {
+                let uid = machine_uid::get().unwrap_or_else(|_| "unknown".to_string());
+                let sanitized: String = uid
+                    .chars()
+                    .map(|c| {
+                        if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                            c
+                        } else {
+                            '-'
+                        }
+                    })
+                    .collect();
+                Name::new(format!("core-node-{sanitized}")).unwrap()
+            }
         };
 
         let node_startup_timeout = node_arguments.node_startup_timeout;

--- a/crates/core-node-internal/src/services.rs
+++ b/crates/core-node-internal/src/services.rs
@@ -17,7 +17,10 @@ use names_generator2::get_random;
 use node_stack::NodeStack;
 use peppylib::MessengerHandle;
 use pmi::Messenger;
+use rand::SeedableRng;
 use rand::rng;
+use rand::rngs::StdRng;
+use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -97,7 +100,7 @@ impl CoreNode {
         let manifest_name = match node_name {
             Some(name) => Name::new(name).unwrap(),
             None => {
-                let raw = machine_uid::get()
+                let seed_source = machine_uid::get()
                     .map_err(|e| {
                         tracing::warn!("machine_uid::get() failed: {e}; falling back to hostname");
                     })
@@ -108,24 +111,25 @@ impl CoreNode {
                             let s = h.to_string_lossy().into_owned();
                             if s.is_empty() { None } else { Some(s) }
                         })
-                    })
-                    .unwrap_or_else(|| {
+                    });
+
+                let generated = match seed_source {
+                    Some(src) => {
+                        // Hash so the published name does not reveal the UID/hostname.
+                        let digest = Sha256::digest(src.as_bytes());
+                        let seed: [u8; 32] = digest.into();
+                        let mut seeded = StdRng::from_seed(seed);
+                        get_random(&mut seeded)
+                    }
+                    None => {
                         tracing::warn!(
-                            "hostname unavailable; falling back to random core node name"
+                            "machine UID and hostname unavailable; falling back to non-deterministic core node name"
                         );
                         get_random(&mut rng())
-                    });
-                let sanitized: String = raw
-                    .chars()
-                    .map(|c| {
-                        if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
-                            c
-                        } else {
-                            '-'
-                        }
-                    })
-                    .collect();
-                Name::new(format!("core-node-{sanitized}")).unwrap()
+                    }
+                };
+
+                Name::new(format!("core-node-{generated}")).unwrap()
             }
         };
 

--- a/crates/core-node-internal/src/services.rs
+++ b/crates/core-node-internal/src/services.rs
@@ -27,7 +27,7 @@ use tracing::info;
 
 const CORE_NODE_TAG: &str = match option_env!("PEPPY_GIT_TAG") {
     Some(tag) => tag,
-    None => "unknown",
+    None => "dev",
 };
 
 #[cfg(test)]
@@ -97,8 +97,25 @@ impl CoreNode {
         let manifest_name = match node_name {
             Some(name) => Name::new(name).unwrap(),
             None => {
-                let uid = machine_uid::get().unwrap_or_else(|_| "unknown".to_string());
-                let sanitized: String = uid
+                let raw = machine_uid::get()
+                    .map_err(|e| {
+                        tracing::warn!("machine_uid::get() failed: {e}; falling back to hostname");
+                    })
+                    .ok()
+                    .filter(|s| !s.is_empty())
+                    .or_else(|| {
+                        hostname::get().ok().and_then(|h| {
+                            let s = h.to_string_lossy().into_owned();
+                            if s.is_empty() { None } else { Some(s) }
+                        })
+                    })
+                    .unwrap_or_else(|| {
+                        tracing::warn!(
+                            "hostname unavailable; falling back to random core node name"
+                        );
+                        get_random(&mut rng())
+                    });
+                let sanitized: String = raw
                     .chars()
                     .map(|c| {
                         if c.is_ascii_alphanumeric() || c == '-' || c == '_' {

--- a/crates/core-node-internal/src/services/node/info.rs
+++ b/crates/core-node-internal/src/services/node/info.rs
@@ -583,7 +583,10 @@ mod tests {
     #[tokio::test]
     async fn resolve_node_config_rejects_http_checksum_mismatch() {
         let bundle = create_http_node_bundle("http_checksum_node", "0.1.0");
-        let actual_sha256 = format!("{:x}", Sha256::digest(&bundle));
+        let actual_sha256: String = Sha256::digest(&bundle)
+            .iter()
+            .map(|b| format!("{:02x}", b))
+            .collect();
         let wrong_sha256 = if let Some(stripped) = actual_sha256.strip_prefix('0') {
             format!("1{}", stripped)
         } else {

--- a/crates/core-node-internal/src/services/tests.rs
+++ b/crates/core-node-internal/src/services/tests.rs
@@ -42,3 +42,67 @@ async fn core_node_execution_has_no_start_cmd_and_no_container() {
         "core node must not have a container config"
     );
 }
+
+/// Verifies that, with no explicit name, the core node derives a deterministic
+/// machine-uid based name with the `core-node-` prefix. Two instances built on
+/// the same machine must produce the same name.
+#[tokio::test]
+async fn core_node_default_name_is_deterministic_and_machine_uid_based() {
+    let peppy_dirs = PeppyDirs::new(std::env::temp_dir());
+    let mk = || CoreNodeArguments {
+        node_startup_timeout: Duration::from_secs(5),
+        node_start_health_timeout: Duration::from_secs(5),
+    };
+
+    let a = CoreNode::new(
+        create_mock_messenger().await,
+        None,
+        mk(),
+        std::env::temp_dir(),
+        peppy_dirs.clone(),
+    );
+    let b = CoreNode::new(
+        create_mock_messenger().await,
+        None,
+        mk(),
+        std::env::temp_dir(),
+        peppy_dirs,
+    );
+
+    let name_a = a.node_config().manifest.name.as_str();
+    let name_b = b.node_config().manifest.name.as_str();
+    assert_eq!(
+        name_a, name_b,
+        "default core node name must be deterministic across instances on the same machine"
+    );
+    assert!(
+        name_a.starts_with("core-node-"),
+        "default core node name must use the `core-node-` prefix, got `{name_a}`"
+    );
+    assert!(
+        name_a.len() > "core-node-".len(),
+        "default core node name must include a machine-uid suffix, got `{name_a}`"
+    );
+}
+
+/// Verifies the explicit `node_name` override still wins over the machine-uid default.
+#[tokio::test]
+async fn core_node_explicit_name_overrides_machine_uid() {
+    let messenger = create_mock_messenger().await;
+    let peppy_dirs = PeppyDirs::new(std::env::temp_dir());
+    let node_arguments = CoreNodeArguments {
+        node_startup_timeout: Duration::from_secs(5),
+        node_start_health_timeout: Duration::from_secs(5),
+    };
+    let core_node = CoreNode::new(
+        messenger,
+        Some("custom_name"),
+        node_arguments,
+        std::env::temp_dir(),
+        peppy_dirs,
+    );
+    assert_eq!(
+        core_node.node_config().manifest.name.as_str(),
+        "custom_name"
+    );
+}

--- a/crates/core-node-internal/tests/common.rs
+++ b/crates/core-node-internal/tests/common.rs
@@ -746,6 +746,7 @@ pub struct StartedCoreNode {
     pub shared_messenger: Arc<Mutex<Messenger>>,
     pub caller_handle: MessengerHandle,
     pub core_node_name: String,
+    pub core_node_tag: String,
     pub node_stack: NodeStack,
     pub peppy_dirs: PeppyDirs,
     pub task: AbortOnDrop<core_node::Result<()>>,
@@ -836,6 +837,7 @@ async fn start_core_node_with_messenger(
         peppy_dirs.clone(),
     );
     let core_node_name = core_node.node_name().to_string();
+    let core_node_tag = core_node.node_config().manifest.tag.clone();
     let node_stack = core_node.node_stack().clone();
 
     // Use start_with_ready to properly synchronize instead of a time-based sleep
@@ -849,6 +851,7 @@ async fn start_core_node_with_messenger(
         shared_messenger,
         caller_handle,
         core_node_name,
+        core_node_tag,
         node_stack,
         peppy_dirs,
         task: AbortOnDrop(task),

--- a/crates/core-node-internal/tests/listen_for_node_add.rs
+++ b/crates/core-node-internal/tests/listen_for_node_add.rs
@@ -794,7 +794,10 @@ async fn listen_for_node_http_add_accepts_correct_sha256() {
     let (_bundle_dir, bundle_bytes) = create_minimal_http_bundle(TARGET_NODE_NAME, TARGET_NODE_TAG);
 
     use sha2::{Digest, Sha256};
-    let correct_sha256 = format!("{:x}", Sha256::digest(&bundle_bytes));
+    let correct_sha256: String = Sha256::digest(&bundle_bytes)
+        .iter()
+        .map(|b| format!("{:02x}", b))
+        .collect();
 
     let (_server, url) = serve_bundle_over_http(bundle_bytes);
 

--- a/crates/core-node-internal/tests/listen_for_node_info.rs
+++ b/crates/core-node-internal/tests/listen_for_node_info.rs
@@ -227,7 +227,10 @@ async fn listen_for_node_info_on_http_node_success() {
         .expect("failed to write compressed bundle");
     encoder.finish().expect("failed to finish encoder");
     let bundle_bytes = std::fs::read(&bundle_path).expect("failed to read bundle");
-    let bundle_sha256 = format!("{:x}", Sha256::digest(&bundle_bytes));
+    let bundle_sha256: String = Sha256::digest(&bundle_bytes)
+        .iter()
+        .map(|b| format!("{:02x}", b))
+        .collect();
 
     let server = Server::run();
     server.expect(

--- a/crates/core-node-internal/tests/listen_for_node_list.rs
+++ b/crates/core-node-internal/tests/listen_for_node_list.rs
@@ -77,7 +77,8 @@ async fn listen_for_node_list_returns_succeeds() {
 
     let has_root = nodes.iter().any(|node| {
         node.get("name").and_then(|v| v.as_str()) == Some(&started_core_node.core_node_name)
-            && node.get("tag").and_then(|v| v.as_str()) == Some("core-node")
+            && node.get("tag").and_then(|v| v.as_str())
+                == Some(started_core_node.core_node_tag.as_str())
     });
     assert!(
         has_root,
@@ -161,7 +162,10 @@ async fn listen_for_node_list_returns_dot_graph() {
         dot_graph
     );
     assert!(
-        dot_graph.contains(&format!("{}:core-node", started_core_node.core_node_name)),
+        dot_graph.contains(&format!(
+            "{}:{}",
+            started_core_node.core_node_name, started_core_node.core_node_tag
+        )),
         "dot_graph should include root node label, got:\n{}",
         dot_graph
     );

--- a/crates/core-node-internal/tests/listen_for_reset.rs
+++ b/crates/core-node-internal/tests/listen_for_reset.rs
@@ -157,7 +157,7 @@ async fn listen_for_node_reset_clears_node_stack() {
     );
     assert_eq!(
         root_after.config().manifest.tag,
-        "core-node",
+        started_core_node.core_node_tag,
         "root node tag should be preserved"
     );
     let root_instance_id_after = root_after


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Node names now derive deterministically from machine identifiers when no explicit name is provided.
  * Core node tag can be set via an environment variable, with a sensible default.

* **Tests**
  * Added tests for deterministic default naming and explicit-name overrides.
  * Normalized SHA-256 hex formatting in several tests and made tag assertions dynamic.

* **Chores**
  * Updated runtime dependencies, including a machine-identifier helper and a cryptography version bump.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->