### PR TITLE
Separate `add` and `build` workflow steps

### DIFF
--- a/crates/config-internal/src/consts.rs
+++ b/crates/config-internal/src/consts.rs
@@ -91,6 +91,11 @@ impl PeppyDirs {
         self.root.join("logs").join("add")
     }
 
+    /// Log directory for `node build` operations.
+    pub fn logs_dir_build(&self) -> PathBuf {
+        self.root.join("logs").join("build")
+    }
+
     /// Log directory for `node start` operations.
     pub fn logs_dir_start(&self) -> PathBuf {
         self.root.join("logs").join("start")

--- a/crates/core-node-internal/schemas/launch.capnp
+++ b/crates/core-node-internal/schemas/launch.capnp
@@ -33,6 +33,7 @@ enum LaunchFeedbackStep {
     launcherStep @0;
     addingNode @1;
     startingNode @2;
+    buildingNode @3;
 }
 
 struct LaunchFeedback {

--- a/crates/core-node-internal/schemas/node.capnp
+++ b/crates/core-node-internal/schemas/node.capnp
@@ -90,13 +90,43 @@ struct NodeAddResult {
     success @0 :Bool;
     # Error message if failed
     errorMessage @1 :Text;
-    # Path where the node was copied (empty on failure)
-    snapshotPath @2 :Text;
     # Path to the log file containing stdout/stderr output
-    logPath @3 :Text;
+    logPath @2 :Text;
     # Name of the added node (empty on failure)
-    nodeName @4 :Text;
+    nodeName @3 :Text;
     # Tag of the added node (empty on failure)
+    nodeTag @4 :Text;
+}
+
+# Node Build Action (streaming version with feedback)
+struct NodeBuildGoal {
+    # Name of the node to build (must be in Added stage)
+    nodeName @0 :Text;
+    # Tag of the node to build
+    nodeTag @1 :Text;
+    # Timeout in seconds for the build operation
+    timeoutSecs @2 :UInt64;
+    # When true, cancel any in-progress build action and start a new one
+    force @3 :Bool;
+}
+
+struct NodeBuildGoalResponse {
+    accepted @0 :Bool;
+    logPath @1 :Text;
+    rejectionReason @2 :Text;
+}
+
+struct NodeBuildFeedback {
+    stream @0 :Text;
+    line @1 :Text;
+}
+
+struct NodeBuildResult {
+    success @0 :Bool;
+    errorMessage @1 :Text;
+    snapshotPath @2 :Text;
+    logPath @3 :Text;
+    nodeName @4 :Text;
     nodeTag @5 :Text;
 }
 

--- a/crates/core-node-internal/schemas/node.capnp
+++ b/crates/core-node-internal/schemas/node.capnp
@@ -69,7 +69,11 @@ struct NodeAddVariantSource {
     httpSha256 @3 :Text;
 }
 
-struct NodeAddGoalResponse {
+# Shared goal-response and feedback schemas for streaming node-level
+# actions (NodeAdd, NodeBuild). Both actions produce the same
+# accepted/logPath/rejectionReason trio on goal submission and stream
+# stdout/stderr/warning lines via the same feedback shape.
+struct NodeActionGoalResponse {
     # Whether the goal was accepted
     accepted @0 :Bool;
     # Path to the log file (empty if rejected)
@@ -78,8 +82,8 @@ struct NodeAddGoalResponse {
     rejectionReason @2 :Text;
 }
 
-struct NodeAddFeedback {
-    # Type of output: "stdout" or "stderr"
+struct NodeActionFeedback {
+    # Type of output: "stdout", "stderr", or "warning"
     stream @0 :Text;
     # The line of output
     line @1 :Text;
@@ -110,24 +114,11 @@ struct NodeBuildGoal {
     force @3 :Bool;
 }
 
-struct NodeBuildGoalResponse {
-    accepted @0 :Bool;
-    logPath @1 :Text;
-    rejectionReason @2 :Text;
-}
-
-struct NodeBuildFeedback {
-    stream @0 :Text;
-    line @1 :Text;
-}
-
 struct NodeBuildResult {
     success @0 :Bool;
     errorMessage @1 :Text;
     snapshotPath @2 :Text;
     logPath @3 :Text;
-    nodeName @4 :Text;
-    nodeTag @5 :Text;
 }
 
 # Node Init service
@@ -177,22 +168,6 @@ struct NodeStartGoal {
     envVars @3 :List(EnvVar);
     # Timeout in seconds for the start operation (used to report remaining time when busy)
     timeoutSecs @4 :UInt64;
-}
-
-struct NodeStartGoalResponse {
-    # Whether the goal was accepted
-    accepted @0 :Bool;
-    # Path to the log file (empty if rejected)
-    logPath @1 :Text;
-    # Rejection reason (empty if accepted)
-    rejectionReason @2 :Text;
-}
-
-struct NodeStartFeedback {
-    # Type of output: "stdout" or "stderr"
-    stream @0 :Text;
-    # The line of output
-    line @1 :Text;
 }
 
 struct NodeStartResult {

--- a/crates/core-node-internal/src/encoding.rs
+++ b/crates/core-node-internal/src/encoding.rs
@@ -14,14 +14,12 @@ pub use launch::{
     NodeAddLogEntry, NodeStartLogEntry,
 };
 pub use node::{
-    add::NodeAddFeedback, add::NodeAddGoal, add::NodeAddGoalResponse, add::NodeAddResult,
+    add::NodeActionFeedback, add::NodeActionGoalResponse, add::NodeAddGoal, add::NodeAddResult,
     add::NodeSource, info::NodeInfoRequest, info::NodeInfoResponse, info::NodeInstanceInfo,
     init::NodeInitRequest, init::NodeInitResponse, list::NodeListRequest, list::NodeListResponse,
-    node_build::NodeBuildFeedback, node_build::NodeBuildGoal, node_build::NodeBuildGoalResponse,
-    node_build::NodeBuildResult, remove::NodeRemoveRequest, remove::NodeRemoveResponse,
-    start::NodeStartFeedback, start::NodeStartGoal, start::NodeStartGoalResponse,
-    start::NodeStartResult, stop::NodeStopRequest, stop::NodeStopResponse, sync::NodeSyncRequest,
-    sync::NodeSyncResponse,
+    node_build::NodeBuildGoal, node_build::NodeBuildResult, remove::NodeRemoveRequest,
+    remove::NodeRemoveResponse, start::NodeStartGoal, start::NodeStartResult,
+    stop::NodeStopRequest, stop::NodeStopResponse, sync::NodeSyncRequest, sync::NodeSyncResponse,
 };
 pub use ping::{PingRequest, PingResponse};
 pub use reset::{NodeResetRequest, NodeResetResponse};

--- a/crates/core-node-internal/src/encoding.rs
+++ b/crates/core-node-internal/src/encoding.rs
@@ -17,9 +17,11 @@ pub use node::{
     add::NodeAddFeedback, add::NodeAddGoal, add::NodeAddGoalResponse, add::NodeAddResult,
     add::NodeSource, info::NodeInfoRequest, info::NodeInfoResponse, info::NodeInstanceInfo,
     init::NodeInitRequest, init::NodeInitResponse, list::NodeListRequest, list::NodeListResponse,
-    remove::NodeRemoveRequest, remove::NodeRemoveResponse, start::NodeStartFeedback,
-    start::NodeStartGoal, start::NodeStartGoalResponse, start::NodeStartResult,
-    stop::NodeStopRequest, stop::NodeStopResponse, sync::NodeSyncRequest, sync::NodeSyncResponse,
+    node_build::NodeBuildFeedback, node_build::NodeBuildGoal, node_build::NodeBuildGoalResponse,
+    node_build::NodeBuildResult, remove::NodeRemoveRequest, remove::NodeRemoveResponse,
+    start::NodeStartFeedback, start::NodeStartGoal, start::NodeStartGoalResponse,
+    start::NodeStartResult, stop::NodeStopRequest, stop::NodeStopResponse, sync::NodeSyncRequest,
+    sync::NodeSyncResponse,
 };
 pub use ping::{PingRequest, PingResponse};
 pub use reset::{NodeResetRequest, NodeResetResponse};

--- a/crates/core-node-internal/src/encoding/launch.rs
+++ b/crates/core-node-internal/src/encoding/launch.rs
@@ -191,6 +191,7 @@ impl LaunchGoalResponse {
 pub enum LaunchFeedbackStep {
     LauncherStep,
     AddingNode,
+    BuildingNode,
     StartingNode,
 }
 /// Feedback message for the Launch action.
@@ -239,6 +240,7 @@ impl LaunchFeedback {
             feedback.set_step(match self.step {
                 LaunchFeedbackStep::LauncherStep => launch_capnp::LaunchFeedbackStep::LauncherStep,
                 LaunchFeedbackStep::AddingNode => launch_capnp::LaunchFeedbackStep::AddingNode,
+                LaunchFeedbackStep::BuildingNode => launch_capnp::LaunchFeedbackStep::BuildingNode,
                 LaunchFeedbackStep::StartingNode => launch_capnp::LaunchFeedbackStep::StartingNode,
             });
         }
@@ -251,6 +253,7 @@ impl LaunchFeedback {
         let step = match feedback.get_step()? {
             launch_capnp::LaunchFeedbackStep::LauncherStep => LaunchFeedbackStep::LauncherStep,
             launch_capnp::LaunchFeedbackStep::AddingNode => LaunchFeedbackStep::AddingNode,
+            launch_capnp::LaunchFeedbackStep::BuildingNode => LaunchFeedbackStep::BuildingNode,
             launch_capnp::LaunchFeedbackStep::StartingNode => LaunchFeedbackStep::StartingNode,
         };
         Ok(Self {

--- a/crates/core-node-internal/src/encoding/node.rs
+++ b/crates/core-node-internal/src/encoding/node.rs
@@ -3,6 +3,7 @@ pub mod add;
 pub mod info;
 pub mod init;
 pub mod list;
+pub mod node_build;
 pub mod remove;
 pub mod start;
 pub mod stop;

--- a/crates/core-node-internal/src/encoding/node/add.rs
+++ b/crates/core-node-internal/src/encoding/node/add.rs
@@ -524,7 +524,6 @@ impl NodeAddFeedback {
 /// Result message for the NodeAdd action.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NodeAddResult {
-    pub snapshot_path: PathBuf,
     pub log_path: PathBuf,
     pub success: bool,
     pub error_message: Option<String>,
@@ -534,13 +533,11 @@ pub struct NodeAddResult {
 
 impl NodeAddResult {
     pub fn success(
-        snapshot_path: impl Into<PathBuf>,
         log_path: impl Into<PathBuf>,
         node_name: impl Into<String>,
         node_tag: impl Into<String>,
     ) -> Self {
         Self {
-            snapshot_path: snapshot_path.into(),
             log_path: log_path.into(),
             success: true,
             error_message: None,
@@ -551,7 +548,6 @@ impl NodeAddResult {
 
     pub fn failure(log_path: impl Into<PathBuf>, error_message: impl Into<String>) -> Self {
         Self {
-            snapshot_path: PathBuf::new(),
             log_path: log_path.into(),
             success: false,
             error_message: Some(error_message.into()),
@@ -568,7 +564,6 @@ impl NodeAddResult {
             if let Some(ref error_message) = self.error_message {
                 result.set_error_message(error_message);
             }
-            result.set_snapshot_path(self.snapshot_path.to_string_lossy().as_ref());
             result.set_log_path(self.log_path.to_string_lossy().as_ref());
             if let Some(ref node_name) = self.node_name {
                 result.set_node_name(node_name);
@@ -583,10 +578,8 @@ impl NodeAddResult {
     pub fn decode(data: &[u8]) -> Result<Self> {
         let reader = decode_message(data)?;
         let result = reader.get_root::<node_capnp::node_add_result::Reader>()?;
-        let snapshot_path = PathBuf::from(result.get_snapshot_path()?.to_str()?);
         let log_path = PathBuf::from(result.get_log_path()?.to_str()?);
         Ok(Self {
-            snapshot_path,
             log_path,
             success: result.get_success(),
             error_message: optional_text(result.get_error_message()?.to_str()?),

--- a/crates/core-node-internal/src/encoding/node/add.rs
+++ b/crates/core-node-internal/src/encoding/node/add.rs
@@ -6,6 +6,7 @@ use crate::node_capnp;
 use capnp::message::Builder;
 use config::node::QoSProfile;
 use gix_url::Url as GitUrl;
+use node_stack::build_io::FeedbackStream;
 use peppylib::messaging::ActionGoalHandle;
 use peppylib::types::Payload;
 use peppylib::{ActionMessenger, MessengerHandle};
@@ -410,13 +411,13 @@ mod tests {
 
 /// Response to the NodeAdd goal request.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct NodeAddGoalResponse {
+pub struct NodeActionGoalResponse {
     pub accepted: bool,
     pub log_path: PathBuf,
     pub rejection_reason: Option<String>,
 }
 
-impl NodeAddGoalResponse {
+impl NodeActionGoalResponse {
     pub fn accepted(log_path: impl Into<PathBuf>) -> Self {
         Self {
             accepted: true,
@@ -436,7 +437,8 @@ impl NodeAddGoalResponse {
     pub fn encode(&self) -> Result<Payload> {
         let mut builder = Builder::new_default();
         {
-            let mut response = builder.init_root::<node_capnp::node_add_goal_response::Builder>();
+            let mut response =
+                builder.init_root::<node_capnp::node_action_goal_response::Builder>();
             response.set_accepted(self.accepted);
             response.set_log_path(self.log_path.to_string_lossy().as_ref());
             if let Some(ref reason) = self.rejection_reason {
@@ -448,7 +450,7 @@ impl NodeAddGoalResponse {
 
     pub fn decode(data: &[u8]) -> Result<Self> {
         let reader = decode_message(data)?;
-        let response = reader.get_root::<node_capnp::node_add_goal_response::Reader>()?;
+        let response = reader.get_root::<node_capnp::node_action_goal_response::Reader>()?;
         Ok(Self {
             accepted: response.get_accepted(),
             log_path: PathBuf::from(response.get_log_path()?.to_str()?),
@@ -457,55 +459,53 @@ impl NodeAddGoalResponse {
     }
 }
 
-/// Feedback message for the NodeAdd action.
-/// Represents a single line of output from the add_cmd process.
+/// Feedback message for the NodeAdd / NodeBuild actions.
+/// Represents a single line of output from the spawned process or daemon.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct NodeAddFeedback {
-    /// The stream type: "stdout", "stderr" or "warning"
-    pub stream: String,
-    /// The line of output
+pub struct NodeActionFeedback {
+    pub stream: FeedbackStream,
     pub line: String,
 }
 
-impl NodeAddFeedback {
+impl NodeActionFeedback {
     pub fn stdout(line: impl Into<String>) -> Self {
         Self {
-            stream: "stdout".to_string(),
+            stream: FeedbackStream::Stdout,
             line: line.into(),
         }
     }
 
     pub fn stderr(line: impl Into<String>) -> Self {
         Self {
-            stream: "stderr".to_string(),
+            stream: FeedbackStream::Stderr,
             line: line.into(),
         }
     }
 
     pub fn warning(line: impl Into<String>) -> Self {
         Self {
-            stream: "warning".to_string(),
+            stream: FeedbackStream::Warning,
             line: line.into(),
         }
     }
 
     pub fn is_stdout(&self) -> bool {
-        self.stream == "stdout"
+        matches!(self.stream, FeedbackStream::Stdout)
     }
 
     pub fn is_stderr(&self) -> bool {
-        self.stream == "stderr"
+        matches!(self.stream, FeedbackStream::Stderr)
     }
 
     pub fn is_warning(&self) -> bool {
-        self.stream == "warning"
+        matches!(self.stream, FeedbackStream::Warning)
     }
 
     pub fn encode(&self) -> Result<Payload> {
         let mut builder = Builder::new_default();
         {
-            let mut feedback = builder.init_root::<node_capnp::node_add_feedback::Builder>();
-            feedback.set_stream(&self.stream);
+            let mut feedback = builder.init_root::<node_capnp::node_action_feedback::Builder>();
+            feedback.set_stream(self.stream.as_str());
             feedback.set_line(&self.line);
         }
         encode_message(&builder)
@@ -513,9 +513,19 @@ impl NodeAddFeedback {
 
     pub fn decode(data: &[u8]) -> Result<Self> {
         let reader = decode_message(data)?;
-        let feedback = reader.get_root::<node_capnp::node_add_feedback::Reader>()?;
+        let feedback = reader.get_root::<node_capnp::node_action_feedback::Reader>()?;
+        let stream = match feedback.get_stream()?.to_str()? {
+            "stdout" => FeedbackStream::Stdout,
+            "stderr" => FeedbackStream::Stderr,
+            "warning" => FeedbackStream::Warning,
+            other => {
+                return Err(crate::Error::Decoding(format!(
+                    "unknown feedback stream: {other}"
+                )));
+            }
+        };
         Ok(Self {
-            stream: feedback.get_stream()?.to_str()?.to_owned(),
+            stream,
             line: feedback.get_line()?.to_str()?.to_owned(),
         })
     }

--- a/crates/core-node-internal/src/encoding/node/node_build.rs
+++ b/crates/core-node-internal/src/encoding/node/node_build.rs
@@ -1,4 +1,7 @@
 //! Encoding types for the NodeBuild action (streaming version with feedback).
+//!
+//! `NodeBuild` uses [`NodeActionGoalResponse`] and [`NodeActionFeedback`] —
+//! the shared streaming-node-action schemas defined alongside `NodeAdd`.
 
 use crate::Result;
 use crate::encoding::{decode_message, encode_message, optional_text};
@@ -94,137 +97,20 @@ impl NodeBuildGoal {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct NodeBuildGoalResponse {
-    pub accepted: bool,
-    pub log_path: PathBuf,
-    pub rejection_reason: Option<String>,
-}
-
-impl NodeBuildGoalResponse {
-    pub fn accepted(log_path: impl Into<PathBuf>) -> Self {
-        Self {
-            accepted: true,
-            log_path: log_path.into(),
-            rejection_reason: None,
-        }
-    }
-
-    pub fn rejected(reason: impl Into<String>) -> Self {
-        Self {
-            accepted: false,
-            log_path: PathBuf::new(),
-            rejection_reason: Some(reason.into()),
-        }
-    }
-
-    pub fn encode(&self) -> Result<Payload> {
-        let mut builder = Builder::new_default();
-        {
-            let mut response = builder.init_root::<node_capnp::node_build_goal_response::Builder>();
-            response.set_accepted(self.accepted);
-            response.set_log_path(self.log_path.to_string_lossy().as_ref());
-            if let Some(ref reason) = self.rejection_reason {
-                response.set_rejection_reason(reason);
-            }
-        }
-        encode_message(&builder)
-    }
-
-    pub fn decode(data: &[u8]) -> Result<Self> {
-        let reader = decode_message(data)?;
-        let response = reader.get_root::<node_capnp::node_build_goal_response::Reader>()?;
-        Ok(Self {
-            accepted: response.get_accepted(),
-            log_path: PathBuf::from(response.get_log_path()?.to_str()?),
-            rejection_reason: optional_text(response.get_rejection_reason()?.to_str()?),
-        })
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct NodeBuildFeedback {
-    pub stream: String,
-    pub line: String,
-}
-
-impl NodeBuildFeedback {
-    pub fn stdout(line: impl Into<String>) -> Self {
-        Self {
-            stream: "stdout".to_string(),
-            line: line.into(),
-        }
-    }
-
-    pub fn stderr(line: impl Into<String>) -> Self {
-        Self {
-            stream: "stderr".to_string(),
-            line: line.into(),
-        }
-    }
-
-    pub fn warning(line: impl Into<String>) -> Self {
-        Self {
-            stream: "warning".to_string(),
-            line: line.into(),
-        }
-    }
-
-    pub fn is_stdout(&self) -> bool {
-        self.stream == "stdout"
-    }
-
-    pub fn is_stderr(&self) -> bool {
-        self.stream == "stderr"
-    }
-
-    pub fn is_warning(&self) -> bool {
-        self.stream == "warning"
-    }
-
-    pub fn encode(&self) -> Result<Payload> {
-        let mut builder = Builder::new_default();
-        {
-            let mut feedback = builder.init_root::<node_capnp::node_build_feedback::Builder>();
-            feedback.set_stream(&self.stream);
-            feedback.set_line(&self.line);
-        }
-        encode_message(&builder)
-    }
-
-    pub fn decode(data: &[u8]) -> Result<Self> {
-        let reader = decode_message(data)?;
-        let feedback = reader.get_root::<node_capnp::node_build_feedback::Reader>()?;
-        Ok(Self {
-            stream: feedback.get_stream()?.to_str()?.to_owned(),
-            line: feedback.get_line()?.to_str()?.to_owned(),
-        })
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NodeBuildResult {
     pub snapshot_path: PathBuf,
     pub log_path: PathBuf,
     pub success: bool,
     pub error_message: Option<String>,
-    pub node_name: Option<String>,
-    pub node_tag: Option<String>,
 }
 
 impl NodeBuildResult {
-    pub fn success(
-        snapshot_path: impl Into<PathBuf>,
-        log_path: impl Into<PathBuf>,
-        node_name: impl Into<String>,
-        node_tag: impl Into<String>,
-    ) -> Self {
+    pub fn success(snapshot_path: impl Into<PathBuf>, log_path: impl Into<PathBuf>) -> Self {
         Self {
             snapshot_path: snapshot_path.into(),
             log_path: log_path.into(),
             success: true,
             error_message: None,
-            node_name: Some(node_name.into()),
-            node_tag: Some(node_tag.into()),
         }
     }
 
@@ -234,8 +120,6 @@ impl NodeBuildResult {
             log_path: log_path.into(),
             success: false,
             error_message: Some(error_message.into()),
-            node_name: None,
-            node_tag: None,
         }
     }
 
@@ -249,12 +133,6 @@ impl NodeBuildResult {
             }
             result.set_snapshot_path(self.snapshot_path.to_string_lossy().as_ref());
             result.set_log_path(self.log_path.to_string_lossy().as_ref());
-            if let Some(ref node_name) = self.node_name {
-                result.set_node_name(node_name);
-            }
-            if let Some(ref node_tag) = self.node_tag {
-                result.set_node_tag(node_tag);
-            }
         }
         encode_message(&builder)
     }
@@ -267,8 +145,6 @@ impl NodeBuildResult {
             log_path: PathBuf::from(result.get_log_path()?.to_str()?),
             success: result.get_success(),
             error_message: optional_text(result.get_error_message()?.to_str()?),
-            node_name: optional_text(result.get_node_name()?.to_str()?),
-            node_tag: optional_text(result.get_node_tag()?.to_str()?),
         })
     }
 

--- a/crates/core-node-internal/src/encoding/node/node_build.rs
+++ b/crates/core-node-internal/src/encoding/node/node_build.rs
@@ -1,0 +1,284 @@
+//! Encoding types for the NodeBuild action (streaming version with feedback).
+
+use crate::Result;
+use crate::encoding::{decode_message, encode_message, optional_text};
+use crate::names;
+use crate::node_capnp;
+use capnp::message::Builder;
+use config::node::QoSProfile;
+use peppylib::messaging::ActionGoalHandle;
+use peppylib::types::Payload;
+use peppylib::{ActionMessenger, MessengerHandle};
+use std::path::PathBuf;
+use std::time::Duration;
+
+/// Goal message for the NodeBuild action. Identifies an already-`Added`
+/// entity by (name, tag). Env vars and prepared working dir live on the
+/// entity itself (set by `node_add`), so the build goal does not carry
+/// them on the wire.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NodeBuildGoal {
+    pub node_name: String,
+    pub node_tag: String,
+    pub timeout_secs: u64,
+    pub force: bool,
+}
+
+impl NodeBuildGoal {
+    pub fn new(
+        node_name: impl Into<String>,
+        node_tag: impl Into<String>,
+        timeout_secs: u64,
+    ) -> Self {
+        Self {
+            node_name: node_name.into(),
+            node_tag: node_tag.into(),
+            timeout_secs,
+            force: false,
+        }
+    }
+
+    pub fn with_force(mut self, force: bool) -> Self {
+        self.force = force;
+        self
+    }
+
+    pub fn encode(&self) -> Result<Payload> {
+        let mut builder = Builder::new_default();
+        {
+            let mut goal = builder.init_root::<node_capnp::node_build_goal::Builder>();
+            goal.set_node_name(&self.node_name);
+            goal.set_node_tag(&self.node_tag);
+            goal.set_timeout_secs(self.timeout_secs);
+            goal.set_force(self.force);
+        }
+        encode_message(&builder)
+    }
+
+    pub fn decode(data: &[u8]) -> Result<Self> {
+        let reader = decode_message(data)?;
+        let goal = reader.get_root::<node_capnp::node_build_goal::Reader>()?;
+        Ok(Self {
+            node_name: goal.get_node_name()?.to_str()?.to_owned(),
+            node_tag: goal.get_node_tag()?.to_str()?.to_owned(),
+            timeout_secs: goal.get_timeout_secs(),
+            force: goal.get_force(),
+        })
+    }
+
+    pub async fn send_goal(
+        &self,
+        messenger: &MessengerHandle,
+        as_core_node: &str,
+        as_instance_id: &str,
+        target_core_node: Option<&str>,
+        target_instance_id: Option<&str>,
+        goal_timeout: Duration,
+    ) -> Result<ActionGoalHandle> {
+        let goal_payload = self.encode()?;
+        let handle = ActionMessenger::send_goal(
+            messenger,
+            as_core_node,
+            as_instance_id,
+            as_core_node,
+            names::NODE_BUILD_ACTION,
+            target_core_node,
+            target_instance_id,
+            goal_payload,
+            QoSProfile::default(),
+            goal_timeout,
+        )
+        .await?;
+        Ok(handle)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NodeBuildGoalResponse {
+    pub accepted: bool,
+    pub log_path: PathBuf,
+    pub rejection_reason: Option<String>,
+}
+
+impl NodeBuildGoalResponse {
+    pub fn accepted(log_path: impl Into<PathBuf>) -> Self {
+        Self {
+            accepted: true,
+            log_path: log_path.into(),
+            rejection_reason: None,
+        }
+    }
+
+    pub fn rejected(reason: impl Into<String>) -> Self {
+        Self {
+            accepted: false,
+            log_path: PathBuf::new(),
+            rejection_reason: Some(reason.into()),
+        }
+    }
+
+    pub fn encode(&self) -> Result<Payload> {
+        let mut builder = Builder::new_default();
+        {
+            let mut response = builder.init_root::<node_capnp::node_build_goal_response::Builder>();
+            response.set_accepted(self.accepted);
+            response.set_log_path(self.log_path.to_string_lossy().as_ref());
+            if let Some(ref reason) = self.rejection_reason {
+                response.set_rejection_reason(reason);
+            }
+        }
+        encode_message(&builder)
+    }
+
+    pub fn decode(data: &[u8]) -> Result<Self> {
+        let reader = decode_message(data)?;
+        let response = reader.get_root::<node_capnp::node_build_goal_response::Reader>()?;
+        Ok(Self {
+            accepted: response.get_accepted(),
+            log_path: PathBuf::from(response.get_log_path()?.to_str()?),
+            rejection_reason: optional_text(response.get_rejection_reason()?.to_str()?),
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NodeBuildFeedback {
+    pub stream: String,
+    pub line: String,
+}
+
+impl NodeBuildFeedback {
+    pub fn stdout(line: impl Into<String>) -> Self {
+        Self {
+            stream: "stdout".to_string(),
+            line: line.into(),
+        }
+    }
+
+    pub fn stderr(line: impl Into<String>) -> Self {
+        Self {
+            stream: "stderr".to_string(),
+            line: line.into(),
+        }
+    }
+
+    pub fn warning(line: impl Into<String>) -> Self {
+        Self {
+            stream: "warning".to_string(),
+            line: line.into(),
+        }
+    }
+
+    pub fn is_stdout(&self) -> bool {
+        self.stream == "stdout"
+    }
+
+    pub fn is_stderr(&self) -> bool {
+        self.stream == "stderr"
+    }
+
+    pub fn is_warning(&self) -> bool {
+        self.stream == "warning"
+    }
+
+    pub fn encode(&self) -> Result<Payload> {
+        let mut builder = Builder::new_default();
+        {
+            let mut feedback = builder.init_root::<node_capnp::node_build_feedback::Builder>();
+            feedback.set_stream(&self.stream);
+            feedback.set_line(&self.line);
+        }
+        encode_message(&builder)
+    }
+
+    pub fn decode(data: &[u8]) -> Result<Self> {
+        let reader = decode_message(data)?;
+        let feedback = reader.get_root::<node_capnp::node_build_feedback::Reader>()?;
+        Ok(Self {
+            stream: feedback.get_stream()?.to_str()?.to_owned(),
+            line: feedback.get_line()?.to_str()?.to_owned(),
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NodeBuildResult {
+    pub snapshot_path: PathBuf,
+    pub log_path: PathBuf,
+    pub success: bool,
+    pub error_message: Option<String>,
+    pub node_name: Option<String>,
+    pub node_tag: Option<String>,
+}
+
+impl NodeBuildResult {
+    pub fn success(
+        snapshot_path: impl Into<PathBuf>,
+        log_path: impl Into<PathBuf>,
+        node_name: impl Into<String>,
+        node_tag: impl Into<String>,
+    ) -> Self {
+        Self {
+            snapshot_path: snapshot_path.into(),
+            log_path: log_path.into(),
+            success: true,
+            error_message: None,
+            node_name: Some(node_name.into()),
+            node_tag: Some(node_tag.into()),
+        }
+    }
+
+    pub fn failure(log_path: impl Into<PathBuf>, error_message: impl Into<String>) -> Self {
+        Self {
+            snapshot_path: PathBuf::new(),
+            log_path: log_path.into(),
+            success: false,
+            error_message: Some(error_message.into()),
+            node_name: None,
+            node_tag: None,
+        }
+    }
+
+    pub fn encode(&self) -> Result<Payload> {
+        let mut builder = Builder::new_default();
+        {
+            let mut result = builder.init_root::<node_capnp::node_build_result::Builder>();
+            result.set_success(self.success);
+            if let Some(ref error_message) = self.error_message {
+                result.set_error_message(error_message);
+            }
+            result.set_snapshot_path(self.snapshot_path.to_string_lossy().as_ref());
+            result.set_log_path(self.log_path.to_string_lossy().as_ref());
+            if let Some(ref node_name) = self.node_name {
+                result.set_node_name(node_name);
+            }
+            if let Some(ref node_tag) = self.node_tag {
+                result.set_node_tag(node_tag);
+            }
+        }
+        encode_message(&builder)
+    }
+
+    pub fn decode(data: &[u8]) -> Result<Self> {
+        let reader = decode_message(data)?;
+        let result = reader.get_root::<node_capnp::node_build_result::Reader>()?;
+        Ok(Self {
+            snapshot_path: PathBuf::from(result.get_snapshot_path()?.to_str()?),
+            log_path: PathBuf::from(result.get_log_path()?.to_str()?),
+            success: result.get_success(),
+            error_message: optional_text(result.get_error_message()?.to_str()?),
+            node_name: optional_text(result.get_node_name()?.to_str()?),
+            node_tag: optional_text(result.get_node_tag()?.to_str()?),
+        })
+    }
+
+    pub async fn request_result(
+        messenger: &MessengerHandle,
+        action_handle: &ActionGoalHandle,
+        result_timeout: Duration,
+    ) -> Result<Self> {
+        let response =
+            ActionMessenger::request_result(messenger, action_handle, result_timeout).await?;
+        Self::decode(response.payload().as_ref())
+    }
+}

--- a/crates/core-node-internal/src/encoding/node/start.rs
+++ b/crates/core-node-internal/src/encoding/node/start.rs
@@ -1,6 +1,5 @@
 //! Encoding types for the NodeStart action (streaming version with feedback).
 
-use std::path::PathBuf;
 use std::time::Duration;
 
 use capnp::message::Builder;
@@ -114,119 +113,6 @@ impl NodeStartGoal {
         )
         .await?;
         Ok(handle)
-    }
-}
-
-/// Response to the NodeStart goal request.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct NodeStartGoalResponse {
-    pub accepted: bool,
-    pub log_path: PathBuf,
-    pub rejection_reason: Option<String>,
-}
-
-impl NodeStartGoalResponse {
-    pub fn accepted(log_path: impl Into<PathBuf>) -> Self {
-        Self {
-            accepted: true,
-            log_path: log_path.into(),
-            rejection_reason: None,
-        }
-    }
-
-    pub fn rejected(reason: impl Into<String>) -> Self {
-        Self {
-            accepted: false,
-            log_path: PathBuf::new(),
-            rejection_reason: Some(reason.into()),
-        }
-    }
-
-    pub fn encode(&self) -> Result<Payload> {
-        let mut builder = Builder::new_default();
-        {
-            let mut response = builder.init_root::<node_capnp::node_start_goal_response::Builder>();
-            response.set_accepted(self.accepted);
-            response.set_log_path(self.log_path.to_string_lossy().as_ref());
-            if let Some(ref reason) = self.rejection_reason {
-                response.set_rejection_reason(reason);
-            }
-        }
-        encode_message(&builder)
-    }
-
-    pub fn decode(data: &[u8]) -> Result<Self> {
-        let reader = decode_message(data)?;
-        let response = reader.get_root::<node_capnp::node_start_goal_response::Reader>()?;
-        Ok(Self {
-            accepted: response.get_accepted(),
-            log_path: PathBuf::from(response.get_log_path()?.to_str()?),
-            rejection_reason: optional_text(response.get_rejection_reason()?.to_str()?),
-        })
-    }
-}
-
-/// Feedback message for the NodeStart action.
-/// Represents a single line of output from the start_cmd process.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct NodeStartFeedback {
-    /// The stream type: "stdout", "stderr" or "warning"
-    pub stream: String,
-    /// The line of output
-    pub line: String,
-}
-
-impl NodeStartFeedback {
-    pub fn stdout(line: impl Into<String>) -> Self {
-        Self {
-            stream: "stdout".to_string(),
-            line: line.into(),
-        }
-    }
-
-    pub fn stderr(line: impl Into<String>) -> Self {
-        Self {
-            stream: "stderr".to_string(),
-            line: line.into(),
-        }
-    }
-
-    pub fn warning(line: impl Into<String>) -> Self {
-        Self {
-            stream: "warning".to_string(),
-            line: line.into(),
-        }
-    }
-
-    pub fn is_stdout(&self) -> bool {
-        self.stream == "stdout"
-    }
-
-    pub fn is_stderr(&self) -> bool {
-        self.stream == "stderr"
-    }
-
-    pub fn is_warning(&self) -> bool {
-        self.stream == "warning"
-    }
-
-    pub fn encode(&self) -> Result<Payload> {
-        let mut builder = Builder::new_default();
-        {
-            let mut feedback = builder.init_root::<node_capnp::node_start_feedback::Builder>();
-            feedback.set_stream(&self.stream);
-            feedback.set_line(&self.line);
-        }
-        encode_message(&builder)
-    }
-
-    pub fn decode(data: &[u8]) -> Result<Self> {
-        let reader = decode_message(data)?;
-        let feedback = reader.get_root::<node_capnp::node_start_feedback::Reader>()?;
-        Ok(Self {
-            stream: feedback.get_stream()?.to_str()?.to_owned(),
-            line: feedback.get_line()?.to_str()?.to_owned(),
-        })
     }
 }
 

--- a/crates/core-node-internal/src/names.rs
+++ b/crates/core-node-internal/src/names.rs
@@ -10,6 +10,7 @@ pub const STACK_RESET: &str = "stack_reset";
 pub const STACK_LIST: &str = "stack_list";
 
 pub const NODE_ADD_ACTION: &str = "node_add";
+pub const NODE_BUILD_ACTION: &str = "node_build";
 pub const NODE_START_ACTION: &str = "node_start";
 pub const NODE_REMOVE: &str = "node_remove";
 pub const NODE_INIT: &str = "node_init";

--- a/crates/core-node-internal/src/services.rs
+++ b/crates/core-node-internal/src/services.rs
@@ -262,6 +262,15 @@ impl CoreNode {
                 self.peppy_dirs.clone(),
             )
             .await?,
+            node::listen_for_node_build(
+                &self.messenger,
+                core_node_name,
+                self.instance_id(),
+                self.node_name(),
+                Arc::clone(&self.node_stack),
+                self.peppy_dirs.clone(),
+            )
+            .await?,
             node::listen_for_node_info(
                 &self.messenger,
                 core_node_name,

--- a/crates/core-node-internal/src/services/node.rs
+++ b/crates/core-node-internal/src/services/node.rs
@@ -124,6 +124,86 @@ pub(crate) fn create_action_log_file(
     Ok((Arc::new(StdMutex::new(file)), log_path))
 }
 
+use crate::encoding::NodeActionFeedback;
+use peppylib::messaging::TopicPublisher;
+use tokio::sync::{Mutex, mpsc};
+use tokio::task::JoinHandle;
+
+/// Handle to the "currently-running goal" slot shared by `node_add` and
+/// `node_build`. Both goals treat an in-flight run as either a rejection
+/// (without `--force`) or an abort-and-replace (with `--force`).
+pub(crate) type RunningSlot = (
+    Arc<Mutex<Option<(Instant, u64)>>>,
+    Arc<Mutex<Option<JoinHandle<()>>>>,
+);
+
+/// Outcome of [`try_acquire_running_slot`]. On success the caller has
+/// transitioned the action state to `Running` and stored the `(start, timeout)`
+/// stamp; on rejection the caller should return the produced payload verbatim.
+pub(crate) enum RunningSlotOutcome {
+    Acquired,
+    Rejected { remaining_secs: u64 },
+}
+
+/// Acquires the shared running-slot guard used by `node_add` and
+/// `node_build` goal handlers. If the action is already `Running` and
+/// `force` is false, returns `Rejected { remaining_secs }` so the caller
+/// can format an action-specific rejection message. If `force` is true the
+/// previous task is aborted and the slot is taken over.
+pub(crate) async fn try_acquire_running_slot<R: super::action_loop::ActionResult>(
+    state: &Arc<Mutex<super::action_loop::ActionState<R>>>,
+    slot: &RunningSlot,
+    force: bool,
+    timeout_secs: u64,
+) -> RunningSlotOutcome {
+    use super::action_loop::ActionState;
+    let (running_since, running_task) = slot;
+    let mut state_guard = state.lock().await;
+    if matches!(*state_guard, ActionState::Running) {
+        if !force {
+            let running_guard = running_since.lock().await;
+            let remaining_secs = running_guard
+                .map(|(started_at, timeout_secs)| {
+                    std::time::Duration::from_secs(timeout_secs)
+                        .saturating_sub(started_at.elapsed())
+                        .as_secs()
+                })
+                .unwrap_or(0);
+            return RunningSlotOutcome::Rejected { remaining_secs };
+        }
+        let mut task_guard = running_task.lock().await;
+        if let Some(handle) = task_guard.take() {
+            handle.abort();
+        }
+    }
+    *state_guard = ActionState::Running;
+    *running_since.lock().await = Some((Instant::now(), timeout_secs));
+    RunningSlotOutcome::Acquired
+}
+
+/// Spawns a task that reads [`FeedbackLine`] values from the returned
+/// sender and publishes them as [`NodeActionFeedback`] on the given topic.
+/// Drop the sender to signal completion, then `.await` the join handle to
+/// drain remaining messages.
+pub(crate) fn spawn_node_feedback_consumer(
+    feedback_publisher: TopicPublisher,
+) -> (mpsc::UnboundedSender<FeedbackLine>, JoinHandle<()>) {
+    let (feedback_tx, mut feedback_rx) = mpsc::unbounded_channel::<FeedbackLine>();
+    let handle = tokio::spawn(async move {
+        while let Some(line) = feedback_rx.recv().await {
+            let feedback = match line.stream {
+                FeedbackStream::Stdout => NodeActionFeedback::stdout(&line.line),
+                FeedbackStream::Stderr => NodeActionFeedback::stderr(&line.line),
+                FeedbackStream::Warning => NodeActionFeedback::warning(&line.line),
+            };
+            if let Ok(payload) = feedback.encode() {
+                let _ = feedback_publisher.publish(payload).await;
+            }
+        }
+    });
+    (feedback_tx, handle)
+}
+
 static SCCACHE_AVAILABLE: OnceLock<bool> = OnceLock::new();
 
 /// Checks whether `sccache` is available on the system PATH.

--- a/crates/core-node-internal/src/services/node.rs
+++ b/crates/core-node-internal/src/services/node.rs
@@ -1,6 +1,7 @@
 mod add;
 mod info;
 mod init;
+mod node_build;
 mod remove;
 mod start;
 mod stop;
@@ -18,6 +19,9 @@ use config::node::{NodeConfig, NodeConfigParser, ParsedNodeConfig, PeppygenLangu
 use git2::{Repository, build::CheckoutBuilder, build::RepoBuilder};
 pub use info::listen_for_node_info;
 pub use init::listen_for_node_init;
+pub use node_build::listen_for_node_build;
+#[allow(unused_imports)]
+pub(crate) use node_build::{NodeBuildActionContext, run_node_build};
 use parking_lot::Mutex as StdMutex;
 use rand::RngExt;
 pub use remove::listen_for_node_remove;

--- a/crates/core-node-internal/src/services/node/add.rs
+++ b/crates/core-node-internal/src/services/node/add.rs
@@ -18,7 +18,7 @@ use config::consts::{NODE_CONFIG_FILE, PEPPY_OUTPUT_DIR, PEPPYGEN_OUTPUT_PATH, P
 use config::node::{DEFAULT_VARIANT_NAME, NodeConfig, NodeConfigParser, ParsedNodeConfig};
 use futures::FutureExt;
 use git2::build::RepoBuilder;
-use node_stack::{BuildContext, InstanceState, NodeStack, validate_dependency_specs};
+use node_stack::{InstanceState, NodeStack, validate_dependency_specs};
 use parking_lot::Mutex as StdMutex;
 use peppylib::messaging::{ServiceRequestContext, TopicPublisher};
 use peppylib::types::Payload;
@@ -1509,7 +1509,7 @@ async fn process_node_add(
             }
         };
     // RAII guard: cleans up the temp working dir on any exit path.
-    let working_dir_cleanup = CleanupDir::new(Some(working_dir.clone()));
+    let mut working_dir_cleanup = CleanupDir::new(Some(working_dir.clone()));
 
     // For variant adds (including auto-resolved default variants), write the
     // merged config (root manifest + interfaces + variant execution) into the
@@ -1628,33 +1628,24 @@ async fn process_node_add(
 
     // Push the node config into the stack as an `Added` entity. The
     // config_path is the source `peppy.json5` (the user-owned location);
-    // the entity will move to `Built` once NodeEntity::build runs.
+    // the entity will be advanced to `Building`/`Ready` by the separate
+    // `node_build` daemon goal, which consumes the pending build input we
+    // stash on the entity below.
     //
-    // `push_config` returns the previous entity snapshot (if any) captured
-    // under the same write lock that performed the in-place replacement,
-    // which we use below for both rollback on build failure and cleanup of
-    // the prior artifact on success.
+    // The previous entity (if any) is replaced in-place by `push_config`.
+    // `node_add` no longer owns build-failure rollback — that responsibility
+    // moved to `node_build` along with the build phase itself.
     let config_path_for_stack = source_path.join(NODE_CONFIG_FILE);
-    let previous_entity_snapshot = match ctx.action.node_stack.push_config_capturing_previous(
+    if let Err(e) = ctx.action.node_stack.push_config_capturing_previous(
         node_config.clone(),
         false,
         &config_path_for_stack,
     ) {
-        Ok(snapshot) => snapshot,
-        Err(e) => {
-            let msg = format!("Failed to add node config: {}", e);
-            write_error_to_log(&ctx.log_file, &msg);
-            return NodeAddResult::failure(&ctx.log_path, msg);
-        }
-    };
-    let previous_snapshot_path = previous_entity_snapshot
-        .as_ref()
-        .and_then(|snap| snap.artifact_path.clone());
+        let msg = format!("Failed to add node config: {}", e);
+        write_error_to_log(&ctx.log_file, &msg);
+        return NodeAddResult::failure(&ctx.log_path, msg);
+    }
 
-    // Drive the build via the entity itself. This either runs apptainer
-    // (container nodes) or archives `working_dir` (process nodes), and
-    // transitions the entity from `Added` to `Built` with the resulting
-    // `.sif`/archive path on success.
     let entity_handle = match ctx.action.node_stack.find(&node_name, &node_tag) {
         Some(handle) => handle,
         None => {
@@ -1667,95 +1658,27 @@ async fn process_node_add(
         }
     };
 
-    // Record the add log path on the entity so `peppy node info` can surface
-    // it. Done under the same write lock that any concurrent reader uses, so
-    // observers see a consistent (entity, log path) pair.
-    entity_handle
-        .write()
-        .set_last_add_log_path(ctx.log_path.clone());
-
-    // Capture the entity generation *before* the build runs so the
-    // failure-path cleanup below removes only the entity that we actually
-    // attempted to build. Reading the generation after `build()` returns
-    // would race with a concurrent `push_config` that replaced the entity
-    // in-place between our failure and the cleanup, causing us to clobber
-    // the new entity.
-    let expected_generation_before_build = entity_handle.read().generation();
-
-    let build_result = node_stack::NodeEntity::build(
-        &entity_handle,
-        BuildContext {
-            working_dir: &working_dir,
-            peppy_dirs: &ctx.action.peppy_dirs,
-            feedback_tx: &ctx.feedback_tx,
-            log_file: Arc::clone(&ctx.log_file),
-            env_vars: &env_vars,
-        },
-    )
-    .await;
-
-    let snapshot_path = match build_result {
-        Ok(path) => path,
-        Err(e) => {
-            // `NodeEntity::build` leaves the entity in `Building` on failure;
-            // the caller owns rollback. See the failure contract on
-            // `NodeEntity::build`.
-            //
-            // If there was a previously-ready entity in this slot, restore it
-            // from the snapshot we captured before `push_config` replaced it.
-            // Otherwise (fresh add), remove the entity entirely. Both code
-            // paths use the pre-build handle+generation so a concurrent
-            // `push_config` that replaced the entity in-place between our
-            // failure and this cleanup is not silently clobbered.
-            if let Some(snapshot) = previous_entity_snapshot {
-                let _ = ctx.action.node_stack.restore_snapshot_if_matches(
-                    node_stack::RestoreTarget {
-                        name: &node_name,
-                        tag: &node_tag,
-                        expected_handle: &entity_handle,
-                        expected_generation: expected_generation_before_build,
-                    },
-                    snapshot,
-                );
-            } else {
-                let _ = ctx.action.node_stack.remove_config_if_matches(
-                    &node_name,
-                    &node_tag,
-                    &entity_handle,
-                    expected_generation_before_build,
-                );
-            }
-            let msg = format!("Failed to build node: {}", e);
-            write_error_to_log(&ctx.log_file, &msg);
-            return NodeAddResult::failure(&ctx.log_path, msg);
-        }
-    };
-
-    // Working dir is no longer needed; clean it up immediately.
-    drop(working_dir_cleanup);
-
-    // Clean up previous snapshot if it differs from the new one.
-    if let Some(previous_snapshot_path) = previous_snapshot_path
-        && previous_snapshot_path != snapshot_path
+    // Stash the working dir + env vars on the entity for the build goal to
+    // consume, and record the add log path on the entity so `peppy node info`
+    // can surface it. All under the same write lock so observers see a
+    // consistent state.
     {
-        let storage_dir = ctx.action.peppy_dirs.added_nodes_dir();
-        if previous_snapshot_path.starts_with(&storage_dir) {
-            if previous_snapshot_path.is_dir() {
-                std::fs::remove_dir_all(&previous_snapshot_path).ok();
-            } else {
-                std::fs::remove_file(&previous_snapshot_path).ok();
-            }
-        }
+        let mut guard = entity_handle.write();
+        guard.set_last_add_log_path(ctx.log_path.clone());
+        guard.set_pending_build_input(node_stack::PendingBuildInput {
+            working_dir: working_dir.clone(),
+            env_vars: env_vars.clone(),
+        });
     }
 
-    debug!(
-        "Added node {}:{} at {}",
-        node_name,
-        node_tag,
-        snapshot_path.display()
-    );
+    // The temp working_dir is now owned by the entity (via pending_build_input).
+    // Suppress the RAII guard so cleanup happens via the build path or via
+    // node_stack on entity removal/overwrite — not when this function returns.
+    let _ = working_dir_cleanup.take();
 
-    NodeAddResult::success(snapshot_path, &ctx.log_path, node_name, node_tag)
+    debug!("Added node {}:{} (pending build)", node_name, node_tag);
+
+    NodeAddResult::success(&ctx.log_path, node_name, node_tag)
 }
 
 #[cfg(test)]

--- a/crates/core-node-internal/src/services/node/add.rs
+++ b/crates/core-node-internal/src/services/node/add.rs
@@ -9,9 +9,7 @@ use super::{
     sanitize_repo_path, write_error_to_log,
 };
 use crate::Result;
-use crate::encoding::{
-    NodeAddFeedback, NodeAddGoal, NodeAddGoalResponse, NodeAddResult, NodeSource,
-};
+use crate::encoding::{NodeActionGoalResponse, NodeAddGoal, NodeAddResult, NodeSource};
 use crate::names;
 use chrono::Local;
 use config::consts::{NODE_CONFIG_FILE, PEPPY_OUTPUT_DIR, PEPPYGEN_OUTPUT_PATH, PeppyDirs};
@@ -1016,12 +1014,12 @@ use super::variant::{resolve_variant, variant_label};
 
 /// Encodes a rejected goal response, mapping encoding errors to `PeppyError`.
 fn encode_rejected_goal(reason: impl Into<String>) -> PeppyResult<Payload> {
-    NodeAddGoalResponse::rejected(reason).encode().map_err(|e| {
-        peppylib::PeppyError::InvalidServiceRequest {
+    NodeActionGoalResponse::rejected(reason)
+        .encode()
+        .map_err(|e| peppylib::PeppyError::InvalidServiceRequest {
             identifier: "node_add_goal".to_string(),
             reason: format!("Failed to encode response: {}", e),
-        }
-    })
+        })
 }
 
 /// Runs the full node-add pipeline: resolves the source, renames the log file
@@ -1276,34 +1274,18 @@ async fn handle_goal_request(
         Err(e) => return encode_rejected_goal(format!("invalid payload: {}", e)),
     };
 
-    // Check if already running and mark as running if not
-    {
-        let mut state_guard = state.lock().await;
-        if matches!(*state_guard, ActionState::Running) {
-            if !goal.force {
-                let running_guard = running_since.lock().await;
-                let remaining = running_guard
-                    .map(|(started_at, timeout_secs)| {
-                        Duration::from_secs(timeout_secs)
-                            .saturating_sub(started_at.elapsed())
-                            .as_secs()
-                    })
-                    .unwrap_or(0);
-                return encode_rejected_goal(format!(
-                    "action already in progress (times out in {remaining}s), \
-                     use `--force` to force adding the node"
-                ));
-            }
-
-            // Force mode: abort the old task and reset state
-            debug!("Force flag set: aborting previous node_add task");
-            let mut task_guard = running_task.lock().await;
-            if let Some(handle) = task_guard.take() {
-                handle.abort();
-            }
+    let slot = (running_since.clone(), running_task.clone());
+    match super::try_acquire_running_slot(&state, &slot, goal.force, goal.timeout_secs).await {
+        super::RunningSlotOutcome::Acquired => {}
+        super::RunningSlotOutcome::Rejected { remaining_secs } => {
+            return encode_rejected_goal(format!(
+                "action already in progress (times out in {remaining_secs}s), \
+                 use `--force` to force adding the node"
+            ));
         }
-        *state_guard = ActionState::Running;
-        *running_since.lock().await = Some((Instant::now(), goal.timeout_secs));
+    }
+    if goal.force {
+        debug!("Force flag set: aborting previous node_add task");
     }
 
     match &goal.source {
@@ -1343,26 +1325,11 @@ async fn handle_goal_request(
 
     debug!("Created log file for node add: {}", log_path.display());
 
-    // Process the add operation in a separate task to not block goal response.
     let state_clone = Arc::clone(&state);
     let log_path_clone = log_path.clone();
     let task_handle = tokio::spawn(async move {
-        // Create a channel for feedback and spawn a consumer that encodes
-        // FeedbackLine values as NodeAddFeedback and publishes to the topic.
-        let (feedback_tx, mut feedback_rx) = mpsc::unbounded_channel::<FeedbackLine>();
-        let feedback_publisher_for_consumer = feedback_publisher.clone();
-        let consumer_handle = tokio::spawn(async move {
-            while let Some(line) = feedback_rx.recv().await {
-                let feedback = match line.stream {
-                    FeedbackStream::Stdout => NodeAddFeedback::stdout(&line.line),
-                    FeedbackStream::Stderr => NodeAddFeedback::stderr(&line.line),
-                    FeedbackStream::Warning => NodeAddFeedback::warning(&line.line),
-                };
-                if let Ok(payload) = feedback.encode() {
-                    let _ = feedback_publisher_for_consumer.publish(payload).await;
-                }
-            }
-        });
+        let (feedback_tx, consumer_handle) =
+            super::spawn_node_feedback_consumer(feedback_publisher);
 
         let result = run_node_add(
             goal,
@@ -1383,7 +1350,7 @@ async fn handle_goal_request(
     // Store the handle so a future --force call can abort this task.
     *running_task.lock().await = Some(task_handle);
 
-    let response = NodeAddGoalResponse::accepted(&log_path);
+    let response = NodeActionGoalResponse::accepted(&log_path);
     response
         .encode()
         .map_err(|e| peppylib::PeppyError::InvalidServiceRequest {
@@ -1627,14 +1594,9 @@ async fn process_node_add(
     }
 
     // Push the node config into the stack as an `Added` entity. The
-    // config_path is the source `peppy.json5` (the user-owned location);
-    // the entity will be advanced to `Building`/`Ready` by the separate
-    // `node_build` daemon goal, which consumes the pending build input we
-    // stash on the entity below.
-    //
-    // The previous entity (if any) is replaced in-place by `push_config`.
-    // `node_add` no longer owns build-failure rollback — that responsibility
-    // moved to `node_build` along with the build phase itself.
+    // config_path is the source `peppy.json5` (the user-owned location).
+    // The `node_build` goal consumes the pending build input we stash
+    // on the entity below.
     let config_path_for_stack = source_path.join(NODE_CONFIG_FILE);
     if let Err(e) = ctx.action.node_stack.push_config_capturing_previous(
         node_config.clone(),
@@ -1662,19 +1624,30 @@ async fn process_node_add(
     // consume, and record the add log path on the entity so `peppy node info`
     // can surface it. All under the same write lock so observers see a
     // consistent state.
+    //
+    // Ownership of `working_dir` transfers to the entity here; suppress the
+    // RAII guard so cleanup happens via the build path or via node_stack on
+    // entity removal/overwrite.
+    let owned_working_dir = working_dir_cleanup
+        .take()
+        .unwrap_or_else(|| working_dir.clone());
     {
         let mut guard = entity_handle.write();
         guard.set_last_add_log_path(ctx.log_path.clone());
-        guard.set_pending_build_input(node_stack::PendingBuildInput {
-            working_dir: working_dir.clone(),
-            env_vars: env_vars.clone(),
-        });
+        if let Err(stage) = guard.set_pending_build_input(node_stack::PendingBuildInput {
+            working_dir: Arc::new(node_stack::WorkingDir::new(owned_working_dir)),
+            env_vars,
+        }) {
+            // Would happen only if `push_config` above somehow landed the
+            // entity in a non-`Added` stage — which the stack API forbids.
+            let msg = format!(
+                "internal error: just-pushed entity {}:{} is in stage {stage} instead of Added",
+                node_name, node_tag
+            );
+            write_error_to_log(&ctx.log_file, &msg);
+            return NodeAddResult::failure(&ctx.log_path, msg);
+        }
     }
-
-    // The temp working_dir is now owned by the entity (via pending_build_input).
-    // Suppress the RAII guard so cleanup happens via the build path or via
-    // node_stack on entity removal/overwrite — not when this function returns.
-    let _ = working_dir_cleanup.take();
 
     debug!("Added node {}:{} (pending build)", node_name, node_tag);
 

--- a/crates/core-node-internal/src/services/node/node_build.rs
+++ b/crates/core-node-internal/src/services/node/node_build.rs
@@ -1,0 +1,325 @@
+use super::super::action_loop::{ActionResult, ActionState, GoalHandler, run_action_loop};
+use super::{FeedbackLine, FeedbackStream, create_action_log_file, write_error_to_log};
+use crate::Result;
+use crate::encoding::{NodeBuildFeedback, NodeBuildGoal, NodeBuildGoalResponse, NodeBuildResult};
+use crate::names;
+use chrono::Local;
+use config::consts::PeppyDirs;
+use futures::FutureExt;
+use node_stack::{BuildContext, NodeStack};
+use parking_lot::Mutex as StdMutex;
+use peppylib::messaging::{ServiceRequestContext, TopicPublisher};
+use peppylib::types::Payload;
+use peppylib::{ActionMessenger, MessengerHandle, PeppyResult};
+use std::fs::File;
+use std::panic::AssertUnwindSafe;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::{Mutex, mpsc};
+use tokio::task::JoinHandle;
+use tracing::debug;
+
+pub async fn listen_for_node_build(
+    messenger: &MessengerHandle,
+    core_node_name: &str,
+    instance_id: &str,
+    node_name: &str,
+    node_stack: Arc<NodeStack>,
+    peppy_dirs: PeppyDirs,
+) -> Result<JoinHandle<Result<()>>> {
+    let action = ActionMessenger::expose(
+        messenger,
+        core_node_name,
+        instance_id,
+        node_name,
+        names::NODE_BUILD_ACTION,
+    )
+    .await?;
+
+    let handler = NodeBuildGoalHandler {
+        context: NodeBuildActionContext {
+            node_stack,
+            peppy_dirs,
+        },
+        running_since: Arc::new(Mutex::new(None)),
+        running_task: Arc::new(Mutex::new(None)),
+    };
+
+    let handle = tokio::spawn(async move { run_action_loop(action, handler).await });
+    Ok(handle)
+}
+
+impl ActionResult for NodeBuildResult {
+    fn identifier() -> &'static str {
+        "node_build_result"
+    }
+
+    fn encode_result(&self) -> crate::Result<Payload> {
+        self.encode()
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct NodeBuildActionContext {
+    pub(crate) node_stack: Arc<NodeStack>,
+    pub(crate) peppy_dirs: PeppyDirs,
+}
+
+#[derive(Clone)]
+struct NodeBuildGoalHandler {
+    context: NodeBuildActionContext,
+    running_since: Arc<Mutex<Option<(Instant, u64)>>>,
+    running_task: Arc<Mutex<Option<JoinHandle<()>>>>,
+}
+
+impl GoalHandler for NodeBuildGoalHandler {
+    type Result = NodeBuildResult;
+
+    async fn handle_goal(
+        &self,
+        context: ServiceRequestContext,
+        feedback_publisher: TopicPublisher,
+        state: Arc<Mutex<ActionState<NodeBuildResult>>>,
+    ) -> PeppyResult<Payload> {
+        handle_goal_request(
+            context,
+            feedback_publisher,
+            state,
+            self.context.clone(),
+            Arc::clone(&self.running_since),
+            Arc::clone(&self.running_task),
+        )
+        .await
+    }
+}
+
+fn encode_rejected_goal(reason: impl Into<String>) -> PeppyResult<Payload> {
+    NodeBuildGoalResponse::rejected(reason)
+        .encode()
+        .map_err(|e| peppylib::PeppyError::InvalidServiceRequest {
+            identifier: "node_build_goal".to_string(),
+            reason: format!("Failed to encode response: {}", e),
+        })
+}
+
+async fn handle_goal_request(
+    context: ServiceRequestContext,
+    feedback_publisher: TopicPublisher,
+    state: Arc<Mutex<ActionState<NodeBuildResult>>>,
+    action_context: NodeBuildActionContext,
+    running_since: Arc<Mutex<Option<(Instant, u64)>>>,
+    running_task: Arc<Mutex<Option<JoinHandle<()>>>>,
+) -> PeppyResult<Payload> {
+    let sender_instance_id = context.message().instance_id();
+    let payload = context.message().payload();
+
+    let goal = match NodeBuildGoal::decode(payload.as_ref()) {
+        Ok(g) => g,
+        Err(e) => return encode_rejected_goal(format!("invalid payload: {}", e)),
+    };
+
+    {
+        let mut state_guard = state.lock().await;
+        if matches!(*state_guard, ActionState::Running) {
+            if !goal.force {
+                let running_guard = running_since.lock().await;
+                let remaining = running_guard
+                    .map(|(started_at, timeout_secs)| {
+                        Duration::from_secs(timeout_secs)
+                            .saturating_sub(started_at.elapsed())
+                            .as_secs()
+                    })
+                    .unwrap_or(0);
+                return encode_rejected_goal(format!(
+                    "action already in progress (times out in {remaining}s), \
+                     use `--force` to force building the node"
+                ));
+            }
+
+            debug!("Force flag set: aborting previous node_build task");
+            let mut task_guard = running_task.lock().await;
+            if let Some(handle) = task_guard.take() {
+                handle.abort();
+            }
+        }
+        *state_guard = ActionState::Running;
+        *running_since.lock().await = Some((Instant::now(), goal.timeout_secs));
+    }
+
+    debug!(
+        "Received `node_build` goal from {sender_instance_id}, {}:{}",
+        goal.node_name, goal.node_tag
+    );
+
+    // Create the log file before spawning the build task so the goal
+    // response can include its path.
+    let log_dir = action_context.peppy_dirs.logs_dir_build();
+    let timestamp = Local::now().format("%Y%m%d_%H%M%S_%3f").to_string();
+    let log_filename = format!("{}_{}_{}.log", goal.node_name, goal.node_tag, timestamp);
+    let (log_file, log_path) = match create_action_log_file(&log_dir, &log_filename) {
+        Ok(result) => result,
+        Err(error_msg) => {
+            debug!("{}", error_msg);
+            let mut state_guard = state.lock().await;
+            *state_guard = ActionState::Rejected;
+            return encode_rejected_goal(error_msg);
+        }
+    };
+
+    debug!("Created log file for node build: {}", log_path.display());
+
+    let state_clone = Arc::clone(&state);
+    let log_path_clone = log_path.clone();
+    let task_handle = tokio::spawn(async move {
+        let (feedback_tx, mut feedback_rx) = mpsc::unbounded_channel::<FeedbackLine>();
+        let feedback_publisher_for_consumer = feedback_publisher.clone();
+        let consumer_handle = tokio::spawn(async move {
+            while let Some(line) = feedback_rx.recv().await {
+                let feedback = match line.stream {
+                    FeedbackStream::Stdout => NodeBuildFeedback::stdout(&line.line),
+                    FeedbackStream::Stderr => NodeBuildFeedback::stderr(&line.line),
+                    FeedbackStream::Warning => NodeBuildFeedback::warning(&line.line),
+                };
+                if let Ok(payload) = feedback.encode() {
+                    let _ = feedback_publisher_for_consumer.publish(payload).await;
+                }
+            }
+        });
+
+        let result =
+            run_node_build(goal, action_context, feedback_tx, log_file, log_path_clone).await;
+
+        let _ = consumer_handle.await;
+        let mut state_guard = state_clone.lock().await;
+        *state_guard = ActionState::Completed { result };
+    });
+
+    *running_task.lock().await = Some(task_handle);
+
+    let response = NodeBuildGoalResponse::accepted(&log_path);
+    response
+        .encode()
+        .map_err(|e| peppylib::PeppyError::InvalidServiceRequest {
+            identifier: "node_build_goal".to_string(),
+            reason: format!("Failed to encode response: {}", e),
+        })
+}
+
+/// Drives the build for an already-`Added` entity. Looks up the entity,
+/// takes the pending build input stashed by `node_add`, and runs
+/// [`NodeEntity::build`]. On any failure the entity is removed from the
+/// stack so the user can re-run `peppy node add` cleanly.
+pub(crate) async fn run_node_build(
+    goal: NodeBuildGoal,
+    action_context: NodeBuildActionContext,
+    feedback_tx: mpsc::UnboundedSender<FeedbackLine>,
+    log_file: Arc<StdMutex<File>>,
+    log_path: PathBuf,
+) -> NodeBuildResult {
+    let log_file_for_panic = log_file.clone();
+    let log_path_for_panic = log_path.clone();
+
+    match AssertUnwindSafe(async {
+        let entity_handle = match action_context
+            .node_stack
+            .find(&goal.node_name, &goal.node_tag)
+        {
+            Some(handle) => handle,
+            None => {
+                let msg = format!(
+                    "node {}:{} is not in the node stack — run `peppy node add` first",
+                    goal.node_name, goal.node_tag
+                );
+                write_error_to_log(&log_file, &msg);
+                return NodeBuildResult::failure(&log_path, msg);
+            }
+        };
+
+        // Take the pending build input under a write lock and record the
+        // build log path on the entity. If there is no pending input, the
+        // entity is not in a state where we can build it (already built, or
+        // never received an add).
+        let pending_input = {
+            let mut guard = entity_handle.write();
+            guard.set_last_add_log_path(log_path.clone());
+            match guard.take_pending_build_input() {
+                Some(input) => input,
+                None => {
+                    let msg = format!(
+                        "node {}:{} has no pending build input — current stage is {}",
+                        goal.node_name,
+                        goal.node_tag,
+                        guard.stage().name()
+                    );
+                    write_error_to_log(&log_file, &msg);
+                    return NodeBuildResult::failure(&log_path, msg);
+                }
+            }
+        };
+
+        // Capture the entity generation before the build runs so the
+        // failure-path cleanup only removes the entity we actually built.
+        let expected_generation = entity_handle.read().generation();
+
+        let build_result = node_stack::NodeEntity::build(
+            &entity_handle,
+            BuildContext {
+                working_dir: &pending_input.working_dir,
+                peppy_dirs: &action_context.peppy_dirs,
+                feedback_tx: &feedback_tx,
+                log_file: Arc::clone(&log_file),
+                env_vars: &pending_input.env_vars,
+            },
+        )
+        .await;
+
+        let snapshot_path = match build_result {
+            Ok(path) => path,
+            Err(e) => {
+                // `NodeEntity::build` leaves the entity in `Building` on
+                // failure. Remove it so the user can re-run `peppy node add`
+                // cleanly. The pointer + generation check guards against a
+                // concurrent `push_config` racing in between.
+                let _ = action_context.node_stack.remove_config_if_matches(
+                    &goal.node_name,
+                    &goal.node_tag,
+                    &entity_handle,
+                    expected_generation,
+                );
+                // Best-effort cleanup of the working dir, since the entity
+                // is gone and the failed build never moved the artifact.
+                let _ = std::fs::remove_dir_all(&pending_input.working_dir);
+                let msg = format!("Failed to build node: {}", e);
+                write_error_to_log(&log_file, &msg);
+                return NodeBuildResult::failure(&log_path, msg);
+            }
+        };
+
+        // Working dir is no longer needed; remove it.
+        let _ = std::fs::remove_dir_all(&pending_input.working_dir);
+
+        debug!(
+            "Built node {}:{} at {}",
+            goal.node_name,
+            goal.node_tag,
+            snapshot_path.display()
+        );
+
+        NodeBuildResult::success(snapshot_path, &log_path, goal.node_name, goal.node_tag)
+    })
+    .catch_unwind()
+    .await
+    {
+        Ok(result) => result,
+        Err(panic_payload) => {
+            let msg = format!(
+                "node_build task panicked: {}",
+                super::panic_message(&*panic_payload)
+            );
+            tracing::error!("{}", msg);
+            write_error_to_log(&log_file_for_panic, &msg);
+            NodeBuildResult::failure(log_path_for_panic, msg)
+        }
+    }
+}

--- a/crates/core-node-internal/src/services/node/node_build.rs
+++ b/crates/core-node-internal/src/services/node/node_build.rs
@@ -1,21 +1,21 @@
 use super::super::action_loop::{ActionResult, ActionState, GoalHandler, run_action_loop};
-use super::{FeedbackLine, FeedbackStream, create_action_log_file, write_error_to_log};
+use super::{create_action_log_file, write_error_to_log};
 use crate::Result;
-use crate::encoding::{NodeBuildFeedback, NodeBuildGoal, NodeBuildGoalResponse, NodeBuildResult};
+use crate::encoding::{NodeActionGoalResponse, NodeBuildGoal, NodeBuildResult};
 use crate::names;
 use chrono::Local;
 use config::consts::PeppyDirs;
 use futures::FutureExt;
-use node_stack::{BuildContext, NodeStack};
+use node_stack::{BuildContext, FeedbackLine, NodeStack};
 use parking_lot::Mutex as StdMutex;
 use peppylib::messaging::{ServiceRequestContext, TopicPublisher};
 use peppylib::types::Payload;
 use peppylib::{ActionMessenger, MessengerHandle, PeppyResult};
 use std::fs::File;
 use std::panic::AssertUnwindSafe;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 use tokio::sync::{Mutex, mpsc};
 use tokio::task::JoinHandle;
 use tracing::debug;
@@ -95,7 +95,7 @@ impl GoalHandler for NodeBuildGoalHandler {
 }
 
 fn encode_rejected_goal(reason: impl Into<String>) -> PeppyResult<Payload> {
-    NodeBuildGoalResponse::rejected(reason)
+    NodeActionGoalResponse::rejected(reason)
         .encode()
         .map_err(|e| peppylib::PeppyError::InvalidServiceRequest {
             identifier: "node_build_goal".to_string(),
@@ -119,32 +119,18 @@ async fn handle_goal_request(
         Err(e) => return encode_rejected_goal(format!("invalid payload: {}", e)),
     };
 
-    {
-        let mut state_guard = state.lock().await;
-        if matches!(*state_guard, ActionState::Running) {
-            if !goal.force {
-                let running_guard = running_since.lock().await;
-                let remaining = running_guard
-                    .map(|(started_at, timeout_secs)| {
-                        Duration::from_secs(timeout_secs)
-                            .saturating_sub(started_at.elapsed())
-                            .as_secs()
-                    })
-                    .unwrap_or(0);
-                return encode_rejected_goal(format!(
-                    "action already in progress (times out in {remaining}s), \
-                     use `--force` to force building the node"
-                ));
-            }
-
-            debug!("Force flag set: aborting previous node_build task");
-            let mut task_guard = running_task.lock().await;
-            if let Some(handle) = task_guard.take() {
-                handle.abort();
-            }
+    let slot = (running_since.clone(), running_task.clone());
+    match super::try_acquire_running_slot(&state, &slot, goal.force, goal.timeout_secs).await {
+        super::RunningSlotOutcome::Acquired => {}
+        super::RunningSlotOutcome::Rejected { remaining_secs } => {
+            return encode_rejected_goal(format!(
+                "action already in progress (times out in {remaining_secs}s), \
+                 use `--force` to force building the node"
+            ));
         }
-        *state_guard = ActionState::Running;
-        *running_since.lock().await = Some((Instant::now(), goal.timeout_secs));
+    }
+    if goal.force {
+        debug!("Force flag set: aborting previous node_build task");
     }
 
     debug!(
@@ -172,20 +158,8 @@ async fn handle_goal_request(
     let state_clone = Arc::clone(&state);
     let log_path_clone = log_path.clone();
     let task_handle = tokio::spawn(async move {
-        let (feedback_tx, mut feedback_rx) = mpsc::unbounded_channel::<FeedbackLine>();
-        let feedback_publisher_for_consumer = feedback_publisher.clone();
-        let consumer_handle = tokio::spawn(async move {
-            while let Some(line) = feedback_rx.recv().await {
-                let feedback = match line.stream {
-                    FeedbackStream::Stdout => NodeBuildFeedback::stdout(&line.line),
-                    FeedbackStream::Stderr => NodeBuildFeedback::stderr(&line.line),
-                    FeedbackStream::Warning => NodeBuildFeedback::warning(&line.line),
-                };
-                if let Ok(payload) = feedback.encode() {
-                    let _ = feedback_publisher_for_consumer.publish(payload).await;
-                }
-            }
-        });
+        let (feedback_tx, consumer_handle) =
+            super::spawn_node_feedback_consumer(feedback_publisher);
 
         let result =
             run_node_build(goal, action_context, feedback_tx, log_file, log_path_clone).await;
@@ -197,7 +171,7 @@ async fn handle_goal_request(
 
     *running_task.lock().await = Some(task_handle);
 
-    let response = NodeBuildGoalResponse::accepted(&log_path);
+    let response = NodeActionGoalResponse::accepted(&log_path);
     response
         .encode()
         .map_err(|e| peppylib::PeppyError::InvalidServiceRequest {
@@ -220,98 +194,27 @@ pub(crate) async fn run_node_build(
     let log_file_for_panic = log_file.clone();
     let log_path_for_panic = log_path.clone();
 
-    match AssertUnwindSafe(async {
-        let entity_handle = match action_context
-            .node_stack
-            .find(&goal.node_name, &goal.node_tag)
-        {
-            Some(handle) => handle,
-            None => {
-                let msg = format!(
-                    "node {}:{} is not in the node stack — run `peppy node add` first",
-                    goal.node_name, goal.node_tag
-                );
-                write_error_to_log(&log_file, &msg);
-                return NodeBuildResult::failure(&log_path, msg);
-            }
-        };
-
-        // Take the pending build input under a write lock and record the
-        // build log path on the entity. If there is no pending input, the
-        // entity is not in a state where we can build it (already built, or
-        // never received an add).
-        let pending_input = {
-            let mut guard = entity_handle.write();
-            guard.set_last_add_log_path(log_path.clone());
-            match guard.take_pending_build_input() {
-                Some(input) => input,
-                None => {
-                    let msg = format!(
-                        "node {}:{} has no pending build input — current stage is {}",
-                        goal.node_name,
-                        goal.node_tag,
-                        guard.stage().name()
-                    );
-                    write_error_to_log(&log_file, &msg);
-                    return NodeBuildResult::failure(&log_path, msg);
-                }
-            }
-        };
-
-        // Capture the entity generation before the build runs so the
-        // failure-path cleanup only removes the entity we actually built.
-        let expected_generation = entity_handle.read().generation();
-
-        let build_result = node_stack::NodeEntity::build(
-            &entity_handle,
-            BuildContext {
-                working_dir: &pending_input.working_dir,
-                peppy_dirs: &action_context.peppy_dirs,
-                feedback_tx: &feedback_tx,
-                log_file: Arc::clone(&log_file),
-                env_vars: &pending_input.env_vars,
-            },
-        )
-        .await;
-
-        let snapshot_path = match build_result {
-            Ok(path) => path,
-            Err(e) => {
-                // `NodeEntity::build` leaves the entity in `Building` on
-                // failure. Remove it so the user can re-run `peppy node add`
-                // cleanly. The pointer + generation check guards against a
-                // concurrent `push_config` racing in between.
-                let _ = action_context.node_stack.remove_config_if_matches(
-                    &goal.node_name,
-                    &goal.node_tag,
-                    &entity_handle,
-                    expected_generation,
-                );
-                // Best-effort cleanup of the working dir, since the entity
-                // is gone and the failed build never moved the artifact.
-                let _ = std::fs::remove_dir_all(&pending_input.working_dir);
-                let msg = format!("Failed to build node: {}", e);
-                write_error_to_log(&log_file, &msg);
-                return NodeBuildResult::failure(&log_path, msg);
-            }
-        };
-
-        // Working dir is no longer needed; remove it.
-        let _ = std::fs::remove_dir_all(&pending_input.working_dir);
-
-        debug!(
-            "Built node {}:{} at {}",
-            goal.node_name,
-            goal.node_tag,
-            snapshot_path.display()
-        );
-
-        NodeBuildResult::success(snapshot_path, &log_path, goal.node_name, goal.node_tag)
-    })
-    .catch_unwind()
-    .await
-    {
-        Ok(result) => result,
+    let fut = AssertUnwindSafe(try_run_build(
+        &goal,
+        &action_context,
+        &feedback_tx,
+        &log_file,
+        &log_path,
+    ));
+    match fut.catch_unwind().await {
+        Ok(Ok(snapshot_path)) => {
+            debug!(
+                "Built node {}:{} at {}",
+                goal.node_name,
+                goal.node_tag,
+                snapshot_path.display()
+            );
+            NodeBuildResult::success(snapshot_path, &log_path)
+        }
+        Ok(Err(msg)) => {
+            write_error_to_log(&log_file, &msg);
+            NodeBuildResult::failure(&log_path, msg)
+        }
         Err(panic_payload) => {
             let msg = format!(
                 "node_build task panicked: {}",
@@ -322,4 +225,71 @@ pub(crate) async fn run_node_build(
             NodeBuildResult::failure(log_path_for_panic, msg)
         }
     }
+}
+
+async fn try_run_build(
+    goal: &NodeBuildGoal,
+    action_context: &NodeBuildActionContext,
+    feedback_tx: &mpsc::UnboundedSender<FeedbackLine>,
+    log_file: &Arc<StdMutex<File>>,
+    log_path: &Path,
+) -> std::result::Result<PathBuf, String> {
+    let entity_handle = action_context
+        .node_stack
+        .find(&goal.node_name, &goal.node_tag)
+        .ok_or_else(|| {
+            format!(
+                "node {}:{} is not in the node stack — run `peppy node add` first",
+                goal.node_name, goal.node_tag
+            )
+        })?;
+
+    // Take the pending build input under a write lock. If there is no
+    // pending input, the entity is not in a state where we can build it —
+    // bail without mutating `last_add_log_path` so a rejected build doesn't
+    // overwrite the previous successful add's recorded log.
+    let pending_input = {
+        let mut guard = entity_handle.write();
+        let Some(input) = guard.take_pending_build_input() else {
+            return Err(format!(
+                "node {}:{} has no pending build input — current stage is {}",
+                goal.node_name,
+                goal.node_tag,
+                guard.stage().name()
+            ));
+        };
+        guard.set_last_add_log_path(log_path.to_path_buf());
+        input
+    };
+
+    // Capture the entity generation before the build runs so the
+    // failure-path cleanup only removes the entity we actually built.
+    let expected_generation = entity_handle.read().generation();
+
+    let build_result = node_stack::NodeEntity::build(
+        &entity_handle,
+        BuildContext {
+            working_dir: pending_input.working_dir.path(),
+            peppy_dirs: &action_context.peppy_dirs,
+            feedback_tx,
+            log_file: Arc::clone(log_file),
+            env_vars: &pending_input.env_vars,
+        },
+    )
+    .await;
+
+    // `pending_input` drops at end of this scope; its `WorkingDir` RAII
+    // handle removes the temp dir automatically.
+
+    build_result.map_err(|e| {
+        // `NodeEntity::build` leaves the entity in `Building` on failure.
+        // Remove it so the user can re-run `peppy node add` cleanly.
+        let _ = action_context.node_stack.remove_config_if_matches(
+            &goal.node_name,
+            &goal.node_tag,
+            &entity_handle,
+            expected_generation,
+        );
+        format!("Failed to build node: {}", e)
+    })
 }

--- a/crates/core-node-internal/src/services/node/start.rs
+++ b/crates/core-node-internal/src/services/node/start.rs
@@ -1,7 +1,7 @@
 use super::super::action_loop::{ActionResult, ActionState, GoalHandler, run_action_loop};
 use super::{FeedbackLine, FeedbackStream, create_action_log_file, write_error_to_log};
 use crate::Result;
-use crate::encoding::{NodeStartFeedback, NodeStartGoal, NodeStartGoalResponse, NodeStartResult};
+use crate::encoding::{NodeActionFeedback, NodeActionGoalResponse, NodeStartGoal, NodeStartResult};
 use crate::names;
 use config::consts::PeppyDirs;
 use config::node::Name;
@@ -365,7 +365,7 @@ async fn handle_goal_request(
     let goal = match NodeStartGoal::decode(payload.as_ref()) {
         Ok(goal) => goal,
         Err(e) => {
-            let response = NodeStartGoalResponse::rejected(format!("invalid payload: {}", e));
+            let response = NodeActionGoalResponse::rejected(format!("invalid payload: {}", e));
             return response
                 .encode()
                 .map_err(|e| peppylib::PeppyError::InvalidServiceRequest {
@@ -386,7 +386,7 @@ async fn handle_goal_request(
                         .as_secs()
                 })
                 .unwrap_or(0);
-            let response = NodeStartGoalResponse::rejected(format!(
+            let response = NodeActionGoalResponse::rejected(format!(
                 "action already in progress (times out in {remaining}s)"
             ));
             return response
@@ -407,7 +407,7 @@ async fn handle_goal_request(
             let error_msg = format!("Failed to parse PEPPY_RUNTIME_CONFIG: {}", e);
             let mut state_guard = state.lock().await;
             *state_guard = ActionState::Rejected;
-            let response = NodeStartGoalResponse::rejected(&error_msg);
+            let response = NodeActionGoalResponse::rejected(&error_msg);
             return response
                 .encode()
                 .map_err(|e| peppylib::PeppyError::InvalidServiceRequest {
@@ -436,7 +436,7 @@ async fn handle_goal_request(
             debug!("{}", error_msg);
             let mut state_guard = state.lock().await;
             *state_guard = ActionState::Rejected;
-            let response = NodeStartGoalResponse::rejected(&error_msg);
+            let response = NodeActionGoalResponse::rejected(&error_msg);
             return response
                 .encode()
                 .map_err(|e| peppylib::PeppyError::InvalidServiceRequest {
@@ -454,15 +454,15 @@ async fn handle_goal_request(
     let state_clone = Arc::clone(&state);
     tokio::spawn(async move {
         // Create a channel for feedback and spawn a consumer that encodes
-        // FeedbackLine values as NodeStartFeedback and publishes to the topic.
+        // FeedbackLine values as NodeActionFeedback and publishes to the topic.
         let (feedback_tx, mut feedback_rx) = mpsc::unbounded_channel::<FeedbackLine>();
         let feedback_publisher_for_consumer = feedback_publisher.clone();
         let _consumer_handle = tokio::spawn(async move {
             while let Some(line) = feedback_rx.recv().await {
                 let feedback = match line.stream {
-                    FeedbackStream::Stdout => NodeStartFeedback::stdout(&line.line),
-                    FeedbackStream::Stderr => NodeStartFeedback::stderr(&line.line),
-                    FeedbackStream::Warning => NodeStartFeedback::warning(&line.line),
+                    FeedbackStream::Stdout => NodeActionFeedback::stdout(&line.line),
+                    FeedbackStream::Stderr => NodeActionFeedback::stderr(&line.line),
+                    FeedbackStream::Warning => NodeActionFeedback::warning(&line.line),
                 };
                 if let Ok(payload) = feedback.encode() {
                     let _ = feedback_publisher_for_consumer.publish(payload).await;
@@ -484,7 +484,7 @@ async fn handle_goal_request(
         *state_guard = ActionState::Completed { result };
     });
 
-    let response = NodeStartGoalResponse::accepted(&log_path);
+    let response = NodeActionGoalResponse::accepted(&log_path);
     response
         .encode()
         .map_err(|e| peppylib::PeppyError::InvalidServiceRequest {

--- a/crates/core-node-internal/src/services/stack/launch.rs
+++ b/crates/core-node-internal/src/services/stack/launch.rs
@@ -394,7 +394,7 @@ async fn build_node_directly(
 
     let (feedback_tx, forwarder_handle) = spawn_feedback_forwarder(
         &ctx.feedback_publisher,
-        LaunchFeedbackStep::AddingNode,
+        LaunchFeedbackStep::BuildingNode,
         &ctx.log_file,
     );
 

--- a/crates/core-node-internal/src/services/stack/launch.rs
+++ b/crates/core-node-internal/src/services/stack/launch.rs
@@ -3,12 +3,13 @@ use crate::encoding::{
     LaunchFeedback, LaunchFeedbackStep, LaunchGoal, LaunchGoalResponse, LaunchResult, NodeAddGoal,
     NodeAddLogEntry, NodeAddResult, NodeSource, NodeStartGoal, NodeStartLogEntry, NodeStartResult,
 };
+use crate::encoding::{NodeBuildGoal, NodeBuildResult};
 use crate::names;
 use crate::services::action_loop::{ActionResult, ActionState, GoalHandler, run_action_loop};
 use crate::services::node::{
-    FeedbackLine, FeedbackStream, NodeAddActionContext, NodeStartActionContext,
-    create_action_log_file, log_label_from_source, resolve_node_config, run_node_add,
-    run_node_start, write_error_to_log,
+    FeedbackLine, FeedbackStream, NodeAddActionContext, NodeBuildActionContext,
+    NodeStartActionContext, create_action_log_file, log_label_from_source, resolve_node_config,
+    run_node_add, run_node_build, run_node_start, write_error_to_log,
 };
 use chrono::Local;
 use config::consts::{DEFAULT_MESSAGING_HOST, DEFAULT_MESSAGING_PORT, PeppyDirs};
@@ -371,6 +372,65 @@ async fn add_node_directly(
             .error_message
             .clone()
             .unwrap_or_else(|| "node_add failed".to_string());
+        (Err(err), final_log_path)
+    }
+}
+
+async fn build_node_directly(
+    ctx: &ProcessLaunchContext,
+    node_name: &str,
+    node_tag: &str,
+) -> (
+    std::result::Result<NodeBuildResult, String>,
+    Option<PathBuf>,
+) {
+    let log_dir = ctx.peppy_dirs.logs_dir_build();
+    let timestamp = Local::now().format("%Y%m%d_%H%M%S_%3f").to_string();
+    let log_filename = format!("{}_{}_{}.log", node_name, node_tag, timestamp);
+    let (log_file, log_path) = match create_action_log_file(&log_dir, &log_filename) {
+        Ok(r) => r,
+        Err(e) => return (Err(e), None),
+    };
+
+    let (feedback_tx, forwarder_handle) = spawn_feedback_forwarder(
+        &ctx.feedback_publisher,
+        LaunchFeedbackStep::AddingNode,
+        &ctx.log_file,
+    );
+
+    let action_context = NodeBuildActionContext {
+        node_stack: Arc::clone(&ctx.node_stack),
+        peppy_dirs: ctx.peppy_dirs.clone(),
+    };
+
+    let goal = NodeBuildGoal::new(node_name, node_tag, ctx.max_timeout_secs);
+    let log_file_for_timeout = log_file.clone();
+    let log_path_for_timeout = log_path.clone();
+    let max_timeout = Duration::from_secs(ctx.max_timeout_secs);
+
+    let result = match tokio::time::timeout(
+        max_timeout,
+        run_node_build(goal, action_context, feedback_tx, log_file, log_path),
+    )
+    .await
+    {
+        Ok(result) => result,
+        Err(_) => {
+            write_error_to_log(&log_file_for_timeout, "max timeout exceeded");
+            NodeBuildResult::failure(&log_path_for_timeout, "timeout: max timeout exceeded")
+        }
+    };
+
+    let _ = forwarder_handle.await;
+
+    let final_log_path = Some(result.log_path.clone());
+    if result.success {
+        (Ok(result), final_log_path)
+    } else {
+        let err = result
+            .error_message
+            .clone()
+            .unwrap_or_else(|| "node_build failed".to_string());
         (Err(err), final_log_path)
     }
 }
@@ -901,6 +961,35 @@ async fn add_nodes_to_stack(
             }
             Err(err) => {
                 let reason = format!("failed to add node {}: {}", key.label(), err);
+                return Err(restore_stack(ctx, backup_stack, reason).await);
+            }
+        }
+
+        // Now drive the build for the just-added entity. Add and build are
+        // separate daemon goals — `node_add` only registers the entity in
+        // `Added`; `node_build` advances it to `Ready`.
+        let (build_result, build_log_path) =
+            build_node_directly(ctx, &item.node_name, &item.node_tag).await;
+        let build_failed = build_result.as_ref().map(|r| !r.success).unwrap_or(true);
+        if let Some(path) = build_log_path {
+            add_log_paths.push(NodeAddLogEntry {
+                node_label: format!("{} (build)", key.label()),
+                log_path: path,
+                failed: build_failed,
+            });
+        }
+        match build_result {
+            Ok(result) => {
+                if !result.success {
+                    let inner = result
+                        .error_message
+                        .unwrap_or_else(|| "node_build failed".to_string());
+                    let reason = format!("failed to build node {}: {}", key.label(), inner);
+                    return Err(restore_stack(ctx, backup_stack, reason).await);
+                }
+            }
+            Err(err) => {
+                let reason = format!("failed to build node {}: {}", key.label(), err);
                 return Err(restore_stack(ctx, backup_stack, reason).await);
             }
         }

--- a/crates/core-node-internal/tests/common.rs
+++ b/crates/core-node-internal/tests/common.rs
@@ -5,9 +5,8 @@ use config::consts::{
 };
 use config::node::{PeppygenLanguage, QoSProfile};
 use core_node::encoding::{
-    NodeAddFeedback, NodeAddGoal, NodeAddGoalResponse, NodeAddResult, NodeBuildFeedback,
-    NodeBuildGoal, NodeBuildGoalResponse, NodeBuildResult, NodeSource, NodeStartFeedback,
-    NodeStartGoal, NodeStartGoalResponse, NodeStartResult,
+    NodeActionFeedback, NodeActionGoalResponse, NodeAddGoal, NodeAddResult, NodeBuildGoal,
+    NodeBuildResult, NodeSource, NodeStartGoal, NodeStartResult,
 };
 use core_node::names;
 use core_node::{CoreNode, CoreNodeArguments};
@@ -98,7 +97,7 @@ pub struct NodeStartTestTimeouts {
 
 /// Combined response from send_node_start_and_wait containing both goal and result responses.
 pub struct NodeStartTestResponse {
-    pub goal_response: NodeStartGoalResponse,
+    pub goal_response: NodeActionGoalResponse,
     pub result: NodeStartResult,
 }
 
@@ -173,7 +172,7 @@ async fn send_node_start_and_wait_internal(
     node_name: &str,
     tag: &str,
     timeouts: &NodeStartTestTimeouts,
-    feedback_tx: Option<UnboundedSender<NodeStartFeedback>>,
+    feedback_tx: Option<UnboundedSender<NodeActionFeedback>>,
     env_vars: Vec<(String, String)>,
 ) -> Result<NodeStartTestResponse, String> {
     let goal = NodeStartGoal::new(
@@ -209,7 +208,7 @@ async fn send_node_start_and_wait_internal(
 
     // Decode the goal response to get log_path
     let goal_response_payload = action_handle.goal_response().payload();
-    let goal_response = NodeStartGoalResponse::decode(&goal_response_payload)
+    let goal_response = NodeActionGoalResponse::decode(&goal_response_payload)
         .map_err(|e| format!("Failed to decode goal response: {}", e))?;
 
     let absolute_deadline = tokio::time::Instant::now() + timeouts.result;
@@ -231,7 +230,7 @@ async fn send_node_start_and_wait_internal(
                 Ok(Ok(msg)) => {
                     last_activity = tokio::time::Instant::now();
                     let payload = msg.payload();
-                    if let Ok(feedback) = NodeStartFeedback::decode(payload.as_ref())
+                    if let Ok(feedback) = NodeActionFeedback::decode(payload.as_ref())
                         && let Some(tx) = feedback_tx
                     {
                         let _ = tx.send(feedback);
@@ -263,7 +262,7 @@ async fn send_node_start_and_wait_internal(
                                 break;
                             };
                             let payload = msg.payload();
-                            if let Ok(feedback) = NodeStartFeedback::decode(payload.as_ref())
+                            if let Ok(feedback) = NodeActionFeedback::decode(payload.as_ref())
                                 && let Some(tx) = feedback_tx
                             {
                                 let _ = tx.send(feedback);
@@ -295,7 +294,7 @@ async fn send_node_add_and_wait_internal<'a>(
     variant: Option<NodeSource>,
     goal_timeout: Duration,
     result_timeout: Duration,
-    feedback_tx: Option<UnboundedSender<NodeAddFeedback>>,
+    feedback_tx: Option<UnboundedSender<NodeActionFeedback>>,
     env_vars: Vec<(String, String)>,
     force: bool,
 ) -> Result<NodeBuildResult, String> {
@@ -384,7 +383,7 @@ async fn send_node_add_and_wait_internal<'a>(
     // This matches the behavior of the CLI client which doesn't poll for results
     // when the goal is rejected.
     let goal_response_payload = action_handle.goal_response().payload();
-    let goal_response = NodeAddGoalResponse::decode(&goal_response_payload)
+    let goal_response = NodeActionGoalResponse::decode(&goal_response_payload)
         .map_err(|e| format!("Failed to decode goal response: {}", e))?;
 
     if !goal_response.accepted {
@@ -415,7 +414,7 @@ async fn send_node_add_and_wait_internal<'a>(
                 Ok(Ok(msg)) => {
                     last_activity = tokio::time::Instant::now();
                     let payload = msg.payload();
-                    if let Ok(feedback) = NodeAddFeedback::decode(payload.as_ref())
+                    if let Ok(feedback) = NodeActionFeedback::decode(payload.as_ref())
                         && let Some(tx) = feedback_tx
                     {
                         let _ = tx.send(feedback);
@@ -447,7 +446,7 @@ async fn send_node_add_and_wait_internal<'a>(
                                 break;
                             };
                             let payload = msg.payload();
-                            if let Ok(feedback) = NodeAddFeedback::decode(payload.as_ref())
+                            if let Ok(feedback) = NodeActionFeedback::decode(payload.as_ref())
                                 && let Some(tx) = feedback_tx
                             {
                                 let _ = tx.send(feedback);
@@ -507,10 +506,10 @@ async fn send_node_add_and_wait_internal<'a>(
 
 /// Optional plumbing for [`send_node_build_and_wait`] that lets the
 /// `node_add` chained-call site forward streamed build feedback into the
-/// add helper's `NodeAddFeedback` channel and merge the build log file
+/// add helper's `NodeActionFeedback` channel and merge the build log file
 /// into the add log file.
 pub struct NodeBuildAddCompat<'a> {
-    pub feedback_tx: Option<&'a UnboundedSender<NodeAddFeedback>>,
+    pub feedback_tx: Option<&'a UnboundedSender<NodeActionFeedback>>,
     pub add_log_path: Option<&'a Path>,
 }
 
@@ -518,7 +517,7 @@ pub struct NodeBuildAddCompat<'a> {
 /// result. Mirrors the polling pattern of `send_node_add_and_wait_internal`.
 ///
 /// When `compat.feedback_tx` is provided, build feedback is re-encoded as
-/// `NodeAddFeedback` and forwarded so legacy add tests that assert on
+/// `NodeActionFeedback` and forwarded so legacy add tests that assert on
 /// streamed build output keep working unchanged.
 pub async fn send_node_build_and_wait(
     messenger: &MessengerHandle,
@@ -559,7 +558,7 @@ pub async fn send_node_build_and_wait(
     .map_err(|e| format!("Failed to send build goal: {}", e))?;
 
     let goal_response_payload = action_handle.goal_response().payload();
-    let goal_response = NodeBuildGoalResponse::decode(&goal_response_payload)
+    let goal_response = NodeActionGoalResponse::decode(&goal_response_payload)
         .map_err(|e| format!("Failed to decode build goal response: {}", e))?;
     if !goal_response.accepted {
         return Ok(NodeBuildResult::failure(
@@ -587,12 +586,12 @@ pub async fn send_node_build_and_wait(
                 Ok(Ok(msg)) => {
                     last_activity = tokio::time::Instant::now();
                     // Re-encode build feedback as add feedback so legacy
-                    // tests that hold a NodeAddFeedback channel keep
+                    // tests that hold a NodeActionFeedback channel keep
                     // receiving streamed build output without changes.
                     if let Some(tx) = feedback_tx {
                         let payload = msg.payload();
-                        if let Ok(b) = NodeBuildFeedback::decode(payload.as_ref()) {
-                            let translated = NodeAddFeedback {
+                        if let Ok(b) = NodeActionFeedback::decode(payload.as_ref()) {
+                            let translated = NodeActionFeedback {
                                 stream: b.stream,
                                 line: b.line,
                             };
@@ -651,7 +650,7 @@ pub async fn send_node_add_and_wait<'a>(
     source: impl Into<NodeAddSource<'a>>,
     goal_timeout: Duration,
     result_timeout: Duration,
-    feedback_tx: Option<UnboundedSender<NodeAddFeedback>>,
+    feedback_tx: Option<UnboundedSender<NodeActionFeedback>>,
 ) -> Result<NodeBuildResult, String> {
     send_node_add_and_wait_internal(
         messenger,
@@ -673,7 +672,7 @@ pub async fn send_node_add_and_wait_with_env<'a>(
     source: impl Into<NodeAddSource<'a>>,
     goal_timeout: Duration,
     result_timeout: Duration,
-    feedback_tx: Option<UnboundedSender<NodeAddFeedback>>,
+    feedback_tx: Option<UnboundedSender<NodeActionFeedback>>,
     env_vars: Vec<(String, String)>,
 ) -> Result<NodeBuildResult, String> {
     send_node_add_and_wait_internal(
@@ -697,7 +696,7 @@ pub async fn send_node_add_and_wait_with_variant<'a>(
     variant: &str,
     goal_timeout: Duration,
     result_timeout: Duration,
-    feedback_tx: Option<UnboundedSender<NodeAddFeedback>>,
+    feedback_tx: Option<UnboundedSender<NodeActionFeedback>>,
 ) -> Result<NodeBuildResult, String> {
     send_node_add_and_wait_internal(
         messenger,
@@ -719,7 +718,7 @@ pub async fn send_node_add_and_wait_with_force<'a>(
     source: impl Into<NodeAddSource<'a>>,
     goal_timeout: Duration,
     result_timeout: Duration,
-    feedback_tx: Option<UnboundedSender<NodeAddFeedback>>,
+    feedback_tx: Option<UnboundedSender<NodeActionFeedback>>,
 ) -> Result<NodeBuildResult, String> {
     send_node_add_and_wait_internal(
         messenger,
@@ -747,7 +746,7 @@ pub async fn send_node_start_and_wait(
     node_name: &str,
     tag: &str,
     timeouts: &NodeStartTestTimeouts,
-    feedback_tx: Option<UnboundedSender<NodeStartFeedback>>,
+    feedback_tx: Option<UnboundedSender<NodeActionFeedback>>,
 ) -> Result<NodeStartTestResponse, String> {
     send_node_start_and_wait_internal(
         messenger,
@@ -770,7 +769,7 @@ pub async fn send_node_start_and_wait_with_env(
     node_name: &str,
     tag: &str,
     timeouts: &NodeStartTestTimeouts,
-    feedback_tx: Option<UnboundedSender<NodeStartFeedback>>,
+    feedback_tx: Option<UnboundedSender<NodeActionFeedback>>,
     env_vars: Vec<(String, String)>,
 ) -> Result<NodeStartTestResponse, String> {
     send_node_start_and_wait_internal(

--- a/crates/core-node-internal/tests/common.rs
+++ b/crates/core-node-internal/tests/common.rs
@@ -5,8 +5,9 @@ use config::consts::{
 };
 use config::node::{PeppygenLanguage, QoSProfile};
 use core_node::encoding::{
-    NodeAddFeedback, NodeAddGoal, NodeAddGoalResponse, NodeAddResult, NodeSource,
-    NodeStartFeedback, NodeStartGoal, NodeStartGoalResponse, NodeStartResult,
+    NodeAddFeedback, NodeAddGoal, NodeAddGoalResponse, NodeAddResult, NodeBuildFeedback,
+    NodeBuildGoal, NodeBuildGoalResponse, NodeBuildResult, NodeSource, NodeStartFeedback,
+    NodeStartGoal, NodeStartGoalResponse, NodeStartResult,
 };
 use core_node::names;
 use core_node::{CoreNode, CoreNodeArguments};
@@ -297,7 +298,7 @@ async fn send_node_add_and_wait_internal<'a>(
     feedback_tx: Option<UnboundedSender<NodeAddFeedback>>,
     env_vars: Vec<(String, String)>,
     force: bool,
-) -> Result<NodeAddResult, String> {
+) -> Result<NodeBuildResult, String> {
     let source = source.into();
 
     let mut goal = match &source {
@@ -387,7 +388,7 @@ async fn send_node_add_and_wait_internal<'a>(
         .map_err(|e| format!("Failed to decode goal response: {}", e))?;
 
     if !goal_response.accepted {
-        return Ok(NodeAddResult::failure(
+        return Ok(NodeBuildResult::failure(
             PathBuf::new(),
             goal_response
                 .rejection_reason
@@ -452,7 +453,44 @@ async fn send_node_add_and_wait_internal<'a>(
                                 let _ = tx.send(feedback);
                             }
                         }
-                        return Ok(result);
+                        // If the add itself failed there is no `Added` entity
+                        // for `node_build` to consume — surface the failure as a
+                        // `NodeBuildResult::failure` so test assertions on
+                        // success/error_message keep working unchanged.
+                        if !result.success {
+                            return Ok(NodeBuildResult::failure(
+                                result.log_path,
+                                result.error_message.unwrap_or_else(|| {
+                                    "node_add failed without an error message".to_string()
+                                }),
+                            ));
+                        }
+                        let node_name = result.node_name.unwrap_or_default();
+                        let node_tag = result.node_tag.unwrap_or_default();
+                        let add_log_path = result.log_path.clone();
+                        let build_result = send_node_build_and_wait(
+                            messenger,
+                            core_node_name,
+                            &node_name,
+                            &node_tag,
+                            goal_timeout,
+                            result_timeout,
+                            NodeBuildAddCompat {
+                                feedback_tx,
+                                add_log_path: Some(add_log_path.as_path()),
+                            },
+                        )
+                        .await?;
+                        // Preserve the add log path on the returned result so
+                        // existing test assertions on `result.log_path` (which
+                        // were written when add owned the build) keep working.
+                        // The build log path lives in `logs_dir_build()` and is
+                        // recorded separately on the entity via
+                        // `last_add_log_path`.
+                        return Ok(NodeBuildResult {
+                            log_path: add_log_path,
+                            ..build_result
+                        });
                     }
                     Err(err) => {
                         check_pending_or_decode_error(payload.as_ref(), err)?;
@@ -467,6 +505,141 @@ async fn send_node_add_and_wait_internal<'a>(
     }
 }
 
+/// Optional plumbing for [`send_node_build_and_wait`] that lets the
+/// `node_add` chained-call site forward streamed build feedback into the
+/// add helper's `NodeAddFeedback` channel and merge the build log file
+/// into the add log file.
+pub struct NodeBuildAddCompat<'a> {
+    pub feedback_tx: Option<&'a UnboundedSender<NodeAddFeedback>>,
+    pub add_log_path: Option<&'a Path>,
+}
+
+/// Sends a `node_build` goal for an already-added entity and polls for the
+/// result. Mirrors the polling pattern of `send_node_add_and_wait_internal`.
+///
+/// When `compat.feedback_tx` is provided, build feedback is re-encoded as
+/// `NodeAddFeedback` and forwarded so legacy add tests that assert on
+/// streamed build output keep working unchanged.
+pub async fn send_node_build_and_wait(
+    messenger: &MessengerHandle,
+    core_node_name: &str,
+    node_name: &str,
+    node_tag: &str,
+    goal_timeout: Duration,
+    result_timeout: Duration,
+    compat: NodeBuildAddCompat<'_>,
+) -> Result<NodeBuildResult, String> {
+    let NodeBuildAddCompat {
+        feedback_tx,
+        add_log_path,
+    } = compat;
+    let goal = NodeBuildGoal::new(node_name, node_tag, result_timeout.as_secs());
+    let goal_payload = goal
+        .encode()
+        .map_err(|e| format!("Failed to encode build goal: {}", e))?;
+
+    let (caller_core_node, caller_instance_id) = if feedback_tx.is_some() {
+        ("*", "*")
+    } else {
+        (core_node_name, CALLER_INSTANCE_ID)
+    };
+    let mut action_handle = ActionMessenger::send_goal(
+        messenger,
+        caller_core_node,
+        caller_instance_id,
+        core_node_name,
+        names::NODE_BUILD_ACTION,
+        Some(core_node_name),
+        None,
+        goal_payload,
+        QoSProfile::default(),
+        goal_timeout,
+    )
+    .await
+    .map_err(|e| format!("Failed to send build goal: {}", e))?;
+
+    let goal_response_payload = action_handle.goal_response().payload();
+    let goal_response = NodeBuildGoalResponse::decode(&goal_response_payload)
+        .map_err(|e| format!("Failed to decode build goal response: {}", e))?;
+    if !goal_response.accepted {
+        return Ok(NodeBuildResult::failure(
+            PathBuf::new(),
+            goal_response
+                .rejection_reason
+                .unwrap_or_else(|| "build goal rejected without reason".to_string()),
+        ));
+    }
+
+    let absolute_deadline = tokio::time::Instant::now() + result_timeout;
+    let mut last_activity = tokio::time::Instant::now();
+
+    let result = loop {
+        loop {
+            let now = tokio::time::Instant::now();
+            if now >= absolute_deadline {
+                return Err("Timeout waiting for node_build result".to_string());
+            }
+            if now.duration_since(last_activity) >= result_timeout {
+                return Err("Timeout waiting for node_build result (idle)".to_string());
+            }
+            let drain_timeout = Duration::from_millis(50);
+            match tokio::time::timeout(drain_timeout, action_handle.on_next_feedback()).await {
+                Ok(Ok(msg)) => {
+                    last_activity = tokio::time::Instant::now();
+                    // Re-encode build feedback as add feedback so legacy
+                    // tests that hold a NodeAddFeedback channel keep
+                    // receiving streamed build output without changes.
+                    if let Some(tx) = feedback_tx {
+                        let payload = msg.payload();
+                        if let Ok(b) = NodeBuildFeedback::decode(payload.as_ref()) {
+                            let translated = NodeAddFeedback {
+                                stream: b.stream,
+                                line: b.line,
+                            };
+                            let _ = tx.send(translated);
+                        }
+                    }
+                }
+                Ok(Err(_)) => break,
+                Err(_) => break,
+            }
+        }
+
+        let now = tokio::time::Instant::now();
+        if now >= absolute_deadline {
+            return Err("Timeout waiting for node_build result".to_string());
+        }
+        let poll_timeout = Duration::from_millis(200);
+        match ActionMessenger::request_result(messenger, &action_handle, poll_timeout).await {
+            Ok(msg) => {
+                let payload = msg.payload();
+                match NodeBuildResult::decode(&payload) {
+                    Ok(result) => break result,
+                    Err(err) => check_pending_or_decode_error(payload.as_ref(), err)?,
+                }
+            }
+            Err(PeppyError::ActionResultTimeout { .. }) => {}
+            Err(err) => return Err(format!("Failed to get build result: {}", err)),
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    };
+
+    // Append the build log file to the add log file so legacy tests that
+    // assert on the add log's contents see the streamed build output. The
+    // build log lives at `result.log_path`.
+    if let Some(add_log) = add_log_path
+        && result.log_path != *add_log
+        && let Ok(build_log_contents) = std::fs::read(&result.log_path)
+        && !build_log_contents.is_empty()
+        && let Ok(mut f) = std::fs::OpenOptions::new().append(true).open(add_log)
+    {
+        use std::io::Write;
+        let _ = f.write_all(&build_log_contents);
+    }
+
+    Ok(result)
+}
+
 /// Helper function to send a node_add goal and wait for the result.
 /// This wraps the action pattern for simpler test usage.
 ///
@@ -479,7 +652,7 @@ pub async fn send_node_add_and_wait<'a>(
     goal_timeout: Duration,
     result_timeout: Duration,
     feedback_tx: Option<UnboundedSender<NodeAddFeedback>>,
-) -> Result<NodeAddResult, String> {
+) -> Result<NodeBuildResult, String> {
     send_node_add_and_wait_internal(
         messenger,
         core_node_name,
@@ -502,7 +675,7 @@ pub async fn send_node_add_and_wait_with_env<'a>(
     result_timeout: Duration,
     feedback_tx: Option<UnboundedSender<NodeAddFeedback>>,
     env_vars: Vec<(String, String)>,
-) -> Result<NodeAddResult, String> {
+) -> Result<NodeBuildResult, String> {
     send_node_add_and_wait_internal(
         messenger,
         core_node_name,
@@ -525,7 +698,7 @@ pub async fn send_node_add_and_wait_with_variant<'a>(
     goal_timeout: Duration,
     result_timeout: Duration,
     feedback_tx: Option<UnboundedSender<NodeAddFeedback>>,
-) -> Result<NodeAddResult, String> {
+) -> Result<NodeBuildResult, String> {
     send_node_add_and_wait_internal(
         messenger,
         core_node_name,
@@ -547,7 +720,7 @@ pub async fn send_node_add_and_wait_with_force<'a>(
     goal_timeout: Duration,
     result_timeout: Duration,
     feedback_tx: Option<UnboundedSender<NodeAddFeedback>>,
-) -> Result<NodeAddResult, String> {
+) -> Result<NodeBuildResult, String> {
     send_node_add_and_wait_internal(
         messenger,
         core_node_name,

--- a/crates/core-node-internal/tests/listen_for_launch.rs
+++ b/crates/core-node-internal/tests/listen_for_launch.rs
@@ -698,11 +698,12 @@ async fn listen_for_launch_configuration_succeed() {
         "robot_brain should have 1 instance"
     );
 
-    // Each deployed node should have an add log entry with a valid path and not marked as failed.
+    // Each deployed node now produces two log entries — one for `node_add`
+    // and one for `node_build` (the build step is a separate daemon goal).
     assert_eq!(
         result.node_add_logs.len(),
-        2,
-        "should have 2 add log entries (uvc_camera and robot_brain)"
+        4,
+        "should have 4 add+build log entries (uvc_camera and robot_brain × add+build)"
     );
     assert!(
         result
@@ -1361,15 +1362,16 @@ async fn listen_for_launch_configuration_fails_when_start_cmd_exits_with_error()
         "{NODE_NAME} should not be present after failed launch"
     );
 
-    // The node was successfully added before the start failed, so we expect one add log entry.
+    // The node was successfully added AND built before the start failed,
+    // so we expect two log entries (add + build).
     assert_eq!(
         result.node_add_logs.len(),
-        1,
-        "should have 1 add log entry for the node that was added before start failed"
+        2,
+        "should have 2 log entries (add + build) for the node that was built before start failed"
     );
     assert!(
-        !result.node_add_logs[0].failed,
-        "add log entry should not be marked failed (add succeeded)"
+        result.node_add_logs.iter().all(|entry| !entry.failed),
+        "add and build log entries should not be marked failed (both succeeded)"
     );
     assert_eq!(
         result.node_add_logs[0].node_label,

--- a/crates/core-node-internal/tests/listen_for_node_add.rs
+++ b/crates/core-node-internal/tests/listen_for_node_add.rs
@@ -11,7 +11,7 @@ use config::consts::{
 };
 use config::node::QoSProfile;
 use config::test_helpers;
-use core_node::encoding::{NodeAddFeedback, NodeAddGoal, NodeAddGoalResponse};
+use core_node::encoding::{NodeActionFeedback, NodeActionGoalResponse, NodeAddGoal};
 use core_node::names;
 use git2::{Repository, Signature};
 use gix_url::Url as GitUrl;
@@ -1824,7 +1824,8 @@ async fn listen_for_node_add_streams_stdout_and_stderr() {
     write_peppy_json5(source_dir.path(), &peppy_json5);
 
     // Use wildcard caller IDs so mock pub/sub can match feedback topics with "*" segments.
-    let (feedback_tx, mut feedback_rx) = tokio::sync::mpsc::unbounded_channel::<NodeAddFeedback>();
+    let (feedback_tx, mut feedback_rx) =
+        tokio::sync::mpsc::unbounded_channel::<NodeActionFeedback>();
     let add_result = send_node_add_and_wait(
         &started_core_node.caller_handle,
         &started_core_node.core_node_name,
@@ -2095,7 +2096,7 @@ async fn listen_for_node_add_abandoned_action_does_not_block_next_goal() {
 
     // Verify first goal was accepted
     let first_goal_response_payload = first_action_handle.goal_response().payload();
-    let first_goal_response = NodeAddGoalResponse::decode(&first_goal_response_payload)
+    let first_goal_response = NodeActionGoalResponse::decode(&first_goal_response_payload)
         .expect("failed to decode first goal response");
     assert!(
         first_goal_response.accepted,
@@ -2330,7 +2331,8 @@ async fn node_add_same_node_shutdown_existing_instances() {
     .expect("write v2 marker");
 
     // Use wildcard caller IDs so mock pub/sub can match feedback topics with "*" segments.
-    let (feedback_tx, mut feedback_rx) = tokio::sync::mpsc::unbounded_channel::<NodeAddFeedback>();
+    let (feedback_tx, mut feedback_rx) =
+        tokio::sync::mpsc::unbounded_channel::<NodeActionFeedback>();
 
     let caller_handle = started_core_node.caller_handle.clone();
     let core_node_name = started_core_node.core_node_name.clone();
@@ -2831,7 +2833,8 @@ async fn listen_for_node_add_reports_excluded_dirs_in_feedback() {
     .replace("{TARGET_NODE_TAG}", TARGET_NODE_TAG);
     write_peppy_json5(source_dir.path(), &peppy_json5);
 
-    let (feedback_tx, mut feedback_rx) = tokio::sync::mpsc::unbounded_channel::<NodeAddFeedback>();
+    let (feedback_tx, mut feedback_rx) =
+        tokio::sync::mpsc::unbounded_channel::<NodeActionFeedback>();
     let add_result = send_node_add_and_wait(
         &started_core_node.caller_handle,
         &started_core_node.core_node_name,
@@ -2920,7 +2923,8 @@ From: nowhere
     std::fs::write(source_dir.path().join("apptainer.def"), broken_def)
         .expect("failed to write broken apptainer definition");
 
-    let (feedback_tx, mut feedback_rx) = tokio::sync::mpsc::unbounded_channel::<NodeAddFeedback>();
+    let (feedback_tx, mut feedback_rx) =
+        tokio::sync::mpsc::unbounded_channel::<NodeActionFeedback>();
     let add_result = send_node_add_and_wait(
         &started_core_node.caller_handle,
         &started_core_node.core_node_name,
@@ -4675,7 +4679,8 @@ async fn listen_for_node_add_variant_manifest_ignored_warning() {
     }"#;
     write_peppy_json5(&variant_dir, variant_config);
 
-    let (feedback_tx, mut feedback_rx) = tokio::sync::mpsc::unbounded_channel::<NodeAddFeedback>();
+    let (feedback_tx, mut feedback_rx) =
+        tokio::sync::mpsc::unbounded_channel::<NodeActionFeedback>();
 
     let add_result = send_node_add_and_wait_with_variant(
         &started_core_node.caller_handle,
@@ -5239,7 +5244,7 @@ async fn listen_for_node_add_rejects_second_goal_when_action_in_progress() {
     .expect("first goal should be sent");
 
     let first_response_payload = first_action_handle.goal_response().payload();
-    let first_response = NodeAddGoalResponse::decode(&first_response_payload)
+    let first_response = NodeActionGoalResponse::decode(&first_response_payload)
         .expect("failed to decode first goal response");
     assert!(first_response.accepted, "first goal should be accepted");
 
@@ -5328,7 +5333,7 @@ async fn listen_for_node_add_force_overrides_in_progress_action() {
     .expect("first goal should be sent");
 
     let first_response_payload = first_action_handle.goal_response().payload();
-    let first_response = NodeAddGoalResponse::decode(&first_response_payload)
+    let first_response = NodeActionGoalResponse::decode(&first_response_payload)
         .expect("failed to decode first goal response");
     assert!(first_response.accepted, "first goal should be accepted");
 
@@ -5505,7 +5510,8 @@ async fn listen_for_node_git_add_emits_clone_feedback() {
 
     let repo_url = GitUrl::try_from(git_repo_path.as_path()).expect("git repo path should parse");
 
-    let (feedback_tx, mut feedback_rx) = tokio::sync::mpsc::unbounded_channel::<NodeAddFeedback>();
+    let (feedback_tx, mut feedback_rx) =
+        tokio::sync::mpsc::unbounded_channel::<NodeActionFeedback>();
     let add_result = send_node_add_and_wait(
         &started_core_node.caller_handle,
         &started_core_node.core_node_name,
@@ -5561,7 +5567,8 @@ async fn listen_for_node_http_add_emits_download_feedback() {
     let (_bundle_dir, bundle_bytes) = create_minimal_http_bundle(TARGET_NODE_NAME, TARGET_NODE_TAG);
     let (server, url) = serve_bundle_over_http(bundle_bytes);
 
-    let (feedback_tx, mut feedback_rx) = tokio::sync::mpsc::unbounded_channel::<NodeAddFeedback>();
+    let (feedback_tx, mut feedback_rx) =
+        tokio::sync::mpsc::unbounded_channel::<NodeActionFeedback>();
     let add_result = send_node_add_and_wait(
         &started_core_node.caller_handle,
         &started_core_node.core_node_name,

--- a/crates/core-node-internal/tests/listen_for_node_add.rs
+++ b/crates/core-node-internal/tests/listen_for_node_add.rs
@@ -2102,20 +2102,16 @@ async fn listen_for_node_add_abandoned_action_does_not_block_next_goal() {
         "first goal should be accepted"
     );
 
-    // Wait for the first action to *fully* settle without polling its
-    // action result (the whole point of this test is that the result is
-    // never requested). We can't rely on the previous `no_starting` clause
-    // — `node add` never registers `Starting` instances, so it was always
-    // true and added nothing — so settling is detected purely via
-    // `stage == Ready` (which the entity transitions to inside `build`)
-    // and `artifact_path().is_some()` (which is recorded under the same
-    // write lock as the stage transition).
+    // `node_add` only advances the entity to `Added` now — wait for that,
+    // not `Ready`. Build is a separate goal which we deliberately do NOT
+    // send for the first node (the whole point of this test is that the
+    // first action's result is never requested and the second goal is
+    // still processed correctly).
     tokio::time::timeout(Duration::from_secs(30), async {
         loop {
             if let Some(handle) = node_stack.find(FIRST_NODE_NAME, FIRST_NODE_TAG) {
                 let guard = handle.read();
-                let is_ready = matches!(guard.stage(), node_stack::NodeStage::Ready { .. });
-                if is_ready && guard.artifact_path().is_some() {
+                if matches!(guard.stage(), node_stack::NodeStage::Added { .. }) {
                     break;
                 }
             }
@@ -2123,7 +2119,8 @@ async fn listen_for_node_add_abandoned_action_does_not_block_next_goal() {
         }
     })
     .await
-    .expect("first node never reached Ready within 30s");
+    .expect("first node never reached Added within 30s");
+    drop(first_action_handle);
 
     // Now send second goal - this should succeed even though we never polled
     // for the first action's result

--- a/crates/core-node-internal/tests/listen_for_node_start.rs
+++ b/crates/core-node-internal/tests/listen_for_node_start.rs
@@ -8,7 +8,7 @@ use common::{
 };
 use config::consts::DEFAULT_ALPINE_BASE_IMAGE;
 use config::node::Name as NodeName;
-use core_node::encoding::NodeStartFeedback;
+use core_node::encoding::NodeActionFeedback;
 use peppylib::messaging::MessengerHandle;
 use peppylib::services::health::listen_for_node_health;
 use peppylib::services::ready::listen_for_node_ready;
@@ -371,7 +371,7 @@ async fn listen_for_node_start_streams_stdout_and_stderr() {
     );
 
     let (feedback_tx, mut feedback_rx) =
-        tokio::sync::mpsc::unbounded_channel::<NodeStartFeedback>();
+        tokio::sync::mpsc::unbounded_channel::<NodeActionFeedback>();
     let start_response = send_node_start_and_wait(
         &started.caller_handle,
         &started.core_node_name,
@@ -985,7 +985,7 @@ async fn listen_for_node_start_abandoned_action_does_not_block_next_goal() {
     // Verify first goal was accepted
     let first_goal_response_payload = first_action_handle.goal_response().payload();
     let first_goal_response =
-        core_node::encoding::NodeStartGoalResponse::decode(&first_goal_response_payload)
+        core_node::encoding::NodeActionGoalResponse::decode(&first_goal_response_payload)
             .expect("failed to decode first goal response");
     assert!(
         first_goal_response.accepted,

--- a/crates/node-stack-internal/src/lib.rs
+++ b/crates/node-stack-internal/src/lib.rs
@@ -9,7 +9,7 @@ pub use error::Error as NodeStackError;
 pub use build_io::{FeedbackLine, FeedbackStream, OutputReaderHooks};
 pub use node_stack::{
     BuildContext, DependencySpec, EntityHandle, EntitySnapshot, InstanceState, NodeEntity,
-    NodeStack, NodeStage, OutputSinks, RestoreTarget, SerializedNodeGraph, StartContext,
-    StartedInstanceCtx, TrackedNodeInstance, collect_dependency_specs, extract_tar_zst,
-    validate_dependency_specs,
+    NodeStack, NodeStage, OutputSinks, PendingBuildInput, RestoreTarget, SerializedNodeGraph,
+    StartContext, StartedInstanceCtx, TrackedNodeInstance, collect_dependency_specs,
+    extract_tar_zst, validate_dependency_specs,
 };

--- a/crates/node-stack-internal/src/lib.rs
+++ b/crates/node-stack-internal/src/lib.rs
@@ -10,6 +10,6 @@ pub use build_io::{FeedbackLine, FeedbackStream, OutputReaderHooks};
 pub use node_stack::{
     BuildContext, DependencySpec, EntityHandle, EntitySnapshot, InstanceState, NodeEntity,
     NodeStack, NodeStage, OutputSinks, PendingBuildInput, RestoreTarget, SerializedNodeGraph,
-    StartContext, StartedInstanceCtx, TrackedNodeInstance, collect_dependency_specs,
+    StartContext, StartedInstanceCtx, TrackedNodeInstance, WorkingDir, collect_dependency_specs,
     extract_tar_zst, validate_dependency_specs,
 };

--- a/crates/node-stack-internal/src/node_stack.rs
+++ b/crates/node-stack-internal/src/node_stack.rs
@@ -5,7 +5,7 @@ mod validation;
 
 pub use entity::{
     BuildContext, DependencySpec, InstanceState, NodeEntity, NodeStage, OutputSinks,
-    SerializedNodeGraph, StartContext, StartedInstanceCtx, TrackedNodeInstance,
+    PendingBuildInput, SerializedNodeGraph, StartContext, StartedInstanceCtx, TrackedNodeInstance,
 };
 pub use start_steps::extract_tar_zst;
 pub use validation::{collect_dependency_specs, validate_dependency_specs};
@@ -424,6 +424,13 @@ impl NodeStackInner {
                     artifact_path: guard.artifact_path().map(|p| p.to_path_buf()),
                 };
 
+                // If the entity we're replacing had a pending build input
+                // (Added but never built), remove its working_dir before we
+                // drop the reference — otherwise the temp directory leaks.
+                if let Some(pending) = guard.pending_build_input() {
+                    let _ = std::fs::remove_dir_all(&pending.working_dir);
+                }
+
                 // Replace the entity in-place under the still-held write
                 // lock. The same `Arc` handle is preserved so any external
                 // readers see the new state.
@@ -689,6 +696,9 @@ impl NodeStack {
                 node_tag: tag.to_string(),
             });
         }
+        if let Some(pending) = entity_guard.pending_build_input() {
+            let _ = std::fs::remove_dir_all(&pending.working_dir);
+        }
         guard.remove_entity(&key);
         // Keep `entity_guard` alive until *after* the unlink so an outside
         // thread holding a clone of the handle still cannot mutate the
@@ -731,7 +741,10 @@ impl NodeStack {
             Arc::ptr_eq(current, expected_handle) && {
                 let entity = current.read();
                 entity.generation() == expected_generation
-                    && matches!(entity.stage(), NodeStage::Building { .. })
+                    && matches!(
+                        entity.stage(),
+                        NodeStage::Building { .. } | NodeStage::Added { .. }
+                    )
             }
         });
 
@@ -739,6 +752,11 @@ impl NodeStack {
             return false;
         }
 
+        if let Some(current) = guard.graph.node_weight(index)
+            && let Some(pending) = current.read().pending_build_input()
+        {
+            let _ = std::fs::remove_dir_all(&pending.working_dir);
+        }
         guard.remove_entity(&key);
         true
     }

--- a/crates/node-stack-internal/src/node_stack.rs
+++ b/crates/node-stack-internal/src/node_stack.rs
@@ -6,6 +6,7 @@ mod validation;
 pub use entity::{
     BuildContext, DependencySpec, InstanceState, NodeEntity, NodeStage, OutputSinks,
     PendingBuildInput, SerializedNodeGraph, StartContext, StartedInstanceCtx, TrackedNodeInstance,
+    WorkingDir,
 };
 pub use start_steps::extract_tar_zst;
 pub use validation::{collect_dependency_specs, validate_dependency_specs};
@@ -424,12 +425,9 @@ impl NodeStackInner {
                     artifact_path: guard.artifact_path().map(|p| p.to_path_buf()),
                 };
 
-                // If the entity we're replacing had a pending build input
-                // (Added but never built), remove its working_dir before we
-                // drop the reference — otherwise the temp directory leaks.
-                if let Some(pending) = guard.pending_build_input() {
-                    let _ = std::fs::remove_dir_all(&pending.working_dir);
-                }
+                // The entity's `PendingBuildInput` (if any) is dropped
+                // along with the old state below; its `WorkingDir` RAII
+                // handle removes the temp dir on last-reference drop.
 
                 // Replace the entity in-place under the still-held write
                 // lock. The same `Arc` handle is preserved so any external
@@ -696,9 +694,8 @@ impl NodeStack {
                 node_tag: tag.to_string(),
             });
         }
-        if let Some(pending) = entity_guard.pending_build_input() {
-            let _ = std::fs::remove_dir_all(&pending.working_dir);
-        }
+        // Dropping `entity_guard` below will drop any `PendingBuildInput`,
+        // whose `WorkingDir` RAII handle cleans up the temp dir.
         guard.remove_entity(&key);
         // Keep `entity_guard` alive until *after* the unlink so an outside
         // thread holding a clone of the handle still cannot mutate the
@@ -752,11 +749,8 @@ impl NodeStack {
             return false;
         }
 
-        if let Some(current) = guard.graph.node_weight(index)
-            && let Some(pending) = current.read().pending_build_input()
-        {
-            let _ = std::fs::remove_dir_all(&pending.working_dir);
-        }
+        // `WorkingDir` RAII handle inside the dropped entity cleans up
+        // the pending temp dir automatically.
         guard.remove_entity(&key);
         true
     }

--- a/crates/node-stack-internal/src/node_stack/entity.rs
+++ b/crates/node-stack-internal/src/node_stack/entity.rs
@@ -281,6 +281,22 @@ fn next_entity_generation() -> u64 {
     NEXT_ENTITY_GENERATION.fetch_add(1, Ordering::Relaxed)
 }
 
+/// Build inputs populated by `node_add` and consumed by `node_build`. Lives
+/// on [`NodeEntity`] (not on [`NodeStage::Added`]) so add-time state can be
+/// threaded across the two daemon goals without widening the stage enum.
+///
+/// The `working_dir` is a temporary directory that holds the copied node
+/// source plus any generated peppygen; `node_build` hands it to
+/// [`NodeEntity::build`] inside [`BuildContext::working_dir`]. Both `node_add`
+/// (on overwrite) and [`crate::node_stack::NodeStack::remove_config`] are
+/// responsible for deleting an un-consumed `working_dir` to avoid leaking
+/// temp storage when the entity is discarded before build runs.
+#[derive(Debug, Clone)]
+pub struct PendingBuildInput {
+    pub working_dir: PathBuf,
+    pub env_vars: Vec<(String, String)>,
+}
+
 #[derive(Clone, Debug)]
 pub struct NodeEntity {
     config: NodeConfig,
@@ -298,6 +314,12 @@ pub struct NodeEntity {
     /// `push_config_impl`). `None` for the synthetic root entity, which
     /// has no add log.
     last_add_log_path: Option<PathBuf>,
+    /// Working dir + env vars prepared by `node_add` and consumed by
+    /// `node_build`. `Some` only while the entity is in `Added` waiting for
+    /// an explicit build. Taken (via `take_pending_build_input`) by the
+    /// build service before driving [`NodeEntity::build`], and cleaned up by
+    /// `NodeStack::push_config`/`remove_config` if the entity is discarded.
+    pending_build_input: Option<PendingBuildInput>,
 }
 
 impl NodeEntity {
@@ -312,6 +334,7 @@ impl NodeEntity {
             },
             generation: next_entity_generation(),
             last_add_log_path: None,
+            pending_build_input: None,
         }
     }
 
@@ -327,6 +350,29 @@ impl NodeEntity {
     /// rest of the entity transition.
     pub fn set_last_add_log_path(&mut self, path: PathBuf) {
         self.last_add_log_path = Some(path);
+    }
+
+    /// Stores the working dir + env vars that `node_build` will feed into
+    /// [`NodeEntity::build`]. Called by the `node_add` service immediately
+    /// after `push_config` publishes the entity in `Added`. Replaces any
+    /// previous pending input.
+    pub fn set_pending_build_input(&mut self, input: PendingBuildInput) {
+        self.pending_build_input = Some(input);
+    }
+
+    /// Removes and returns the pending build input stashed by `node_add`.
+    /// The `node_build` service calls this under a write lock before
+    /// driving [`NodeEntity::build`], so the stored working_dir can only be
+    /// consumed once.
+    pub fn take_pending_build_input(&mut self) -> Option<PendingBuildInput> {
+        self.pending_build_input.take()
+    }
+
+    /// Returns a reference to the currently-stashed pending build input, if
+    /// any. Used by cleanup paths (`push_config` overwrite,
+    /// `remove_config`) that need to delete the working_dir on disk.
+    pub fn pending_build_input(&self) -> Option<&PendingBuildInput> {
+        self.pending_build_input.as_ref()
     }
 
     /// Returns the entity's monotonic generation token. Bumped on every
@@ -946,6 +992,7 @@ impl NodeEntity {
             },
             generation: next_entity_generation(),
             last_add_log_path: None,
+            pending_build_input: None,
         }
     }
 
@@ -987,6 +1034,7 @@ impl NodeEntity {
             stage,
             generation: next_entity_generation(),
             last_add_log_path: None,
+            pending_build_input: None,
         }
     }
 

--- a/crates/node-stack-internal/src/node_stack/entity.rs
+++ b/crates/node-stack-internal/src/node_stack/entity.rs
@@ -124,6 +124,12 @@ impl From<&NodeEntity> for SerializedNode {
 pub enum NodeStage {
     Added {
         config_path: PathBuf,
+        /// Working dir + env vars prepared by `node_add` and consumed by
+        /// `node_build`. `Some` while the entity is waiting for an explicit
+        /// build; `None` once `node_build` has taken the input (briefly, in
+        /// the window between take and the stage transition to `Building`)
+        /// or if the entity was rehydrated from a snapshot.
+        pending: Option<PendingBuildInput>,
     },
     Building {
         config_path: PathBuf,
@@ -281,19 +287,39 @@ fn next_entity_generation() -> u64 {
     NEXT_ENTITY_GENERATION.fetch_add(1, Ordering::Relaxed)
 }
 
-/// Build inputs populated by `node_add` and consumed by `node_build`. Lives
-/// on [`NodeEntity`] (not on [`NodeStage::Added`]) so add-time state can be
-/// threaded across the two daemon goals without widening the stage enum.
+/// Owning RAII handle for a temporary working directory. When the last
+/// reference is dropped the directory is best-effort removed from disk —
+/// callers no longer need to remember to clean up on every discard path.
 ///
-/// The `working_dir` is a temporary directory that holds the copied node
-/// source plus any generated peppygen; `node_build` hands it to
-/// [`NodeEntity::build`] inside [`BuildContext::working_dir`]. Both `node_add`
-/// (on overwrite) and [`crate::node_stack::NodeStack::remove_config`] are
-/// responsible for deleting an un-consumed `working_dir` to avoid leaking
-/// temp storage when the entity is discarded before build runs.
+/// Wrapped in an `Arc` inside [`PendingBuildInput`] so the entity snapshot
+/// machinery (which clones entities) shares a single deletion signal
+/// instead of racing on `remove_dir_all`.
+#[derive(Debug)]
+pub struct WorkingDir(PathBuf);
+
+impl WorkingDir {
+    pub fn new(path: PathBuf) -> Self {
+        Self(path)
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl Drop for WorkingDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+/// Build inputs populated by `node_add` and consumed by `node_build`.
+/// Lives inside [`NodeStage::Added`]`.pending`. The temp working dir is
+/// cleaned up automatically when the last `PendingBuildInput` referencing
+/// it is dropped (via [`WorkingDir`]'s `Drop` impl).
 #[derive(Debug, Clone)]
 pub struct PendingBuildInput {
-    pub working_dir: PathBuf,
+    pub working_dir: Arc<WorkingDir>,
     pub env_vars: Vec<(String, String)>,
 }
 
@@ -314,12 +340,6 @@ pub struct NodeEntity {
     /// `push_config_impl`). `None` for the synthetic root entity, which
     /// has no add log.
     last_add_log_path: Option<PathBuf>,
-    /// Working dir + env vars prepared by `node_add` and consumed by
-    /// `node_build`. `Some` only while the entity is in `Added` waiting for
-    /// an explicit build. Taken (via `take_pending_build_input`) by the
-    /// build service before driving [`NodeEntity::build`], and cleaned up by
-    /// `NodeStack::push_config`/`remove_config` if the entity is discarded.
-    pending_build_input: Option<PendingBuildInput>,
 }
 
 impl NodeEntity {
@@ -331,10 +351,10 @@ impl NodeEntity {
             config,
             stage: NodeStage::Added {
                 config_path: config_path.into(),
+                pending: None,
             },
             generation: next_entity_generation(),
             last_add_log_path: None,
-            pending_build_input: None,
         }
     }
 
@@ -350,29 +370,6 @@ impl NodeEntity {
     /// rest of the entity transition.
     pub fn set_last_add_log_path(&mut self, path: PathBuf) {
         self.last_add_log_path = Some(path);
-    }
-
-    /// Stores the working dir + env vars that `node_build` will feed into
-    /// [`NodeEntity::build`]. Called by the `node_add` service immediately
-    /// after `push_config` publishes the entity in `Added`. Replaces any
-    /// previous pending input.
-    pub fn set_pending_build_input(&mut self, input: PendingBuildInput) {
-        self.pending_build_input = Some(input);
-    }
-
-    /// Removes and returns the pending build input stashed by `node_add`.
-    /// The `node_build` service calls this under a write lock before
-    /// driving [`NodeEntity::build`], so the stored working_dir can only be
-    /// consumed once.
-    pub fn take_pending_build_input(&mut self) -> Option<PendingBuildInput> {
-        self.pending_build_input.take()
-    }
-
-    /// Returns a reference to the currently-stashed pending build input, if
-    /// any. Used by cleanup paths (`push_config` overwrite,
-    /// `remove_config`) that need to delete the working_dir on disk.
-    pub fn pending_build_input(&self) -> Option<&PendingBuildInput> {
-        self.pending_build_input.as_ref()
     }
 
     /// Returns the entity's monotonic generation token. Bumped on every
@@ -395,10 +392,45 @@ impl NodeEntity {
     /// present regardless of which stage the entity is in.
     pub fn config_path(&self) -> &Path {
         match &self.stage {
-            NodeStage::Added { config_path } => config_path,
+            NodeStage::Added { config_path, .. } => config_path,
             NodeStage::Building { config_path } => config_path,
             NodeStage::Ready { config_path, .. } => config_path,
             NodeStage::Root { config_path, .. } => config_path,
+        }
+    }
+
+    /// Sets the pending build input on the entity. Returns `Err(stage_name)`
+    /// if the entity is not in `Added`.
+    pub fn set_pending_build_input(
+        &mut self,
+        input: PendingBuildInput,
+    ) -> std::result::Result<(), &'static str> {
+        match &mut self.stage {
+            NodeStage::Added { pending, .. } => {
+                *pending = Some(input);
+                Ok(())
+            }
+            other => Err(other.name()),
+        }
+    }
+
+    /// Removes and returns the pending build input stashed on the `Added`
+    /// stage. Returns `None` if the entity is not in `Added` or nothing has
+    /// been stashed yet.
+    pub fn take_pending_build_input(&mut self) -> Option<PendingBuildInput> {
+        match &mut self.stage {
+            NodeStage::Added { pending, .. } => pending.take(),
+            _ => None,
+        }
+    }
+
+    /// Returns a reference to the currently-stashed pending build input, if
+    /// any. Used by cleanup paths that need to delete the working_dir on
+    /// disk when the entity is discarded before build runs.
+    pub fn pending_build_input(&self) -> Option<&PendingBuildInput> {
+        match &self.stage {
+            NodeStage::Added { pending, .. } => pending.as_ref(),
+            _ => None,
         }
     }
 
@@ -465,7 +497,7 @@ impl NodeEntity {
                     to: "Ready",
                 });
             }
-            let NodeStage::Added { config_path } = &guard.stage else {
+            let NodeStage::Added { config_path, .. } = &guard.stage else {
                 unreachable!("ensure_buildable just verified Added")
             };
             let config_path = config_path.clone();
@@ -992,7 +1024,6 @@ impl NodeEntity {
             },
             generation: next_entity_generation(),
             last_add_log_path: None,
-            pending_build_input: None,
         }
     }
 
@@ -1018,7 +1049,10 @@ impl NodeEntity {
         instances: Vec<TrackedNodeInstance>,
     ) -> Self {
         let stage = match (artifact_path, instances.is_empty()) {
-            (None, true) => NodeStage::Added { config_path },
+            (None, true) => NodeStage::Added {
+                config_path,
+                pending: None,
+            },
             (None, false) => unreachable!(
                 "snapshot with instances must have an artifact_path — \
                  a node cannot have instances without a built artifact"
@@ -1034,7 +1068,6 @@ impl NodeEntity {
             stage,
             generation: next_entity_generation(),
             last_add_log_path: None,
-            pending_build_input: None,
         }
     }
 

--- a/crates/node-stack-internal/tests/tests_modules/lifecycle_transitions.rs
+++ b/crates/node-stack-internal/tests/tests_modules/lifecycle_transitions.rs
@@ -50,7 +50,10 @@ fn push_config_creates_entity_in_added_stage() {
     let handle = stack.find("sensor", "1.0.0").expect("entity should exist");
     let guard = handle.read();
 
-    if let NodeStage::Added { config_path: cp } = guard.stage() {
+    if let NodeStage::Added {
+        config_path: cp, ..
+    } = guard.stage()
+    {
         assert_eq!(cp, &config_path);
     } else {
         panic!("expected Added stage, got {:?}", guard.stage());
@@ -240,7 +243,9 @@ async fn push_config_resets_existing_entity_to_added() {
     let handle_after = stack.find("sensor", "1.0.0").expect("entity should exist");
     let guard = handle_after.read();
     match guard.stage() {
-        NodeStage::Added { config_path: cp } => {
+        NodeStage::Added {
+            config_path: cp, ..
+        } => {
             assert_eq!(cp, &config_path_v2);
         }
         other => panic!("expected Added after re-push, got {:?}", other),
@@ -1043,6 +1048,7 @@ mod backwards_transitions_are_rejected {
     fn added() -> NodeStage {
         NodeStage::Added {
             config_path: PathBuf::from("/tmp/sensor"),
+            pending: None,
         }
     }
 
@@ -1318,7 +1324,7 @@ async fn restore_snapshot_if_matches_no_op_on_generation_drift() {
     {
         let guard = handle.read();
         match guard.stage() {
-            NodeStage::Added { config_path } => {
+            NodeStage::Added { config_path, .. } => {
                 assert_eq!(
                     config_path, &config_path_v2,
                     "concurrent replacement must stay in place"

--- a/crates/peppy/src/commands/node/add.rs
+++ b/crates/peppy/src/commands/node/add.rs
@@ -1,6 +1,8 @@
+use crate::context::DaemonConnection;
 use core_node::encoding::{
-    NodeAddFeedback, NodeAddGoal, NodeAddGoalResponse, NodeAddResult, NodeInfoRequest,
-    NodeInfoResponse, NodeSource,
+    NodeAddFeedback, NodeAddGoal, NodeAddGoalResponse, NodeAddResult, NodeBuildFeedback,
+    NodeBuildGoal, NodeBuildGoalResponse, NodeBuildResult, NodeInfoRequest, NodeInfoResponse,
+    NodeSource,
 };
 use peppylib::MessengerHandle;
 use std::io::BufRead;
@@ -125,9 +127,10 @@ async fn add_node_async(ctx: &Arc<AppContext>, params: AddNodeParams) -> Result<
 
     // Create and send the goal to start the add action
     // Pass max timeout as the goal timeout for daemon-side busy reporting
-    let mut add_goal = NodeAddGoal::from_source(node_source, conn.git_hash, timeouts.max_secs)
-        .with_env_vars(caller_env_overrides())
-        .with_force(force);
+    let mut add_goal =
+        NodeAddGoal::from_source(node_source, conn.git_hash.clone(), timeouts.max_secs)
+            .with_env_vars(caller_env_overrides())
+            .with_force(force);
     if let Some(variant_source) = variant_source {
         add_goal = add_goal.with_variant_source(variant_source);
     }
@@ -194,30 +197,33 @@ async fn add_node_async(ctx: &Arc<AppContext>, params: AddNodeParams) -> Result<
         ));
     }
 
-    if let (Some(name), Some(tag)) = (&add_result.node_name, &add_result.node_tag) {
-        info!("Added node {}:{} to the node stack", name, tag);
-    } else {
-        info!("Added node to the node stack");
-    }
+    let node_name = add_result.node_name.clone().ok_or_else(|| {
+        Error::ExecutionFailed(
+            "Failed to determine node name after adding. Try running `peppy node list`.".into(),
+        )
+    })?;
+    let node_tag = add_result.node_tag.clone().ok_or_else(|| {
+        Error::ExecutionFailed(
+            "Failed to determine node tag after adding. Try running `peppy node list`.".into(),
+        )
+    })?;
+    info!("Added node {}:{} to the node stack", node_name, node_tag);
+
+    // node_add only registers the entity in `Added`. The build is now a
+    // separate daemon goal — drive it before optionally starting an instance.
+    let build_result = run_node_build_goal(&conn, &node_name, &node_tag, &timeouts, force).await?;
     info!(
-        "Snapshot path: {}",
-        add_result.snapshot_path.to_string_lossy()
+        "Built node {}:{} (snapshot: {})",
+        node_name,
+        node_tag,
+        build_result.snapshot_path.display()
     );
 
     let Some(start_options) = start_options else {
         return Ok(());
     };
-
-    let node_name = add_result.node_name.as_deref().ok_or_else(|| {
-        Error::ExecutionFailed(
-            "Failed to determine node name after adding. Try running `peppy node list`.".into(),
-        )
-    })?;
-    let node_tag = add_result.node_tag.as_deref().ok_or_else(|| {
-        Error::ExecutionFailed(
-            "Failed to determine node tag after adding. Try running `peppy node list`.".into(),
-        )
-    })?;
+    let node_name = node_name.as_str();
+    let node_tag = node_tag.as_str();
 
     start_instance_async(
         conn.messenger,
@@ -231,6 +237,83 @@ async fn add_node_async(ctx: &Arc<AppContext>, params: AddNodeParams) -> Result<
     .await?;
 
     Ok(())
+}
+
+/// Sends a `node_build` goal to the daemon for an already-`Added` entity and
+/// polls it to completion. Mirrors the `node_add` goal lifecycle: send goal,
+/// validate goal response, stream feedback, decode result, surface failures.
+async fn run_node_build_goal(
+    conn: &DaemonConnection<'_>,
+    node_name: &str,
+    node_tag: &str,
+    timeouts: &TimeoutConfig,
+    force: bool,
+) -> Result<NodeBuildResult> {
+    let build_goal = NodeBuildGoal::new(node_name, node_tag, timeouts.max_secs).with_force(force);
+    let mut action_handle = build_goal
+        .send_goal(
+            conn.messenger,
+            &conn.core_node_name,
+            CALLER_INSTANCE_ID,
+            Some(&conn.core_node_name),
+            None,
+            GOAL_TIMEOUT,
+        )
+        .await
+        .map_err(|e| Error::ExecutionFailed(format!("Failed to send node_build goal: {}", e)))?;
+
+    let goal_response_payload = action_handle.goal_response().payload();
+    let goal_response = NodeBuildGoalResponse::decode(&goal_response_payload).map_err(|e| {
+        Error::ExecutionFailed(format!("Failed to decode build goal response: {}", e))
+    })?;
+
+    if !goal_response.accepted {
+        return Err(Error::ExecutionFailed(format!(
+            "Build goal rejected: {}",
+            goal_response
+                .rejection_reason
+                .unwrap_or_else(|| "unknown reason".to_string())
+        )));
+    }
+
+    info!("Build log file: {}", goal_response.log_path.display());
+
+    let mut scrolling_output = ScrollingOutput::new(SCROLLING_OUTPUT_LINES);
+
+    let build_result = crate::commands::action_poll::poll_action_to_completion(
+        conn.messenger,
+        &mut action_handle,
+        timeouts,
+        &mut scrolling_output,
+        |payload, output| {
+            if let Ok(feedback) = NodeBuildFeedback::decode(payload) {
+                output.add_line(&feedback.line, feedback.is_stderr());
+            }
+        },
+        |payload| match NodeBuildResult::decode(payload) {
+            Ok(result) => Ok(Some(result)),
+            Err(err) => {
+                if peppylib::encoding::is_result_pending(payload) {
+                    Ok(None)
+                } else {
+                    Err(format!("Failed to decode node_build result: {err}"))
+                }
+            }
+        },
+    )
+    .await?;
+
+    scrolling_output.clear();
+
+    if !build_result.success {
+        return Err(Error::ExecutionFailed(
+            build_result
+                .error_message
+                .unwrap_or_else(|| "node_build failed with no error message".to_string()),
+        ));
+    }
+
+    Ok(build_result)
 }
 
 /// Fetches node info for a given source using NodeInfoRequest.

--- a/crates/peppy/src/commands/node/add.rs
+++ b/crates/peppy/src/commands/node/add.rs
@@ -1,8 +1,7 @@
 use crate::context::DaemonConnection;
 use core_node::encoding::{
-    NodeAddFeedback, NodeAddGoal, NodeAddGoalResponse, NodeAddResult, NodeBuildFeedback,
-    NodeBuildGoal, NodeBuildGoalResponse, NodeBuildResult, NodeInfoRequest, NodeInfoResponse,
-    NodeSource,
+    NodeActionFeedback, NodeActionGoalResponse, NodeAddGoal, NodeAddResult, NodeBuildGoal,
+    NodeBuildResult, NodeInfoRequest, NodeInfoResponse, NodeSource,
 };
 use peppylib::MessengerHandle;
 use std::io::BufRead;
@@ -148,7 +147,7 @@ async fn add_node_async(ctx: &Arc<AppContext>, params: AddNodeParams) -> Result<
 
     // Read the goal response to get the log file path
     let goal_response_payload = action_handle.goal_response().payload();
-    let goal_response = NodeAddGoalResponse::decode(&goal_response_payload)
+    let goal_response = NodeActionGoalResponse::decode(&goal_response_payload)
         .map_err(|e| Error::ExecutionFailed(format!("Failed to decode goal response: {}", e)))?;
 
     if !goal_response.accepted {
@@ -170,7 +169,7 @@ async fn add_node_async(ctx: &Arc<AppContext>, params: AddNodeParams) -> Result<
         &timeouts,
         &mut scrolling_output,
         |payload, output| {
-            if let Ok(feedback) = NodeAddFeedback::decode(payload) {
+            if let Ok(feedback) = NodeActionFeedback::decode(payload) {
                 output.add_line(&feedback.line, feedback.is_stderr());
             }
         },
@@ -263,7 +262,7 @@ async fn run_node_build_goal(
         .map_err(|e| Error::ExecutionFailed(format!("Failed to send node_build goal: {}", e)))?;
 
     let goal_response_payload = action_handle.goal_response().payload();
-    let goal_response = NodeBuildGoalResponse::decode(&goal_response_payload).map_err(|e| {
+    let goal_response = NodeActionGoalResponse::decode(&goal_response_payload).map_err(|e| {
         Error::ExecutionFailed(format!("Failed to decode build goal response: {}", e))
     })?;
 
@@ -286,7 +285,7 @@ async fn run_node_build_goal(
         timeouts,
         &mut scrolling_output,
         |payload, output| {
-            if let Ok(feedback) = NodeBuildFeedback::decode(payload) {
+            if let Ok(feedback) = NodeActionFeedback::decode(payload) {
                 output.add_line(&feedback.line, feedback.is_stderr());
             }
         },

--- a/crates/peppy/src/commands/node/start.rs
+++ b/crates/peppy/src/commands/node/start.rs
@@ -2,7 +2,7 @@ use config::AnyType;
 use config::launcher::Name;
 use config::runtime::{NodeInstanceConfig, RuntimeConfig};
 use core_node::encoding::{
-    NodeStartFeedback, NodeStartGoal, NodeStartGoalResponse, NodeStartResult,
+    NodeActionFeedback, NodeActionGoalResponse, NodeStartGoal, NodeStartResult,
 };
 use names_generator2::get_random;
 use peppylib::MessengerHandle;
@@ -193,7 +193,7 @@ pub async fn start_instance_async(
 
     // Decode the goal response to get log_path
     let goal_response_payload = action_handle.goal_response().payload();
-    let goal_response = NodeStartGoalResponse::decode(&goal_response_payload)
+    let goal_response = NodeActionGoalResponse::decode(&goal_response_payload)
         .map_err(|e| Error::ExecutionFailed(format!("Failed to decode goal response: {}", e)))?;
 
     if !goal_response.accepted {
@@ -215,7 +215,7 @@ pub async fn start_instance_async(
         timeouts,
         &mut scrolling_output,
         |payload, output| {
-            if let Ok(feedback) = NodeStartFeedback::decode(payload) {
+            if let Ok(feedback) = NodeActionFeedback::decode(payload) {
                 output.add_line(&feedback.line, feedback.is_stderr());
             }
         },

--- a/crates/peppy/src/commands/stack/launch.rs
+++ b/crates/peppy/src/commands/stack/launch.rs
@@ -82,7 +82,9 @@ fn handle_feedback(
                 eprintln!("{}", feedback.line);
             }
         }
-        LaunchFeedbackStep::AddingNode | LaunchFeedbackStep::StartingNode => {
+        LaunchFeedbackStep::AddingNode
+        | LaunchFeedbackStep::BuildingNode
+        | LaunchFeedbackStep::StartingNode => {
             let output = scrolling_output
                 .get_or_insert_with(|| ScrollingOutput::new(SCROLLING_OUTPUT_LINES));
             output.add_line(&feedback.line, feedback.is_stderr());


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a build phase to the node deployment lifecycle: nodes now progress through Add → Build → Start stages.
  * Build feedback (stdout, stderr, warnings) now streams during node deployment.
  * Build logs are captured and available for troubleshooting.
  * Launch feedback now displays the building step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->