### PR TITLE
Change `node info` to look up nodes by name:tag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -668,7 +668,7 @@ dependencies = [
  "parking_lot",
  "peppylib",
  "pmi",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rust-embed",
  "serde_json",
  "serde_json5",
@@ -1131,7 +1131,7 @@ checksum = "4e7f34442dbe69c60fe8eaf58a8cafff81a1f278816d8ab4db255b3bef4ac3c4"
 dependencies = [
  "getrandom 0.3.4",
  "libm",
- "rand 0.9.2",
+ "rand 0.9.3",
  "siphasher",
 ]
 
@@ -2316,9 +2316,9 @@ dependencies = [
 
 [[package]]
 name = "netdev"
-version = "0.41.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395f1acaf7a073f756fc22068e0b526d2cf22d09f5e13802b516ef8eeaeee5eb"
+checksum = "e30af1a5073b82356d9317c18226826370b4288eba2f71c7e84e18bae51b3847"
 dependencies = [
  "block2",
  "dispatch2",
@@ -2396,7 +2396,7 @@ dependencies = [
  "names-generator2",
  "parking_lot",
  "petgraph",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde",
  "serde_json5",
  "tar",
@@ -2764,7 +2764,7 @@ dependencies = [
  "parking_lot",
  "peppylib",
  "pmi",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rayon",
  "serde",
  "serde_json",
@@ -2790,7 +2790,7 @@ dependencies = [
  "futures",
  "jsonschema",
  "pmi",
- "rand 0.10.0",
+ "rand 0.10.1",
  "regex",
  "schemars 1.2.1",
  "schemars_derive",
@@ -2820,7 +2820,7 @@ dependencies = [
  "pyo3-async-runtimes",
  "pyo3-build-config",
  "pythonize",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde_json",
  "tokio",
 ]
@@ -3210,7 +3210,7 @@ dependencies = [
  "fastbloom",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.3",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3271,9 +3271,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -3281,9 +3281,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",

--- a/crates/containers-internal/src/apptainer/lima.rs
+++ b/crates/containers-internal/src/apptainer/lima.rs
@@ -40,13 +40,25 @@ fn check_output(
 /// Check that the bundled Lima version meets the minimum requirement.
 pub(crate) fn check_lima_version(limactl: &Path) -> Result<()> {
     let output = Command::new(limactl).arg("--version").output()?;
+    validate_lima_version_output(limactl, output.status, &output.stdout, &output.stderr)
+}
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+/// Pure validator for `limactl --version` output. Split out of
+/// [`check_lima_version`] so tests can drive it without spawning a subprocess
+/// (which would otherwise race with parallel tests' fork/exec — see the ETXTBSY
+/// discussion in the test module).
+fn validate_lima_version_output(
+    limactl: &Path,
+    status: std::process::ExitStatus,
+    stdout: &[u8],
+    stderr: &[u8],
+) -> Result<()> {
+    if !status.success() {
+        let stderr = String::from_utf8_lossy(stderr).trim().to_string();
         return Err(Error::LimaVersionCheckFailed(format!(
             "`{} --version` exited with {}{}",
             limactl.display(),
-            output.status,
+            status,
             if stderr.is_empty() {
                 String::new()
             } else {
@@ -55,7 +67,7 @@ pub(crate) fn check_lima_version(limactl: &Path) -> Result<()> {
         )));
     }
 
-    let version_str = String::from_utf8_lossy(&output.stdout);
+    let version_str = String::from_utf8_lossy(stdout);
     let found = parse_lima_version(&version_str).unwrap_or_default();
 
     if found < MIN_LIMA_VERSION {
@@ -520,15 +532,35 @@ pub(crate) fn parse_lima_version(version_output: &str) -> Option<(u32, u32, u32)
 /// Idempotent: returns `Ok(())` if the instance is already stopped or does not
 /// exist, so callers do not need to guard against these cases.
 pub(crate) fn stop_instance(limactl: &Path, lima_home: &Path, instance: &str) -> Result<()> {
-    let status = query_instance_status(limactl, lima_home, instance)?;
+    stop_instance_inner(
+        instance,
+        || query_instance_status(limactl, lima_home, instance),
+        || {
+            Command::new(limactl)
+                .env("LIMA_HOME", lima_home)
+                .args(["stop", instance])
+                .output()
+                .map_err(Error::from)
+        },
+    )
+}
+
+/// Branch logic for [`stop_instance`], parameterized by the status query and
+/// the stop-command spawner. Split out so tests can drive the full decision
+/// matrix with canned closures — avoiding subprocess execution (and the
+/// Linux ETXTBSY race that bites when parallel test threads fork while
+/// another thread holds a writable FD to a fake `limactl` script).
+fn stop_instance_inner<Q, S>(instance: &str, query_status: Q, run_stop: S) -> Result<()>
+where
+    Q: FnOnce() -> Result<Option<String>>,
+    S: FnOnce() -> Result<std::process::Output>,
+{
+    let status = query_status()?;
 
     match status.as_deref() {
         Some("Running") => {
             tracing::info!("Stopping Lima {} instance...", instance);
-            let output = Command::new(limactl)
-                .env("LIMA_HOME", lima_home)
-                .args(["stop", instance])
-                .output()?;
+            let output = run_stop()?;
 
             check_output(&output, |stderr| {
                 Error::LimaInstanceError(format!(
@@ -781,33 +813,28 @@ mod tests {
         );
     }
 
-    /// Write a shell script and make it executable atomically to avoid ETXTBSY
-    /// races that occur when `fs::write` + `fs::set_permissions` are separate steps.
-    #[cfg(unix)]
-    fn write_executable_script(path: &std::path::Path, content: &str) {
-        use std::io::Write;
-        use std::os::unix::fs::OpenOptionsExt;
-
-        let mut f = fs::OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .mode(0o755)
-            .open(path)
-            .expect("create executable script");
-        f.write_all(content.as_bytes())
-            .expect("write script content");
-    }
+    // These tests previously spawned fake `limactl` shell scripts via tempdirs
+    // and hit Linux ETXTBSY races: when Thread A held a writable FD to a newly
+    // written script, a parallel test on Thread B calling `Command::spawn`
+    // would fork, inheriting Thread A's writable FD, and the kernel refused
+    // Thread A's subsequent `execve` until Thread B's child finished its own
+    // `execve`. The fix is to exercise the pure branch logic directly via the
+    // `validate_lima_version_output` and `stop_instance_inner` helpers — no
+    // subprocess, no race.
 
     #[cfg(unix)]
     #[test]
     fn test_check_lima_version_returns_version_check_error_on_nonzero_exit() {
-        let dir = tempdir().expect("create temp dir");
-        let limactl = dir.path().join("limactl");
+        use std::os::unix::process::ExitStatusExt;
 
-        write_executable_script(&limactl, "#!/bin/sh\n>&2 echo 'bad lima'\nexit 42\n");
-
-        let err = check_lima_version(&limactl).expect_err("expected version check failure");
+        let status = std::process::ExitStatus::from_raw(42 << 8);
+        let err = validate_lima_version_output(
+            std::path::Path::new("/fake/limactl"),
+            status,
+            b"",
+            b"bad lima",
+        )
+        .expect_err("expected version check failure");
         match err {
             Error::LimaVersionCheckFailed(msg) => {
                 assert!(msg.contains("--version"), "unexpected message: {msg}");
@@ -820,20 +847,39 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn test_check_lima_version_rejects_unparseable_stdout() {
+        // `parse_lima_version` returns `None` for garbage, which `unwrap_or_default()`
+        // turns into (0, 0, 0) — that should fail the MIN_LIMA_VERSION check.
+        let status = std::process::ExitStatus::default();
+        let err = validate_lima_version_output(
+            std::path::Path::new("/fake/limactl"),
+            status,
+            b"not a version",
+            b"",
+        )
+        .expect_err("expected version-too-old failure");
+        match err {
+            Error::LimaVersionTooOld { found, minimum } => {
+                assert_eq!(found, "0.0.0");
+                assert_eq!(
+                    minimum,
+                    format!(
+                        "{}.{}.{}",
+                        MIN_LIMA_VERSION.0, MIN_LIMA_VERSION.1, MIN_LIMA_VERSION.2
+                    )
+                );
+            }
+            other => panic!("expected LimaVersionTooOld, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn test_stop_instance_is_idempotent_for_nonexistent() {
-        let dir = tempdir().expect("create temp dir");
-        let limactl = dir.path().join("limactl");
-        let lima_home = dir.path().join("lima_home");
-        fs::create_dir_all(&lima_home).expect("create lima home");
-
-        // Fake limactl: `list` returns empty status (instance doesn't exist),
-        // `stop` would fail — but should never be called.
-        write_executable_script(
-            &limactl,
-            "#!/bin/sh\nif [ \"$1\" = \"list\" ]; then echo ''; exit 0; else echo 'should not be called' >&2; exit 1; fi\n",
+        let result = stop_instance_inner(
+            "nonexistent_instance",
+            || Ok(None),
+            || panic!("stop should not be called for a non-existent instance"),
         );
-
-        let result = stop_instance(&limactl, &lima_home, "nonexistent_instance");
         assert!(
             result.is_ok(),
             "stop_instance should succeed for non-existent instance, got: {:?}",
@@ -841,27 +887,75 @@ mod tests {
         );
     }
 
-    #[cfg(unix)]
     #[test]
     fn test_stop_instance_is_idempotent_for_stopped() {
-        let dir = tempdir().expect("create temp dir");
-        let limactl = dir.path().join("limactl");
-        let lima_home = dir.path().join("lima_home");
-        fs::create_dir_all(&lima_home).expect("create lima home");
-
-        // Fake limactl: `list` returns "Stopped" status.
-        // `stop` would fail — but should never be called.
-        write_executable_script(
-            &limactl,
-            "#!/bin/sh\nif [ \"$1\" = \"list\" ]; then echo 'Stopped'; exit 0; else echo 'should not be called' >&2; exit 1; fi\n",
+        let result = stop_instance_inner(
+            "stopped_instance",
+            || Ok(Some("Stopped".to_string())),
+            || panic!("stop should not be called for an already-stopped instance"),
         );
-
-        let result = stop_instance(&limactl, &lima_home, "stopped_instance");
         assert!(
             result.is_ok(),
             "stop_instance should succeed for already-stopped instance, got: {:?}",
             result.unwrap_err()
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_stop_instance_runs_stop_when_running() {
+        use std::cell::Cell;
+
+        let stop_called = Cell::new(false);
+        let result = stop_instance_inner(
+            "running_instance",
+            || Ok(Some("Running".to_string())),
+            || {
+                stop_called.set(true);
+                Ok(std::process::Output {
+                    status: std::process::ExitStatus::default(),
+                    stdout: Vec::new(),
+                    stderr: Vec::new(),
+                })
+            },
+        );
+        assert!(
+            result.is_ok(),
+            "stop_instance should succeed when stop command succeeds, got: {:?}",
+            result.unwrap_err()
+        );
+        assert!(stop_called.get(), "stop closure should have been invoked");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_stop_instance_reports_error_when_stop_fails() {
+        use std::os::unix::process::ExitStatusExt;
+
+        let result = stop_instance_inner(
+            "running_instance",
+            || Ok(Some("Running".to_string())),
+            || {
+                Ok(std::process::Output {
+                    status: std::process::ExitStatus::from_raw(1 << 8),
+                    stdout: Vec::new(),
+                    stderr: b"limactl exploded".to_vec(),
+                })
+            },
+        );
+        match result {
+            Err(Error::LimaInstanceError(msg)) => {
+                assert!(
+                    msg.contains("running_instance"),
+                    "unexpected message: {msg}"
+                );
+                assert!(
+                    msg.contains("limactl exploded"),
+                    "unexpected message: {msg}"
+                );
+            }
+            other => panic!("expected LimaInstanceError, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/core-node-internal/schemas/node.capnp
+++ b/crates/core-node-internal/schemas/node.capnp
@@ -242,10 +242,6 @@ struct NodeResetResponse {
 }
 
 # Node Info service
-#
-# `node info` looks up a node already present in the node stack by
-# `(node_name, node_tag)`. If the requested node is not in the stack the
-# daemon returns an `InvalidServiceRequest` error.
 struct NodeInfoRequest {
     # Name of the node to look up in the stack
     nodeName @0 :Text;
@@ -260,18 +256,34 @@ struct NodeInstanceInfo {
     state @1 :Text;
 }
 
+# Node info lookup result.
+#
+# The response is a union so that "no such node in the stack" is a
+# first-class successful outcome rather than a protocol-level error. This
+# lets the `peppy node add` preflight check, `peppy node info`, and any
+# other caller disambiguate "not found" from a real fault without having
+# to sniff the error-string payload of an `InvalidServiceRequest`.
 struct NodeInfoResponse {
-    # JSON5-serialized NodeConfig as stored in the node stack
-    configJson5 @0 :Text;
-    # SHA256 of the entire NodeConfig file
-    configSha256 @1 :Text;
-    # Lifecycle stage of the in-stack entity ("Added"/"Building"/"Ready"/"Root").
-    stage @2 :Text;
-    # All tracked instances of this entity, including in-flight `Starting` ones.
-    instances @3 :List(NodeInstanceInfo);
-    # Path to the most-recent add/build log file for this entity.
-    # Empty string when no add log has been produced yet.
-    addLogPath @4 :Text;
-    # Per-instance run log paths, aligned with `instances` (same order).
-    runLogPaths @5 :List(Text);
+    union {
+        # The node is not in the stack. Carries no payload — the caller
+        # already knows which `(name, tag)` it asked about.
+        notInStack @0 :Void;
+        # The node is in the stack. All of the node metadata is grouped
+        # under this arm; callers must match on the union before reading.
+        found :group {
+            # JSON5-serialized NodeConfig as stored in the node stack
+            configJson5 @1 :Text;
+            # SHA256 of the entire NodeConfig file
+            configSha256 @2 :Text;
+            # Lifecycle stage of the in-stack entity ("Added"/"Building"/"Ready"/"Root").
+            stage @3 :Text;
+            # All tracked instances of this entity, including in-flight `Starting` ones.
+            instances @4 :List(NodeInstanceInfo);
+            # Path to the most-recent add/build log file for this entity.
+            # Empty string when no add log has been produced yet.
+            addLogPath @5 :Text;
+            # Per-instance run log paths, aligned with `instances` (same order).
+            runLogPaths @6 :List(Text);
+        }
+    }
 }

--- a/crates/core-node-internal/schemas/node.capnp
+++ b/crates/core-node-internal/schemas/node.capnp
@@ -242,22 +242,15 @@ struct NodeResetResponse {
 }
 
 # Node Info service
+#
+# `node info` looks up a node already present in the node stack by
+# `(node_name, node_tag)`. If the requested node is not in the stack the
+# daemon returns an `InvalidServiceRequest` error.
 struct NodeInfoRequest {
-    # Source of the node to get info for
-    source :union {
-        # Filesystem path to the node directory
-        fs @0 :Text;
-        # Git repository source
-        git @1 :NodeAddGitSource;
-        # HTTP URL source
-        http @2 :Text;
-    }
-    # Optional SHA256 checksum for HTTP sources
-    httpSha256 @4 :Text;
-    # Optional variant source — when set, the main source points to the root node
-    # and this identifies which variant to resolve and merge.
-    # Fs = variant name (lookup in manifest), Git/Http = direct source.
-    variant @3 :NodeAddVariantSource;
+    # Name of the node to look up in the stack
+    nodeName @0 :Text;
+    # Tag of the node to look up in the stack
+    nodeTag @1 :Text;
 }
 
 struct NodeInstanceInfo {
@@ -268,28 +261,17 @@ struct NodeInstanceInfo {
 }
 
 struct NodeInfoResponse {
-    # JSON5-serialized NodeConfig (merged with variant runtime when variant is requested)
+    # JSON5-serialized NodeConfig as stored in the node stack
     configJson5 @0 :Text;
-    # Whether the node is already in the node stack
-    isInNodeStack @1 :Bool;
-    # Names of running instances of this node (Running only — kept for back-compat)
-    instancesNames @2 :List(Text);
     # SHA256 of the entire NodeConfig file
-    configSha256 @3 :Text;
-    # Name of the variant applied (empty string when no variant)
-    variantName @4 :Text;
-    # Non-fatal issues encountered during resolution (e.g. unknown variant).
-    # Empty when resolution was fully successful.
-    issues @5 :List(Text);
+    configSha256 @1 :Text;
     # Lifecycle stage of the in-stack entity ("Added"/"Building"/"Ready"/"Root").
-    # Empty string when the node is not in the stack.
-    stage @6 :Text;
+    stage @2 :Text;
     # All tracked instances of this entity, including in-flight `Starting` ones.
-    # Empty when the node is not in the stack.
-    instances @7 :List(NodeInstanceInfo);
+    instances @3 :List(NodeInstanceInfo);
     # Path to the most-recent add/build log file for this entity.
-    # Empty string when not in stack or no add log has been produced yet.
-    addLogPath @8 :Text;
+    # Empty string when no add log has been produced yet.
+    addLogPath @4 :Text;
     # Per-instance run log paths, aligned with `instances` (same order).
-    runLogPaths @9 :List(Text);
+    runLogPaths @5 :List(Text);
 }

--- a/crates/core-node-internal/src/encoding.rs
+++ b/crates/core-node-internal/src/encoding.rs
@@ -19,12 +19,12 @@ pub use launch::{
 pub use node::{
     add::NodeAddFeedback, add::NodeAddGoal, add::NodeAddGoalResponse, add::NodeAddResult,
     add::NodeSource, builder::NodeBuildFeedback, builder::NodeBuildGoal,
-    builder::NodeBuildGoalResponse, builder::NodeBuildResult, info::NodeInfoRequest,
-    info::NodeInfoResponse, info::NodeInstanceInfo, init::NodeInitRequest, init::NodeInitResponse,
-    list::NodeListRequest, list::NodeListResponse, remove::NodeRemoveRequest,
-    remove::NodeRemoveResponse, run::NodeRunFeedback, run::NodeRunGoal, run::NodeRunGoalResponse,
-    run::NodeRunResult, stop::NodeStopRequest, stop::NodeStopResponse, sync::NodeSyncRequest,
-    sync::NodeSyncResponse,
+    builder::NodeBuildGoalResponse, builder::NodeBuildResult, info::NodeInfo,
+    info::NodeInfoRequest, info::NodeInfoResponse, info::NodeInstanceInfo, init::NodeInitRequest,
+    init::NodeInitResponse, list::NodeListRequest, list::NodeListResponse,
+    remove::NodeRemoveRequest, remove::NodeRemoveResponse, run::NodeRunFeedback, run::NodeRunGoal,
+    run::NodeRunGoalResponse, run::NodeRunResult, stop::NodeStopRequest, stop::NodeStopResponse,
+    sync::NodeSyncRequest, sync::NodeSyncResponse,
 };
 pub use ping::{PingRequest, PingResponse};
 pub use reset::{NodeResetRequest, NodeResetResponse};

--- a/crates/core-node-internal/src/encoding/node/info.rs
+++ b/crates/core-node-internal/src/encoding/node/info.rs
@@ -12,71 +12,44 @@ use crate::Result;
 use crate::names;
 use crate::node_capnp;
 
-use super::add::NodeSource;
 use crate::encoding::{decode_message, encode_message, optional_text};
 
+/// Request payload for the `node_info` service.
+///
+/// Identifies a node already present in the node stack by `(name, tag)`.
+/// Unlike `node_add`, `node_info` does not resolve configs from filesystem,
+/// git, or HTTP sources — it only inspects what is already in the stack.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NodeInfoRequest {
-    pub source: NodeSource,
+    pub node_name: String,
+    pub node_tag: String,
 }
 
 impl NodeInfoRequest {
-    pub fn new(source: NodeSource) -> Self {
-        Self { source }
+    pub fn new(node_name: impl Into<String>, node_tag: impl Into<String>) -> Self {
+        Self {
+            node_name: node_name.into(),
+            node_tag: node_tag.into(),
+        }
     }
 
     pub fn encode(&self) -> Result<Payload> {
         let mut builder = Builder::new_default();
         {
             let mut request = builder.init_root::<node_capnp::node_info_request::Builder>();
-            let mut source = request.reborrow().init_source();
-            match &self.source {
-                NodeSource::Fs(path) => {
-                    source.set_fs(path.to_string_lossy().as_ref());
-                }
-                NodeSource::Git {
-                    repo_url,
-                    repo_path,
-                    repo_ref,
-                } => {
-                    let mut git = source.init_git();
-                    git.set_repo_url(repo_url.to_bstring().to_string());
-                    git.set_repo_path(repo_path);
-                    git.set_repo_ref(repo_ref.as_deref().unwrap_or(""));
-                }
-                NodeSource::Http { url, sha256 } => {
-                    source.set_http(url.as_str());
-                    if let Some(digest) = NodeSource::normalize_http_sha256(sha256.as_deref()) {
-                        request.reborrow().set_http_sha256(&digest);
-                    }
-                }
-            }
+            request.set_node_name(&self.node_name);
+            request.set_node_tag(&self.node_tag);
         }
         encode_message(&builder)
     }
 
     pub fn decode(data: &[u8]) -> Result<Self> {
-        use crate::node_capnp::node_info_request::source::Which;
-
         let reader = decode_message(data)?;
         let request = reader.get_root::<node_capnp::node_info_request::Reader>()?;
-        let source = match request.get_source().which()? {
-            Which::Fs(fs) => NodeSource::decode_fs(fs?.to_str()?)?,
-            Which::Git(git) => {
-                let git = git?;
-                NodeSource::decode_git(
-                    git.get_repo_url()?.to_str()?,
-                    git.get_repo_path()?.to_str()?,
-                    git.get_repo_ref()?.to_str()?,
-                )?
-            }
-            Which::Http(http) => NodeSource::decode_http(
-                http?.to_str()?,
-                Some(request.get_http_sha256()?.to_str()?),
-            )?,
-        };
-
-        Ok(Self { source })
+        Ok(Self {
+            node_name: request.get_node_name()?.to_str()?.to_owned(),
+            node_tag: request.get_node_tag()?.to_str()?.to_owned(),
+        })
     }
 
     pub async fn poll(
@@ -111,24 +84,21 @@ pub struct NodeInstanceInfo {
     pub state: String,
 }
 
+/// Response payload for the `node_info` service.
+///
+/// Always describes a node that is currently in the node stack — the daemon
+/// errors out for unknown `(name, tag)` pairs, so there is no "not found"
+/// representation to carry here.
 #[derive(Debug, Clone)]
 pub struct NodeInfoResponse {
+    /// Resolved NodeConfig as stored in the node stack.
     pub config: NodeConfig,
-    pub is_in_node_stack: bool,
-    /// IDs of `Running` instances only — kept for back-compat with existing
-    /// consumers. New code should prefer `instances`, which includes
-    /// in-flight `Starting` instances and exposes their state.
-    pub instances_names: Vec<String>,
-    /// SHA256 of the entire NodeConfig file taken from NodeSource
+    /// SHA256 of the serialized NodeConfig at the time of the response.
     pub config_integrity: String,
-    /// Name of the variant applied, if any.
-    pub variant_name: Option<String>,
-    /// Non-fatal issues encountered during resolution (e.g. unknown variant).
-    pub issues: Vec<String>,
-    /// Lifecycle stage of the in-stack entity. `None` when not in stack.
-    pub stage: Option<String>,
+    /// Lifecycle stage of the entity ("Added"/"Building"/"Ready"/"Root").
+    pub stage: String,
     /// All tracked instances of this entity, including in-flight `Starting`
-    /// ones, with their per-instance state. Empty when not in stack.
+    /// ones, with their per-instance state.
     pub instances: Vec<NodeInstanceInfo>,
     /// Most-recent add/build log file produced for this entity, if any.
     pub add_log_path: Option<PathBuf>,
@@ -145,22 +115,8 @@ impl NodeInfoResponse {
                 crate::Error::Encoding(format!("failed to serialize config: {}", e))
             })?;
             response.set_config_json5(&config_json5);
-            response.set_is_in_node_stack(self.is_in_node_stack);
-            let mut instances = response
-                .reborrow()
-                .init_instances_names(self.instances_names.len() as u32);
-            for (i, name) in self.instances_names.iter().enumerate() {
-                instances.set(i as u32, name);
-            }
             response.set_config_sha256(&self.config_integrity);
-            response.set_variant_name(self.variant_name.as_deref().unwrap_or(""));
-            {
-                let mut issues_builder = response.reborrow().init_issues(self.issues.len() as u32);
-                for (i, issue) in self.issues.iter().enumerate() {
-                    issues_builder.set(i as u32, issue);
-                }
-            }
-            response.set_stage(self.stage.as_deref().unwrap_or(""));
+            response.set_stage(&self.stage);
             {
                 let mut instances_builder = response
                     .reborrow()
@@ -196,20 +152,8 @@ impl NodeInfoResponse {
         let config_json5 = response.get_config_json5()?.to_str()?;
         let config: NodeConfig = serde_json5::from_str(config_json5)
             .map_err(|e| crate::Error::Decoding(format!("failed to deserialize config: {}", e)))?;
-        let is_in_node_stack = response.get_is_in_node_stack();
-        let instances_names_reader = response.get_instances_names()?;
-        let mut instances_names = Vec::with_capacity(instances_names_reader.len() as usize);
-        for i in 0..instances_names_reader.len() {
-            instances_names.push(instances_names_reader.get(i)?.to_str()?.to_owned());
-        }
         let config_integrity = response.get_config_sha256()?.to_str()?.to_owned();
-        let variant_name = optional_text(response.get_variant_name()?.to_str()?);
-        let issues_reader = response.get_issues()?;
-        let mut issues = Vec::with_capacity(issues_reader.len() as usize);
-        for i in 0..issues_reader.len() {
-            issues.push(issues_reader.get(i)?.to_str()?.to_owned());
-        }
-        let stage = optional_text(response.get_stage()?.to_str()?);
+        let stage = response.get_stage()?.to_str()?.to_owned();
         let instances_reader = response.get_instances()?;
         let mut instances = Vec::with_capacity(instances_reader.len() as usize);
         for i in 0..instances_reader.len() {
@@ -227,11 +171,7 @@ impl NodeInfoResponse {
         }
         Ok(Self {
             config,
-            is_in_node_stack,
-            instances_names,
             config_integrity,
-            variant_name,
-            issues,
             stage,
             instances,
             add_log_path,
@@ -245,24 +185,13 @@ mod tests {
     use super::*;
 
     #[test]
-    fn node_info_request_http_source_roundtrips_sha256() {
-        let url = url::Url::parse("https://example.com/node.tar.zst").unwrap();
-        let sha256 = "c".repeat(64);
-
-        let encoded = NodeInfoRequest::new(NodeSource::Http {
-            url: url.clone(),
-            sha256: Some(sha256.clone()),
-        })
-        .encode()
-        .expect("encoding should succeed");
+    fn node_info_request_roundtrips_name_tag() {
+        let encoded = NodeInfoRequest::new("sensor_node", "0.1.0")
+            .encode()
+            .expect("encoding should succeed");
         let decoded = NodeInfoRequest::decode(&encoded).expect("decoding should succeed");
 
-        assert_eq!(
-            decoded.source,
-            NodeSource::Http {
-                url,
-                sha256: Some(sha256)
-            }
-        );
+        assert_eq!(decoded.node_name, "sensor_node");
+        assert_eq!(decoded.node_tag, "0.1.0");
     }
 }

--- a/crates/core-node-internal/src/encoding/node/info.rs
+++ b/crates/core-node-internal/src/encoding/node/info.rs
@@ -115,7 +115,7 @@ pub enum NodeInfoResponse {
     /// The `(name, tag)` pair is not currently in the node stack.
     NotInStack,
     /// The node is in the stack — carries its full metadata.
-    Found(NodeInfo),
+    Found(Box<NodeInfo>),
 }
 
 impl NodeInfoResponse {
@@ -197,14 +197,14 @@ impl NodeInfoResponse {
                 for i in 0..run_log_paths_reader.len() {
                     run_log_paths.push(PathBuf::from(run_log_paths_reader.get(i)?.to_str()?));
                 }
-                Ok(NodeInfoResponse::Found(NodeInfo {
+                Ok(NodeInfoResponse::Found(Box::new(NodeInfo {
                     config,
                     config_integrity,
                     stage,
                     instances,
                     add_log_path,
                     run_log_paths,
-                }))
+                })))
             }
         }
     }

--- a/crates/core-node-internal/src/encoding/node/info.rs
+++ b/crates/core-node-internal/src/encoding/node/info.rs
@@ -84,13 +84,10 @@ pub struct NodeInstanceInfo {
     pub state: String,
 }
 
-/// Response payload for the `node_info` service.
-///
-/// Always describes a node that is currently in the node stack — the daemon
-/// errors out for unknown `(name, tag)` pairs, so there is no "not found"
-/// representation to carry here.
+/// Body of a successful `node_info` lookup — carries all metadata about a
+/// node that was found in the stack.
 #[derive(Debug, Clone)]
-pub struct NodeInfoResponse {
+pub struct NodeInfo {
     /// Resolved NodeConfig as stored in the node stack.
     pub config: NodeConfig,
     /// SHA256 of the serialized NodeConfig at the time of the response.
@@ -106,40 +103,64 @@ pub struct NodeInfoResponse {
     pub run_log_paths: Vec<PathBuf>,
 }
 
+/// Response payload for the `node_info` service.
+///
+/// `NotInStack` is a first-class *successful* negative answer to the lookup,
+/// not a protocol-level error. Prior to this shape, the daemon rejected
+/// missing-node lookups with `InvalidServiceRequest`, which conflated "no
+/// such node" with "malformed request" and produced spurious ERROR logs
+/// during normal flows like the preflight inside `peppy node add`.
+#[derive(Debug, Clone)]
+pub enum NodeInfoResponse {
+    /// The `(name, tag)` pair is not currently in the node stack.
+    NotInStack,
+    /// The node is in the stack — carries its full metadata.
+    Found(NodeInfo),
+}
+
 impl NodeInfoResponse {
     pub fn encode(&self) -> Result<Payload> {
         let mut builder = Builder::new_default();
         {
-            let mut response = builder.init_root::<node_capnp::node_info_response::Builder>();
-            let config_json5 = serde_json5::to_string(&self.config).map_err(|e| {
-                crate::Error::Encoding(format!("failed to serialize config: {}", e))
-            })?;
-            response.set_config_json5(&config_json5);
-            response.set_config_sha256(&self.config_integrity);
-            response.set_stage(&self.stage);
-            {
-                let mut instances_builder = response
-                    .reborrow()
-                    .init_instances(self.instances.len() as u32);
-                for (i, info) in self.instances.iter().enumerate() {
-                    let mut entry = instances_builder.reborrow().get(i as u32);
-                    entry.set_instance_id(&info.instance_id);
-                    entry.set_state(&info.state);
+            let response = builder.init_root::<node_capnp::node_info_response::Builder>();
+            match self {
+                NodeInfoResponse::NotInStack => {
+                    // Select the `notInStack :Void` arm of the union.
+                    let mut response = response;
+                    response.set_not_in_stack(());
                 }
-            }
-            response.set_add_log_path(
-                self.add_log_path
-                    .as_ref()
-                    .map(|p| p.to_string_lossy().into_owned())
-                    .unwrap_or_default()
-                    .as_str(),
-            );
-            {
-                let mut paths_builder = response
-                    .reborrow()
-                    .init_run_log_paths(self.run_log_paths.len() as u32);
-                for (i, path) in self.run_log_paths.iter().enumerate() {
-                    paths_builder.set(i as u32, path.to_string_lossy().as_ref());
+                NodeInfoResponse::Found(info) => {
+                    let mut found = response.init_found();
+                    let config_json5 = serde_json5::to_string(&info.config).map_err(|e| {
+                        crate::Error::Encoding(format!("failed to serialize config: {}", e))
+                    })?;
+                    found.set_config_json5(&config_json5);
+                    found.set_config_sha256(&info.config_integrity);
+                    found.set_stage(&info.stage);
+                    {
+                        let mut instances_builder =
+                            found.reborrow().init_instances(info.instances.len() as u32);
+                        for (i, inst) in info.instances.iter().enumerate() {
+                            let mut entry = instances_builder.reborrow().get(i as u32);
+                            entry.set_instance_id(&inst.instance_id);
+                            entry.set_state(&inst.state);
+                        }
+                    }
+                    found.set_add_log_path(
+                        info.add_log_path
+                            .as_ref()
+                            .map(|p| p.to_string_lossy().into_owned())
+                            .unwrap_or_default()
+                            .as_str(),
+                    );
+                    {
+                        let mut paths_builder = found
+                            .reborrow()
+                            .init_run_log_paths(info.run_log_paths.len() as u32);
+                        for (i, path) in info.run_log_paths.iter().enumerate() {
+                            paths_builder.set(i as u32, path.to_string_lossy().as_ref());
+                        }
+                    }
                 }
             }
         }
@@ -149,34 +170,43 @@ impl NodeInfoResponse {
     pub fn decode(data: &[u8]) -> Result<Self> {
         let reader = decode_message(data)?;
         let response = reader.get_root::<node_capnp::node_info_response::Reader>()?;
-        let config_json5 = response.get_config_json5()?.to_str()?;
-        let config: NodeConfig = serde_json5::from_str(config_json5)
-            .map_err(|e| crate::Error::Decoding(format!("failed to deserialize config: {}", e)))?;
-        let config_integrity = response.get_config_sha256()?.to_str()?.to_owned();
-        let stage = response.get_stage()?.to_str()?.to_owned();
-        let instances_reader = response.get_instances()?;
-        let mut instances = Vec::with_capacity(instances_reader.len() as usize);
-        for i in 0..instances_reader.len() {
-            let entry = instances_reader.get(i);
-            instances.push(NodeInstanceInfo {
-                instance_id: entry.get_instance_id()?.to_str()?.to_owned(),
-                state: entry.get_state()?.to_str()?.to_owned(),
-            });
+        match response.which()? {
+            node_capnp::node_info_response::Which::NotInStack(()) => {
+                Ok(NodeInfoResponse::NotInStack)
+            }
+            node_capnp::node_info_response::Which::Found(found) => {
+                let config_json5 = found.get_config_json5()?.to_str()?;
+                let config: NodeConfig = serde_json5::from_str(config_json5).map_err(|e| {
+                    crate::Error::Decoding(format!("failed to deserialize config: {}", e))
+                })?;
+                let config_integrity = found.get_config_sha256()?.to_str()?.to_owned();
+                let stage = found.get_stage()?.to_str()?.to_owned();
+                let instances_reader = found.get_instances()?;
+                let mut instances = Vec::with_capacity(instances_reader.len() as usize);
+                for i in 0..instances_reader.len() {
+                    let entry = instances_reader.get(i);
+                    instances.push(NodeInstanceInfo {
+                        instance_id: entry.get_instance_id()?.to_str()?.to_owned(),
+                        state: entry.get_state()?.to_str()?.to_owned(),
+                    });
+                }
+                let add_log_path =
+                    optional_text(found.get_add_log_path()?.to_str()?).map(PathBuf::from);
+                let run_log_paths_reader = found.get_run_log_paths()?;
+                let mut run_log_paths = Vec::with_capacity(run_log_paths_reader.len() as usize);
+                for i in 0..run_log_paths_reader.len() {
+                    run_log_paths.push(PathBuf::from(run_log_paths_reader.get(i)?.to_str()?));
+                }
+                Ok(NodeInfoResponse::Found(NodeInfo {
+                    config,
+                    config_integrity,
+                    stage,
+                    instances,
+                    add_log_path,
+                    run_log_paths,
+                }))
+            }
         }
-        let add_log_path = optional_text(response.get_add_log_path()?.to_str()?).map(PathBuf::from);
-        let run_log_paths_reader = response.get_run_log_paths()?;
-        let mut run_log_paths = Vec::with_capacity(run_log_paths_reader.len() as usize);
-        for i in 0..run_log_paths_reader.len() {
-            run_log_paths.push(PathBuf::from(run_log_paths_reader.get(i)?.to_str()?));
-        }
-        Ok(Self {
-            config,
-            config_integrity,
-            stage,
-            instances,
-            add_log_path,
-            run_log_paths,
-        })
     }
 }
 

--- a/crates/core-node-internal/src/services/node/info.rs
+++ b/crates/core-node-internal/src/services/node/info.rs
@@ -162,14 +162,14 @@ async fn handle_node_info_request_inner(
         .map_err(|e| InfoError::Internal(format!("failed to serialize node config: {}", e)))?;
     let config_integrity = fingerprint_for_bytes(config_json.as_bytes());
 
-    NodeInfoResponse::Found(NodeInfo {
+    NodeInfoResponse::Found(Box::new(NodeInfo {
         config: node_config,
         config_integrity,
         stage,
         instances,
         add_log_path,
         run_log_paths,
-    })
+    }))
     .encode()
     .map_err(|e| InfoError::Internal(format!("failed to encode NodeInfoResponse: {}", e)))
 }

--- a/crates/core-node-internal/src/services/node/info.rs
+++ b/crates/core-node-internal/src/services/node/info.rs
@@ -1,4 +1,4 @@
-use super::variant::{resolve_variant, variant_label};
+use super::variant::resolve_variant;
 use super::{
     checkout_repo_ref, is_supported_fs_archive, resolve_local_archive_source, sanitize_repo_path,
 };
@@ -83,13 +83,9 @@ async fn handle_node_info_request(
 ) -> PeppyResult<Payload> {
     let sender_instance_id = context.message().instance_id().to_string();
 
-    // Cooperative deadline fires slightly before the outer safety-net timeout,
-    // giving the blocking task a chance to abort and clean up resources.
-    let deadline = Some(Instant::now() + timeout.saturating_sub(Duration::from_millis(500)));
-
     match tokio::time::timeout(
         timeout,
-        handle_node_info_request_inner(&context, node_stack, peppy_dirs, deadline),
+        handle_node_info_request_inner(&context, node_stack, peppy_dirs),
     )
     .await
     {
@@ -114,94 +110,50 @@ async fn handle_node_info_request_inner(
     context: &ServiceRequestContext,
     node_stack: Arc<NodeStack>,
     peppy_dirs: PeppyDirs,
-    deadline: Option<Instant>,
 ) -> std::result::Result<Payload, InfoError> {
     let sender_instance_id = context.message().instance_id();
     let payload = context.message().payload();
 
     let request = NodeInfoRequest::decode(payload.as_ref()).map_err(|e| format!("{}", e))?;
 
-    debug!("Received `node_info` request from {sender_instance_id}");
+    debug!(
+        "Received `node_info` request from {sender_instance_id} for {}:{}",
+        request.node_name, request.node_tag
+    );
 
-    // Variant resolution errors are collected as issues rather than failing the request,
-    // since info calls are display-only and should always return useful information.
-    let (root_config, root_source_path, cleanup_dir) =
-        resolve_node_config_with_source_path(request.source, &peppy_dirs, deadline).await?;
-    let _cleanup_guard = super::add::CleanupDir::new(cleanup_dir);
+    let entity = node_stack
+        .find(&request.node_name, &request.node_tag)
+        .ok_or_else(|| {
+            InfoError::Invalid(format!(
+                "Node '{}:{}' is not in the node stack",
+                request.node_name, request.node_tag
+            ))
+        })?;
 
-    let (node_config, variant_name, issues) = if root_config.has_default_variant() {
-        let variant_source = NodeSource::Fs(DEFAULT_VARIANT_NAME.into());
-        let label = variant_label(&variant_source);
-        match resolve_variant(
-            &variant_source,
-            &root_config,
-            &root_source_path,
-            &peppy_dirs,
-            deadline,
-        )
-        .await
-        {
-            Ok(resolved) => (
-                merged_config_with_variant_cleanup(resolved),
-                Some(label),
-                Vec::new(),
-            ),
-            Err(variant_err) => (
-                root_config.into_resolved_or_default(),
-                None,
-                vec![variant_err],
-            ),
+    let (node_config, stage, instances, run_log_paths) = {
+        let guard = entity.read();
+        let stage = guard.stage().name().to_string();
+        let node_config = guard.config().clone();
+        let tracked = guard.instances();
+        let run_log_dir = peppy_dirs.logs_dir_run();
+        let mut instances: Vec<NodeInstanceInfo> = Vec::with_capacity(tracked.len());
+        let mut run_log_paths: Vec<PathBuf> = Vec::with_capacity(tracked.len());
+        for instance in tracked.iter() {
+            let id = instance.instance_id().as_str();
+            let state = instance.state();
+            instances.push(NodeInstanceInfo {
+                instance_id: id.to_owned(),
+                state: match state {
+                    InstanceState::Starting => "starting".to_string(),
+                    InstanceState::Running => "running".to_string(),
+                },
+            });
+            run_log_paths.push(run_log_dir.join(format!("{}.log", id)));
         }
-    } else {
-        (
-            root_config.into_resolved().map_err(|e| e.to_string())?,
-            None,
-            Vec::new(),
-        )
+        (node_config, stage, instances, run_log_paths)
     };
 
-    let node_name = node_config.manifest.name.as_str();
-    let node_tag = node_config.manifest.tag.as_str();
-
-    let (is_in_node_stack, instances_names, stage, instances, add_log_path, run_log_paths) =
-        match node_stack.find(node_name, node_tag) {
-            Some(entity) => {
-                let guard = entity.read();
-                {
-                    let stage = Some(guard.stage().name().to_string());
-                    let tracked = guard.instances();
-                    let run_log_dir = peppy_dirs.logs_dir_run();
-                    let mut instances: Vec<NodeInstanceInfo> = Vec::with_capacity(tracked.len());
-                    let mut instances_names: Vec<String> = Vec::new();
-                    let mut run_log_paths: Vec<PathBuf> = Vec::with_capacity(tracked.len());
-                    for instance in tracked.iter() {
-                        let id = instance.instance_id().as_str();
-                        let state = instance.state();
-                        instances.push(NodeInstanceInfo {
-                            instance_id: id.to_owned(),
-                            state: match state {
-                                InstanceState::Starting => "starting".to_string(),
-                                InstanceState::Running => "running".to_string(),
-                            },
-                        });
-                        if state == InstanceState::Running {
-                            instances_names.push(id.to_owned());
-                        }
-                        run_log_paths.push(run_log_dir.join(format!("{}.log", id)));
-                    }
-                    let add_log_path = node_stack.add_log_path(node_name, node_tag);
-                    (
-                        true,
-                        instances_names,
-                        stage,
-                        instances,
-                        add_log_path,
-                        run_log_paths,
-                    )
-                }
-            }
-            None => (false, Vec::new(), None, Vec::new(), None, Vec::new()),
-        };
+    let add_log_path = node_stack.add_log_path(&request.node_name, &request.node_tag);
 
     let config_json = serde_json5::to_string(&node_config)
         .map_err(|e| InfoError::Internal(format!("failed to serialize node config: {}", e)))?;
@@ -209,11 +161,7 @@ async fn handle_node_info_request_inner(
 
     NodeInfoResponse {
         config: node_config,
-        is_in_node_stack,
-        instances_names,
         config_integrity,
-        variant_name,
-        issues,
         stage,
         instances,
         add_log_path,

--- a/crates/core-node-internal/src/services/node/info.rs
+++ b/crates/core-node-internal/src/services/node/info.rs
@@ -3,7 +3,7 @@ use super::{
     checkout_repo_ref, is_supported_fs_archive, resolve_local_archive_source, sanitize_repo_path,
 };
 use crate::Result;
-use crate::encoding::{NodeInfoRequest, NodeInfoResponse, NodeInstanceInfo, NodeSource};
+use crate::encoding::{NodeInfo, NodeInfoRequest, NodeInfoResponse, NodeInstanceInfo, NodeSource};
 use crate::names;
 use config::consts::{NODE_CONFIG_FILE, PeppyDirs};
 use config::fingerprint::fingerprint_for_bytes;
@@ -121,14 +121,17 @@ async fn handle_node_info_request_inner(
         request.node_name, request.node_tag
     );
 
-    let entity = node_stack
-        .find(&request.node_name, &request.node_tag)
-        .ok_or_else(|| {
-            InfoError::Invalid(format!(
-                "Node '{}:{}' is not in the node stack",
-                request.node_name, request.node_tag
-            ))
-        })?;
+    // A missing `(name, tag)` is a *successful* negative lookup, not a
+    // malformed request. Encode it as `NodeInfoResponse::NotInStack` so
+    // callers (e.g. the `peppy node add` preflight) can handle it without
+    // provoking the generic service-handler error log. Malformed requests
+    // (decode failures above) still route to `InfoError::Invalid` and are
+    // the only legitimate caller-fault path through this handler.
+    let Some(entity) = node_stack.find(&request.node_name, &request.node_tag) else {
+        return NodeInfoResponse::NotInStack
+            .encode()
+            .map_err(|e| InfoError::Internal(format!("failed to encode NodeInfoResponse: {}", e)));
+    };
 
     let (node_config, stage, instances, run_log_paths) = {
         let guard = entity.read();
@@ -159,14 +162,14 @@ async fn handle_node_info_request_inner(
         .map_err(|e| InfoError::Internal(format!("failed to serialize node config: {}", e)))?;
     let config_integrity = fingerprint_for_bytes(config_json.as_bytes());
 
-    NodeInfoResponse {
+    NodeInfoResponse::Found(NodeInfo {
         config: node_config,
         config_integrity,
         stage,
         instances,
         add_log_path,
         run_log_paths,
-    }
+    })
     .encode()
     .map_err(|e| InfoError::Internal(format!("failed to encode NodeInfoResponse: {}", e)))
 }

--- a/crates/core-node-internal/tests/listen_for_node_add.rs
+++ b/crates/core-node-internal/tests/listen_for_node_add.rs
@@ -2804,7 +2804,7 @@ async fn listen_for_node_add_variant_local_source_after_sync() {
 /// path, not the root.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn listen_for_node_add_variant_only_node_after_sync() {
-    use core_node::encoding::{NodeInfoRequest, NodeSyncRequest};
+    use core_node::encoding::NodeSyncRequest;
 
     const ROOT_NODE_NAME: &str = "variant_only_robot";
     const ROOT_NODE_TAG: &str = "0.1.0";
@@ -2896,23 +2896,7 @@ async fn listen_for_node_add_variant_only_node_after_sync() {
         "variant .peppy directory should exist after sync"
     );
 
-    // Step 2: Preflight node_info check — mirrors what the CLI does before add.
-    // Must succeed for variant-only nodes (auto-resolves the default variant).
-    let info_response = NodeInfoRequest::new(core_node::encoding::NodeSource::Fs(root_dir.clone()))
-        .poll(
-            &started_core_node.caller_handle,
-            &started_core_node.core_node_name,
-            CALLER_INSTANCE_ID,
-            &started_core_node.core_node_name,
-            Duration::from_secs(5),
-        )
-        .await
-        .expect("node_info preflight should succeed for variant-only nodes");
-
-    assert_eq!(info_response.config.manifest.name.as_str(), ROOT_NODE_NAME);
-    assert_eq!(info_response.config.manifest.tag.as_str(), ROOT_NODE_TAG);
-
-    // Step 3: Run node add with the variant — must succeed despite no .peppy variant file at the repo root.
+    // Step 2: Run node add with the variant — must succeed despite no .peppy variant file at the repo root.
     let add_result = send_node_add_and_wait_with_variant(
         &started_core_node.caller_handle,
         &started_core_node.core_node_name,

--- a/crates/core-node-internal/tests/listen_for_node_info.rs
+++ b/crates/core-node-internal/tests/listen_for_node_info.rs
@@ -42,7 +42,7 @@ async fn poll_node_info(
     timeout: Duration,
 ) -> core_node::Result<NodeInfo> {
     match poll_node_info_raw(started_core_node, request, timeout).await? {
-        NodeInfoResponse::Found(info) => Ok(info),
+        NodeInfoResponse::Found(info) => Ok(*info),
         NodeInfoResponse::NotInStack => panic!(
             "node_info unexpectedly reported `{}:{}` as not in the stack",
             request.node_name, request.node_tag

--- a/crates/core-node-internal/tests/listen_for_node_info.rs
+++ b/crates/core-node-internal/tests/listen_for_node_info.rs
@@ -1,25 +1,19 @@
 mod common;
 
 use common::{
-    AbortOnDrop, CALLER_INSTANCE_ID, create_tar_zst_from_dir, real_build_and_spawn_instance,
-    start_core_node_with_mock_messenger, write_peppy_json5,
+    AbortOnDrop, CALLER_INSTANCE_ID, NodeRunTestTimeouts, real_build_and_spawn_instance,
+    send_node_add_then_build, send_node_run_and_wait, start_core_node_with_mock_messenger,
+    write_peppy_json5,
 };
-use common::{NodeRunTestTimeouts, send_node_add_then_build, send_node_run_and_wait};
-use config::consts::NODE_CONFIG_FILE;
-use config::node::{Name, PeppygenLanguage};
-use config::test_helpers;
-use core_node::encoding::{NodeInfoRequest, NodeInfoResponse, NodeSource};
+use config::node::Name;
+use core_node::encoding::{NodeInfoRequest, NodeInfoResponse};
 use core_node::names;
-use gix_url::Url as GitUrl;
 use peppylib::PeppyError;
 use peppylib::messaging::MessengerHandle;
 use peppylib::services::health::listen_for_node_health;
 use peppylib::services::ready::listen_for_node_ready;
-use sha2::{Digest, Sha256};
-use std::io::Write;
 use std::sync::Arc;
 use std::time::Duration;
-use tempfile::TempDir;
 
 /// Sends a `NODE_INFO` poll request to the given core node and returns the raw result.
 async fn poll_node_info(
@@ -37,13 +31,12 @@ async fn poll_node_info(
         )
         .await
 }
-use {
-    httptest::Expectation, httptest::Server, httptest::matchers::request,
-    httptest::responders::status_code,
-};
 
+/// Happy path: add a node + start an instance, then `node info` reports the
+/// stage, instance list, run logs, and (after it's set) the add log path.
+/// This is the rewrite of `listen_for_node_info_on_fs_node_success`.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn listen_for_node_info_on_fs_node_success() {
+async fn node_info_reports_stage_instances_and_logs_for_stack_resident_node() {
     const TARGET_NODE_NAME: &str = "fs_node";
     const TARGET_NODE_TAG: &str = "0.1.0";
     const TARGET_INSTANCE_ID: &str = "fs_instance";
@@ -55,47 +48,27 @@ async fn listen_for_node_info_on_fs_node_success() {
     let peppy_json5 = r#"{
             schema_version: 1,
             manifest: {
-                name: "{TARGET_NODE_NAME}",
-                tag: "{TARGET_NODE_TAG}",
+                name: "fs_node",
+                tag: "0.1.0",
             },
             execution: {
                 language: "rust",
                 run_cmd: ["sleep", "10"]
             }
-        }"#
-    .replace("{TARGET_NODE_NAME}", TARGET_NODE_NAME)
-    .replace("{TARGET_NODE_TAG}", TARGET_NODE_TAG);
-    write_peppy_json5(node_dir.path(), &peppy_json5);
+        }"#;
+    write_peppy_json5(node_dir.path(), peppy_json5);
 
-    let request = NodeInfoRequest::new(NodeSource::Fs(node_dir.path().to_path_buf()));
-
-    let info_response = poll_node_info(&started_core_node, &request, Duration::from_secs(5))
-        .await
-        .expect("node_info request should succeed");
-
-    assert_eq!(
-        info_response.config.manifest.name.as_str(),
-        TARGET_NODE_NAME
-    );
-    assert_eq!(info_response.config.manifest.tag, TARGET_NODE_TAG);
-    assert!(
-        !info_response.is_in_node_stack,
-        "node should not yet be in the node stack"
-    );
-    assert!(
-        info_response.instances_names.is_empty(),
-        "no instances should be reported when node is not in stack"
-    );
-
-    assert_eq!(
-        info_response.config_integrity.len(),
-        64,
-        "config_integrity should be a 64-character hex SHA256 hash"
-    );
-
+    // Parse the config and push it directly — we don't need the full add
+    // pipeline for an info-only test, and `real_build_and_spawn_instance`
+    // takes it from there.
+    let config = config::node::NodeConfigParser::from_path(node_dir.path().join("peppy.json5"))
+        .expect("parse config")
+        .into_resolved()
+        .expect("resolve config");
     node_stack
-        .push_config(info_response.config.clone(), false, node_dir.path())
+        .push_config(config, false, node_dir.path())
         .expect("push_config should succeed");
+
     let instance_id = Name::new(TARGET_INSTANCE_ID).expect("valid instance id");
     let _running = real_build_and_spawn_instance(
         &started_core_node,
@@ -105,26 +78,24 @@ async fn listen_for_node_info_on_fs_node_success() {
     )
     .await;
 
-    let request = NodeInfoRequest::new(NodeSource::Fs(node_dir.path().to_path_buf()));
-
+    let request = NodeInfoRequest::new(TARGET_NODE_NAME, TARGET_NODE_TAG);
     let info_response = poll_node_info(&started_core_node, &request, Duration::from_secs(5))
         .await
         .expect("node_info request should succeed");
 
-    assert!(info_response.is_in_node_stack, "node should be in stack");
     assert_eq!(
-        info_response.instances_names,
-        vec![TARGET_INSTANCE_ID.to_string()]
+        info_response.config.manifest.name.as_str(),
+        TARGET_NODE_NAME
     );
-
-    // New fields surfaced for `peppy node info`: stage name, per-instance
-    // state, start log paths (derived from peppy_dirs + instance id), and
-    // add log path. The latter is exercised via the entity setter because
-    // `force_built_and_start_instance` bypasses `process_node_add`.
+    assert_eq!(info_response.config.manifest.tag, TARGET_NODE_TAG);
     assert_eq!(
-        info_response.stage.as_deref(),
-        Some("Ready"),
-        "stage should be exposed when in stack"
+        info_response.config_integrity.len(),
+        64,
+        "config_integrity should be a 64-character hex SHA256 hash"
+    );
+    assert_eq!(
+        info_response.stage, "Ready",
+        "stage should be Ready after build + spawn"
     );
     assert_eq!(info_response.instances.len(), 1);
     assert_eq!(info_response.instances[0].instance_id, TARGET_INSTANCE_ID);
@@ -140,202 +111,32 @@ async fn listen_for_node_info_on_fs_node_success() {
         "force_built bypass does not record an add log"
     );
 
-    // Now record an add log path via the public setter and re-poll —
-    // the response should pick it up.
+    // Record an add log path via the public setter and re-poll — the response
+    // should surface it.
     let recorded_add_log = started_core_node
         .peppy_dirs
         .logs_dir_add()
         .join("recorded.log");
     node_stack.set_add_log_path(TARGET_NODE_NAME, TARGET_NODE_TAG, recorded_add_log.clone());
-    let request = NodeInfoRequest::new(NodeSource::Fs(node_dir.path().to_path_buf()));
-    let info_response = poll_node_info(&started_core_node, &request, Duration::from_secs(5))
-        .await
-        .expect("node_info request should succeed");
+    let info_response = poll_node_info(
+        &started_core_node,
+        &NodeInfoRequest::new(TARGET_NODE_NAME, TARGET_NODE_TAG),
+        Duration::from_secs(5),
+    )
+    .await
+    .expect("node_info request should succeed");
     assert_eq!(
         info_response.add_log_path.as_deref(),
         Some(recorded_add_log.as_path())
     );
 }
 
+/// Full add-then-build-then-run-then-info: verifies that after two instances
+/// are spawned through the real goal pipeline, `node info` reports both of
+/// them with their per-instance state. Direct port of
+/// `listen_for_node_info_has_instance_ids` with the request input swapped.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn listen_for_node_info_on_git_node_success() {
-    const TARGET_NODE_NAME: &str = "uvc_camera";
-    const TARGET_NODE_TAG: &str = "0.1.0";
-    const TARGET_REPO_PATH: &str = "nodes/uvc_camera";
-    const TARGET_INSTANCE_ID: &str = "git_instance";
-
-    let git_repo_temp_dir = TempDir::new().expect("failed to create temp dir for git repo");
-    let git_repo_path = test_helpers::create_nodes_git_repo(&git_repo_temp_dir);
-    let repo_url = GitUrl::try_from(git_repo_path.as_path()).expect("git repo path should parse");
-
-    let started_core_node = start_core_node_with_mock_messenger().await;
-    let node_stack = started_core_node.node_stack.clone();
-
-    let request = NodeInfoRequest::new(NodeSource::Git {
-        repo_url,
-        repo_path: TARGET_REPO_PATH.to_owned(),
-        repo_ref: Some(TARGET_NODE_TAG.to_owned()),
-    });
-
-    let info_response = poll_node_info(&started_core_node, &request, Duration::from_secs(10))
-        .await
-        .expect("node_info request should succeed");
-
-    assert_eq!(
-        info_response.config.manifest.name.as_str(),
-        TARGET_NODE_NAME
-    );
-    assert_eq!(info_response.config.manifest.tag, TARGET_NODE_TAG);
-    assert!(
-        !info_response.is_in_node_stack,
-        "node should not yet be in the node stack"
-    );
-    assert!(
-        info_response.instances_names.is_empty(),
-        "no instances should be reported when node is not in stack"
-    );
-
-    let git_node_path = git_repo_path.join(TARGET_REPO_PATH);
-    node_stack
-        .push_config(info_response.config.clone(), false, &git_node_path)
-        .expect("push_config should succeed");
-    let instance_id = Name::new(TARGET_INSTANCE_ID).expect("valid instance id");
-    let _running = real_build_and_spawn_instance(
-        &started_core_node,
-        TARGET_NODE_NAME,
-        TARGET_NODE_TAG,
-        &instance_id,
-    )
-    .await;
-
-    let request = NodeInfoRequest::new(NodeSource::Git {
-        repo_url: GitUrl::try_from(git_repo_path.as_path()).expect("git repo path should parse"),
-        repo_path: TARGET_REPO_PATH.to_owned(),
-        repo_ref: Some(TARGET_NODE_TAG.to_owned()),
-    });
-
-    let info_response = poll_node_info(&started_core_node, &request, Duration::from_secs(10))
-        .await
-        .expect("node_info request should succeed");
-
-    assert!(info_response.is_in_node_stack, "node should be in stack");
-    assert_eq!(
-        info_response.instances_names,
-        vec![TARGET_INSTANCE_ID.to_string()]
-    );
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn listen_for_node_info_on_http_node_success() {
-    const TARGET_NODE_NAME: &str = "http_node";
-    const TARGET_NODE_TAG: &str = "0.1.0";
-    const TARGET_INSTANCE_ID: &str = "http_instance";
-
-    let started_core_node = start_core_node_with_mock_messenger().await;
-    let node_stack = started_core_node.node_stack.clone();
-
-    let bundle_dir = tempfile::tempdir().expect("failed to create temp bundle dir");
-    let peppy_json5 = r#"{
-            schema_version: 1,
-            manifest: {
-                name: "{TARGET_NODE_NAME}",
-                tag: "{TARGET_NODE_TAG}",
-            },
-            execution: {
-                language: "rust",
-                run_cmd: ["sleep", "10"]
-            }
-        }"#
-    .replace("{TARGET_NODE_NAME}", TARGET_NODE_NAME)
-    .replace("{TARGET_NODE_TAG}", TARGET_NODE_TAG);
-
-    let manifest_path = bundle_dir.path().join(NODE_CONFIG_FILE);
-    std::fs::write(&manifest_path, &peppy_json5).expect("failed to write manifest");
-
-    let mut tar_data = Vec::new();
-    {
-        let mut tar_builder = tar::Builder::new(&mut tar_data);
-        tar_builder
-            .append_path_with_name(&manifest_path, NODE_CONFIG_FILE)
-            .expect("failed to append manifest to tar");
-        tar_builder.finish().expect("failed to finish tar");
-    }
-
-    let bundle_path = bundle_dir.path().join("http_node.tar.zst");
-    let bundle_file = std::fs::File::create(&bundle_path).expect("failed to create bundle file");
-    let mut encoder = zstd::Encoder::new(bundle_file, 0).expect("failed to create zstd encoder");
-    encoder
-        .write_all(&tar_data)
-        .expect("failed to write compressed bundle");
-    encoder.finish().expect("failed to finish encoder");
-    let bundle_bytes = std::fs::read(&bundle_path).expect("failed to read bundle");
-    let bundle_sha256: String = Sha256::digest(&bundle_bytes)
-        .iter()
-        .map(|b| format!("{:02x}", b))
-        .collect();
-
-    let server = Server::run();
-    server.expect(
-        Expectation::matching(request::method_path("GET", "/bundles/http_node.tar.zst"))
-            .times(2)
-            .respond_with(status_code(200).body(bundle_bytes)),
-    );
-    let url = url::Url::parse(&server.url("/bundles/http_node.tar.zst").to_string())
-        .expect("http bundle url should parse");
-
-    let request = NodeInfoRequest::new(NodeSource::Http {
-        url: url.clone(),
-        sha256: Some(bundle_sha256.clone()),
-    });
-
-    let info_response = poll_node_info(&started_core_node, &request, Duration::from_secs(10))
-        .await
-        .expect("node_info request should succeed");
-
-    assert_eq!(
-        info_response.config.manifest.name.as_str(),
-        TARGET_NODE_NAME
-    );
-    assert_eq!(info_response.config.manifest.tag, TARGET_NODE_TAG);
-    assert!(
-        !info_response.is_in_node_stack,
-        "node should not yet be in the node stack"
-    );
-    assert!(
-        info_response.instances_names.is_empty(),
-        "no instances should be reported when node is not in stack"
-    );
-
-    node_stack
-        .push_config(info_response.config.clone(), false, bundle_dir.path())
-        .expect("push_config should succeed");
-    let instance_id = Name::new(TARGET_INSTANCE_ID).expect("valid instance id");
-    let _running = real_build_and_spawn_instance(
-        &started_core_node,
-        TARGET_NODE_NAME,
-        TARGET_NODE_TAG,
-        &instance_id,
-    )
-    .await;
-
-    let request = NodeInfoRequest::new(NodeSource::Http {
-        url,
-        sha256: Some(bundle_sha256),
-    });
-
-    let info_response = poll_node_info(&started_core_node, &request, Duration::from_secs(10))
-        .await
-        .expect("node_info request should succeed");
-
-    assert!(info_response.is_in_node_stack, "node should be in stack");
-    assert_eq!(
-        info_response.instances_names,
-        vec![TARGET_INSTANCE_ID.to_string()]
-    );
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn listen_for_node_info_has_instance_ids() {
+async fn node_info_has_instance_ids() {
     const TARGET_NODE_NAME: &str = "instance_ids_node";
     const TARGET_NODE_TAG: &str = "0.1.0";
     const TARGET_INSTANCE_ID_1: &str = "instance_one";
@@ -347,17 +148,15 @@ async fn listen_for_node_info_has_instance_ids() {
     let peppy_json5 = r#"{
             schema_version: 1,
             manifest: {
-                name: "{TARGET_NODE_NAME}",
-                tag: "{TARGET_NODE_TAG}",
+                name: "instance_ids_node",
+                tag: "0.1.0",
             },
             execution: {
                 language: "rust",
                 run_cmd: ["sleep", "10"]
             }
-        }"#
-    .replace("{TARGET_NODE_NAME}", TARGET_NODE_NAME)
-    .replace("{TARGET_NODE_TAG}", TARGET_NODE_TAG);
-    write_peppy_json5(source_dir.path(), &peppy_json5);
+        }"#;
+    write_peppy_json5(source_dir.path(), peppy_json5);
 
     let add_result = send_node_add_then_build(
         &started_core_node.caller_handle,
@@ -371,12 +170,13 @@ async fn listen_for_node_info_has_instance_ids() {
 
     assert!(
         add_result.success,
-        "node_add should succeed, got error: {:?}",
+        "node_build should succeed, got error: {:?}",
         add_result.error_message
     );
 
-    // Simulate the node exposing ready/health services for each instance so the node_run action
-    // can proceed when using the mock messenger (we start `sleep` rather than an actual node).
+    // Simulate each instance exposing ready/health services so the node_run
+    // action can proceed against the mock messenger (we start `sleep` rather
+    // than a real node).
     let node_handle = MessengerHandle::from_shared(Arc::clone(&started_core_node.shared_messenger));
     let _ready_task_1 = AbortOnDrop(
         listen_for_node_ready(
@@ -398,7 +198,6 @@ async fn listen_for_node_info_has_instance_ids() {
         .await
         .expect("failed to start node_health service (instance 1)"),
     );
-
     let _ready_task_2 = AbortOnDrop(
         listen_for_node_ready(
             &node_handle,
@@ -427,7 +226,6 @@ async fn listen_for_node_info_has_instance_ids() {
         TARGET_NODE_NAME,
         TARGET_INSTANCE_ID_1,
     );
-
     let start_response_1 = send_node_run_and_wait(
         &started_core_node.caller_handle,
         &started_core_node.core_node_name,
@@ -442,7 +240,6 @@ async fn listen_for_node_info_has_instance_ids() {
     )
     .await
     .expect("node_run (instance 1) should complete");
-
     assert!(
         start_response_1.result.success,
         "node_run (instance 1) should succeed, got error: {:?}",
@@ -454,7 +251,6 @@ async fn listen_for_node_info_has_instance_ids() {
         TARGET_NODE_NAME,
         TARGET_INSTANCE_ID_2,
     );
-
     let start_response_2 = send_node_run_and_wait(
         &started_core_node.caller_handle,
         &started_core_node.core_node_name,
@@ -469,50 +265,64 @@ async fn listen_for_node_info_has_instance_ids() {
     )
     .await
     .expect("node_run (instance 2) should complete");
-
     assert!(
         start_response_2.result.success,
         "node_run (instance 2) should succeed, got error: {:?}",
         start_response_2.result.error_message
     );
 
-    let request = NodeInfoRequest::new(NodeSource::Fs(add_result.artifact_path.clone()));
+    let info_response = poll_node_info(
+        &started_core_node,
+        &NodeInfoRequest::new(TARGET_NODE_NAME, TARGET_NODE_TAG),
+        Duration::from_secs(5),
+    )
+    .await
+    .expect("node_info request should succeed");
 
-    let info_response = poll_node_info(&started_core_node, &request, Duration::from_secs(5))
-        .await
-        .expect("node_info request should succeed");
-
-    assert!(info_response.is_in_node_stack, "node should be in stack");
-
-    let mut instances = info_response.instances_names;
-    instances.sort();
+    let mut instance_ids: Vec<String> = info_response
+        .instances
+        .iter()
+        .map(|i| i.instance_id.clone())
+        .collect();
+    instance_ids.sort();
     assert_eq!(
-        instances,
+        instance_ids,
         vec![
             TARGET_INSTANCE_ID_1.to_string(),
             TARGET_INSTANCE_ID_2.to_string()
         ]
     );
+    for inst in &info_response.instances {
+        assert_eq!(
+            inst.state, "running",
+            "instance {} should be running",
+            inst.instance_id
+        );
+    }
 }
 
+/// An unknown `(name, tag)` should produce an `InvalidServiceRequest` error
+/// from the daemon. Direct port of the old "recovers after invalid request"
+/// test: after the daemon rejects the bad request, it must still answer a
+/// follow-up valid request.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn listen_for_node_info_recovers_after_invalid_request() {
+async fn node_info_errors_for_missing_node_and_recovers() {
     const TARGET_NODE_NAME: &str = "fs_node";
     const TARGET_NODE_TAG: &str = "0.1.0";
 
     let started_core_node = start_core_node_with_mock_messenger().await;
 
-    // First, send a request that is guaranteed to fail quickly without performing I/O.
-    let bad_url = url::Url::parse("https://example.com/bad_url")
-        .expect("bad test URL should parse as a valid URL");
-    let bad_request = NodeInfoRequest::new(NodeSource::Http {
-        url: bad_url,
-        sha256: None,
-    });
-
-    let err = poll_node_info(&started_core_node, &bad_request, Duration::from_secs(2))
-        .await
-        .expect_err("node_info should return an error for invalid HTTP source");
+    // First: an unknown node — the daemon returns `InvalidServiceRequest`
+    // which the caller-side transport wraps back as a `ServiceError` whose
+    // reason embeds the original "invalid service request '<id>': <msg>"
+    // formatted string (see peppylib::Error::InvalidServiceRequest Display impl).
+    let err = poll_node_info(
+        &started_core_node,
+        &NodeInfoRequest::new("ghost_node", "9.9.9"),
+        Duration::from_secs(2),
+    )
+    .await
+    .expect_err("node_info should fail when the node is not in the stack");
 
     let core_node::Error::Peppylib(PeppyError::ServiceError {
         service_name,
@@ -522,278 +332,48 @@ async fn listen_for_node_info_recovers_after_invalid_request() {
     else {
         panic!("expected ServiceError, got: {err:?}");
     };
-
     assert_eq!(service_name, names::NODE_INFO);
     assert!(
-        reason.contains("tar.zst") || reason.contains("tar.zstd") || reason.contains(".tzst"),
-        "error reason should mention supported archive types; got: {reason}"
+        reason.contains("invalid service request")
+            && reason.contains("ghost_node:9.9.9")
+            && reason.contains("not in the node stack"),
+        "error reason should identify the missing node; got: {reason}"
     );
 
-    // Then send a valid request to ensure the node_info listener is still alive.
+    // Then: after rejection, a valid request against a stack-resident node
+    // must still succeed — i.e., the info listener is still alive.
     let node_dir = tempfile::tempdir().expect("failed to create temp node dir");
     let peppy_json5 = r#"{
             schema_version: 1,
             manifest: {
-                name: "{TARGET_NODE_NAME}",
-                tag: "{TARGET_NODE_TAG}",
+                name: "fs_node",
+                tag: "0.1.0",
             },
             execution: {
                 language: "rust",
                 run_cmd: ["sleep", "10"]
             }
-        }"#
-    .replace("{TARGET_NODE_NAME}", TARGET_NODE_NAME)
-    .replace("{TARGET_NODE_TAG}", TARGET_NODE_TAG);
-    write_peppy_json5(node_dir.path(), &peppy_json5);
+        }"#;
+    write_peppy_json5(node_dir.path(), peppy_json5);
+    let config = config::node::NodeConfigParser::from_path(node_dir.path().join("peppy.json5"))
+        .expect("parse config")
+        .into_resolved()
+        .expect("resolve config");
+    started_core_node
+        .node_stack
+        .push_config(config, false, node_dir.path())
+        .expect("push_config should succeed");
 
-    let request = NodeInfoRequest::new(NodeSource::Fs(node_dir.path().to_path_buf()));
-
-    let info_response = poll_node_info(&started_core_node, &request, Duration::from_secs(5))
-        .await
-        .expect("node_info should still work after a failed request");
+    let info_response = poll_node_info(
+        &started_core_node,
+        &NodeInfoRequest::new(TARGET_NODE_NAME, TARGET_NODE_TAG),
+        Duration::from_secs(5),
+    )
+    .await
+    .expect("node_info should still work after a failed request");
     assert_eq!(
         info_response.config.manifest.name.as_str(),
         TARGET_NODE_NAME
     );
     assert_eq!(info_response.config.manifest.tag, TARGET_NODE_TAG);
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn listen_for_node_info_without_variant_shows_available_variants() {
-    let started_core_node = start_core_node_with_mock_messenger().await;
-
-    // Create root node with variants declared in manifest.
-    let root_dir = tempfile::tempdir().expect("failed to create temp root dir");
-    let root_peppy_json5 = r#"{
-        schema_version: 1,
-        manifest: {
-            name: "multi_variant_node",
-            tag: "1.0.0",
-            variants: [
-                { name: "mock", source: { local: "./mock" } },
-                { name: "sim", source: { local: "./sim" } }
-            ]
-        },
-        execution: {
-            language: "rust",
-            run_cmd: ["sleep", "10"]
-        }
-    }"#;
-    write_peppy_json5(root_dir.path(), root_peppy_json5);
-
-    // Request WITHOUT variant on FS
-    let request = NodeInfoRequest::new(NodeSource::Fs(root_dir.path().to_path_buf()));
-
-    let info_response = poll_node_info(&started_core_node, &request, Duration::from_secs(5))
-        .await
-        .expect("node_info should succeed");
-
-    // No variant applied
-    assert!(
-        info_response.variant_name.is_none(),
-        "variant_name should be None when no variant requested"
-    );
-
-    // Manifest should contain variant declarations
-    let variants = info_response
-        .config
-        .manifest
-        .variants
-        .as_ref()
-        .expect("manifest should contain variants");
-    let variant_names: Vec<&str> = variants.iter().map(|v| v.name.as_str()).collect();
-    assert_eq!(variant_names, vec!["mock", "sim"]);
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn listen_for_node_info_auto_resolves_default_variant() {
-    const ROOT_NODE_NAME: &str = "default_variant_node";
-    const ROOT_NODE_TAG: &str = "0.1.0";
-
-    let started_core_node = start_core_node_with_mock_messenger().await;
-
-    // Create root node with a "default" variant and NO execution in root config.
-    let root_dir = tempfile::tempdir().expect("failed to create temp root dir");
-    let root_peppy_json5 = r#"{
-        schema_version: 1,
-        manifest: {
-            name: "default_variant_node",
-            tag: "0.1.0",
-            variants: [
-                { name: "default", source: { local: "./default_variant" } }
-            ]
-        },
-        interfaces: {
-            topics: {
-                emits: [{ name: "sensor_data" }]
-            }
-        }
-    }"#;
-    write_peppy_json5(root_dir.path(), root_peppy_json5);
-
-    // Create the default variant subdirectory with execution.
-    let variant_dir = root_dir.path().join("default_variant");
-    std::fs::create_dir_all(&variant_dir).expect("failed to create default variant dir");
-    std::fs::write(
-        variant_dir.join(NODE_CONFIG_FILE),
-        r#"{
-            schema_version: 1,
-            execution: {
-                language: "python",
-                run_cmd: ["python", "main.py"]
-            }
-        }"#,
-    )
-    .expect("failed to write default variant config");
-
-    // Request WITHOUT specifying a variant — should auto-resolve "default".
-    let request = NodeInfoRequest::new(NodeSource::Fs(root_dir.path().to_path_buf()));
-
-    let info_response = poll_node_info(&started_core_node, &request, Duration::from_secs(5))
-        .await
-        .expect("node_info should auto-resolve default variant without panic");
-
-    // Manifest comes from root
-    assert_eq!(info_response.config.manifest.name.as_str(), ROOT_NODE_NAME);
-    assert_eq!(info_response.config.manifest.tag, ROOT_NODE_TAG);
-
-    // Interfaces inherited from root
-    assert!(
-        info_response.config.interfaces.topics.is_some(),
-        "interfaces should be inherited from root"
-    );
-
-    // Execution comes from the default variant
-    assert_eq!(
-        info_response.config.execution.language,
-        PeppygenLanguage::Python
-    );
-    assert_eq!(
-        info_response.config.execution.run_cmd.as_deref(),
-        Some(&["python".to_string(), "main.py".to_string()][..])
-    );
-
-    // Variant name should be reported as "default"
-    assert_eq!(
-        info_response.variant_name.as_deref(),
-        Some("default"),
-        "auto-resolved default variant name should be reported"
-    );
-}
-
-/// Verifies that default variant resolution from a filesystem archive (`.tar.zst`) uses the
-/// archived root directory, not the host filesystem. A decoy variant directory is placed
-/// on the host to catch incorrect path resolution.
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn listen_for_node_info_archive_default_variant_uses_archived_root() {
-    let started_core_node = start_core_node_with_mock_messenger().await;
-
-    let bundle_dir = tempfile::tempdir().expect("failed to create temp bundle dir");
-    let archived_root_dir = bundle_dir.path().join("archived_root");
-    let archived_variant_dir = archived_root_dir.join("default_variant");
-    std::fs::create_dir_all(&archived_variant_dir).expect("failed to create archived variant dir");
-
-    let root_peppy_json5 = r#"{
-        schema_version: 1,
-        manifest: {
-            name: "archive_variant_root",
-            tag: "0.3.0",
-            variants: [
-                { name: "default", source: { local: "./default_variant" } }
-            ]
-        }
-    }"#;
-    write_peppy_json5(&archived_root_dir, root_peppy_json5);
-
-    write_peppy_json5(
-        &archived_variant_dir,
-        r#"{
-            schema_version: 1,
-            execution: {
-                language: "python",
-                run_cmd: ["python", "from_archive.py"]
-            }
-        }"#,
-    );
-
-    // Place a decoy on the host to detect incorrect path resolution.
-    let host_decoy_variant_dir = bundle_dir.path().join("default_variant");
-    std::fs::create_dir_all(&host_decoy_variant_dir)
-        .expect("failed to create host decoy variant dir");
-    write_peppy_json5(
-        &host_decoy_variant_dir,
-        r#"{
-            schema_version: 1,
-            execution: {
-                language: "python",
-                run_cmd: ["python", "from_host_dir.py"]
-            }
-        }"#,
-    );
-
-    let bundle_path = bundle_dir.path().join("archive_variant_root.tar.zst");
-    create_tar_zst_from_dir(&archived_root_dir, &bundle_path, "root_node");
-
-    let request = NodeInfoRequest::new(NodeSource::Fs(bundle_path));
-
-    let info_response = poll_node_info(&started_core_node, &request, Duration::from_secs(5))
-        .await
-        .expect("node_info with archive default variant should succeed");
-
-    assert_eq!(
-        info_response.config.manifest.name.as_str(),
-        "archive_variant_root"
-    );
-    assert_eq!(info_response.config.manifest.tag, "0.3.0");
-    assert_eq!(
-        info_response.config.execution.language,
-        PeppygenLanguage::Python
-    );
-    assert_eq!(
-        info_response.config.execution.run_cmd.as_deref(),
-        Some(&["python".to_string(), "from_archive.py".to_string()][..]),
-        "execution should come from the archived variant, not the host decoy"
-    );
-    assert_eq!(info_response.variant_name.as_deref(), Some("default"));
-}
-
-/// When the default variant directory does not exist, the response should contain
-/// issues describing the failure and fall back to the root config.
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn listen_for_node_info_with_missing_default_variant_returns_issues() {
-    let started_core_node = start_core_node_with_mock_messenger().await;
-
-    // Root declares a default variant, but the directory doesn't exist.
-    let root_dir = tempfile::tempdir().expect("failed to create temp root dir");
-    let root_peppy_json5 = r#"{
-        schema_version: 1,
-        manifest: {
-            name: "broken_default_node",
-            tag: "0.1.0",
-            variants: [
-                { name: "default", source: { local: "./nonexistent" } }
-            ]
-        }
-    }"#;
-    write_peppy_json5(root_dir.path(), root_peppy_json5);
-
-    let request = NodeInfoRequest::new(NodeSource::Fs(root_dir.path().to_path_buf()));
-
-    let info_response = poll_node_info(&started_core_node, &request, Duration::from_secs(5))
-        .await
-        .expect("node_info with missing default variant should succeed with issues");
-
-    assert!(
-        !info_response.issues.is_empty(),
-        "response should contain issues for missing default variant"
-    );
-    assert!(
-        info_response.variant_name.is_none(),
-        "variant_name should be None when default variant resolution failed"
-    );
-    assert_eq!(
-        info_response.config.manifest.name.as_str(),
-        "broken_default_node",
-        "should return root config when default variant resolution fails"
-    );
 }

--- a/crates/core-node-internal/tests/listen_for_node_info.rs
+++ b/crates/core-node-internal/tests/listen_for_node_info.rs
@@ -6,17 +6,18 @@ use common::{
     write_peppy_json5,
 };
 use config::node::Name;
-use core_node::encoding::{NodeInfoRequest, NodeInfoResponse};
-use core_node::names;
-use peppylib::PeppyError;
+use core_node::encoding::{NodeInfo, NodeInfoRequest, NodeInfoResponse};
 use peppylib::messaging::MessengerHandle;
 use peppylib::services::health::listen_for_node_health;
 use peppylib::services::ready::listen_for_node_ready;
 use std::sync::Arc;
 use std::time::Duration;
 
-/// Sends a `NODE_INFO` poll request to the given core node and returns the raw result.
-async fn poll_node_info(
+/// Sends a `NODE_INFO` poll request and returns the raw response enum.
+///
+/// Most tests assert on the `Found` body and use `poll_node_info_found`
+/// below; the negative-lookup test uses this variant directly.
+async fn poll_node_info_raw(
     started_core_node: &common::StartedCoreNode,
     request: &NodeInfoRequest,
     timeout: Duration,
@@ -30,6 +31,23 @@ async fn poll_node_info(
             timeout,
         )
         .await
+}
+
+/// Sends a `NODE_INFO` poll request and unwraps the `Found` body. Panics
+/// if the daemon answers `NotInStack` — happy-path tests expect the node
+/// they set up to be present.
+async fn poll_node_info(
+    started_core_node: &common::StartedCoreNode,
+    request: &NodeInfoRequest,
+    timeout: Duration,
+) -> core_node::Result<NodeInfo> {
+    match poll_node_info_raw(started_core_node, request, timeout).await? {
+        NodeInfoResponse::Found(info) => Ok(info),
+        NodeInfoResponse::NotInStack => panic!(
+            "node_info unexpectedly reported `{}:{}` as not in the stack",
+            request.node_name, request.node_tag
+        ),
+    }
 }
 
 /// Happy path: add a node + start an instance, then `node info` reports the
@@ -301,47 +319,35 @@ async fn node_info_has_instance_ids() {
     }
 }
 
-/// An unknown `(name, tag)` should produce an `InvalidServiceRequest` error
-/// from the daemon. Direct port of the old "recovers after invalid request"
-/// test: after the daemon rejects the bad request, it must still answer a
-/// follow-up valid request.
+/// An unknown `(name, tag)` should be reported as a *successful*
+/// `NodeInfoResponse::NotInStack` rather than a protocol-level error — this
+/// is the whole point of the breaking response-shape change. The listener
+/// must also remain healthy after a negative lookup and serve a follow-up
+/// valid request.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn node_info_errors_for_missing_node_and_recovers() {
+async fn node_info_reports_not_in_stack_and_recovers() {
     const TARGET_NODE_NAME: &str = "fs_node";
     const TARGET_NODE_TAG: &str = "0.1.0";
 
     let started_core_node = start_core_node_with_mock_messenger().await;
 
-    // First: an unknown node — the daemon returns `InvalidServiceRequest`
-    // which the caller-side transport wraps back as a `ServiceError` whose
-    // reason embeds the original "invalid service request '<id>': <msg>"
-    // formatted string (see peppylib::Error::InvalidServiceRequest Display impl).
-    let err = poll_node_info(
+    // First: an unknown node — the daemon answers `NotInStack` on the
+    // successful response channel. No error log, no transport fault.
+    let response = poll_node_info_raw(
         &started_core_node,
         &NodeInfoRequest::new("ghost_node", "9.9.9"),
         Duration::from_secs(2),
     )
     .await
-    .expect_err("node_info should fail when the node is not in the stack");
-
-    let core_node::Error::Peppylib(PeppyError::ServiceError {
-        service_name,
-        reason,
-        ..
-    }) = err
-    else {
-        panic!("expected ServiceError, got: {err:?}");
-    };
-    assert_eq!(service_name, names::NODE_INFO);
+    .expect("node_info should return a successful response for an unknown node");
     assert!(
-        reason.contains("invalid service request")
-            && reason.contains("ghost_node:9.9.9")
-            && reason.contains("not in the node stack"),
-        "error reason should identify the missing node; got: {reason}"
+        matches!(response, NodeInfoResponse::NotInStack),
+        "expected NotInStack for an unknown `(name, tag)`, got: {response:?}"
     );
 
-    // Then: after rejection, a valid request against a stack-resident node
-    // must still succeed — i.e., the info listener is still alive.
+    // Then: after the negative lookup, a valid request against a
+    // stack-resident node must still succeed — i.e., the info listener
+    // is still alive.
     let node_dir = tempfile::tempdir().expect("failed to create temp node dir");
     let peppy_json5 = r#"{
             schema_version: 1,

--- a/crates/peppy/Cargo.toml
+++ b/crates/peppy/Cargo.toml
@@ -27,7 +27,7 @@ derive_more = { version = "2", features = ["from"] }
 rayon = "1.11.0"
 service-manager = "0.11"
 ipnet = "2.11"
-netdev = "0.41"
+netdev = "0.42"
 libc = "0.2"
 dirs = "6"
 names-generator2 = "0.2.1"

--- a/crates/peppy/src/commands/node.rs
+++ b/crates/peppy/src/commands/node.rs
@@ -235,19 +235,16 @@ pub enum NodeCommands {
         #[arg(long)]
         force: bool,
     },
-    /// Return the information about a node configuration and its presence in the node stack
+    /// Return the information about a node currently in the node stack
+    ///
+    /// Takes a reference to a node that has already been added via
+    /// `peppy node add`. If the node is not in the stack, the command exits
+    /// with an error — inspecting sources on disk is the job of `node add`,
+    /// not `node info`.
     Info {
-        /// Source location of a node (directory containing peppy.json5).
-        ///
-        /// Supported formats:
-        /// - Local path: `/path/to/node` or `./relative/path`
-        /// - Git URL: `https://github.com/org/repo.git/subpath`
-        /// - Git URL with ref: `https://github.com/org/repo.git/subpath --ref tag-or-branch`
-        /// - HTTP archive: `https://example.com/node.tar.zst`
-        source: String,
-        /// Git ref (tag/branch/commit) to checkout before reading `subpath` (git sources only).
-        #[arg(long = "ref")]
-        git_ref: Option<String>,
+        /// Node reference in the format node_name:tag (e.g., my_node:v1)
+        #[arg(value_parser = parse_node_ref)]
+        node_ref: (String, String),
     },
 }
 
@@ -375,15 +372,11 @@ impl Command for NodeCommand {
                 info!("Remove node {}:{}...", node_name, tag);
                 remove::remove_node(ctx, node_name, tag, stop_instances, force)
             }
-            NodeCommands::Info { source, git_ref } => {
-                let display_source = if source::is_probably_remote_source(&source) {
-                    source.clone()
-                } else {
-                    let path = PathBuf::from(&source);
-                    path.canonicalize().unwrap_or(path).display().to_string()
-                };
-                info!("Getting node info for {}...", display_source);
-                info::node_info(ctx, source, git_ref)
+            NodeCommands::Info {
+                node_ref: (node_name, node_tag),
+            } => {
+                info!("Getting node info for {}:{}...", node_name, node_tag);
+                info::node_info(ctx, node_name, node_tag)
             }
         }
     }

--- a/crates/peppy/src/commands/node/add.rs
+++ b/crates/peppy/src/commands/node/add.rs
@@ -1,8 +1,9 @@
 use config::node::NodeConfigParser;
 use core_node::encoding::{
-    NodeAddFeedback, NodeAddGoal, NodeAddGoalResponse, NodeAddResult, NodeInfoRequest, NodeSource,
+    NodeAddFeedback, NodeAddGoal, NodeAddGoalResponse, NodeAddResult, NodeInfoRequest,
+    NodeInfoResponse, NodeSource,
 };
-use peppylib::{MessengerHandle, PeppyError};
+use peppylib::MessengerHandle;
 use std::io::BufRead;
 use std::path::Path;
 use std::sync::Arc;
@@ -243,7 +244,8 @@ async fn add_node_async(ctx: &Arc<AppContext>, params: AddNodeParams) -> Result<
 /// Returns `None` when:
 /// - The local config can't be parsed (the add action itself will surface a
 ///   clearer error once it tries to use the source).
-/// - The node isn't in the stack yet (nothing to confirm).
+/// - The node isn't in the stack yet (the daemon answers with
+///   `NodeInfoResponse::NotInStack` — a successful negative lookup).
 /// - The node is in the stack but has no active instances (the add action
 ///   can safely overwrite it without prompting).
 async fn fetch_active_instances_for_local_source(
@@ -259,7 +261,7 @@ async fn fetch_active_instances_for_local_source(
     let node_name = parsed.manifest_name().to_owned();
     let node_tag = parsed.manifest_tag().to_owned();
 
-    let info = match NodeInfoRequest::new(node_name.clone(), node_tag.clone())
+    let response = NodeInfoRequest::new(node_name.clone(), node_tag.clone())
         .poll(
             messenger,
             core_node_name,
@@ -268,24 +270,16 @@ async fn fetch_active_instances_for_local_source(
             timeout,
         )
         .await
-    {
-        Ok(info) => info,
-        // The daemon returns `InvalidServiceRequest` when the node isn't in
-        // the stack. The caller-side transport reflects that as a
-        // `ServiceError` whose reason begins with "invalid service request"
-        // (from `PeppyError::InvalidServiceRequest`'s Display impl). Any
-        // such rejection means "not in the stack yet" — nothing to confirm.
-        Err(core_node::Error::Peppylib(PeppyError::ServiceError { ref reason, .. }))
-            if reason.contains("invalid service request") =>
-        {
-            return Ok(None);
-        }
-        Err(e) => {
-            return Err(Error::ExecutionFailed(format!(
-                "Failed to check node info before adding: {}",
-                e
-            )));
-        }
+        .map_err(|e| {
+            Error::ExecutionFailed(format!("Failed to check node info before adding: {}", e))
+        })?;
+
+    // `NotInStack` is a normal first-time-add case; there is nothing to
+    // confirm. The daemon no longer reports this as an error, so we match
+    // on the response variant directly instead of sniffing error strings.
+    let info = match response {
+        NodeInfoResponse::NotInStack => return Ok(None),
+        NodeInfoResponse::Found(info) => info,
     };
 
     let active: Vec<String> = info

--- a/crates/peppy/src/commands/node/add.rs
+++ b/crates/peppy/src/commands/node/add.rs
@@ -121,19 +121,21 @@ async fn add_node_async(ctx: &Arc<AppContext>, params: AddNodeParams) -> Result<
         source, conn.core_node_name
     );
 
-    // Preflight conflict check: if we can extract (name, tag) from the source
-    // locally without hitting the network, ask the daemon whether that node is
-    // already in the stack with running instances and prompt for overwrite.
+    // Preflight conflict check: if the *root* source is local, we can read
+    // `(name, tag)` from its `peppy.json5` without touching the network and
+    // ask the daemon whether that node is already in the stack with active
+    // instances.
     //
-    // Variants and remote sources cannot be preflighted from the client: their
-    // effective (name, tag) requires fetching + merging, which only the daemon
-    // does (during the add action itself). In those cases we skip the prompt
-    // and let the daemon's add action stop any existing instances transparently.
-    if !force
-        && variant_source.is_none()
-        && let NodeSource::Fs(ref path) = node_source
-    {
-        let running_instances = fetch_running_instances_for_local_source(
+    // The variant source (if any) doesn't affect the effective `(name, tag)`:
+    // `resolve_variant` always merges the root manifest over the variant
+    // (see crates/core-node-internal/src/services/node/variant.rs), so any
+    // variant we'd eventually pick shares the root's identity.
+    //
+    // Remote root sources still skip the preflight since we'd need to fetch
+    // them to read the manifest; the daemon's add action stops existing
+    // instances transparently in that path.
+    if !force && let NodeSource::Fs(ref path) = node_source {
+        let active_instances = fetch_active_instances_for_local_source(
             conn.messenger,
             &conn.core_node_name,
             path,
@@ -141,7 +143,7 @@ async fn add_node_async(ctx: &Arc<AppContext>, params: AddNodeParams) -> Result<
         )
         .await?;
 
-        if let Some((node_name, node_tag, instance_ids)) = running_instances {
+        if let Some((node_name, node_tag, instance_ids)) = active_instances {
             let confirm =
                 confirm_overwrite(&node_name, &node_tag, &instance_ids, confirm_reader.take())?;
             if !confirm {
@@ -232,17 +234,19 @@ async fn add_node_async(ctx: &Arc<AppContext>, params: AddNodeParams) -> Result<
 ///
 /// Parses the node's `peppy.json5` locally to extract `(name, tag)`, then asks
 /// the daemon whether that entity is currently in the stack. Returns
-/// `Some((name, tag, running_instance_ids))` only when the node exists in the
-/// stack AND has at least one `Running` instance — exactly the case that
-/// needs a user confirmation before overwrite.
+/// `Some((name, tag, active_instance_ids))` only when the node exists in the
+/// stack AND has at least one active instance (`Starting` or `Running`) —
+/// exactly the case that needs a user confirmation before overwrite. Both
+/// states count as active because the daemon tears down every tracked
+/// instance when it overwrites a node, regardless of lifecycle state.
 ///
 /// Returns `None` when:
 /// - The local config can't be parsed (the add action itself will surface a
 ///   clearer error once it tries to use the source).
 /// - The node isn't in the stack yet (nothing to confirm).
-/// - The node is in the stack but has no running instances (the add action
+/// - The node is in the stack but has no active instances (the add action
 ///   can safely overwrite it without prompting).
-async fn fetch_running_instances_for_local_source(
+async fn fetch_active_instances_for_local_source(
     messenger: &MessengerHandle,
     core_node_name: &str,
     source_path: &Path,
@@ -284,17 +288,17 @@ async fn fetch_running_instances_for_local_source(
         }
     };
 
-    let running: Vec<String> = info
+    let active: Vec<String> = info
         .instances
         .iter()
-        .filter(|inst| inst.state == "running")
+        .filter(|inst| matches!(inst.state.as_str(), "running" | "starting"))
         .map(|inst| inst.instance_id.clone())
         .collect();
 
-    if running.is_empty() {
+    if active.is_empty() {
         Ok(None)
     } else {
-        Ok(Some((node_name, node_tag, running)))
+        Ok(Some((node_name, node_tag, active)))
     }
 }
 
@@ -312,7 +316,7 @@ fn confirm_overwrite(
     let pronoun = if count == 1 { "it" } else { "them" };
 
     let message = format!(
-        "Node `{node_name}:{tag}` already exists with {count} running {suffix} ({ids}). \
+        "Node `{node_name}:{tag}` already exists with {count} active {suffix} ({ids}). \
          Adding this node will stop {pronoun} and overwrite the existing node. Continue? [y/n] ",
     );
 

--- a/crates/peppy/src/commands/node/add.rs
+++ b/crates/peppy/src/commands/node/add.rs
@@ -1,9 +1,10 @@
+use config::node::NodeConfigParser;
 use core_node::encoding::{
-    NodeAddFeedback, NodeAddGoal, NodeAddGoalResponse, NodeAddResult, NodeInfoRequest,
-    NodeInfoResponse, NodeSource,
+    NodeAddFeedback, NodeAddGoal, NodeAddGoalResponse, NodeAddResult, NodeInfoRequest, NodeSource,
 };
-use peppylib::MessengerHandle;
+use peppylib::{MessengerHandle, PeppyError};
 use std::io::BufRead;
+use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 use tracing::info;
@@ -120,36 +121,34 @@ async fn add_node_async(ctx: &Arc<AppContext>, params: AddNodeParams) -> Result<
         source, conn.core_node_name
     );
 
-    let pre_add_node_info = if !force {
-        Some(
-            fetch_node_info(
-                conn.messenger,
-                &conn.core_node_name,
-                node_source.clone(),
-                Duration::from_secs(timeouts.max_secs),
-            )
-            .await?,
-        )
-    } else {
-        None
-    };
-
-    // Check for existing instances and prompt for confirmation if needed
-    if let Some(ref info) = pre_add_node_info
-        && !info.instances_names.is_empty()
+    // Preflight conflict check: if we can extract (name, tag) from the source
+    // locally without hitting the network, ask the daemon whether that node is
+    // already in the stack with running instances and prompt for overwrite.
+    //
+    // Variants and remote sources cannot be preflighted from the client: their
+    // effective (name, tag) requires fetching + merging, which only the daemon
+    // does (during the add action itself). In those cases we skip the prompt
+    // and let the daemon's add action stop any existing instances transparently.
+    if !force
+        && variant_source.is_none()
+        && let NodeSource::Fs(ref path) = node_source
     {
-        let node_name = info.config.manifest.name.as_str();
-        let node_tag = &info.config.manifest.tag;
-        let confirm = confirm_overwrite(
-            node_name,
-            node_tag,
-            &info.instances_names,
-            confirm_reader.take(),
-        )?;
-        if !confirm {
-            return Err(Error::ExecutionFailed(
-                "Node add aborted by user".to_string(),
-            ));
+        let running_instances = fetch_running_instances_for_local_source(
+            conn.messenger,
+            &conn.core_node_name,
+            path,
+            Duration::from_secs(timeouts.max_secs),
+        )
+        .await?;
+
+        if let Some((node_name, node_tag, instance_ids)) = running_instances {
+            let confirm =
+                confirm_overwrite(&node_name, &node_tag, &instance_ids, confirm_reader.take())?;
+            if !confirm {
+                return Err(Error::ExecutionFailed(
+                    "Node add aborted by user".to_string(),
+                ));
+            }
         }
     }
 
@@ -229,15 +228,34 @@ async fn add_node_async(ctx: &Arc<AppContext>, params: AddNodeParams) -> Result<
     Ok(())
 }
 
-/// Fetches node info for a given source using NodeInfoRequest.
-/// This includes the node config, whether it's in the node stack, and running instance names.
-async fn fetch_node_info(
+/// Preflight check for the overwrite confirmation prompt.
+///
+/// Parses the node's `peppy.json5` locally to extract `(name, tag)`, then asks
+/// the daemon whether that entity is currently in the stack. Returns
+/// `Some((name, tag, running_instance_ids))` only when the node exists in the
+/// stack AND has at least one `Running` instance — exactly the case that
+/// needs a user confirmation before overwrite.
+///
+/// Returns `None` when:
+/// - The local config can't be parsed (the add action itself will surface a
+///   clearer error once it tries to use the source).
+/// - The node isn't in the stack yet (nothing to confirm).
+/// - The node is in the stack but has no running instances (the add action
+///   can safely overwrite it without prompting).
+async fn fetch_running_instances_for_local_source(
     messenger: &MessengerHandle,
     core_node_name: &str,
-    node_source: NodeSource,
+    source_path: &Path,
     timeout: Duration,
-) -> Result<NodeInfoResponse> {
-    NodeInfoRequest::new(node_source)
+) -> Result<Option<(String, String, Vec<String>)>> {
+    let config_path = source_path.join(config::consts::NODE_CONFIG_FILE);
+    let Ok(parsed) = NodeConfigParser::from_path(&config_path) else {
+        return Ok(None);
+    };
+    let node_name = parsed.manifest_name().to_owned();
+    let node_tag = parsed.manifest_tag().to_owned();
+
+    let info = match NodeInfoRequest::new(node_name.clone(), node_tag.clone())
         .poll(
             messenger,
             core_node_name,
@@ -246,9 +264,38 @@ async fn fetch_node_info(
             timeout,
         )
         .await
-        .map_err(|e| {
-            Error::ExecutionFailed(format!("Failed to check node info before adding: {}", e))
-        })
+    {
+        Ok(info) => info,
+        // The daemon returns `InvalidServiceRequest` when the node isn't in
+        // the stack. The caller-side transport reflects that as a
+        // `ServiceError` whose reason begins with "invalid service request"
+        // (from `PeppyError::InvalidServiceRequest`'s Display impl). Any
+        // such rejection means "not in the stack yet" — nothing to confirm.
+        Err(core_node::Error::Peppylib(PeppyError::ServiceError { ref reason, .. }))
+            if reason.contains("invalid service request") =>
+        {
+            return Ok(None);
+        }
+        Err(e) => {
+            return Err(Error::ExecutionFailed(format!(
+                "Failed to check node info before adding: {}",
+                e
+            )));
+        }
+    };
+
+    let running: Vec<String> = info
+        .instances
+        .iter()
+        .filter(|inst| inst.state == "running")
+        .map(|inst| inst.instance_id.clone())
+        .collect();
+
+    if running.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some((node_name, node_tag, running)))
+    }
 }
 
 fn confirm_overwrite(

--- a/crates/peppy/src/commands/node/info.rs
+++ b/crates/peppy/src/commands/node/info.rs
@@ -4,28 +4,20 @@ use std::collections::BTreeSet;
 use std::sync::Arc;
 use std::time::Duration;
 
-use super::source::parse_node_source;
 use crate::commands::CALLER_INSTANCE_ID;
 use crate::context::AppContext;
 use crate::error::{Error, Result};
 
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
-pub fn node_info(ctx: &Arc<AppContext>, source: String, git_ref: Option<String>) -> Result<()> {
-    crate::commands::block_on(node_info_async(ctx, source, git_ref))
+pub fn node_info(ctx: &Arc<AppContext>, node_name: String, node_tag: String) -> Result<()> {
+    crate::commands::block_on(node_info_async(ctx, node_name, node_tag))
 }
 
-async fn node_info_async(
-    ctx: &Arc<AppContext>,
-    source: String,
-    git_ref: Option<String>,
-) -> Result<()> {
-    let node_source = parse_node_source(&source, git_ref)?;
+async fn node_info_async(ctx: &Arc<AppContext>, node_name: String, node_tag: String) -> Result<()> {
     let conn = ctx.connect_to_daemon().await?;
 
-    let request = NodeInfoRequest::new(node_source);
-
-    let response = request
+    let response = NodeInfoRequest::new(node_name, node_tag)
         .poll(
             conn.messenger,
             &conn.core_node_name,
@@ -64,11 +56,6 @@ fn format_node_info(out: &mut String, response: &NodeInfoResponse) {
         let _ = writeln!(out, "Labels:    {}", labels.join(", "));
     }
 
-    // Variant info
-    if let Some(ref variant_name) = response.variant_name {
-        let _ = writeln!(out, "Variant:   {}", variant_name);
-    }
-
     // Available variants (from manifest)
     if let Some(variants) = &manifest.variants
         && !variants.is_empty()
@@ -88,59 +75,52 @@ fn format_node_info(out: &mut String, response: &NodeInfoResponse) {
         let _ = writeln!(out, "Container: {}", container.def_file);
     }
 
-    // Node stack status
+    // Node stack status — the daemon only answers node_info requests for
+    // nodes that are in the stack, so we always have a stage + instance list.
     let _ = writeln!(out);
     let _ = writeln!(out, "Node Stack Status");
     let _ = writeln!(out, "{}", "-".repeat(50));
-    if response.is_in_node_stack {
-        let _ = writeln!(out, "Status:    In node stack");
-        if let Some(stage) = response.stage.as_deref() {
-            let _ = writeln!(out, "Stage:     {}", stage);
+    let _ = writeln!(out, "Stage:     {}", response.stage);
+    if response.instances.is_empty() {
+        let _ = writeln!(out, "Instances: None tracked");
+    } else {
+        let _ = writeln!(out, "Instances: {} tracked", response.instances.len());
+        for instance in &response.instances {
+            let _ = writeln!(
+                out,
+                "           - {}  [{}]",
+                instance.instance_id, instance.state
+            );
         }
-        if response.instances.is_empty() {
-            let _ = writeln!(out, "Instances: None tracked");
-        } else {
-            let _ = writeln!(out, "Instances: {} tracked", response.instances.len());
-            for instance in &response.instances {
+    }
+
+    // Logs grouped under <name>:<tag>. Only printed when at least one
+    // log path is available — if neither the add log nor any run log
+    // is set, the section is suppressed entirely.
+    let has_add_log = response.add_log_path.is_some();
+    let has_run_logs = !response.run_log_paths.is_empty();
+    if has_add_log || has_run_logs {
+        let _ = writeln!(out);
+        let _ = writeln!(out, "Logs");
+        let _ = writeln!(out, "{}", "-".repeat(50));
+        let _ = writeln!(out, "{}:{}", manifest.name.as_str(), manifest.tag);
+        if let Some(add_log_path) = response.add_log_path.as_ref() {
+            let _ = writeln!(out, "  Add log: {}", add_log_path.display());
+        }
+        if has_run_logs {
+            let _ = writeln!(out, "  Run logs:");
+            // `run_log_paths` is aligned 1:1 with `instances` (same
+            // order, same length) — see the info handler.
+            for (instance, log_path) in response.instances.iter().zip(response.run_log_paths.iter())
+            {
                 let _ = writeln!(
                     out,
-                    "           - {}  [{}]",
-                    instance.instance_id, instance.state
+                    "    - {}: {}",
+                    instance.instance_id,
+                    log_path.display()
                 );
             }
         }
-
-        // Logs grouped under <name>:<tag>. Only printed when at least one
-        // log path is available — if neither the add log nor any run log
-        // is set, the section is suppressed entirely.
-        let has_add_log = response.add_log_path.is_some();
-        let has_run_logs = !response.run_log_paths.is_empty();
-        if has_add_log || has_run_logs {
-            let _ = writeln!(out);
-            let _ = writeln!(out, "Logs");
-            let _ = writeln!(out, "{}", "-".repeat(50));
-            let _ = writeln!(out, "{}:{}", manifest.name.as_str(), manifest.tag);
-            if let Some(add_log_path) = response.add_log_path.as_ref() {
-                let _ = writeln!(out, "  Add log: {}", add_log_path.display());
-            }
-            if has_run_logs {
-                let _ = writeln!(out, "  Run logs:");
-                // `run_log_paths` is aligned 1:1 with `instances` (same
-                // order, same length) — see the info handler.
-                for (instance, log_path) in
-                    response.instances.iter().zip(response.run_log_paths.iter())
-                {
-                    let _ = writeln!(
-                        out,
-                        "    - {}: {}",
-                        instance.instance_id,
-                        log_path.display()
-                    );
-                }
-            }
-        }
-    } else {
-        let _ = writeln!(out, "Status:    Not in node stack");
     }
 
     // Dependencies (extracted from consumes interfaces)
@@ -336,16 +316,6 @@ fn format_node_info(out: &mut String, response: &NodeInfoResponse) {
         }
     }
 
-    // Issues
-    if !response.issues.is_empty() {
-        let _ = writeln!(out);
-        let _ = writeln!(out, "Issues");
-        let _ = writeln!(out, "{}", "-".repeat(50));
-        for issue in &response.issues {
-            let _ = writeln!(out, "  - {}", issue);
-        }
-    }
-
     // Integrity
     let _ = writeln!(out);
     let _ = writeln!(out, "Integrity");
@@ -415,12 +385,8 @@ mod tests {
             .expect("resolve config");
         NodeInfoResponse {
             config,
-            is_in_node_stack: true,
-            instances_names: vec!["inst-abc".to_string()],
             config_integrity: "0".repeat(64),
-            variant_name: None,
-            issues: Vec::new(),
-            stage: Some("Ready".to_string()),
+            stage: "Ready".to_string(),
             instances: vec![
                 NodeInstanceInfo {
                     instance_id: "inst-abc".to_string(),
@@ -499,23 +465,5 @@ mod tests {
             !out.contains("\nLogs\n"),
             "Logs section should be suppressed when no paths are present:\n{out}"
         );
-    }
-
-    #[test]
-    fn print_node_info_skips_stage_when_not_in_stack() {
-        let mut response = sample_response();
-        response.is_in_node_stack = false;
-        response.stage = None;
-        response.instances.clear();
-        response.instances_names.clear();
-        response.add_log_path = None;
-        response.run_log_paths.clear();
-
-        let mut out = String::new();
-        format_node_info(&mut out, &response);
-
-        assert!(out.contains("Status:    Not in node stack"));
-        assert!(!out.contains("Stage:"));
-        assert!(!out.contains("\nLogs\n"));
     }
 }

--- a/crates/peppy/src/commands/node/info.rs
+++ b/crates/peppy/src/commands/node/info.rs
@@ -1,5 +1,5 @@
 use config::AnyType;
-use core_node::encoding::{NodeInfoRequest, NodeInfoResponse};
+use core_node::encoding::{NodeInfo, NodeInfoRequest, NodeInfoResponse};
 use std::collections::BTreeSet;
 use std::sync::Arc;
 use std::time::Duration;
@@ -17,7 +17,7 @@ pub fn node_info(ctx: &Arc<AppContext>, node_name: String, node_tag: String) -> 
 async fn node_info_async(ctx: &Arc<AppContext>, node_name: String, node_tag: String) -> Result<()> {
     let conn = ctx.connect_to_daemon().await?;
 
-    let response = NodeInfoRequest::new(node_name, node_tag)
+    let response = NodeInfoRequest::new(node_name.clone(), node_tag.clone())
         .poll(
             conn.messenger,
             &conn.core_node_name,
@@ -28,26 +28,39 @@ async fn node_info_async(ctx: &Arc<AppContext>, node_name: String, node_tag: Str
         .await
         .map_err(|e| Error::ExecutionFailed(format!("Failed to get node info: {}", e)))?;
 
-    // `response.run_log_paths` is aligned 1:1 with `response.instances` (same
-    // order, same length) — see `NodeInfoResponse` in
+    // "Not in stack" is now a first-class successful outcome of the lookup
+    // rather than a daemon-side error. Surface it to the user as a clean
+    // failure message without the generic "Failed to get node info:" prefix.
+    let info = match response {
+        NodeInfoResponse::NotInStack => {
+            return Err(Error::ExecutionFailed(format!(
+                "Node '{}:{}' is not in the node stack",
+                node_name, node_tag
+            )));
+        }
+        NodeInfoResponse::Found(info) => info,
+    };
+
+    // `info.run_log_paths` is aligned 1:1 with `info.instances` (same
+    // order, same length) — see `NodeInfo` in
     // crates/core-node-internal/src/encoding/node/info.rs. `format_node_info`
     // consumes them via `.zip()`, which would silently truncate on drift.
     // Fail loud here instead so encoding/version mismatches surface clearly.
-    if response.instances.len() != response.run_log_paths.len() {
+    if info.instances.len() != info.run_log_paths.len() {
         return Err(Error::ExecutionFailed(format!(
             "daemon returned mismatched node_info lengths: {} instances vs {} run log paths — this is an internal encoding bug",
-            response.instances.len(),
-            response.run_log_paths.len(),
+            info.instances.len(),
+            info.run_log_paths.len(),
         )));
     }
 
     let mut out = String::new();
-    format_node_info(&mut out, &response);
+    format_node_info(&mut out, &info);
     print!("{}", out);
     Ok(())
 }
 
-fn format_node_info(out: &mut String, response: &NodeInfoResponse) {
+fn format_node_info(out: &mut String, response: &NodeInfo) {
     use std::fmt::Write as _;
     let config = &response.config;
     let manifest = &config.manifest;
@@ -341,14 +354,17 @@ fn format_node_info(out: &mut String, response: &NodeInfoResponse) {
         let _ = writeln!(out, "Parameters");
         let _ = writeln!(out, "{}", "-".repeat(50));
         for (key, value) in &config.execution.parameters {
-            let _ = writeln!(out, "  {}: {}", key, format_any_type(value));
+            write_any_type(out, key, value, 1);
         }
     }
 
     let _ = writeln!(out);
 }
 
-fn format_any_type(value: &AnyType) -> String {
+/// Render a primitive/leaf `AnyType` (or an empty container) as a single
+/// inline string. Used for same-line key/value output and for arrays whose
+/// elements are all primitives.
+fn format_any_type_inline(value: &AnyType) -> String {
     match value {
         AnyType::Null => "null".to_string(),
         AnyType::Bool(b) => b.to_string(),
@@ -357,15 +373,102 @@ fn format_any_type(value: &AnyType) -> String {
         AnyType::UInt(u) => u.to_string(),
         AnyType::Float(f) => f.to_string(),
         AnyType::Array(arr) => {
-            let items: Vec<String> = arr.iter().map(format_any_type).collect();
+            let items: Vec<String> = arr.iter().map(format_any_type_inline).collect();
             format!("[{}]", items.join(", "))
         }
         AnyType::Object(obj) => {
             let items: Vec<String> = obj
                 .iter()
-                .map(|(k, v)| format!("{}: {}", k, format_any_type(v)))
+                .map(|(k, v)| format!("{}: {}", k, format_any_type_inline(v)))
                 .collect();
             format!("{{{}}}", items.join(", "))
+        }
+    }
+}
+
+/// True when every element of `arr` is a primitive (and not a nested
+/// container). Primitive-only arrays stay inline for readability.
+fn is_primitive_array(arr: &[AnyType]) -> bool {
+    arr.iter()
+        .all(|v| !matches!(v, AnyType::Array(_) | AnyType::Object(_),))
+}
+
+/// Recursively render `value` under `key` into `out` using a YAML-ish
+/// indented tree layout. `indent` is measured in 2-space units.
+fn write_any_type(out: &mut String, key: &str, value: &AnyType, indent: usize) {
+    use std::fmt::Write as _;
+    let pad = "  ".repeat(indent);
+    match value {
+        // Objects expand onto multiple lines unless empty.
+        AnyType::Object(obj) if !obj.is_empty() => {
+            let _ = writeln!(out, "{}{}:", pad, key);
+            for (child_key, child_value) in obj {
+                write_any_type(out, child_key, child_value, indent + 1);
+            }
+        }
+        // Arrays of objects/arrays expand onto multiple lines with `- ` bullets.
+        AnyType::Array(arr) if !arr.is_empty() && !is_primitive_array(arr) => {
+            let _ = writeln!(out, "{}{}:", pad, key);
+            let bullet_pad = "  ".repeat(indent + 1);
+            for item in arr {
+                match item {
+                    AnyType::Object(obj) if !obj.is_empty() => {
+                        // First field sits on the `- ` line; the rest align
+                        // underneath at the same column.
+                        let mut first = true;
+                        for (child_key, child_value) in obj {
+                            if first {
+                                first = false;
+                                match child_value {
+                                    AnyType::Object(_) | AnyType::Array(_) => {
+                                        let _ = writeln!(out, "{}- {}:", bullet_pad, child_key);
+                                        // Nested contents indent two more levels
+                                        // past the bullet (one for `- `, one for
+                                        // the child's own body).
+                                        match child_value {
+                                            AnyType::Object(inner) => {
+                                                for (k, v) in inner {
+                                                    write_any_type(out, k, v, indent + 3);
+                                                }
+                                            }
+                                            AnyType::Array(_) => {
+                                                // Recurse via a synthetic key — rare
+                                                // enough that we keep it simple.
+                                                write_any_type(
+                                                    out,
+                                                    child_key,
+                                                    child_value,
+                                                    indent + 2,
+                                                );
+                                            }
+                                            _ => unreachable!(),
+                                        }
+                                    }
+                                    _ => {
+                                        let _ = writeln!(
+                                            out,
+                                            "{}- {}: {}",
+                                            bullet_pad,
+                                            child_key,
+                                            format_any_type_inline(child_value)
+                                        );
+                                    }
+                                }
+                            } else {
+                                write_any_type(out, child_key, child_value, indent + 2);
+                            }
+                        }
+                    }
+                    _ => {
+                        let _ = writeln!(out, "{}- {}", bullet_pad, format_any_type_inline(item));
+                    }
+                }
+            }
+        }
+        // Everything else (primitives, empty containers, primitive-only arrays)
+        // stays on a single line.
+        _ => {
+            let _ = writeln!(out, "{}{}: {}", pad, key, format_any_type_inline(value));
         }
     }
 }
@@ -377,18 +480,26 @@ mod tests {
     use core_node::encoding::NodeInstanceInfo;
     use std::path::PathBuf;
 
-    fn sample_response() -> NodeInfoResponse {
-        let config_json5 = r#"{
-            schema_version: 1,
-            manifest: {
-                name: "sensor_node",
-                tag: "0.1.0",
-            },
-            execution: {
+    fn sample_response() -> NodeInfo {
+        sample_response_with_execution(
+            r#"{
                 language: "rust",
                 run_cmd: ["sleep", "10"]
-            }
-        }"#;
+            }"#,
+        )
+    }
+
+    fn sample_response_with_execution(execution_json5: &str) -> NodeInfo {
+        let config_json5 = format!(
+            r#"{{
+                schema_version: 1,
+                manifest: {{
+                    name: "sensor_node",
+                    tag: "0.1.0",
+                }},
+                execution: {execution_json5}
+            }}"#
+        );
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("peppy.json5");
         std::fs::write(&path, config_json5).expect("write config");
@@ -396,7 +507,7 @@ mod tests {
             .expect("parse config")
             .into_resolved()
             .expect("resolve config");
-        NodeInfoResponse {
+        NodeInfo {
             config,
             config_integrity: "0".repeat(64),
             stage: "Ready".to_string(),
@@ -477,6 +588,83 @@ mod tests {
         assert!(
             !out.contains("\nLogs\n"),
             "Logs section should be suppressed when no paths are present:\n{out}"
+        );
+    }
+
+    #[test]
+    fn print_node_info_renders_nested_parameters_as_indented_tree() {
+        let response = sample_response_with_execution(
+            r#"{
+                language: "rust",
+                run_cmd: ["sleep", "10"],
+                parameters: {
+                    device_path: "string",
+                    video: {
+                        camera_encoding: "string",
+                        frame_rate: "u16",
+                        resolution: {
+                            height: "u32",
+                            width: "u32",
+                        },
+                        topic_encoding: "string",
+                    },
+                }
+            }"#,
+        );
+
+        let mut out = String::new();
+        format_node_info(&mut out, &response);
+
+        // Primitive parameters still render inline.
+        assert!(
+            out.contains("  device_path: \"string\""),
+            "primitive parameter missing:\n{out}"
+        );
+
+        // Nested object parameters must NOT render as an inline `{...}` blob.
+        assert!(
+            !out.contains("video: {"),
+            "nested parameter should not be rendered inline:\n{out}"
+        );
+
+        // Parent object renders as a bare key with its children on subsequent lines.
+        assert!(
+            out.contains("  video:\n    camera_encoding: \"string\""),
+            "nested parameter not rendered as indented tree:\n{out}"
+        );
+        assert!(
+            out.contains("    frame_rate: \"u16\""),
+            "second-level child missing:\n{out}"
+        );
+        // Deeply nested (resolution) indented one more level.
+        assert!(
+            out.contains("    resolution:\n      height: \"u32\""),
+            "third-level child missing:\n{out}"
+        );
+        assert!(
+            out.contains("      width: \"u32\""),
+            "third-level child missing:\n{out}"
+        );
+    }
+
+    #[test]
+    fn print_node_info_renders_primitive_array_parameter_inline() {
+        let response = sample_response_with_execution(
+            r#"{
+                language: "rust",
+                run_cmd: ["sleep", "10"],
+                parameters: {
+                    tags: ["a", "b", "c"],
+                }
+            }"#,
+        );
+
+        let mut out = String::new();
+        format_node_info(&mut out, &response);
+
+        assert!(
+            out.contains("  tags: [\"a\", \"b\", \"c\"]"),
+            "primitive array should stay inline:\n{out}"
         );
     }
 }

--- a/crates/peppy/src/commands/node/info.rs
+++ b/crates/peppy/src/commands/node/info.rs
@@ -28,6 +28,19 @@ async fn node_info_async(ctx: &Arc<AppContext>, node_name: String, node_tag: Str
         .await
         .map_err(|e| Error::ExecutionFailed(format!("Failed to get node info: {}", e)))?;
 
+    // `response.run_log_paths` is aligned 1:1 with `response.instances` (same
+    // order, same length) — see `NodeInfoResponse` in
+    // crates/core-node-internal/src/encoding/node/info.rs. `format_node_info`
+    // consumes them via `.zip()`, which would silently truncate on drift.
+    // Fail loud here instead so encoding/version mismatches surface clearly.
+    if response.instances.len() != response.run_log_paths.len() {
+        return Err(Error::ExecutionFailed(format!(
+            "daemon returned mismatched node_info lengths: {} instances vs {} run log paths — this is an internal encoding bug",
+            response.instances.len(),
+            response.run_log_paths.len(),
+        )));
+    }
+
     let mut out = String::new();
     format_node_info(&mut out, &response);
     print!("{}", out);

--- a/crates/peppy/tests/node_add.rs
+++ b/crates/peppy/tests/node_add.rs
@@ -100,6 +100,18 @@ fn node_add_command_succeeds() {
         logs
     );
 
+    // Regression: a first-time `node add` runs a `NodeInfoRequest` preflight
+    // to check for existing instances before overwriting. When the node
+    // isn't in the stack (the happy-path case here), that lookup used to
+    // surface as a daemon-side ERROR log from `run_handler` even though the
+    // CLI intentionally swallows the rejection. Assert that no such spurious
+    // service-handler error is emitted during a clean add.
+    assert!(
+        !logs.contains("service handler returned error"),
+        "first-time node add should not emit a service-handler error log. Logs:\n{}",
+        logs
+    );
+
     // Query the node stack to verify the node was added
     let messenger_handle = node_ctx
         .messenger_handle()

--- a/crates/peppy/tests/node_info.rs
+++ b/crates/peppy/tests/node_info.rs
@@ -1,12 +1,19 @@
-use core_node::encoding::{NodeInfoRequest, NodeInfoResponse, NodeSource};
-use peppy::test_support::ServeCommandEmulation;
-use peppylib::ServiceMessenger;
-use peppylib::messaging::MessengerHandle;
+use core_node::encoding::NodeInfoRequest;
+use peppy::commands::Command;
+use peppy::commands::node::{NodeCommand, NodeCommands, TimeoutConfig};
+use peppy::context::AppContext;
+use peppy::test_support::{LogCapture, ServeCommandEmulation};
+use peppylib::PeppyError;
 use std::collections::BTreeSet;
 use std::io::Write;
+use std::sync::Arc;
 use std::time::Duration;
 
 const CALLER_INSTANCE_ID: &str = "peppy-test";
+const DEFAULTS: TimeoutConfig = TimeoutConfig {
+    idle_secs: 60,
+    max_secs: 3600,
+};
 
 fn write_peppy_json5(dir: &std::path::Path, content: &str) {
     let peppy_json5_path = dir.join("peppy.json5");
@@ -15,18 +22,141 @@ fn write_peppy_json5(dir: &std::path::Path, content: &str) {
         .expect("write peppy.json5");
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn node_info_shows_dependencies_from_consumed_interfaces() {
+/// Spins up a serve emulation, adds the node described by `peppy_json5` to the
+/// node stack (without building it), and returns the pieces each test needs
+/// to query `node_info` afterwards. This mirrors what a user would do when
+/// calling `peppy node info name:tag` in practice: add first, then inspect.
+struct AddedNode {
+    rt: tokio::runtime::Runtime,
+    _serve: ServeCommandEmulation,
+    core_node_name: String,
+    node_ctx: Arc<AppContext>,
+    _node_dir: tempfile::TempDir,
+    _dep_dirs: Vec<tempfile::TempDir>,
+    _work_dir: tempfile::TempDir,
+    _log_guard: tracing::subscriber::DefaultGuard,
+}
+
+fn add_node_to_stack(peppy_json5: &str) -> AddedNode {
+    add_nodes_to_stack(&[], peppy_json5)
+}
+
+/// Adds each `dependency` config first, then the main `peppy_json5`. Useful
+/// for tests where the main node declares `depends_on` — the stack rejects
+/// adds whose declared dependencies aren't already present.
+fn add_nodes_to_stack(dependencies: &[&str], peppy_json5: &str) -> AddedNode {
+    let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
+    let serve = rt
+        .block_on(ServeCommandEmulation::with_mock())
+        .expect("failed to create serve emulation");
+    let shared_messenger = serve.messenger();
+    let core_node_name = serve.core_node_name().to_string();
+
+    // A separate working directory for AppContext so it doesn't clobber any
+    // node's `peppy.json5` — the CLI treats `.` as the working dir, not the
+    // node source.
+    let work_dir = tempfile::tempdir().expect("failed to create temp work dir");
+
+    let node_ctx = Arc::new(
+        AppContext::with_messenger(work_dir.path(), Arc::clone(&shared_messenger))
+            .with_daemon_state_file(serve.daemon_state_path()),
+    );
+
+    // Capture tracing output so the `info!()` line from the Add command stays
+    // out of the test output unless the test explicitly asserts on it.
+    let log_capture = LogCapture::new();
+    let subscriber = tracing_subscriber::fmt()
+        .with_ansi(false)
+        .without_time()
+        .with_writer(log_capture.clone())
+        .finish();
+    let log_guard = tracing::subscriber::set_default(subscriber);
+
+    // Keep the dependency node dirs alive for the lifetime of the test so the
+    // daemon can resolve any lazy paths stashed in its NodeEntity copies.
+    let mut dep_dirs: Vec<tempfile::TempDir> = Vec::with_capacity(dependencies.len());
+    for dep_peppy_json5 in dependencies {
+        let dep_dir = tempfile::tempdir().expect("failed to create temp dep dir");
+        write_peppy_json5(dep_dir.path(), dep_peppy_json5);
+        NodeCommand {
+            command: NodeCommands::Add {
+                source: Some(dep_dir.path().display().to_string()),
+                git_ref: None,
+                variant: None,
+                sync: false,
+                build: false,
+                run: false,
+                args: Vec::new(),
+                instance_id: None,
+                idle_timeout: DEFAULTS.idle_secs,
+                max_timeout: DEFAULTS.max_secs,
+                force: true,
+            },
+        }
+        .execute(&node_ctx)
+        .expect("dependency node add should succeed");
+        dep_dirs.push(dep_dir);
+    }
+
+    let node_dir = tempfile::tempdir().expect("failed to create temp node dir");
+    write_peppy_json5(node_dir.path(), peppy_json5);
+
+    NodeCommand {
+        command: NodeCommands::Add {
+            source: Some(node_dir.path().display().to_string()),
+            git_ref: None,
+            variant: None,
+            sync: false,
+            build: false,
+            run: false,
+            args: Vec::new(),
+            instance_id: None,
+            idle_timeout: DEFAULTS.idle_secs,
+            max_timeout: DEFAULTS.max_secs,
+            force: true,
+        },
+    }
+    .execute(&node_ctx)
+    .expect("node add command should succeed");
+
+    AddedNode {
+        rt,
+        _serve: serve,
+        core_node_name,
+        node_ctx,
+        _node_dir: node_dir,
+        _dep_dirs: dep_dirs,
+        _work_dir: work_dir,
+        _log_guard: log_guard,
+    }
+}
+
+fn fetch_info(
+    added: &AddedNode,
+    node_name: &str,
+    node_tag: &str,
+) -> core_node::encoding::NodeInfoResponse {
+    let messenger_handle = added
+        .node_ctx
+        .messenger_handle()
+        .expect("messenger handle should be available");
+    added
+        .rt
+        .block_on(NodeInfoRequest::new(node_name, node_tag).poll(
+            messenger_handle,
+            &added.core_node_name,
+            CALLER_INSTANCE_ID,
+            &added.core_node_name,
+            Duration::from_secs(10),
+        ))
+        .expect("node_info request should succeed")
+}
+
+#[test]
+fn node_info_shows_dependencies_from_consumed_interfaces() {
     const NODE_NAME: &str = "consumer_node";
     const NODE_TAG: &str = "0.1.0";
 
-    let serve = ServeCommandEmulation::with_mock()
-        .await
-        .expect("failed to create serve emulation");
-    let core_node_name = serve.core_node_name().to_string();
-
-    // Create a node directory with dependencies (consumes interfaces)
-    let node_dir = tempfile::tempdir().expect("failed to create temp node dir");
     let peppy_json5 = r#"{
             schema_version: 1,
             manifest: {
@@ -67,34 +197,62 @@ async fn node_info_shows_dependencies_from_consumed_interfaces() {
         }"#
     .replace("{NODE_NAME}", NODE_NAME)
     .replace("{NODE_TAG}", NODE_TAG);
-    write_peppy_json5(node_dir.path(), &peppy_json5);
 
-    // Send NodeInfoRequest to the core node
-    let caller_handle = MessengerHandle::from_shared(serve.messenger());
+    // The stack rejects adds whose declared dependencies are missing — spin
+    // up minimal publisher nodes that expose exactly the interfaces
+    // `consumer_node` consumes, so the add resolves cleanly.
+    let camera_node = r#"{
+            schema_version: 1,
+            manifest: { name: "camera_node", tag: "0.1.0" },
+            interfaces: {
+                topics: {
+                    emits: [
+                        { name: "video_stream" },
+                        { name: "depth_stream" }
+                    ]
+                }
+            },
+            execution: { language: "rust", run_cmd: ["sleep", "10"] }
+        }"#;
+    let lidar_node = r#"{
+            schema_version: 1,
+            manifest: { name: "lidar_node", tag: "0.1.0" },
+            interfaces: {
+                topics: { emits: [{ name: "point_cloud" }] }
+            },
+            execution: { language: "rust", run_cmd: ["sleep", "10"] }
+        }"#;
+    let config_node = r#"{
+            schema_version: 1,
+            manifest: { name: "config_node", tag: "0.1.0" },
+            interfaces: {
+                services: { exposes: [{ name: "get_config" }] }
+            },
+            execution: { language: "rust", run_cmd: ["sleep", "10"] }
+        }"#;
+    let navigation_node = r#"{
+            schema_version: 1,
+            manifest: { name: "navigation_node", tag: "0.1.0" },
+            interfaces: {
+                actions: { exposes: [{ name: "go_to_pose" }] }
+            },
+            execution: { language: "rust", run_cmd: ["sleep", "10"] }
+        }"#;
 
-    let request = NodeInfoRequest::new(NodeSource::Fs(node_dir.path().to_path_buf()));
-    let request_payload = request.encode().expect("encode should succeed");
-
-    let response = ServiceMessenger::poll(
-        &caller_handle,
-        &core_node_name,
-        CALLER_INSTANCE_ID,
-        &core_node_name,
-        core_node::names::NODE_INFO,
-        Some(&core_node_name),
-        None,
-        request_payload,
-        Duration::from_secs(10),
-    )
-    .await
-    .expect("node_info request should succeed");
-
-    let info_response =
-        NodeInfoResponse::decode(&response.payload()).expect("decode should succeed");
+    let added = add_nodes_to_stack(
+        &[camera_node, lidar_node, config_node, navigation_node],
+        &peppy_json5,
+    );
+    let info_response = fetch_info(&added, NODE_NAME, NODE_TAG);
 
     // Verify basic info
     assert_eq!(info_response.config.manifest.name.as_str(), NODE_NAME);
     assert_eq!(info_response.config.manifest.tag, NODE_TAG);
+    assert_eq!(
+        info_response.stage, "Added",
+        "node added with build=false should be in Added stage, got {:?}",
+        info_response.stage
+    );
 
     // Verify consumed interfaces exist
     let topics = info_response
@@ -124,7 +282,8 @@ async fn node_info_shows_dependencies_from_consumed_interfaces() {
         .expect("consumed actions should exist");
     assert_eq!(actions.len(), 1, "should have 1 consumed action");
 
-    // Extract dependencies (unique local_node_id values) - this mirrors what print_node_info does
+    // Extract dependencies (unique local_node_id values) - mirrors what
+    // `format_node_info` does when rendering the "Dependencies" section.
     let mut dependencies: BTreeSet<&str> = BTreeSet::new();
     for topic in topics {
         if let config::node::ConsumedTopic::Linked(linked) = topic {
@@ -140,26 +299,6 @@ async fn node_info_shows_dependencies_from_consumed_interfaces() {
         }
     }
 
-    // Verify we have the expected unique dependencies
-    assert_eq!(dependencies.len(), 4, "should have 4 unique dependencies");
-    assert!(
-        dependencies.contains("camera_node"),
-        "should depend on camera_node"
-    );
-    assert!(
-        dependencies.contains("lidar_node"),
-        "should depend on lidar_node"
-    );
-    assert!(
-        dependencies.contains("config_node"),
-        "should depend on config_node"
-    );
-    assert!(
-        dependencies.contains("navigation_node"),
-        "should depend on navigation_node"
-    );
-
-    // Verify the dependencies are in sorted order (BTreeSet guarantees this)
     let deps_vec: Vec<&str> = dependencies.iter().copied().collect();
     assert_eq!(
         deps_vec,
@@ -173,18 +312,11 @@ async fn node_info_shows_dependencies_from_consumed_interfaces() {
     );
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn node_info_no_dependencies_when_no_consumes() {
+#[test]
+fn node_info_no_dependencies_when_no_consumes() {
     const NODE_NAME: &str = "standalone_node";
     const NODE_TAG: &str = "0.1.0";
 
-    let serve = ServeCommandEmulation::with_mock()
-        .await
-        .expect("failed to create serve emulation");
-    let core_node_name = serve.core_node_name().to_string();
-
-    // Create a node with no dependencies (only exposes interfaces, doesn't subscribe)
-    let node_dir = tempfile::tempdir().expect("failed to create temp node dir");
     let peppy_json5 = r#"{
             schema_version: 1,
             manifest: {
@@ -205,32 +337,10 @@ async fn node_info_no_dependencies_when_no_consumes() {
         }"#
     .replace("{NODE_NAME}", NODE_NAME)
     .replace("{NODE_TAG}", NODE_TAG);
-    write_peppy_json5(node_dir.path(), &peppy_json5);
 
-    // Send NodeInfoRequest
-    let caller_handle = MessengerHandle::from_shared(serve.messenger());
+    let added = add_node_to_stack(&peppy_json5);
+    let info_response = fetch_info(&added, NODE_NAME, NODE_TAG);
 
-    let request = NodeInfoRequest::new(NodeSource::Fs(node_dir.path().to_path_buf()));
-    let request_payload = request.encode().expect("encode should succeed");
-
-    let response = ServiceMessenger::poll(
-        &caller_handle,
-        &core_node_name,
-        CALLER_INSTANCE_ID,
-        &core_node_name,
-        core_node::names::NODE_INFO,
-        Some(&core_node_name),
-        None,
-        request_payload,
-        Duration::from_secs(10),
-    )
-    .await
-    .expect("node_info request should succeed");
-
-    let info_response =
-        NodeInfoResponse::decode(&response.payload()).expect("decode should succeed");
-
-    // Verify basic info
     assert_eq!(info_response.config.manifest.name.as_str(), NODE_NAME);
 
     // Verify emits exists
@@ -243,7 +353,7 @@ async fn node_info_no_dependencies_when_no_consumes() {
         .expect("emitted topics should exist");
     assert!(!emitted_topics.is_empty(), "should have emitted topics");
 
-    // Verify no expects (no dependencies)
+    // No consumed interfaces anywhere.
     let no_consumed_topics = info_response
         .config
         .interfaces
@@ -268,5 +378,44 @@ async fn node_info_no_dependencies_when_no_consumes() {
     assert!(
         no_consumed_topics && no_consumed_services && no_consumed_actions,
         "standalone node should have no dependencies"
+    );
+    let _ = added;
+}
+
+/// Asking for a node that was never added should fail fast with a
+/// clear "not in the node stack" error — the whole point of the breaking
+/// change is that `node info` only inspects the stack.
+#[test]
+fn node_info_errors_when_node_not_in_stack() {
+    let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
+    let serve = rt
+        .block_on(ServeCommandEmulation::with_mock())
+        .expect("failed to create serve emulation");
+    let shared_messenger = serve.messenger();
+    let core_node_name = serve.core_node_name().to_string();
+
+    let caller_handle = peppylib::MessengerHandle::from_shared(shared_messenger);
+
+    let err = rt
+        .block_on(NodeInfoRequest::new("ghost_node", "9.9.9").poll(
+            &caller_handle,
+            &core_node_name,
+            CALLER_INSTANCE_ID,
+            &core_node_name,
+            Duration::from_secs(5),
+        ))
+        .expect_err("node_info should fail when the node is not in the stack");
+
+    // The daemon returns `InvalidServiceRequest`, which the caller-side
+    // transport reflects back as a `ServiceError` wrapping the original
+    // reason string.
+    let core_node::Error::Peppylib(PeppyError::ServiceError { reason, .. }) = err else {
+        panic!("expected ServiceError, got: {err:?}");
+    };
+    assert!(
+        reason.contains("invalid service request")
+            && reason.contains("ghost_node:9.9.9")
+            && reason.contains("not in the node stack"),
+        "error reason should identify the missing node, got: {reason}"
     );
 }

--- a/crates/peppy/tests/node_info.rs
+++ b/crates/peppy/tests/node_info.rs
@@ -1,9 +1,8 @@
-use core_node::encoding::NodeInfoRequest;
+use core_node::encoding::{NodeInfoRequest, NodeInfoResponse};
 use peppy::commands::Command;
 use peppy::commands::node::{NodeCommand, NodeCommands, TimeoutConfig};
 use peppy::context::AppContext;
 use peppy::test_support::{LogCapture, ServeCommandEmulation};
-use peppylib::PeppyError;
 use std::collections::BTreeSet;
 use std::io::Write;
 use std::sync::Arc;
@@ -131,16 +130,12 @@ fn add_nodes_to_stack(dependencies: &[&str], peppy_json5: &str) -> AddedNode {
     }
 }
 
-fn fetch_info(
-    added: &AddedNode,
-    node_name: &str,
-    node_tag: &str,
-) -> core_node::encoding::NodeInfoResponse {
+fn fetch_info(added: &AddedNode, node_name: &str, node_tag: &str) -> core_node::encoding::NodeInfo {
     let messenger_handle = added
         .node_ctx
         .messenger_handle()
         .expect("messenger handle should be available");
-    added
+    let response = added
         .rt
         .block_on(NodeInfoRequest::new(node_name, node_tag).poll(
             messenger_handle,
@@ -149,7 +144,14 @@ fn fetch_info(
             &added.core_node_name,
             Duration::from_secs(10),
         ))
-        .expect("node_info request should succeed")
+        .expect("node_info request should succeed");
+    match response {
+        core_node::encoding::NodeInfoResponse::Found(info) => info,
+        core_node::encoding::NodeInfoResponse::NotInStack => panic!(
+            "node_info unexpectedly reported `{}:{}` as not in the stack",
+            node_name, node_tag
+        ),
+    }
 }
 
 #[test]
@@ -382,11 +384,13 @@ fn node_info_no_dependencies_when_no_consumes() {
     let _ = added;
 }
 
-/// Asking for a node that was never added should fail fast with a
-/// clear "not in the node stack" error — the whole point of the breaking
-/// change is that `node info` only inspects the stack.
+/// Asking for a node that was never added returns a *successful*
+/// `NodeInfoResponse::NotInStack`. Prior to the response-shape change,
+/// the daemon answered with `InvalidServiceRequest` — a protocol error
+/// that produced a spurious ERROR log on every first-time `peppy node
+/// add` because the preflight check passes through this same path.
 #[test]
-fn node_info_errors_when_node_not_in_stack() {
+fn node_info_returns_not_in_stack_when_node_not_in_stack() {
     let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
     let serve = rt
         .block_on(ServeCommandEmulation::with_mock())
@@ -396,7 +400,18 @@ fn node_info_errors_when_node_not_in_stack() {
 
     let caller_handle = peppylib::MessengerHandle::from_shared(shared_messenger);
 
-    let err = rt
+    // Also capture daemon-side logs so we can assert that no
+    // service-handler ERROR is emitted for the negative lookup — the
+    // original regression pollution came from this path.
+    let log_capture = LogCapture::new();
+    let subscriber = tracing_subscriber::fmt()
+        .with_ansi(false)
+        .without_time()
+        .with_writer(log_capture.clone())
+        .finish();
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    let response = rt
         .block_on(NodeInfoRequest::new("ghost_node", "9.9.9").poll(
             &caller_handle,
             &core_node_name,
@@ -404,18 +419,17 @@ fn node_info_errors_when_node_not_in_stack() {
             &core_node_name,
             Duration::from_secs(5),
         ))
-        .expect_err("node_info should fail when the node is not in the stack");
+        .expect("node_info should return a successful response for an unknown node");
 
-    // The daemon returns `InvalidServiceRequest`, which the caller-side
-    // transport reflects back as a `ServiceError` wrapping the original
-    // reason string.
-    let core_node::Error::Peppylib(PeppyError::ServiceError { reason, .. }) = err else {
-        panic!("expected ServiceError, got: {err:?}");
-    };
     assert!(
-        reason.contains("invalid service request")
-            && reason.contains("ghost_node:9.9.9")
-            && reason.contains("not in the node stack"),
-        "error reason should identify the missing node, got: {reason}"
+        matches!(response, NodeInfoResponse::NotInStack),
+        "expected NotInStack for ghost_node:9.9.9, got: {response:?}"
+    );
+
+    let logs = log_capture.logs();
+    assert!(
+        !logs.contains("service handler returned error"),
+        "negative node_info lookup must not emit a service-handler error log. Logs:\n{}",
+        logs
     );
 }

--- a/crates/peppy/tests/node_info.rs
+++ b/crates/peppy/tests/node_info.rs
@@ -146,7 +146,7 @@ fn fetch_info(added: &AddedNode, node_name: &str, node_tag: &str) -> core_node::
         ))
         .expect("node_info request should succeed");
     match response {
-        core_node::encoding::NodeInfoResponse::Found(info) => info,
+        core_node::encoding::NodeInfoResponse::Found(info) => *info,
         core_node::encoding::NodeInfoResponse::NotInStack => panic!(
             "node_info unexpectedly reported `{}:{}` as not in the stack",
             node_name, node_tag

--- a/docs/src/content/docs/guides/node_stack.mdx
+++ b/docs/src/content/docs/guides/node_stack.mdx
@@ -129,10 +129,10 @@ Per-instance state (`starting`, `running`) lives inside the bracketed instance l
 
 ## Inspecting a node with `peppy node info`
 
-When you need more than the one-line view from `stack list`, `peppy node info` dumps the node's stage, its currently-tracked instances with their individual states, and the paths to its add log and per-instance run logs. It takes a source directory (or git / http URL) just like `peppy node add`:
+When you need more than the one-line view from `stack list`, `peppy node info` dumps the node's stage, its currently-tracked instances with their individual states, and the paths to its add log and per-instance run logs. It takes a `<node_name>:<node_tag>` reference to a node **that has already been added to the stack** — it doesn't touch the filesystem or any git/http source, so run `peppy node add` first if the node isn't in the stack yet:
 
 ```sh
-peppy node info ./hello_world
+peppy node info hello_world:0.1.0
 ```
 
 ```


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `node info` now accepts node refs as `<node_name>:<node_tag>`.

* **Bug Fixes**
  * Missing nodes return a clean "not in stack" response without spurious error logs.
  * Validates that instance list and run-log entries align to avoid truncated output.

* **User-facing changes**
  * Output removed Variant/Issues section; always shows Stage, Instances, and Run logs as `instance_id: <path>`.
  * Add-node overwrite prompt reports “active” instances only.

* **Documentation**
  * Examples updated to use `<node_name>:<node_tag>`.

* **Tests**
  * Tests switched to stack-driven add-then-query workflow and cover negative lookup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->