### PR TITLE
Add `node` command shorthands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2775,6 +2775,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "walkdir",
 ]
 
 [[package]]

--- a/crates/core-node-internal/schemas/node.capnp
+++ b/crates/core-node-internal/schemas/node.capnp
@@ -153,6 +153,12 @@ struct NodeGenerateRequest {
     nodeRootDir @0 :Text;
     # Git commit hash of the node being synced
     gitHash @1 :Text;
+    # Optional peer node root directories that should also be considered
+    # when resolving this node's dependencies. Used by `node sync -a` so the
+    # daemon can find sibling nodes that have not been added to the persistent
+    # node stack yet. The list is consumed only for this single request and
+    # never persisted.
+    localPeers @2 :List(Text);
 }
 
 struct NodeSyncResponse {

--- a/crates/core-node-internal/src/encoding/node/sync.rs
+++ b/crates/core-node-internal/src/encoding/node/sync.rs
@@ -15,13 +15,23 @@ use crate::encoding::{decode_message, encode_message};
 pub struct NodeSyncRequest {
     pub node_root_dir: PathBuf,
     pub git_hash: String,
+    /// Peer node root directories whose `peppy.json5` should be considered
+    /// when resolving this node's dependencies. Used by `node sync -a` so the
+    /// daemon can resolve sibling nodes that have not been added to the
+    /// persistent node stack yet. Empty for plain `node sync`.
+    pub local_peers: Vec<PathBuf>,
 }
 
 impl NodeSyncRequest {
-    pub fn new(node_root_dir: impl Into<PathBuf>, git_hash: impl Into<String>) -> Self {
+    pub fn new(
+        node_root_dir: impl Into<PathBuf>,
+        git_hash: impl Into<String>,
+        local_peers: Vec<PathBuf>,
+    ) -> Self {
         Self {
             node_root_dir: node_root_dir.into(),
             git_hash: git_hash.into(),
+            local_peers,
         }
     }
 
@@ -31,6 +41,15 @@ impl NodeSyncRequest {
             let mut request = builder.init_root::<node_capnp::node_generate_request::Builder>();
             request.set_node_root_dir(self.node_root_dir.to_string_lossy());
             request.set_git_hash(&self.git_hash);
+            let peer_count: u32 = self
+                .local_peers
+                .len()
+                .try_into()
+                .expect("local_peers count exceeds u32::MAX");
+            let mut peers = request.init_local_peers(peer_count);
+            for (i, peer) in self.local_peers.iter().enumerate() {
+                peers.set(i as u32, peer.to_string_lossy());
+            }
         }
         encode_message(&builder)
     }
@@ -39,9 +58,17 @@ impl NodeSyncRequest {
         let reader = decode_message(data)?;
         let request = reader.get_root::<node_capnp::node_generate_request::Reader>()?;
         let git_hash = request.get_git_hash()?.to_str()?.to_owned();
+        let mut local_peers = Vec::new();
+        if request.has_local_peers() {
+            let peers_reader = request.get_local_peers()?;
+            for peer in peers_reader.iter() {
+                local_peers.push(PathBuf::from(peer?.to_str()?));
+            }
+        }
         Ok(Self {
             node_root_dir: PathBuf::from(request.get_node_root_dir()?.to_str()?),
             git_hash,
+            local_peers,
         })
     }
 

--- a/crates/core-node-internal/src/services/node/add.rs
+++ b/crates/core-node-internal/src/services/node/add.rs
@@ -3,6 +3,7 @@ use super::super::stack::STACK_LAUNCH_GIT_HASH;
 use super::gate::ConcurrencyGate;
 use super::sync::{
     self, AutoSyncParams, AutoSyncVariant, collect_consumed_interfaces, generate_peppygen_for_node,
+    stack_resolver,
 };
 use super::{
     checkout_repo_ref, extract_tar_zst, generate_random_id, is_supported_fs_archive,
@@ -1350,7 +1351,7 @@ async fn process_node_add(
     let consumed_interfaces = match collect_consumed_interfaces(
         &node_config.manifest,
         &node_config.interfaces,
-        &ctx.action.node_stack,
+        stack_resolver(&ctx.action.node_stack),
     ) {
         Ok(v) => v,
         Err(reason) => {

--- a/crates/core-node-internal/src/services/node/sync.rs
+++ b/crates/core-node-internal/src/services/node/sync.rs
@@ -182,6 +182,54 @@ async fn handle_node_sync_request_inner(
         .encode();
     }
 
+    // Parse any local peer node configs supplied by the caller (`node sync -a`).
+    // These are checked first when resolving dependencies, before falling back
+    // to the persistent node stack. The peer map lives only for this request.
+    let mut local_peers: std::collections::HashMap<(String, String), config::node::NodeConfig> =
+        std::collections::HashMap::new();
+    for peer_dir in &request.local_peers {
+        let peer_config_path = peer_dir.join(config::consts::NODE_CONFIG_FILE);
+        if !peer_config_path.is_file() {
+            return NodeSyncResponse::failure(format!(
+                "Local peer config does not exist: {}",
+                peer_config_path.display()
+            ))
+            .encode();
+        }
+        match NodeConfigParser::from_path(&peer_config_path) {
+            Ok(parsed) => {
+                let peer_name = parsed.manifest_name().to_owned();
+                let peer_tag = parsed.manifest_tag().to_owned();
+                // `into_resolved_or_default` keeps the manifest+interfaces
+                // intact while substituting a default execution for
+                // variant-only roots — execution is irrelevant for dependency
+                // resolution since only `interfaces` is read downstream.
+                let cfg = parsed.into_resolved_or_default();
+                local_peers.insert((peer_name, peer_tag), cfg);
+            }
+            Err(e) => {
+                return NodeSyncResponse::failure(format!(
+                    "Failed to parse local peer config at {}: {}",
+                    peer_config_path.display(),
+                    e
+                ))
+                .encode();
+            }
+        }
+    }
+
+    // Resolver closure: peers first, then the persistent node stack.
+    let resolve_dep = |name: &str, tag: &str| -> Option<config::node::NodeConfig> {
+        local_peers
+            .get(&(name.to_owned(), tag.to_owned()))
+            .cloned()
+            .or_else(|| {
+                node_stack
+                    .find(name, tag)
+                    .map(|e| e.read().config().clone())
+            })
+    };
+
     // Validate dependencies before generation and collect consumed interfaces
     let node_config_path = request.node_root_dir.join(config::consts::NODE_CONFIG_FILE);
     let (
@@ -205,11 +253,7 @@ async fn handle_node_sync_request_inner(
                     node_config.interfaces(),
                     node_config.manifest_name(),
                     node_config.manifest_tag(),
-                    |name, tag| {
-                        node_stack
-                            .find(name, tag)
-                            .map(|e| e.read().config().clone())
-                    },
+                    resolve_dep,
                 );
 
                 let mut missing_dependencies: HashSet<String> = HashSet::new();
@@ -290,7 +334,7 @@ async fn handle_node_sync_request_inner(
                 let interfaces = match collect_consumed_interfaces(
                     node_config.manifest(),
                     node_config.interfaces(),
-                    node_stack,
+                    resolve_dep,
                 ) {
                     Ok(v) => v,
                     Err(reason) => {
@@ -325,6 +369,7 @@ async fn handle_node_sync_request_inner(
     let NodeSyncRequest {
         node_root_dir,
         git_hash,
+        local_peers: _,
     } = request;
 
     let node_root_dir_for_variants = node_root_dir.clone();
@@ -554,27 +599,34 @@ fn build_dependency_lookup(
         .unwrap_or_default()
 }
 
-/// Collects consumed interfaces from a node config and resolves their message formats
-/// by looking up the exposed interfaces from dependency nodes in the node stack.
+/// Collects consumed interfaces from a node config and resolves their message
+/// formats by looking up the exposed interfaces from dependency nodes via the
+/// caller-supplied resolver.
+///
+/// The `resolve` closure returns a [`config::node::NodeConfig`] for a given
+/// `(name, tag)` pair, or `None` if the dependency cannot be found. Callers
+/// usually wrap a [`NodeStack`] (see [`stack_resolver`]) but can also chain a
+/// peer map first to resolve sibling nodes that haven't been added to the
+/// stack yet — used by `node sync -a` for batch operations.
 pub fn collect_consumed_interfaces(
     manifest: &config::node::Manifest,
     interfaces_cfg: &config::node::Interfaces,
-    node_stack: &NodeStack,
+    resolve: impl Fn(&str, &str) -> Option<config::node::NodeConfig>,
 ) -> std::result::Result<Vec<DeploymentInterface>, String> {
     let mut interfaces = Vec::new();
     let dep_lookup = build_dependency_lookup(manifest);
 
-    // Pre-resolve each unique (name, tag) to its entity handle so the per-
-    // item loops below can skip the repeated `node_stack.find()` calls that
-    // would otherwise run once per consumed topic/service/action.
-    let mut dep_handles: std::collections::HashMap<(String, String), node_stack::EntityHandle> =
+    // Pre-resolve each unique (name, tag) into a cloned NodeConfig so the
+    // per-item loops below don't repeatedly hit the resolver (which may take
+    // a NodeStack read lock or do filesystem I/O).
+    let mut dep_configs: std::collections::HashMap<(String, String), config::node::NodeConfig> =
         std::collections::HashMap::new();
     for (dep_name, dep_tag) in dep_lookup.values() {
         let key = (dep_name.clone(), dep_tag.clone());
-        if !dep_handles.contains_key(&key)
-            && let Some(handle) = node_stack.find(dep_name, dep_tag)
+        if !dep_configs.contains_key(&key)
+            && let Some(cfg) = resolve(dep_name, dep_tag)
         {
-            dep_handles.insert(key, handle);
+            dep_configs.insert(key, cfg);
         }
     }
 
@@ -589,24 +641,21 @@ pub fn collect_consumed_interfaces(
                     else {
                         continue;
                     };
-                    if let Some(dep_handle) = dep_handles.get(&(dep_name.clone(), dep_tag.clone()))
+                    if let Some(dep_config) = dep_configs.get(&(dep_name.clone(), dep_tag.clone()))
+                        && let Some(dep_topics) = &dep_config.interfaces.topics
+                        && let Some(emitted_topics) = &dep_topics.emits
+                        && let Some(emitted_topic) = emitted_topics
+                            .iter()
+                            .find(|t| t.name.trim() == linked.name.trim())
+                        && let Some(message_format) = &emitted_topic.message_format
                     {
-                        let guard = dep_handle.read();
-                        if let Some(dep_topics) = &guard.config().interfaces.topics
-                            && let Some(emitted_topics) = &dep_topics.emits
-                            && let Some(emitted_topic) = emitted_topics
-                                .iter()
-                                .find(|t| t.name.trim() == linked.name.trim())
-                            && let Some(message_format) = &emitted_topic.message_format
-                        {
-                            interfaces.push(DeploymentInterface::new(
-                                InterfaceVariant::ConsumedTopic {
-                                    topic: consumed_topic.clone(),
-                                    message_format: message_format.clone(),
-                                    dependency_node_name: dep_name.clone(),
-                                },
-                            ));
-                        }
+                        interfaces.push(DeploymentInterface::new(
+                            InterfaceVariant::ConsumedTopic {
+                                topic: consumed_topic.clone(),
+                                message_format: message_format.clone(),
+                                dependency_node_name: dep_name.clone(),
+                            },
+                        ));
                     }
                 }
                 config::node::ConsumedTopic::External(external) => {
@@ -629,29 +678,27 @@ pub fn collect_consumed_interfaces(
             let Some((dep_name, dep_tag)) = dep_lookup.get(&consumed_service.local_node_id) else {
                 continue;
             };
-            if let Some(dep_handle) = dep_handles.get(&(dep_name.clone(), dep_tag.clone())) {
-                let guard = dep_handle.read();
-                if let Some(dep_services) = &guard.config().interfaces.services
-                    && let Some(exposed_services) = &dep_services.exposes
-                    && let Some(exposed_service) = exposed_services
-                        .iter()
-                        .find(|s| s.name.trim() == consumed_service.name.trim())
-                {
-                    interfaces.push(DeploymentInterface::new(
-                        InterfaceVariant::ConsumedService {
-                            service: consumed_service.clone(),
-                            request_format: exposed_service
-                                .request_message_format
-                                .clone()
-                                .unwrap_or_default(),
-                            response_format: exposed_service
-                                .response_message_format
-                                .clone()
-                                .unwrap_or_default(),
-                            dependency_node_name: dep_name.clone(),
-                        },
-                    ));
-                }
+            if let Some(dep_config) = dep_configs.get(&(dep_name.clone(), dep_tag.clone()))
+                && let Some(dep_services) = &dep_config.interfaces.services
+                && let Some(exposed_services) = &dep_services.exposes
+                && let Some(exposed_service) = exposed_services
+                    .iter()
+                    .find(|s| s.name.trim() == consumed_service.name.trim())
+            {
+                interfaces.push(DeploymentInterface::new(
+                    InterfaceVariant::ConsumedService {
+                        service: consumed_service.clone(),
+                        request_format: exposed_service
+                            .request_message_format
+                            .clone()
+                            .unwrap_or_default(),
+                        response_format: exposed_service
+                            .response_message_format
+                            .clone()
+                            .unwrap_or_default(),
+                        dependency_node_name: dep_name.clone(),
+                    },
+                ));
             }
         }
     }
@@ -664,48 +711,60 @@ pub fn collect_consumed_interfaces(
             let Some((dep_name, dep_tag)) = dep_lookup.get(&consumed_action.local_node_id) else {
                 continue;
             };
-            if let Some(dep_handle) = dep_handles.get(&(dep_name.clone(), dep_tag.clone())) {
-                let guard = dep_handle.read();
-                if let Some(dep_actions) = &guard.config().interfaces.actions
-                    && let Some(exposed_actions) = &dep_actions.exposes
-                    && let Some(exposed_action) = exposed_actions
-                        .iter()
-                        .find(|a| a.name.trim() == consumed_action.name.trim())
-                {
-                    let action_message = ConsumedActionMessage {
-                        goal_request: exposed_action
-                            .goal_service
-                            .as_ref()
-                            .and_then(|s| s.request_message_format.clone()),
-                        goal_response: exposed_action
-                            .goal_service
-                            .as_ref()
-                            .and_then(|s| s.response_message_format.clone()),
-                        feedback: exposed_action
-                            .feedback_topic
-                            .as_ref()
-                            .and_then(|t| t.message_format.clone()),
-                        result_request: exposed_action
-                            .result_service
-                            .as_ref()
-                            .and_then(|s| s.request_message_format.clone()),
-                        result_response: exposed_action
-                            .result_service
-                            .as_ref()
-                            .and_then(|s| s.response_message_format.clone()),
-                    };
+            if let Some(dep_config) = dep_configs.get(&(dep_name.clone(), dep_tag.clone()))
+                && let Some(dep_actions) = &dep_config.interfaces.actions
+                && let Some(exposed_actions) = &dep_actions.exposes
+                && let Some(exposed_action) = exposed_actions
+                    .iter()
+                    .find(|a| a.name.trim() == consumed_action.name.trim())
+            {
+                let action_message = ConsumedActionMessage {
+                    goal_request: exposed_action
+                        .goal_service
+                        .as_ref()
+                        .and_then(|s| s.request_message_format.clone()),
+                    goal_response: exposed_action
+                        .goal_service
+                        .as_ref()
+                        .and_then(|s| s.response_message_format.clone()),
+                    feedback: exposed_action
+                        .feedback_topic
+                        .as_ref()
+                        .and_then(|t| t.message_format.clone()),
+                    result_request: exposed_action
+                        .result_service
+                        .as_ref()
+                        .and_then(|s| s.request_message_format.clone()),
+                    result_response: exposed_action
+                        .result_service
+                        .as_ref()
+                        .and_then(|s| s.response_message_format.clone()),
+                };
 
-                    interfaces.push(DeploymentInterface::new(InterfaceVariant::ConsumedAction {
-                        action: consumed_action.clone(),
-                        messages: action_message,
-                        dependency_node_name: dep_name.clone(),
-                    }));
-                }
+                interfaces.push(DeploymentInterface::new(InterfaceVariant::ConsumedAction {
+                    action: consumed_action.clone(),
+                    messages: action_message,
+                    dependency_node_name: dep_name.clone(),
+                }));
             }
         }
     }
 
     Ok(interfaces)
+}
+
+/// Convenience helper that builds a resolver closure backed by a [`NodeStack`].
+///
+/// Use this for callers that don't have any local peers to layer on top of
+/// the daemon's persistent stack — i.e. `node add` and `auto_sync_if_missing`.
+pub fn stack_resolver(
+    node_stack: &NodeStack,
+) -> impl Fn(&str, &str) -> Option<config::node::NodeConfig> + '_ {
+    move |name, tag| {
+        node_stack
+            .find(name, tag)
+            .map(|e| e.read().config().clone())
+    }
 }
 
 /// Parameters for [`auto_sync_if_missing`].
@@ -764,14 +823,17 @@ pub fn auto_sync_if_missing(
 
         let gen_result: crate::Result<()> = (|| {
             if let Some(language) = params.execution_language {
-                let consumed =
-                    collect_consumed_interfaces(params.manifest, params.interfaces, node_stack)
-                        .map_err(|reason| {
-                            crate::Error::Io(std::io::Error::other(format!(
-                                "failed to resolve consumed interfaces: {}",
-                                reason
-                            )))
-                        })?;
+                let consumed = collect_consumed_interfaces(
+                    params.manifest,
+                    params.interfaces,
+                    stack_resolver(node_stack),
+                )
+                .map_err(|reason| {
+                    crate::Error::Io(std::io::Error::other(format!(
+                        "failed to resolve consumed interfaces: {}",
+                        reason
+                    )))
+                })?;
                 generate_peppygen_for_node(
                     language,
                     params.node_dir,
@@ -857,13 +919,17 @@ pub fn auto_sync_if_missing(
         // error here must not leave the variant's `.peppy` dir missing.
         // Doing this after the rename would short-circuit past the
         // `gen_result` restore path below.
-        let consumed = collect_consumed_interfaces(params.manifest, params.interfaces, node_stack)
-            .map_err(|reason| {
-                crate::Error::Io(std::io::Error::other(format!(
-                    "failed to resolve consumed interfaces: {}",
-                    reason
-                )))
-            })?;
+        let consumed = collect_consumed_interfaces(
+            params.manifest,
+            params.interfaces,
+            stack_resolver(node_stack),
+        )
+        .map_err(|reason| {
+            crate::Error::Io(std::io::Error::other(format!(
+                "failed to resolve consumed interfaces: {}",
+                reason
+            )))
+        })?;
 
         // Back up existing .peppy so we can restore it on failure.
         let peppy_dir = v.dir.join(config::consts::PEPPY_OUTPUT_DIR);

--- a/crates/core-node-internal/tests/listen_for_node_add.rs
+++ b/crates/core-node-internal/tests/listen_for_node_add.rs
@@ -2724,7 +2724,7 @@ async fn listen_for_node_add_variant_local_source_after_sync() {
     std::fs::write(&variant_config_path, variant_config).expect("failed to write variant config");
 
     // Step 1: Run node sync — this generates peppygen + fingerprint for root and variant.
-    let sync_response = NodeSyncRequest::new(&root_dir, TEST_GIT_HASH)
+    let sync_response = NodeSyncRequest::new(&root_dir, TEST_GIT_HASH, vec![])
         .poll(
             &started_core_node.caller_handle,
             &started_core_node.core_node_name,
@@ -2857,7 +2857,7 @@ async fn listen_for_node_add_variant_only_node_after_sync() {
 
     // Step 1: Run node sync — generates peppygen only for the variant (not root,
     // since root has no execution block).
-    let sync_response = NodeSyncRequest::new(&root_dir, TEST_GIT_HASH)
+    let sync_response = NodeSyncRequest::new(&root_dir, TEST_GIT_HASH, vec![])
         .poll(
             &started_core_node.caller_handle,
             &started_core_node.core_node_name,
@@ -2987,7 +2987,7 @@ async fn listen_for_node_add_variant_fingerprint_mismatch_after_sync() {
         .expect("failed to write variant config");
 
     // Step 1: Sync — generates peppygen and fingerprint for both root and variant.
-    let sync_response = NodeSyncRequest::new(&root_dir, TEST_GIT_HASH)
+    let sync_response = NodeSyncRequest::new(&root_dir, TEST_GIT_HASH, vec![])
         .poll(
             &started_core_node.caller_handle,
             &started_core_node.core_node_name,

--- a/crates/core-node-internal/tests/listen_for_node_sync.rs
+++ b/crates/core-node-internal/tests/listen_for_node_sync.rs
@@ -46,7 +46,7 @@ async fn listen_for_node_sync_success() {
     );
 
     let expected_git_hash = "deadbeef";
-    let response = NodeSyncRequest::new(node_dir.path(), expected_git_hash)
+    let response = NodeSyncRequest::new(node_dir.path(), expected_git_hash, vec![])
         .poll(
             &started_core_node.caller_handle,
             &started_core_node.core_node_name,
@@ -112,7 +112,7 @@ async fn listen_for_node_sync_success() {
 async fn listen_for_node_sync_missing_node_root_dir_fails() {
     let started_core_node = start_core_node_with_mock_messenger().await;
 
-    let response = NodeSyncRequest::new("", common::TEST_GIT_HASH)
+    let response = NodeSyncRequest::new("", common::TEST_GIT_HASH, vec![])
         .poll(
             &started_core_node.caller_handle,
             &started_core_node.core_node_name,
@@ -143,7 +143,7 @@ async fn listen_for_node_sync_node_root_dir_does_not_exist_fails() {
         missing_dir.display()
     );
 
-    let response = NodeSyncRequest::new(missing_dir, common::TEST_GIT_HASH)
+    let response = NodeSyncRequest::new(missing_dir, common::TEST_GIT_HASH, vec![])
         .poll(
             &started_core_node.caller_handle,
             &started_core_node.core_node_name,
@@ -172,7 +172,7 @@ async fn listen_for_node_sync_node_root_dir_is_not_a_directory_fails() {
     let file_path = tmp.path().join("not_a_directory");
     fs::write(&file_path, "not a dir").expect("failed to write temp file");
 
-    let response = NodeSyncRequest::new(file_path, common::TEST_GIT_HASH)
+    let response = NodeSyncRequest::new(file_path, common::TEST_GIT_HASH, vec![])
         .poll(
             &started_core_node.caller_handle,
             &started_core_node.core_node_name,
@@ -201,7 +201,7 @@ async fn listen_for_node_sync_missing_peppy_json5_fails() {
     let peppygen_dir = node_dir.path().join(PEPPYGEN_OUTPUT_PATH);
     let cargo_toml_path = node_dir.path().join("Cargo.toml");
 
-    let response = NodeSyncRequest::new(node_dir.path(), common::TEST_GIT_HASH)
+    let response = NodeSyncRequest::new(node_dir.path(), common::TEST_GIT_HASH, vec![])
         .poll(
             &started_core_node.caller_handle,
             &started_core_node.core_node_name,
@@ -242,7 +242,7 @@ async fn listen_for_node_sync_invalid_peppy_json5_fails() {
 
     let peppygen_dir = node_dir.path().join(PEPPYGEN_OUTPUT_PATH);
 
-    let response = NodeSyncRequest::new(node_dir.path(), common::TEST_GIT_HASH)
+    let response = NodeSyncRequest::new(node_dir.path(), common::TEST_GIT_HASH, vec![])
         .poll(
             &started_core_node.caller_handle,
             &started_core_node.core_node_name,
@@ -265,6 +265,138 @@ async fn listen_for_node_sync_invalid_peppy_json5_fails() {
         !peppygen_dir.exists(),
         "peppygen directory should not exist at {}",
         peppygen_dir.display()
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn listen_for_node_sync_resolves_dependency_via_local_peers() {
+    // Verifies that `local_peers` lets the daemon resolve dependencies that
+    // exist on disk but have NOT been registered in the persistent node stack
+    // (which is what `peppy node sync -a` relies on).
+    let started_core_node = start_core_node_with_mock_messenger().await;
+
+    // Camera node — emits a `video_stream` topic.
+    let camera_dir = tempdir().expect("failed to create camera tempdir");
+    write_node_config(
+        camera_dir.path(),
+        r#"
+        {
+            schema_version: 1,
+            manifest: {
+                name: "uvc_camera",
+                tag: "0.1.0",
+                labels: ["camera"],
+            },
+            interfaces: {
+                topics: {
+                    emits: [
+                      {
+                        name: "video_stream",
+                        qos_profile: "sensor_data",
+                        message_format: {
+                            header: {
+                              $type: "object",
+                              stamp: "time",
+                              frame_id: "u32",
+                            },
+                            encoding: "string",
+                            width: "u32",
+                            height: "u32",
+                            frame: {
+                              $type: "array",
+                              $items: "u8"
+                            },
+                        },
+                      }
+                    ],
+                    consumes: [],
+                },
+                services: { exposes: [] },
+                actions: { exposes: [] },
+            },
+            execution: {
+                language: "rust",
+                build_cmd: ["true"],
+                run_cmd: ["sleep", "10"],
+            },
+        }
+        "#,
+    );
+
+    // Brain node — depends on the camera. The camera is NOT added to the
+    // node stack; it is supplied only via `local_peers`.
+    let brain_dir = tempdir().expect("failed to create brain tempdir");
+    write_node_config(
+        brain_dir.path(),
+        r#"
+        {
+            schema_version: 1,
+            manifest: {
+                name: "my_robot_brain",
+                tag: "0.1.0",
+                labels: ["brain"],
+                depends_on: {
+                    nodes: [
+                        { name: "uvc_camera", tag: "0.1.0", local_id: "uvc_camera" }
+                    ]
+                },
+            },
+            interfaces: {
+                topics: {
+                    emits: [],
+                    consumes: [
+                        {
+                          local_node_id: "uvc_camera",
+                          name: "video_stream",
+                        }
+                    ],
+                },
+                services: { exposes: [] },
+                actions: { exposes: [] },
+            },
+            execution: {
+                language: "rust",
+                build_cmd: ["true"],
+                run_cmd: ["sleep", "10"],
+            },
+        }
+        "#,
+    );
+
+    let response = NodeSyncRequest::new(
+        brain_dir.path(),
+        common::TEST_GIT_HASH,
+        vec![camera_dir.path().to_path_buf()],
+    )
+    .poll(
+        &started_core_node.caller_handle,
+        &started_core_node.core_node_name,
+        CALLER_INSTANCE_ID,
+        &started_core_node.core_node_name,
+        Duration::from_secs(5),
+    )
+    .await
+    .expect("node_sync request should complete");
+
+    assert!(
+        response.success,
+        "brain node_sync should succeed with local peer resolution, got error: {}",
+        response.error_message
+    );
+
+    // Confirm peppygen was generated for the consumed topic — that file only
+    // exists when the resolver successfully fetched the camera's emitted topic
+    // metadata via `local_peers`.
+    let consumed_topic_path = brain_dir
+        .path()
+        .join(PEPPYGEN_OUTPUT_PATH)
+        .join("src")
+        .join("consumed_topics")
+        .join("uvc_camera_video_stream.rs");
+    assert!(
+        consumed_topic_path.exists(),
+        "expected generated peppygen file at {}",
+        consumed_topic_path.display()
     );
 }
 
@@ -322,7 +454,7 @@ async fn listen_for_node_sync_missing_dependency_fails() {
 
     let peppygen_dir = node_dir.path().join(PEPPYGEN_OUTPUT_PATH);
 
-    let response = NodeSyncRequest::new(node_dir.path(), common::TEST_GIT_HASH)
+    let response = NodeSyncRequest::new(node_dir.path(), common::TEST_GIT_HASH, vec![])
         .poll(
             &started_core_node.caller_handle,
             &started_core_node.core_node_name,
@@ -386,7 +518,7 @@ async fn listen_for_node_sync_multiple_missing_dependencies_fails() {
 
     let peppygen_dir = node_dir.path().join(PEPPYGEN_OUTPUT_PATH);
 
-    let response = NodeSyncRequest::new(node_dir.path(), common::TEST_GIT_HASH)
+    let response = NodeSyncRequest::new(node_dir.path(), common::TEST_GIT_HASH, vec![])
         .poll(
             &started_core_node.caller_handle,
             &started_core_node.core_node_name,
@@ -491,7 +623,7 @@ async fn listen_for_node_sync_generates_rust_interfaces() {
 
     // Generate peppygen for the uvc_camera node first
     let uvc_camera_response =
-        NodeSyncRequest::new(uvc_camera_node_dir.path(), common::TEST_GIT_HASH)
+        NodeSyncRequest::new(uvc_camera_node_dir.path(), common::TEST_GIT_HASH, vec![])
             .poll(
                 &started_core_node.caller_handle,
                 &started_core_node.core_node_name,
@@ -575,7 +707,7 @@ async fn listen_for_node_sync_generates_rust_interfaces() {
     );
 
     // Generate the brain node - this should succeed now that uvc_camera is in the stack
-    let brain_response = NodeSyncRequest::new(brain_node_dir.path(), common::TEST_GIT_HASH)
+    let brain_response = NodeSyncRequest::new(brain_node_dir.path(), common::TEST_GIT_HASH, vec![])
         .poll(
             &started_core_node.caller_handle,
             &started_core_node.core_node_name,
@@ -691,7 +823,7 @@ async fn listen_for_node_sync_generates_rust_consumed_service_interfaces() {
     );
 
     let uvc_camera_response =
-        NodeSyncRequest::new(uvc_camera_node_dir.path(), common::TEST_GIT_HASH)
+        NodeSyncRequest::new(uvc_camera_node_dir.path(), common::TEST_GIT_HASH, vec![])
             .poll(
                 &started_core_node.caller_handle,
                 &started_core_node.core_node_name,
@@ -772,7 +904,7 @@ async fn listen_for_node_sync_generates_rust_consumed_service_interfaces() {
         "#,
     );
 
-    let brain_response = NodeSyncRequest::new(brain_node_dir.path(), common::TEST_GIT_HASH)
+    let brain_response = NodeSyncRequest::new(brain_node_dir.path(), common::TEST_GIT_HASH, vec![])
         .poll(
             &started_core_node.caller_handle,
             &started_core_node.core_node_name,
@@ -852,7 +984,7 @@ async fn listen_for_node_sync_generates_rust_consumed_topic_interfaces() {
     );
 
     let uvc_camera_response =
-        NodeSyncRequest::new(uvc_camera_node_dir.path(), common::TEST_GIT_HASH)
+        NodeSyncRequest::new(uvc_camera_node_dir.path(), common::TEST_GIT_HASH, vec![])
             .poll(
                 &started_core_node.caller_handle,
                 &started_core_node.core_node_name,
@@ -933,7 +1065,7 @@ async fn listen_for_node_sync_generates_rust_consumed_topic_interfaces() {
         "#,
     );
 
-    let brain_response = NodeSyncRequest::new(brain_node_dir.path(), common::TEST_GIT_HASH)
+    let brain_response = NodeSyncRequest::new(brain_node_dir.path(), common::TEST_GIT_HASH, vec![])
         .poll(
             &started_core_node.caller_handle,
             &started_core_node.core_node_name,
@@ -1019,7 +1151,7 @@ async fn listen_for_node_sync_generates_rust_consumed_action_interfaces() {
     );
 
     let action_server_response =
-        NodeSyncRequest::new(action_server_node_dir.path(), common::TEST_GIT_HASH)
+        NodeSyncRequest::new(action_server_node_dir.path(), common::TEST_GIT_HASH, vec![])
             .poll(
                 &started_core_node.caller_handle,
                 &started_core_node.core_node_name,
@@ -1101,7 +1233,7 @@ async fn listen_for_node_sync_generates_rust_consumed_action_interfaces() {
     );
 
     let controller_response =
-        NodeSyncRequest::new(controller_node_dir.path(), common::TEST_GIT_HASH)
+        NodeSyncRequest::new(controller_node_dir.path(), common::TEST_GIT_HASH, vec![])
             .poll(
                 &started_core_node.caller_handle,
                 &started_core_node.core_node_name,
@@ -1176,7 +1308,7 @@ async fn listen_for_node_sync_generates_rust_parameters() {
     );
 
     // Generate peppygen for the uvc_camera node first
-    let response = NodeSyncRequest::new(node_dir.path(), common::TEST_GIT_HASH)
+    let response = NodeSyncRequest::new(node_dir.path(), common::TEST_GIT_HASH, vec![])
         .poll(
             &started_core_node.caller_handle,
             &started_core_node.core_node_name,
@@ -1272,7 +1404,7 @@ async fn listen_for_node_sync_deletes_previous_peppy_folder() {
     );
 
     // First generation - creates the .peppy folder
-    let response = NodeSyncRequest::new(node_dir.path(), common::TEST_GIT_HASH)
+    let response = NodeSyncRequest::new(node_dir.path(), common::TEST_GIT_HASH, vec![])
         .poll(
             &started_core_node.caller_handle,
             &started_core_node.core_node_name,
@@ -1306,7 +1438,7 @@ async fn listen_for_node_sync_deletes_previous_peppy_folder() {
     );
 
     // Second generation - should delete the .peppy folder and recreate it
-    let response = NodeSyncRequest::new(node_dir.path(), common::TEST_GIT_HASH)
+    let response = NodeSyncRequest::new(node_dir.path(), common::TEST_GIT_HASH, vec![])
         .poll(
             &started_core_node.caller_handle,
             &started_core_node.core_node_name,
@@ -1404,7 +1536,7 @@ async fn listen_for_node_sync_with_variant_succeeds() {
     );
 
     let expected_git_hash = "deadbeef";
-    let response = NodeSyncRequest::new(node_dir.path(), expected_git_hash)
+    let response = NodeSyncRequest::new(node_dir.path(), expected_git_hash, vec![])
         .poll(
             &started_core_node.caller_handle,
             &started_core_node.core_node_name,
@@ -1557,7 +1689,7 @@ async fn listen_for_node_sync_variant_missing_directory_fails() {
         }"#,
     );
 
-    let response = NodeSyncRequest::new(node_dir.path(), common::TEST_GIT_HASH)
+    let response = NodeSyncRequest::new(node_dir.path(), common::TEST_GIT_HASH, vec![])
         .poll(
             &started_core_node.caller_handle,
             &started_core_node.core_node_name,
@@ -1612,7 +1744,7 @@ async fn listen_for_node_sync_variant_invalid_config_fails() {
         }"#,
     );
 
-    let response = NodeSyncRequest::new(node_dir.path(), common::TEST_GIT_HASH)
+    let response = NodeSyncRequest::new(node_dir.path(), common::TEST_GIT_HASH, vec![])
         .poll(
             &started_core_node.caller_handle,
             &started_core_node.core_node_name,
@@ -1686,7 +1818,7 @@ async fn listen_for_node_sync_default_variant_skips_root_codegen() {
     );
 
     let expected_git_hash = "abc12345";
-    let response = NodeSyncRequest::new(node_dir.path(), expected_git_hash)
+    let response = NodeSyncRequest::new(node_dir.path(), expected_git_hash, vec![])
         .poll(
             &started_core_node.caller_handle,
             &started_core_node.core_node_name,
@@ -1789,7 +1921,7 @@ async fn listen_for_node_sync_default_variant_cleans_stale_root_peppy_dir() {
         }"#,
     );
 
-    let response = NodeSyncRequest::new(node_dir.path(), common::TEST_GIT_HASH)
+    let response = NodeSyncRequest::new(node_dir.path(), common::TEST_GIT_HASH, vec![])
         .poll(
             &started_core_node.caller_handle,
             &started_core_node.core_node_name,
@@ -1840,7 +1972,7 @@ async fn listen_for_node_sync_default_variant_cleans_stale_root_peppy_dir() {
     );
 
     // Second sync: language is None at root — should clean up stale root .peppy
-    let response = NodeSyncRequest::new(node_dir.path(), common::TEST_GIT_HASH)
+    let response = NodeSyncRequest::new(node_dir.path(), common::TEST_GIT_HASH, vec![])
         .poll(
             &started_core_node.caller_handle,
             &started_core_node.core_node_name,
@@ -1927,7 +2059,7 @@ async fn listen_for_node_sync_undeclared_local_node_id_fails() {
 
     let peppygen_dir = node_dir.path().join(PEPPYGEN_OUTPUT_PATH);
 
-    let response = NodeSyncRequest::new(node_dir.path(), common::TEST_GIT_HASH)
+    let response = NodeSyncRequest::new(node_dir.path(), common::TEST_GIT_HASH, vec![])
         .poll(
             &started_core_node.caller_handle,
             &started_core_node.core_node_name,

--- a/crates/node-stack-internal/src/error.rs
+++ b/crates/node-stack-internal/src/error.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use config::ConfigError;
 use thiserror::Error;
 
@@ -76,5 +78,16 @@ pub enum Error {
         node_name: String,
         node_tag: String,
         reason: String,
+    },
+
+    // -- virtual deptree errors
+    #[error("Virtual dependency tree contains a cycle involving: {nodes:?}")]
+    VirtualDeptreeCycle { nodes: Vec<String> },
+    #[error("Duplicate local node `{name}:{tag}` discovered at `{first}` and `{second}`")]
+    DuplicateLocalNode {
+        name: String,
+        tag: String,
+        first: PathBuf,
+        second: PathBuf,
     },
 }

--- a/crates/node-stack-internal/src/lib.rs
+++ b/crates/node-stack-internal/src/lib.rs
@@ -4,6 +4,7 @@ pub mod archive;
 pub mod build_io;
 mod error;
 mod node_stack;
+mod virtual_deptree;
 
 pub use error::Error as NodeStackError;
 
@@ -16,3 +17,4 @@ pub use node_stack::{
     StartContext, StartedInstanceCtx, TrackedNodeInstance, WorkingDirGuard,
     collect_dependency_specs, validate_dependency_specs,
 };
+pub use virtual_deptree::{NodeKey, VirtualDeptree, VirtualNodeInfo};

--- a/crates/node-stack-internal/src/virtual_deptree.rs
+++ b/crates/node-stack-internal/src/virtual_deptree.rs
@@ -1,0 +1,348 @@
+//! Transient, in-memory dependency tree built from a set of locally-discovered
+//! nodes (typically from a filesystem walk).
+//!
+//! Used by `peppy node sync -a` to determine the order in which nodes must be
+//! synced so that each node's dependencies are already known by the time the
+//! daemon tries to resolve their interfaces. Unlike the persistent
+//! [`crate::NodeStack`], a `VirtualDeptree` is built from on-disk
+//! `peppy.json5` files, lives only for the duration of the operation, and is
+//! discarded immediately after — it never mutates the daemon's real node
+//! stack.
+//!
+//! Edges in the underlying graph go from a *dependency* to its *dependant*, so
+//! `petgraph::algo::toposort` returns a slice with all dependencies before any
+//! of their dependants.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use config::node::NodeConfig;
+use petgraph::algo::toposort;
+use petgraph::stable_graph::{NodeIndex, StableDiGraph};
+
+use crate::error::{Error, Result};
+
+/// `(name, tag)` identifier used to address a node in the virtual dep tree.
+pub type NodeKey = (String, String);
+
+/// One node sitting in the virtual dependency tree.
+#[derive(Debug, Clone)]
+pub struct VirtualNodeInfo {
+    pub root_dir: PathBuf,
+    pub config: NodeConfig,
+}
+
+impl VirtualNodeInfo {
+    pub fn key(&self) -> NodeKey {
+        (
+            self.config.manifest.name.as_str().to_owned(),
+            self.config.manifest.tag.clone(),
+        )
+    }
+}
+
+/// Transient dependency graph for a batch of locally-discovered nodes.
+///
+/// Construction validates uniqueness (no two inputs may share the same
+/// `name:tag`) and freedom from cycles. `depends_on` entries that don't match
+/// any node in the input set are silently ignored — those are external
+/// dependencies that the daemon will resolve via its persistent node stack.
+#[derive(Debug)]
+pub struct VirtualDeptree {
+    graph: StableDiGraph<NodeKey, ()>,
+    by_key: HashMap<NodeKey, NodeIndex>,
+    infos: HashMap<NodeIndex, VirtualNodeInfo>,
+}
+
+impl VirtualDeptree {
+    /// Builds a virtual dep tree from a list of `(root_dir, NodeConfig)` pairs.
+    ///
+    /// Returns:
+    /// - [`Error::DuplicateLocalNode`] when two inputs share the same
+    ///   `name:tag`.
+    /// - [`Error::VirtualDeptreeCycle`] when the resulting graph is not a DAG.
+    pub fn build(nodes: Vec<(PathBuf, NodeConfig)>) -> Result<Self> {
+        let mut graph: StableDiGraph<NodeKey, ()> = StableDiGraph::new();
+        let mut by_key: HashMap<NodeKey, NodeIndex> = HashMap::with_capacity(nodes.len());
+        let mut infos: HashMap<NodeIndex, VirtualNodeInfo> = HashMap::with_capacity(nodes.len());
+        let mut origin_paths: HashMap<NodeKey, PathBuf> = HashMap::with_capacity(nodes.len());
+
+        // First pass: register every input node and detect duplicates.
+        for (root_dir, config) in nodes {
+            let key = (
+                config.manifest.name.as_str().to_owned(),
+                config.manifest.tag.clone(),
+            );
+
+            if let Some(first) = origin_paths.get(&key) {
+                return Err(Error::DuplicateLocalNode {
+                    name: key.0,
+                    tag: key.1,
+                    first: first.clone(),
+                    second: root_dir,
+                });
+            }
+
+            let info = VirtualNodeInfo {
+                root_dir: root_dir.clone(),
+                config,
+            };
+            let idx = graph.add_node(key.clone());
+            by_key.insert(key.clone(), idx);
+            infos.insert(idx, info);
+            origin_paths.insert(key, root_dir);
+        }
+
+        // Second pass: add edges from each declared dependency that is also
+        // present in the input set. Unknown deps are skipped here — the daemon
+        // will resolve them against its persistent node stack at sync time.
+        for idx in graph.node_indices().collect::<Vec<_>>() {
+            let info = &infos[&idx];
+            let Some(depends_on) = info.config.manifest.depends_on.as_ref() else {
+                continue;
+            };
+            for dep in &depends_on.nodes {
+                let dep_key = (dep.name.as_str().to_owned(), dep.tag.clone());
+                if let Some(dep_idx) = by_key.get(&dep_key) {
+                    // Edge: dep -> dependant. Toposort returns a slice in
+                    // dependency order (deps first).
+                    graph.add_edge(*dep_idx, idx, ());
+                }
+            }
+        }
+
+        // Validate DAG.
+        if let Err(cycle) = toposort(&graph, None) {
+            let offending = cycle.node_id();
+            let key = graph
+                .node_weight(offending)
+                .cloned()
+                .unwrap_or_else(|| ("?".to_owned(), "?".to_owned()));
+            return Err(Error::VirtualDeptreeCycle {
+                nodes: vec![format!("{}:{}", key.0, key.1)],
+            });
+        }
+
+        Ok(Self {
+            graph,
+            by_key,
+            infos,
+        })
+    }
+
+    /// Returns the dependency-ordered slice of node infos. Dependencies are
+    /// guaranteed to appear before any of their dependants.
+    pub fn topological_order(&self) -> Vec<&VirtualNodeInfo> {
+        // Already validated as acyclic in `build`.
+        let order = toposort(&self.graph, None).expect("graph is a DAG by construction");
+        order.into_iter().map(|idx| &self.infos[&idx]).collect()
+    }
+
+    /// Returns the on-disk root directories of every node in the tree.
+    /// Order is unspecified — callers that need ordering should use
+    /// [`Self::topological_order`].
+    pub fn peer_root_dirs(&self) -> Vec<PathBuf> {
+        self.infos.values().map(|i| i.root_dir.clone()).collect()
+    }
+
+    /// Returns the number of nodes in the tree.
+    pub fn len(&self) -> usize {
+        self.infos.len()
+    }
+
+    /// Returns `true` when the tree contains no nodes.
+    pub fn is_empty(&self) -> bool {
+        self.infos.is_empty()
+    }
+
+    /// Looks up a node by `(name, tag)`.
+    pub fn get(&self, key: &NodeKey) -> Option<&VirtualNodeInfo> {
+        self.by_key.get(key).and_then(|idx| self.infos.get(idx))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use config::node::NodeConfigParser;
+    use std::path::Path;
+    use tempfile::TempDir;
+
+    fn write_node(dir: &Path, name: &str, deps: &[(&str, &str)]) -> NodeConfig {
+        std::fs::create_dir_all(dir).unwrap();
+        let depends_on = if deps.is_empty() {
+            String::new()
+        } else {
+            let entries = deps
+                .iter()
+                .map(|(n, t)| format!(r#"{{ name: "{n}", tag: "{t}", local_id: "{n}" }}"#))
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("depends_on: {{ nodes: [{entries}] }},")
+        };
+        let json5 = format!(
+            r#"{{
+                schema_version: 1,
+                manifest: {{
+                    name: "{name}",
+                    tag: "0.1.0",
+                    {depends_on}
+                }},
+                execution: {{ language: "rust", run_cmd: ["./bin"] }}
+            }}"#
+        );
+        let path = dir.join(config::consts::NODE_CONFIG_FILE);
+        std::fs::write(&path, json5).unwrap();
+        NodeConfigParser::from_path(&path)
+            .unwrap()
+            .into_resolved()
+            .unwrap()
+    }
+
+    fn key_of(info: &VirtualNodeInfo) -> NodeKey {
+        info.key()
+    }
+
+    #[test]
+    fn build_empty_returns_empty_order() {
+        let tree = VirtualDeptree::build(vec![]).unwrap();
+        assert!(tree.is_empty());
+        assert_eq!(tree.len(), 0);
+        assert!(tree.topological_order().is_empty());
+        assert!(tree.peer_root_dirs().is_empty());
+    }
+
+    #[test]
+    fn build_two_independent_nodes_includes_both() {
+        let tmp = TempDir::new().unwrap();
+        let a_dir = tmp.path().join("a");
+        let b_dir = tmp.path().join("b");
+        let a = write_node(&a_dir, "a", &[]);
+        let b = write_node(&b_dir, "b", &[]);
+
+        let tree = VirtualDeptree::build(vec![(a_dir.clone(), a), (b_dir.clone(), b)]).unwrap();
+        assert_eq!(tree.len(), 2);
+        let order = tree.topological_order();
+        assert_eq!(order.len(), 2);
+        let names: Vec<String> = order.iter().map(|n| key_of(n).0).collect();
+        assert!(names.contains(&"a".to_string()));
+        assert!(names.contains(&"b".to_string()));
+        let peers = tree.peer_root_dirs();
+        assert_eq!(peers.len(), 2);
+        assert!(peers.contains(&a_dir));
+        assert!(peers.contains(&b_dir));
+    }
+
+    #[test]
+    fn build_chain_a_b_c_orders_a_first() {
+        let tmp = TempDir::new().unwrap();
+        let a_dir = tmp.path().join("a");
+        let b_dir = tmp.path().join("b");
+        let c_dir = tmp.path().join("c");
+        let a = write_node(&a_dir, "a", &[]);
+        let b = write_node(&b_dir, "b", &[("a", "0.1.0")]);
+        let c = write_node(&c_dir, "c", &[("b", "0.1.0")]);
+
+        let tree = VirtualDeptree::build(vec![
+            (c_dir.clone(), c),
+            (a_dir.clone(), a),
+            (b_dir.clone(), b),
+        ])
+        .unwrap();
+        let order: Vec<String> = tree
+            .topological_order()
+            .iter()
+            .map(|n| key_of(n).0)
+            .collect();
+        assert_eq!(
+            order,
+            vec!["a".to_string(), "b".to_string(), "c".to_string()]
+        );
+    }
+
+    #[test]
+    fn build_diamond_orders_root_first_leaf_last() {
+        let tmp = TempDir::new().unwrap();
+        let a = write_node(&tmp.path().join("a"), "a", &[]);
+        let b = write_node(&tmp.path().join("b"), "b", &[("a", "0.1.0")]);
+        let c = write_node(&tmp.path().join("c"), "c", &[("a", "0.1.0")]);
+        let d = write_node(
+            &tmp.path().join("d"),
+            "d",
+            &[("b", "0.1.0"), ("c", "0.1.0")],
+        );
+
+        let tree = VirtualDeptree::build(vec![
+            (tmp.path().join("d"), d),
+            (tmp.path().join("c"), c),
+            (tmp.path().join("b"), b),
+            (tmp.path().join("a"), a),
+        ])
+        .unwrap();
+        let order: Vec<String> = tree
+            .topological_order()
+            .iter()
+            .map(|n| key_of(n).0)
+            .collect();
+        assert_eq!(order.first().unwrap(), "a");
+        assert_eq!(order.last().unwrap(), "d");
+        // b and c can be in either order in between
+        let middle: Vec<&String> = order.iter().skip(1).take(2).collect();
+        assert!(middle.iter().any(|s| s.as_str() == "b"));
+        assert!(middle.iter().any(|s| s.as_str() == "c"));
+    }
+
+    #[test]
+    fn build_detects_two_node_cycle() {
+        let tmp = TempDir::new().unwrap();
+        let a = write_node(&tmp.path().join("a"), "a", &[("b", "0.1.0")]);
+        let b = write_node(&tmp.path().join("b"), "b", &[("a", "0.1.0")]);
+
+        let result =
+            VirtualDeptree::build(vec![(tmp.path().join("a"), a), (tmp.path().join("b"), b)]);
+        match result {
+            Err(Error::VirtualDeptreeCycle { .. }) => {}
+            other => panic!("expected VirtualDeptreeCycle, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn build_ignores_external_dep() {
+        let tmp = TempDir::new().unwrap();
+        let a_dir = tmp.path().join("a");
+        let a = write_node(&a_dir, "a", &[("external_x", "9.9.9")]);
+
+        let tree = VirtualDeptree::build(vec![(a_dir.clone(), a)]).unwrap();
+        assert_eq!(tree.len(), 1);
+        let order = tree.topological_order();
+        assert_eq!(order.len(), 1);
+        assert_eq!(key_of(order[0]).0, "a");
+        // peer_root_dirs only contains the FS-discovered node, not the external dep
+        assert_eq!(tree.peer_root_dirs(), vec![a_dir]);
+    }
+
+    #[test]
+    fn build_rejects_duplicate_name_tag() {
+        let tmp = TempDir::new().unwrap();
+        let first_dir = tmp.path().join("first");
+        let second_dir = tmp.path().join("second");
+        let a1 = write_node(&first_dir, "shared", &[]);
+        let a2 = write_node(&second_dir, "shared", &[]);
+
+        let result = VirtualDeptree::build(vec![(first_dir.clone(), a1), (second_dir.clone(), a2)]);
+        match result {
+            Err(Error::DuplicateLocalNode {
+                name,
+                tag,
+                first,
+                second,
+            }) => {
+                assert_eq!(name, "shared");
+                assert_eq!(tag, "0.1.0");
+                assert_eq!(first, first_dir);
+                assert_eq!(second, second_dir);
+            }
+            other => panic!("expected DuplicateLocalNode, got {:?}", other),
+        }
+    }
+}

--- a/crates/peppy/Cargo.toml
+++ b/crates/peppy/Cargo.toml
@@ -33,6 +33,7 @@ dirs = "6"
 names-generator2 = "0.2.1"
 rand = "0.10"
 crossterm = "0.29"
+walkdir = "2.5"
 tempfile = { version = "3.8", optional = true }
 parking_lot = { workspace = true, optional = true }
 

--- a/crates/peppy/src/commands/node.rs
+++ b/crates/peppy/src/commands/node.rs
@@ -175,7 +175,11 @@ pub enum NodeCommands {
     /// Regenerate the node's interface code (peppygen) based on peppy.json5
     Sync {
         /// Optional path to the node directory. Defaults to the current directory.
+        /// When combined with `--all`, this is the root of the recursive search.
         path: Option<PathBuf>,
+        /// Recursively find every `peppy.json5` under `path` and sync each one.
+        #[arg(short = 'a', long)]
+        all: bool,
     },
     /// Runs an instance from a node added to the node stack
     ///
@@ -336,9 +340,13 @@ impl Command for NodeCommand {
                     },
                 )
             }
-            NodeCommands::Sync { path } => {
-                info!("Syncing node interfaces...");
-                sync::sync_node(ctx, path)
+            NodeCommands::Sync { path, all } => {
+                if all {
+                    sync::sync_all_nodes(ctx, path)
+                } else {
+                    info!("Syncing node interfaces...");
+                    sync::sync_node(ctx, path)
+                }
             }
             NodeCommands::Run {
                 node_ref,

--- a/crates/peppy/src/commands/node.rs
+++ b/crates/peppy/src/commands/node.rs
@@ -154,7 +154,7 @@ pub enum NodeCommands {
         #[arg(long, default_value_t = DEFAULT_MAX_TIMEOUT_SECS)]
         max_timeout: u64,
         /// When set, bypass the confirmation prompt and stop running instances before overwriting
-        #[arg(long)]
+        #[arg(short = 'f', long)]
         force: bool,
     },
     /// Build a node previously added to the node stack
@@ -169,7 +169,7 @@ pub enum NodeCommands {
         #[arg(long, default_value_t = DEFAULT_MAX_TIMEOUT_SECS)]
         max_timeout: u64,
         /// Cancel any in-progress build for this node and start a new one
-        #[arg(long)]
+        #[arg(short = 'f', long)]
         force: bool,
     },
     /// Regenerate the node's interface code (peppygen) based on peppy.json5
@@ -196,7 +196,7 @@ pub enum NodeCommands {
         #[arg(value_parser = parse_key_value_arg)]
         args: Vec<(String, String)>,
         /// Optional: specify a deterministic instance ID
-        #[arg(long)]
+        #[arg(short = 'i', long)]
         instance_id: Option<String>,
         /// Idle timeout in seconds — resets whenever output is received
         #[arg(long, default_value_t = DEFAULT_IDLE_TIMEOUT_SECS)]
@@ -204,6 +204,10 @@ pub enum NodeCommands {
         /// Absolute max timeout in seconds (safety net)
         #[arg(long, default_value_t = DEFAULT_MAX_TIMEOUT_SECS)]
         max_timeout: u64,
+        /// If set, build the node first if it has not already been built.
+        /// No-op (with a message) when the node is already built.
+        #[arg(short = 'b', long)]
+        build: bool,
     },
     /// Prints out the runtime config of a node instance
     #[command(group(ArgGroup::new("node_source").required(true).args(["node_name", "node_dir"])))]
@@ -232,7 +236,7 @@ pub enum NodeCommands {
         #[arg(long)]
         stop_instances: bool,
         /// When set, bypass the confirmation prompt and stop running instances before removal
-        #[arg(long)]
+        #[arg(short = 'f', long)]
         force: bool,
     },
     /// Return the information about a node currently in the node stack
@@ -344,6 +348,7 @@ impl Command for NodeCommand {
                 instance_id,
                 idle_timeout,
                 max_timeout,
+                build,
             } => {
                 let (node_name, tag) = node_ref
                     .or_else(|| node_name.zip(tag))
@@ -353,7 +358,7 @@ impl Command for NodeCommand {
                     idle_secs: idle_timeout,
                     max_secs: max_timeout,
                 };
-                run::run_node(ctx, node_name, tag, args, instance_id, timeouts)
+                run::run_node(ctx, node_name, tag, args, instance_id, timeouts, build)
             }
             NodeCommands::RuntimeConfig {
                 node_name,
@@ -410,6 +415,44 @@ mod tests {
         }
     }
 
+    fn parse_run(args: &[&str]) -> bool {
+        let full: Vec<&str> = std::iter::once("peppy")
+            .chain(std::iter::once("run"))
+            .chain(args.iter().copied())
+            .collect();
+        let cli = TestCli::try_parse_from(full).expect("should parse");
+        match cli.command {
+            NodeCommands::Run { build, .. } => build,
+            _ => panic!("expected Run variant"),
+        }
+    }
+
+    fn parse_run_instance_id(args: &[&str]) -> Option<String> {
+        let full: Vec<&str> = std::iter::once("peppy")
+            .chain(std::iter::once("run"))
+            .chain(args.iter().copied())
+            .collect();
+        let cli = TestCli::try_parse_from(full).expect("should parse");
+        match cli.command {
+            NodeCommands::Run { instance_id, .. } => instance_id,
+            _ => panic!("expected Run variant"),
+        }
+    }
+
+    fn parse_subcommand_force(subcommand: &str, args: &[&str]) -> bool {
+        let full: Vec<&str> = std::iter::once("peppy")
+            .chain(std::iter::once(subcommand))
+            .chain(args.iter().copied())
+            .collect();
+        let cli = TestCli::try_parse_from(full).expect("should parse");
+        match cli.command {
+            NodeCommands::Add { force, .. }
+            | NodeCommands::Build { force, .. }
+            | NodeCommands::Remove { force, .. } => force,
+            _ => panic!("expected Add/Build/Remove variant"),
+        }
+    }
+
     #[test]
     fn add_sr_short_bundle_sets_sync_and_run() {
         let (sync, build, run) = parse_add(&[".", "-sr"]);
@@ -451,5 +494,98 @@ mod tests {
         assert!(!sync, "sync should default to false");
         assert!(build);
         assert!(!run);
+    }
+
+    #[test]
+    fn run_b_short_flag_sets_build() {
+        assert!(
+            parse_run(&["foo:0.1.0", "-b"]),
+            "-b should set build on run"
+        );
+    }
+
+    #[test]
+    fn run_long_build_flag_sets_build() {
+        assert!(
+            parse_run(&["foo:0.1.0", "--build"]),
+            "--build should set build on run"
+        );
+    }
+
+    #[test]
+    fn run_without_build_flag_defaults_to_false() {
+        assert!(
+            !parse_run(&["foo:0.1.0"]),
+            "build should default to false on run"
+        );
+    }
+
+    #[test]
+    fn run_i_short_flag_sets_instance_id() {
+        assert_eq!(
+            parse_run_instance_id(&["foo:0.1.0", "-i", "my-inst"]),
+            Some("my-inst".to_string()),
+            "-i should set instance_id on run"
+        );
+    }
+
+    #[test]
+    fn run_long_instance_id_flag_sets_instance_id() {
+        assert_eq!(
+            parse_run_instance_id(&["foo:0.1.0", "--instance-id", "my-inst"]),
+            Some("my-inst".to_string()),
+            "--instance-id should set instance_id on run"
+        );
+    }
+
+    #[test]
+    fn run_bi_short_bundle_sets_build_and_instance_id() {
+        // `-bi <id>` ≡ `-b -i <id>`: clap treats `-bi` as a bundled short-flag
+        // run with `i` consuming the next positional as its value.
+        let full: Vec<&str> = vec!["peppy", "run", "foo:0.1.0", "-bi", "my-inst"];
+        let cli = TestCli::try_parse_from(full).expect("should parse");
+        match cli.command {
+            NodeCommands::Run {
+                build, instance_id, ..
+            } => {
+                assert!(build, "-bi should set build");
+                assert_eq!(
+                    instance_id,
+                    Some("my-inst".to_string()),
+                    "-bi should set instance_id"
+                );
+            }
+            _ => panic!("expected Run variant"),
+        }
+    }
+
+    #[test]
+    fn add_f_short_flag_sets_force() {
+        assert!(parse_subcommand_force("add", &[".", "-f"]));
+    }
+
+    #[test]
+    fn build_f_short_flag_sets_force() {
+        assert!(parse_subcommand_force("build", &["foo:0.1.0", "-f"]));
+    }
+
+    #[test]
+    fn remove_f_short_flag_sets_force() {
+        assert!(parse_subcommand_force("remove", &["foo:0.1.0", "-f"]));
+    }
+
+    #[test]
+    fn add_without_force_flag_defaults_to_false() {
+        assert!(!parse_subcommand_force("add", &["."]));
+    }
+
+    #[test]
+    fn build_without_force_flag_defaults_to_false() {
+        assert!(!parse_subcommand_force("build", &["foo:0.1.0"]));
+    }
+
+    #[test]
+    fn remove_without_force_flag_defaults_to_false() {
+        assert!(!parse_subcommand_force("remove", &["foo:0.1.0"]));
     }
 }

--- a/crates/peppy/src/commands/node/run.rs
+++ b/crates/peppy/src/commands/node/run.rs
@@ -46,6 +46,40 @@ enum BuildDecision {
     Wait,
 }
 
+/// Pure helper: compute the remaining `max_secs` budget given how many
+/// seconds have already elapsed. Split out from `remaining_timeouts` so the
+/// budget-arithmetic + error path can be unit-tested without needing a
+/// tokio runtime or time-mocking feature.
+fn remaining_max_secs(original_max: u64, elapsed: u64, stage: &str) -> Result<u64> {
+    if elapsed >= original_max {
+        return Err(Error::ExecutionFailed(format!(
+            "Timeout: max timeout of {original_max}s exceeded before {stage}. \
+             Use --max-timeout <seconds> to increase."
+        )));
+    }
+    Ok(original_max - elapsed)
+}
+
+/// Derive a new `TimeoutConfig` whose `max_secs` is what remains of the
+/// original `max_secs` budget after the time elapsed since `start`. Returns
+/// an `ExecutionFailed` error if no budget remains, so callers never kick
+/// off a stage with a zero deadline.
+///
+/// `idle_secs` is preserved as-is: it's a per-call "no output" guard, not a
+/// wall-clock budget, so it should not shrink across stages.
+fn remaining_timeouts(
+    timeouts: &TimeoutConfig,
+    start: Instant,
+    stage: &str,
+) -> Result<TimeoutConfig> {
+    let elapsed = start.elapsed().as_secs();
+    let max_secs = remaining_max_secs(timeouts.max_secs, elapsed, stage)?;
+    Ok(TimeoutConfig {
+        idle_secs: timeouts.idle_secs,
+        max_secs,
+    })
+}
+
 /// Classify a node's lifecycle stage into a `run -b` action.
 ///
 /// This is split out as a pure function so the stage-matching logic can be
@@ -350,6 +384,14 @@ async fn run_node_async(
 ) -> Result<()> {
     let conn = ctx.connect_to_daemon().await?;
 
+    // Single end-to-end budget: every subsequent blocking stage (build, wait,
+    // run) derives its `max_secs` from what's left of this budget, so the sum
+    // of their wall-clock deadlines cannot exceed the original
+    // `timeouts.max_secs`. The preflight `NodeInfoRequest` below intentionally
+    // uses its own fixed-30s timeout and is exempt (see
+    // `NODE_INFO_PREFLIGHT_TIMEOUT` docs above).
+    let start = Instant::now();
+
     if build {
         // Look up the node's current lifecycle stage so we only trigger a
         // build when the node is not yet built. The same `NodeInfoRequest`
@@ -390,7 +432,7 @@ async fn run_node_async(
                     &conn.core_node_name,
                     &node_name,
                     &tag,
-                    &timeouts,
+                    &remaining_timeouts(&timeouts, start, "build")?,
                     false,
                 )
                 .await?;
@@ -401,7 +443,7 @@ async fn run_node_async(
                     &conn.core_node_name,
                     &node_name,
                     &tag,
-                    &timeouts,
+                    &remaining_timeouts(&timeouts, start, "wait-for-build")?,
                 )
                 .await?;
             }
@@ -415,7 +457,7 @@ async fn run_node_async(
         &tag,
         &args,
         instance_id,
-        &timeouts,
+        &remaining_timeouts(&timeouts, start, "run")?,
     )
     .await?;
 
@@ -579,6 +621,30 @@ mod tests {
             msg.contains("root"),
             "error should mention root stage: {msg}"
         );
+    }
+
+    #[test]
+    fn remaining_max_secs_subtracts_elapsed() {
+        let remaining = remaining_max_secs(100, 25, "build")
+            .expect("remaining budget should still be positive");
+        assert_eq!(remaining, 75);
+    }
+
+    #[test]
+    fn remaining_max_secs_errors_when_budget_exhausted() {
+        // Equal to budget — already exhausted (we refuse zero-deadline calls).
+        let err_exact =
+            remaining_max_secs(30, 30, "run").expect_err("exhausted budget should error");
+        let msg = format!("{err_exact}");
+        assert!(msg.contains("30s"), "error should cite original max: {msg}");
+        assert!(msg.contains("run"), "error should cite stage label: {msg}");
+        assert!(
+            msg.contains("--max-timeout"),
+            "error should hint at the CLI flag: {msg}"
+        );
+
+        // Past budget — same error path.
+        assert!(remaining_max_secs(30, 45, "run").is_err());
     }
 
     #[test]

--- a/crates/peppy/src/commands/node/run.rs
+++ b/crates/peppy/src/commands/node/run.rs
@@ -11,6 +11,7 @@ use rand::rng;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::Duration;
+use tokio::time::{Instant, sleep};
 use tracing::info;
 
 use crate::commands::{CALLER_INSTANCE_ID, GOAL_TIMEOUT};
@@ -25,6 +26,111 @@ use super::env::caller_env_overrides;
 /// not a long-running action, so it must fail fast if the daemon is down
 /// rather than waiting out `timeouts.max_secs` (which can be 1 hour).
 const NODE_INFO_PREFLIGHT_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Interval between `NodeInfoRequest` polls while waiting for an in-flight
+/// build to transition `Building -> Ready`. Builds typically take
+/// seconds-to-minutes, so 500 ms keeps CLI latency low without flooding the
+/// daemon.
+const BUILD_WAIT_POLL_INTERVAL: Duration = Duration::from_millis(500);
+
+/// What `run -b` should do with a node based on its current lifecycle stage.
+#[derive(Debug, PartialEq, Eq)]
+enum BuildDecision {
+    /// Stage is `Ready` — artifact exists, skip the build and run directly.
+    Skip,
+    /// Stage is `Added` — trigger `build_node_async`.
+    Build,
+    /// Stage is `Building` — another build is in flight, poll until it
+    /// finishes instead of trying to start a second build (the daemon
+    /// rejects concurrent builds).
+    Wait,
+}
+
+/// Classify a node's lifecycle stage into a `run -b` action.
+///
+/// This is split out as a pure function so the stage-matching logic can be
+/// unit-tested directly. Documented stage values come from
+/// `core_node::encoding::NodeInfo::stage`: `Added | Building | Ready | Root`.
+fn classify_stage(stage: &str, node_name: &str, tag: &str) -> Result<BuildDecision> {
+    match stage {
+        "Ready" => Ok(BuildDecision::Skip),
+        "Added" => Ok(BuildDecision::Build),
+        "Building" => Ok(BuildDecision::Wait),
+        "Root" => Err(Error::ExecutionFailed(format!(
+            "Node '{}:{}' is a root node and cannot be built or run via `node run`",
+            node_name, tag
+        ))),
+        other => Err(Error::ExecutionFailed(format!(
+            "Node '{}:{}' is in unexpected stage '{}'; cannot safely proceed with `run -b`",
+            node_name, tag, other
+        ))),
+    }
+}
+
+/// Polls `NodeInfoRequest` until the node's stage transitions out of
+/// `Building`. Returns `Ok(())` when the stage becomes `Ready`; returns an
+/// error on timeout, on unexpected stage transitions (e.g. a failed build
+/// falling back to `Added`), or if the node disappears from the stack.
+async fn wait_for_build_to_finish(
+    messenger: &MessengerHandle,
+    core_node_name: &str,
+    node_name: &str,
+    tag: &str,
+    timeouts: &TimeoutConfig,
+) -> Result<()> {
+    info!(
+        "Node {}:{} is already building, waiting for the in-flight build to finish...",
+        node_name, tag
+    );
+
+    let deadline = Instant::now() + Duration::from_secs(timeouts.max_secs);
+
+    loop {
+        let response = NodeInfoRequest::new(node_name.to_string(), tag.to_string())
+            .poll(
+                messenger,
+                core_node_name,
+                CALLER_INSTANCE_ID,
+                core_node_name,
+                NODE_INFO_PREFLIGHT_TIMEOUT,
+            )
+            .await
+            .map_err(|e| {
+                Error::ExecutionFailed(format!(
+                    "Failed to poll node info while waiting for build: {}",
+                    e
+                ))
+            })?;
+
+        match response {
+            NodeInfoResponse::NotInStack => {
+                return Err(Error::ExecutionFailed(format!(
+                    "Node '{}:{}' disappeared from the stack while waiting for build to finish",
+                    node_name, tag
+                )));
+            }
+            NodeInfoResponse::Found(info) => match info.stage.as_str() {
+                "Ready" => return Ok(()),
+                "Building" => { /* still in flight — keep polling */ }
+                other => {
+                    return Err(Error::ExecutionFailed(format!(
+                        "Node '{}:{}' transitioned to unexpected stage '{}' while waiting for build to finish",
+                        node_name, tag, other
+                    )));
+                }
+            },
+        }
+
+        if Instant::now() >= deadline {
+            return Err(Error::ExecutionFailed(format!(
+                "Timed out waiting for node '{}:{}' build to finish",
+                node_name, tag
+            )));
+        }
+
+        sleep(BUILD_WAIT_POLL_INTERVAL).await;
+    }
+}
 
 /// Converts a list of key=value string pairs into node arguments.
 /// Dot-separated keys are converted into nested objects.
@@ -271,21 +377,34 @@ async fn run_node_async(
             NodeInfoResponse::Found(info) => info,
         };
 
-        if info.stage == "Ready" {
-            info!(
-                "Node {}:{} has already been built, skipping build",
-                node_name, tag
-            );
-        } else {
-            super::builder::build_node_async(
-                conn.messenger,
-                &conn.core_node_name,
-                &node_name,
-                &tag,
-                &timeouts,
-                false,
-            )
-            .await?;
+        match classify_stage(info.stage.as_str(), &node_name, &tag)? {
+            BuildDecision::Skip => {
+                info!(
+                    "Node {}:{} has already been built, skipping build",
+                    node_name, tag
+                );
+            }
+            BuildDecision::Build => {
+                super::builder::build_node_async(
+                    conn.messenger,
+                    &conn.core_node_name,
+                    &node_name,
+                    &tag,
+                    &timeouts,
+                    false,
+                )
+                .await?;
+            }
+            BuildDecision::Wait => {
+                wait_for_build_to_finish(
+                    conn.messenger,
+                    &conn.core_node_name,
+                    &node_name,
+                    &tag,
+                    &timeouts,
+                )
+                .await?;
+            }
         }
     }
 
@@ -418,5 +537,59 @@ mod tests {
             }
             _ => panic!("video should be an object"),
         }
+    }
+
+    #[test]
+    fn classify_stage_ready_skips() {
+        assert_eq!(
+            classify_stage("Ready", "n", "t").expect("Ready should classify"),
+            BuildDecision::Skip
+        );
+    }
+
+    #[test]
+    fn classify_stage_added_builds() {
+        assert_eq!(
+            classify_stage("Added", "n", "t").expect("Added should classify"),
+            BuildDecision::Build
+        );
+    }
+
+    #[test]
+    fn classify_stage_building_waits_does_not_rebuild() {
+        // Regression: previously stage "Building" fell through to the
+        // "build" branch, and the daemon rejected the second build goal
+        // with "action already in progress" / "cannot build". The CLI now
+        // waits for the in-flight build instead of trying to start a new
+        // one.
+        assert_eq!(
+            classify_stage("Building", "n", "t").expect("Building should classify"),
+            BuildDecision::Wait
+        );
+    }
+
+    #[test]
+    fn classify_stage_root_fails_fast() {
+        let err =
+            classify_stage("Root", "my_node", "v1").expect_err("Root should fail to classify");
+        let msg = format!("{err}");
+        assert!(msg.contains("my_node"), "error should name node: {msg}");
+        assert!(msg.contains("v1"), "error should name tag: {msg}");
+        assert!(
+            msg.contains("root"),
+            "error should mention root stage: {msg}"
+        );
+    }
+
+    #[test]
+    fn classify_stage_unknown_fails_fast() {
+        let err = classify_stage("Mystery", "my_node", "v1")
+            .expect_err("unknown stage should fail to classify");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("Mystery"),
+            "error should quote unknown stage: {msg}"
+        );
+        assert!(msg.contains("my_node"), "error should name node: {msg}");
     }
 }

--- a/crates/peppy/src/commands/node/run.rs
+++ b/crates/peppy/src/commands/node/run.rs
@@ -20,6 +20,12 @@ use crate::error::{Error, Result};
 use super::TimeoutConfig;
 use super::env::caller_env_overrides;
 
+/// Timeout for the quick `NodeInfoRequest` preflight in the `run -b` flow.
+/// Matches `node info`'s request timeout — this is a metadata lookup,
+/// not a long-running action, so it must fail fast if the daemon is down
+/// rather than waiting out `timeouts.max_secs` (which can be 1 hour).
+const NODE_INFO_PREFLIGHT_TIMEOUT: Duration = Duration::from_secs(30);
+
 /// Converts a list of key=value string pairs into node arguments.
 /// Dot-separated keys are converted into nested objects.
 /// For example: "device.physical=/dev/video0" becomes {"device": {"physical": "/dev/video0"}}
@@ -248,7 +254,7 @@ async fn run_node_async(
                 &conn.core_node_name,
                 CALLER_INSTANCE_ID,
                 &conn.core_node_name,
-                Duration::from_secs(timeouts.max_secs),
+                NODE_INFO_PREFLIGHT_TIMEOUT,
             )
             .await
             .map_err(|e| {

--- a/crates/peppy/src/commands/node/run.rs
+++ b/crates/peppy/src/commands/node/run.rs
@@ -1,12 +1,16 @@
 use config::AnyType;
 use config::launcher::Name;
 use config::runtime::{NodeInstanceConfig, RuntimeConfig};
-use core_node::encoding::{NodeRunFeedback, NodeRunGoal, NodeRunGoalResponse, NodeRunResult};
+use core_node::encoding::{
+    NodeInfoRequest, NodeInfoResponse, NodeRunFeedback, NodeRunGoal, NodeRunGoalResponse,
+    NodeRunResult,
+};
 use names_generator2::get_random;
 use peppylib::MessengerHandle;
 use rand::rng;
 use std::collections::BTreeMap;
 use std::sync::Arc;
+use std::time::Duration;
 use tracing::info;
 
 use crate::commands::{CALLER_INSTANCE_ID, GOAL_TIMEOUT};
@@ -210,6 +214,7 @@ pub fn run_node(
     args: Vec<(String, String)>,
     instance_id: Option<String>,
     timeouts: TimeoutConfig,
+    build: bool,
 ) -> Result<()> {
     crate::commands::block_on(run_node_async(
         ctx,
@@ -218,6 +223,7 @@ pub fn run_node(
         args,
         instance_id,
         timeouts,
+        build,
     ))
 }
 
@@ -228,8 +234,54 @@ async fn run_node_async(
     args: Vec<(String, String)>,
     instance_id: Option<String>,
     timeouts: TimeoutConfig,
+    build: bool,
 ) -> Result<()> {
     let conn = ctx.connect_to_daemon().await?;
+
+    if build {
+        // Look up the node's current lifecycle stage so we only trigger a
+        // build when the node is not yet built. The same `NodeInfoRequest`
+        // is used by the `node add` preflight (see add.rs).
+        let response = NodeInfoRequest::new(node_name.clone(), tag.clone())
+            .poll(
+                conn.messenger,
+                &conn.core_node_name,
+                CALLER_INSTANCE_ID,
+                &conn.core_node_name,
+                Duration::from_secs(timeouts.max_secs),
+            )
+            .await
+            .map_err(|e| {
+                Error::ExecutionFailed(format!("Failed to check node info before run: {}", e))
+            })?;
+
+        let info = match response {
+            NodeInfoResponse::NotInStack => {
+                return Err(Error::ExecutionFailed(format!(
+                    "Node '{}:{}' is not in the node stack",
+                    node_name, tag
+                )));
+            }
+            NodeInfoResponse::Found(info) => info,
+        };
+
+        if info.stage == "Ready" {
+            info!(
+                "Node {}:{} has already been built, skipping build",
+                node_name, tag
+            );
+        } else {
+            super::builder::build_node_async(
+                conn.messenger,
+                &conn.core_node_name,
+                &node_name,
+                &tag,
+                &timeouts,
+                false,
+            )
+            .await?;
+        }
+    }
 
     run_instance_async(
         conn.messenger,

--- a/crates/peppy/src/commands/node/sync.rs
+++ b/crates/peppy/src/commands/node/sync.rs
@@ -1,9 +1,12 @@
-use std::path::PathBuf;
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
+use config::consts::NODE_CONFIG_FILE;
 use core_node::encoding::NodeSyncRequest;
-use tracing::info;
+use tracing::{info, warn};
+use walkdir::WalkDir;
 
 use super::source::resolve_node_root_dir;
 use crate::commands::CALLER_INSTANCE_ID;
@@ -12,8 +15,23 @@ use crate::error::{Error, Result};
 
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Directory names that should never be descended into while searching for
+/// root `peppy.json5` files.
+const PRUNED_DIR_NAMES: &[&str] = &[
+    ".git",
+    ".peppy",
+    "target",
+    "node_modules",
+    ".venv",
+    "__pycache__",
+];
+
 pub fn sync_node(ctx: &Arc<AppContext>, path: Option<PathBuf>) -> Result<()> {
     crate::commands::block_on(sync_node_async(ctx, path))
+}
+
+pub fn sync_all_nodes(ctx: &Arc<AppContext>, path: Option<PathBuf>) -> Result<()> {
+    crate::commands::block_on(sync_all_nodes_async(ctx, path))
 }
 
 pub(super) async fn sync_node_async(ctx: &Arc<AppContext>, path: Option<PathBuf>) -> Result<()> {
@@ -24,6 +42,59 @@ pub(super) async fn sync_node_async(ctx: &Arc<AppContext>, path: Option<PathBuf>
         None => ctx.root_dir.clone(),
     };
     let node_root_dir = resolve_node_root_dir(&base_dir)?;
+    sync_resolved_node(ctx, &node_root_dir).await
+}
+
+async fn sync_all_nodes_async(ctx: &Arc<AppContext>, path: Option<PathBuf>) -> Result<()> {
+    let base_dir = match path {
+        Some(p) => ctx.root_dir.join(p),
+        None => ctx.root_dir.clone(),
+    };
+
+    info!("Searching for nodes under {}...", base_dir.display());
+    let roots = find_root_node_dirs(&base_dir);
+    if roots.is_empty() {
+        return Err(Error::ExecutionFailed(format!(
+            "No {} root configs found under '{}'",
+            NODE_CONFIG_FILE,
+            base_dir.display()
+        )));
+    }
+
+    info!("Found {} node(s) to sync", roots.len());
+
+    let mut failures: Vec<(PathBuf, Error)> = Vec::new();
+    for root in &roots {
+        info!("Syncing node at {}...", root.display());
+        if let Err(err) = sync_resolved_node(ctx, root).await {
+            warn!("Failed to sync node at {}: {}", root.display(), err);
+            failures.push((root.clone(), err));
+        }
+    }
+
+    let synced = roots.len() - failures.len();
+    info!("Synced {} node(s)", synced);
+
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        let details = failures
+            .iter()
+            .map(|(dir, err)| format!("  - {}: {}", dir.display(), err))
+            .collect::<Vec<_>>()
+            .join("\n");
+        Err(Error::ExecutionFailed(format!(
+            "Failed to sync {} of {} node(s):\n{}",
+            failures.len(),
+            roots.len(),
+            details
+        )))
+    }
+}
+
+/// Runs the daemon-side `node_generate` service for a node directory that has
+/// already been resolved to its canonical root.
+async fn sync_resolved_node(ctx: &Arc<AppContext>, node_root_dir: &Path) -> Result<()> {
     let conn = ctx.connect_to_daemon().await?;
 
     info!(
@@ -32,7 +103,7 @@ pub(super) async fn sync_node_async(ctx: &Arc<AppContext>, path: Option<PathBuf>
         conn.core_node_name
     );
 
-    let request = NodeSyncRequest::new(node_root_dir, conn.git_hash);
+    let request = NodeSyncRequest::new(node_root_dir.to_path_buf(), conn.git_hash);
     let response = request
         .poll(
             conn.messenger,
@@ -55,6 +126,162 @@ pub(super) async fn sync_node_async(ctx: &Arc<AppContext>, path: Option<PathBuf>
         return Err(Error::ExecutionFailed(msg));
     }
 
-    info!("Synced node interfaces successfully");
+    info!("Synced node interfaces at {}", node_root_dir.display());
     Ok(())
+}
+
+/// Recursively finds every root node directory under `base`.
+///
+/// A "root node directory" is any directory whose `peppy.json5` is classified
+/// as a root by [`resolve_node_root_dir`]. Variant subdirectory configs are
+/// deduped back to their owning root. Malformed configs are skipped with a
+/// warning so that a single bad file does not abort the whole search.
+fn find_root_node_dirs(base: &Path) -> Vec<PathBuf> {
+    let mut roots: BTreeSet<PathBuf> = BTreeSet::new();
+
+    let walker = WalkDir::new(base)
+        .follow_links(false)
+        .into_iter()
+        .filter_entry(|entry| {
+            if !entry.file_type().is_dir() {
+                return true;
+            }
+            // Always include the starting directory.
+            if entry.depth() == 0 {
+                return true;
+            }
+            let name = entry.file_name().to_string_lossy();
+            !PRUNED_DIR_NAMES.iter().any(|pruned| name == *pruned)
+        });
+
+    for entry in walker {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(err) => {
+                warn!(
+                    "Skipping directory entry while searching for nodes: {}",
+                    err
+                );
+                continue;
+            }
+        };
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        if entry.file_name() != NODE_CONFIG_FILE {
+            continue;
+        }
+        let Some(parent) = entry.path().parent() else {
+            continue;
+        };
+        match resolve_node_root_dir(parent) {
+            Ok(root) => {
+                roots.insert(root);
+            }
+            Err(err) => {
+                warn!(
+                    "Skipping {} at {}: {}",
+                    NODE_CONFIG_FILE,
+                    parent.display(),
+                    err
+                );
+            }
+        }
+    }
+
+    roots.into_iter().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use config::consts::NODE_CONFIG_FILE;
+
+    fn write_root_config(dir: &Path, name: &str) {
+        std::fs::create_dir_all(dir).unwrap();
+        std::fs::write(
+            dir.join(NODE_CONFIG_FILE),
+            format!(
+                r#"{{
+                    schema_version: 1,
+                    manifest: {{
+                        name: "{name}",
+                        tag: "0.1.0",
+                    }},
+                    execution: {{ language: "rust", run_cmd: ["./bin"] }}
+                }}"#
+            ),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn find_root_node_dirs_finds_nested_nodes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path();
+
+        write_root_config(&base.join("node_a"), "node_a");
+        write_root_config(&base.join("subdir").join("node_b"), "node_b");
+        write_root_config(&base.join("deep").join("nested").join("node_c"), "node_c");
+
+        let roots = find_root_node_dirs(base);
+        assert_eq!(roots.len(), 3, "expected 3 roots, got {:?}", roots);
+        assert!(roots.contains(&base.join("node_a")));
+        assert!(roots.contains(&base.join("subdir").join("node_b")));
+        assert!(roots.contains(&base.join("deep").join("nested").join("node_c")));
+    }
+
+    #[test]
+    fn find_root_node_dirs_skips_pruned_directories() {
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path();
+
+        write_root_config(&base.join("node_a"), "node_a");
+        // These should be ignored by the walker pruning.
+        write_root_config(&base.join("target").join("ghost"), "ghost");
+        write_root_config(&base.join(".git").join("ghost"), "ghost");
+        write_root_config(&base.join(".peppy").join("ghost"), "ghost");
+
+        let roots = find_root_node_dirs(base);
+        assert_eq!(roots, vec![base.join("node_a")]);
+    }
+
+    #[test]
+    fn find_root_node_dirs_dedupes_variant_to_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path();
+        let root = base.join("my_node");
+        let variant = root.join("variants").join("linux");
+        std::fs::create_dir_all(&variant).unwrap();
+
+        // Root with variants
+        std::fs::write(
+            root.join(NODE_CONFIG_FILE),
+            r#"{
+                schema_version: 1,
+                manifest: {
+                    name: "my_node",
+                    tag: "0.1.0",
+                    variants: [
+                        { name: "default", source: { local: "./variants/linux" } }
+                    ]
+                },
+                interfaces: {}
+            }"#,
+        )
+        .unwrap();
+
+        // Variant config (no manifest)
+        std::fs::write(
+            variant.join(NODE_CONFIG_FILE),
+            r#"{
+                schema_version: 1,
+                execution: { language: "rust", run_cmd: ["sleep", "1"] }
+            }"#,
+        )
+        .unwrap();
+
+        let roots = find_root_node_dirs(base);
+        assert_eq!(roots, vec![root]);
+    }
 }

--- a/crates/peppy/src/commands/node/sync.rs
+++ b/crates/peppy/src/commands/node/sync.rs
@@ -4,7 +4,9 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use config::consts::NODE_CONFIG_FILE;
+use config::node::NodeConfigParser;
 use core_node::encoding::NodeSyncRequest;
+use node_stack::VirtualDeptree;
 use tracing::{info, warn};
 use walkdir::WalkDir;
 
@@ -42,7 +44,7 @@ pub(super) async fn sync_node_async(ctx: &Arc<AppContext>, path: Option<PathBuf>
         None => ctx.root_dir.clone(),
     };
     let node_root_dir = resolve_node_root_dir(&base_dir)?;
-    sync_resolved_node(ctx, &node_root_dir).await
+    sync_resolved_node(ctx, &node_root_dir, &[]).await
 }
 
 async fn sync_all_nodes_async(ctx: &Arc<AppContext>, path: Option<PathBuf>) -> Result<()> {
@@ -61,18 +63,47 @@ async fn sync_all_nodes_async(ctx: &Arc<AppContext>, path: Option<PathBuf>) -> R
         )));
     }
 
-    info!("Found {} node(s) to sync", roots.len());
+    // Parse every discovered `peppy.json5` so we can build a virtual dependency
+    // tree below. We use `into_resolved_or_default` so that variant-only roots
+    // (where execution lives in a child variant config) still parse — only
+    // their manifest is needed for dependency analysis.
+    let mut parsed: Vec<(PathBuf, config::node::NodeConfig)> = Vec::with_capacity(roots.len());
+    for root in &roots {
+        let cfg_path = root.join(NODE_CONFIG_FILE);
+        let parsed_cfg = NodeConfigParser::from_path(&cfg_path).map_err(|e| {
+            Error::ExecutionFailed(format!("Failed to parse {}: {}", cfg_path.display(), e))
+        })?;
+        parsed.push((root.clone(), parsed_cfg.into_resolved_or_default()));
+    }
+
+    // Build the in-memory dependency tree. This is the only place ordering is
+    // decided; the daemon never sees the tree itself, only the flat peer list.
+    // The tree is dropped at the end of this function.
+    let tree = VirtualDeptree::build(parsed).map_err(|e| Error::ExecutionFailed(e.to_string()))?;
+
+    let peer_paths = tree.peer_root_dirs();
+    let ordered = tree.topological_order();
+    info!(
+        "Found {} node(s) to sync (resolved dep order)",
+        ordered.len()
+    );
 
     let mut failures: Vec<(PathBuf, Error)> = Vec::new();
-    for root in &roots {
-        info!("Syncing node at {}...", root.display());
-        if let Err(err) = sync_resolved_node(ctx, root).await {
-            warn!("Failed to sync node at {}: {}", root.display(), err);
-            failures.push((root.clone(), err));
+    for info in &ordered {
+        info!("Syncing node at {}...", info.root_dir.display());
+        if let Err(err) = sync_resolved_node(ctx, &info.root_dir, &peer_paths).await {
+            warn!(
+                "Failed to sync node at {}: {}",
+                info.root_dir.display(),
+                err
+            );
+            failures.push((info.root_dir.clone(), err));
         }
     }
 
-    let synced = roots.len() - failures.len();
+    // The `tree` is purely scoped to this function — `ordered` borrows from
+    // it, so it stays alive until the function returns and is then dropped.
+    let synced = ordered.len() - failures.len();
     info!("Synced {} node(s)", synced);
 
     if failures.is_empty() {
@@ -86,7 +117,7 @@ async fn sync_all_nodes_async(ctx: &Arc<AppContext>, path: Option<PathBuf>) -> R
         Err(Error::ExecutionFailed(format!(
             "Failed to sync {} of {} node(s):\n{}",
             failures.len(),
-            roots.len(),
+            ordered.len(),
             details
         )))
     }
@@ -94,7 +125,16 @@ async fn sync_all_nodes_async(ctx: &Arc<AppContext>, path: Option<PathBuf>) -> R
 
 /// Runs the daemon-side `node_generate` service for a node directory that has
 /// already been resolved to its canonical root.
-async fn sync_resolved_node(ctx: &Arc<AppContext>, node_root_dir: &Path) -> Result<()> {
+///
+/// `local_peers` carries sibling node root directories that the daemon should
+/// consider when resolving dependencies for this request — used by `node sync
+/// -a` to make freshly-discovered peers visible without touching the daemon's
+/// persistent node stack. For plain `node sync`, pass `&[]`.
+async fn sync_resolved_node(
+    ctx: &Arc<AppContext>,
+    node_root_dir: &Path,
+    local_peers: &[PathBuf],
+) -> Result<()> {
     let conn = ctx.connect_to_daemon().await?;
 
     info!(
@@ -103,7 +143,11 @@ async fn sync_resolved_node(ctx: &Arc<AppContext>, node_root_dir: &Path) -> Resu
         conn.core_node_name
     );
 
-    let request = NodeSyncRequest::new(node_root_dir.to_path_buf(), conn.git_hash);
+    let request = NodeSyncRequest::new(
+        node_root_dir.to_path_buf(),
+        conn.git_hash,
+        local_peers.to_vec(),
+    );
     let response = request
         .poll(
             conn.messenger,

--- a/crates/peppy/tests/main.rs
+++ b/crates/peppy/tests/main.rs
@@ -8,6 +8,7 @@ mod node_run;
 mod node_runtime_config;
 mod node_stop;
 mod node_sync;
+mod node_sync_all_dependency_order;
 mod service_install;
 mod service_reset;
 mod service_serve;

--- a/crates/peppy/tests/node_add.rs
+++ b/crates/peppy/tests/node_add.rs
@@ -403,7 +403,10 @@ fn node_add_after_failed_sync_succeeds() {
     );
 
     NodeCommand {
-        command: NodeCommands::Sync { path: None },
+        command: NodeCommands::Sync {
+            path: None,
+            all: false,
+        },
     }
     .execute(&sync_ctx)
     .expect("node sync command should succeed");

--- a/crates/peppy/tests/node_add.rs
+++ b/crates/peppy/tests/node_add.rs
@@ -1539,7 +1539,7 @@ fn node_add_with_sync_flag_refreshes_stale_git_hash() {
     );
     // The sync log line should also appear, proving --sync fired
     assert!(
-        logs.contains("Synced node interfaces successfully"),
+        logs.contains("Synced node interfaces at"),
         "logs should show sync ran. Logs:\n{}",
         logs
     );

--- a/crates/peppy/tests/node_run.rs
+++ b/crates/peppy/tests/node_run.rs
@@ -3,7 +3,7 @@ use peppy::test_support::{LogCapture, ServeCommandEmulation};
 use std::sync::Arc;
 use std::time::Duration;
 
-use core_node::encoding::NodeListRequest;
+use core_node::encoding::{NodeInfoRequest, NodeInfoResponse, NodeListRequest};
 use node_stack::SerializedNodeGraph;
 use peppy::commands::Command;
 use peppy::commands::node::{NodeCommand, NodeCommands, NodeName};
@@ -149,6 +149,7 @@ async fn node_run_command_succeeds() {
             instance_id: Some(instance_id.to_string()),
             idle_timeout: 60,
             max_timeout: 3600,
+            build: false,
         },
     }
     .execute(&node_ctx)
@@ -375,6 +376,7 @@ async fn node_run_command_with_args_succeeds() {
             instance_id: Some(instance_id.to_string()),
             idle_timeout: 60,
             max_timeout: 3600,
+            build: false,
         },
     }
     .execute(&node_ctx)
@@ -572,6 +574,7 @@ async fn node_run_command_with_custom_instance_id_succeeds() {
             instance_id: Some(custom_instance_id.to_string()),
             idle_timeout: 60,
             max_timeout: 3600,
+            build: false,
         },
     }
     .execute(&node_ctx)
@@ -624,5 +627,324 @@ async fn node_run_command_with_custom_instance_id_succeeds() {
             .iter()
             .map(|n| (n.label(), n.instance_count()))
             .collect::<Vec<_>>()
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn node_run_with_build_flag_on_unbuilt_node_builds_then_runs() {
+    // Mock messaging is sufficient: we run in-process node services for health/ready.
+    let serve = ServeCommandEmulation::with_mock()
+        .await
+        .expect("failed to create serve emulation");
+    let shared_messenger = serve.messenger();
+    let core_node_name = serve.core_node_name().to_string();
+    assert!(
+        !core_node_name.is_empty(),
+        "core_node_name should not be empty"
+    );
+
+    let node_dir = tempfile::tempdir().expect("failed to create temp dir for node");
+    let node_name = "test_run_b_unbuilt_node";
+    let instance_id = "test_run_b_unbuilt_instance";
+
+    let node_ctx = Arc::new(
+        AppContext::with_messenger(node_dir.path(), Arc::clone(&shared_messenger))
+            .with_daemon_state_file(serve.daemon_state_path()),
+    );
+
+    let log_capture = LogCapture::new();
+    let subscriber = tracing_subscriber::fmt()
+        .with_ansi(false)
+        .without_time()
+        .with_writer(log_capture.clone())
+        .finish();
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    NodeCommand {
+        command: NodeCommands::Init {
+            node_name: NodeName::new(node_name).expect("valid node name"),
+            to_dir: None,
+            toolchain: Toolchain::Cargo,
+            with_container: false,
+        },
+    }
+    .execute(&node_ctx)
+    .expect("node init command should succeed");
+
+    let node_path = node_dir.path().join(node_name);
+    let peppy_json5_path = node_path.join("peppy.json5");
+    assert!(peppy_json5_path.exists());
+    peppy::test_support::override_run_cmd(&peppy_json5_path);
+
+    // Add the node WITHOUT building it. The node should land in the `Added`
+    // stage so that `node run -b` has something to build.
+    NodeCommand {
+        command: NodeCommands::Add {
+            source: Some(node_path.display().to_string()),
+            git_ref: None,
+            variant: None,
+            sync: false,
+            build: false,
+            run: false,
+            args: Vec::new(),
+            instance_id: None,
+            idle_timeout: 60,
+            max_timeout: 3600,
+            force: false,
+        },
+    }
+    .execute(&node_ctx)
+    .expect("node add command should succeed");
+
+    let messenger_handle = node_ctx
+        .messenger_handle()
+        .expect("messenger handle should be available");
+
+    // Pre-state: the node is in the stack and is in the `Added` stage
+    // (not yet built).
+    let info_response = NodeInfoRequest::new(node_name, "0.1.0")
+        .poll(
+            messenger_handle,
+            &core_node_name,
+            CALLER_INSTANCE_ID,
+            &core_node_name,
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("node_info request should complete");
+    match info_response {
+        NodeInfoResponse::Found(info) => {
+            assert_eq!(
+                info.stage, "Added",
+                "node should be in Added stage before `run -b`, got {:?}",
+                info.stage
+            );
+        }
+        NodeInfoResponse::NotInStack => {
+            panic!("node should be in the stack before `run -b`")
+        }
+    }
+
+    // Start in-process node services for health/ready so node_run can succeed.
+    let node_messenger = MessengerHandle::from_shared(Arc::clone(&shared_messenger));
+    let _node_ready_handle =
+        listen_for_node_ready(&node_messenger, &core_node_name, instance_id, node_name)
+            .await
+            .expect("node ready service should start");
+    let _node_health_handle =
+        listen_for_node_health(&node_messenger, &core_node_name, instance_id, node_name)
+            .await
+            .expect("node health service should start");
+
+    // Run with `-b` set: should build first, then start the instance.
+    NodeCommand {
+        command: NodeCommands::Run {
+            node_ref: None,
+            node_name: Some(node_name.to_string()),
+            tag: Some("0.1.0".to_string()),
+            args: Vec::new(),
+            instance_id: Some(instance_id.to_string()),
+            idle_timeout: 60,
+            max_timeout: 3600,
+            build: true,
+        },
+    }
+    .execute(&node_ctx)
+    .expect("node run -b should succeed on an unbuilt node");
+
+    let logs = log_capture.logs();
+    assert!(
+        logs.contains("Building node"),
+        "logs should mention that the node is being built. Logs:\n{}",
+        logs
+    );
+    assert!(
+        !logs.contains("has already been built"),
+        "logs should NOT contain the already-built skip message. Logs:\n{}",
+        logs
+    );
+    assert!(
+        logs.contains("Started node instance"),
+        "logs should mention that the instance was started. Logs:\n{}",
+        logs
+    );
+
+    let response = NodeListRequest::new(false)
+        .poll(
+            messenger_handle,
+            &core_node_name,
+            CALLER_INSTANCE_ID,
+            &core_node_name,
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("node_list request should complete");
+    let graph: SerializedNodeGraph =
+        serde_json::from_str(&response.graph_json).expect("graph_json should parse");
+    let node = graph
+        .nodes
+        .iter()
+        .find(|n| n.name == node_name && n.tag == "0.1.0")
+        .expect("graph should contain the added node");
+    assert_eq!(
+        node.instance_count(),
+        1,
+        "graph should show 1 instance after `run -b`"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn node_run_with_build_flag_on_already_built_node_skips_build() {
+    let serve = ServeCommandEmulation::with_mock()
+        .await
+        .expect("failed to create serve emulation");
+    let shared_messenger = serve.messenger();
+    let core_node_name = serve.core_node_name().to_string();
+    assert!(
+        !core_node_name.is_empty(),
+        "core_node_name should not be empty"
+    );
+
+    let node_dir = tempfile::tempdir().expect("failed to create temp dir for node");
+    let node_name = "test_run_b_built_node";
+    let instance_id = "test_run_b_built_instance";
+
+    let node_ctx = Arc::new(
+        AppContext::with_messenger(node_dir.path(), Arc::clone(&shared_messenger))
+            .with_daemon_state_file(serve.daemon_state_path()),
+    );
+
+    let log_capture = LogCapture::new();
+    let subscriber = tracing_subscriber::fmt()
+        .with_ansi(false)
+        .without_time()
+        .with_writer(log_capture.clone())
+        .finish();
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    NodeCommand {
+        command: NodeCommands::Init {
+            node_name: NodeName::new(node_name).expect("valid node name"),
+            to_dir: None,
+            toolchain: Toolchain::Cargo,
+            with_container: false,
+        },
+    }
+    .execute(&node_ctx)
+    .expect("node init command should succeed");
+
+    let node_path = node_dir.path().join(node_name);
+    let peppy_json5_path = node_path.join("peppy.json5");
+    assert!(peppy_json5_path.exists());
+    peppy::test_support::override_run_cmd(&peppy_json5_path);
+
+    // Add the node WITH building it. The node should land in the `Ready`
+    // stage so that `node run -b` finds it already built.
+    NodeCommand {
+        command: NodeCommands::Add {
+            source: Some(node_path.display().to_string()),
+            git_ref: None,
+            variant: None,
+            sync: false,
+            build: true,
+            run: false,
+            args: Vec::new(),
+            instance_id: None,
+            idle_timeout: 60,
+            max_timeout: 3600,
+            force: false,
+        },
+    }
+    .execute(&node_ctx)
+    .expect("node add command should succeed");
+
+    let messenger_handle = node_ctx
+        .messenger_handle()
+        .expect("messenger handle should be available");
+
+    // Sanity check: node is in `Ready` stage before we run `-b`.
+    let info_response = NodeInfoRequest::new(node_name, "0.1.0")
+        .poll(
+            messenger_handle,
+            &core_node_name,
+            CALLER_INSTANCE_ID,
+            &core_node_name,
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("node_info request should complete");
+    match info_response {
+        NodeInfoResponse::Found(info) => {
+            assert_eq!(
+                info.stage, "Ready",
+                "node should be in Ready stage before `run -b`, got {:?}",
+                info.stage
+            );
+        }
+        NodeInfoResponse::NotInStack => {
+            panic!("node should be in the stack before `run -b`")
+        }
+    }
+
+    let node_messenger = MessengerHandle::from_shared(Arc::clone(&shared_messenger));
+    let _node_ready_handle =
+        listen_for_node_ready(&node_messenger, &core_node_name, instance_id, node_name)
+            .await
+            .expect("node ready service should start");
+    let _node_health_handle =
+        listen_for_node_health(&node_messenger, &core_node_name, instance_id, node_name)
+            .await
+            .expect("node health service should start");
+
+    // Run with `-b` set: should detect the node is already built, skip the
+    // build, and run.
+    NodeCommand {
+        command: NodeCommands::Run {
+            node_ref: None,
+            node_name: Some(node_name.to_string()),
+            tag: Some("0.1.0".to_string()),
+            args: Vec::new(),
+            instance_id: Some(instance_id.to_string()),
+            idle_timeout: 60,
+            max_timeout: 3600,
+            build: true,
+        },
+    }
+    .execute(&node_ctx)
+    .expect("node run -b should succeed on an already-built node");
+
+    let logs = log_capture.logs();
+    assert!(
+        logs.contains("has already been built"),
+        "logs should contain the already-built skip message. Logs:\n{}",
+        logs
+    );
+    assert!(
+        logs.contains("Started node instance"),
+        "logs should mention that the instance was started. Logs:\n{}",
+        logs
+    );
+
+    let response = NodeListRequest::new(false)
+        .poll(
+            messenger_handle,
+            &core_node_name,
+            CALLER_INSTANCE_ID,
+            &core_node_name,
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("node_list request should complete");
+    let graph: SerializedNodeGraph =
+        serde_json::from_str(&response.graph_json).expect("graph_json should parse");
+    let node = graph
+        .nodes
+        .iter()
+        .find(|n| n.name == node_name && n.tag == "0.1.0")
+        .expect("graph should contain the added node");
+    assert_eq!(
+        node.instance_count(),
+        1,
+        "graph should show 1 instance after `run -b`"
     );
 }

--- a/crates/peppy/tests/node_stop.rs
+++ b/crates/peppy/tests/node_stop.rs
@@ -157,6 +157,7 @@ async fn node_stop_command_succeeds() {
             instance_id: Some(instance_id.to_string()),
             idle_timeout: 60,
             max_timeout: 3600,
+            build: false,
         },
     }
     .execute(&node_ctx)

--- a/crates/peppy/tests/node_sync.rs
+++ b/crates/peppy/tests/node_sync.rs
@@ -110,7 +110,10 @@ async fn node_sync_rust_command_succeeds() {
             .with_daemon_state_file(serve.daemon_state_path()),
     );
     NodeCommand {
-        command: NodeCommands::Sync { path: None },
+        command: NodeCommands::Sync {
+            path: None,
+            all: false,
+        },
     }
     .execute(&sync_ctx)
     .expect("node sync command should succeed");
@@ -127,7 +130,7 @@ async fn node_sync_rust_command_succeeds() {
 
     let logs = log_capture.logs();
     assert!(
-        logs.contains("Synced node interfaces successfully"),
+        logs.contains("Synced node interfaces at"),
         "logs should contain sync success message. Logs:\n{}",
         logs
     );
@@ -227,7 +230,10 @@ async fn node_sync_python_command_succeeds() {
             .with_daemon_state_file(serve.daemon_state_path()),
     );
     NodeCommand {
-        command: NodeCommands::Sync { path: None },
+        command: NodeCommands::Sync {
+            path: None,
+            all: false,
+        },
     }
     .execute(&sync_ctx)
     .expect("node sync command should succeed");
@@ -244,7 +250,7 @@ async fn node_sync_python_command_succeeds() {
 
     let logs = log_capture.logs();
     assert!(
-        logs.contains("Synced node interfaces successfully"),
+        logs.contains("Synced node interfaces at"),
         "logs should contain sync success message. Logs:\n{}",
         logs
     );
@@ -340,6 +346,7 @@ async fn node_sync_with_path_succeeds() {
     NodeCommand {
         command: NodeCommands::Sync {
             path: Some(PathBuf::from(node_name)),
+            all: false,
         },
     }
     .execute(&sync_ctx)
@@ -357,7 +364,7 @@ async fn node_sync_with_path_succeeds() {
 
     let logs = log_capture.logs();
     assert!(
-        logs.contains("Synced node interfaces successfully"),
+        logs.contains("Synced node interfaces at"),
         "logs should contain sync success message. Logs:\n{}",
         logs
     );
@@ -370,5 +377,145 @@ async fn node_sync_with_path_succeeds() {
         goodbye_world_topic_path.exists(),
         "goodbye_world topic should be generated at {}",
         goodbye_world_topic_path.display()
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn node_sync_all_succeeds_across_multiple_nodes() {
+    let serve = ServeCommandEmulation::with_mock()
+        .await
+        .expect("failed to create serve emulation");
+    let shared_messenger = serve.messenger();
+
+    let workspace = tempfile::tempdir().expect("failed to create temp dir for workspace");
+    let workspace_path = workspace.path();
+
+    // Set up logging
+    let log_capture = LogCapture::new();
+    let subscriber = tracing_subscriber::fmt()
+        .with_ansi(false)
+        .without_time()
+        .with_writer(log_capture.clone())
+        .finish();
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    // Create three rust nodes at varying depths in the workspace:
+    //   <tmp>/node_a
+    //   <tmp>/subdir/node_b
+    //   <tmp>/deep/nested/node_c
+    let node_layouts: Vec<(PathBuf, &str)> = vec![
+        (workspace_path.to_path_buf(), "node_a"),
+        (workspace_path.join("subdir"), "node_b"),
+        (workspace_path.join("deep").join("nested"), "node_c"),
+    ];
+
+    for (parent_dir, node_name) in &node_layouts {
+        std::fs::create_dir_all(parent_dir).expect("create parent dir");
+        let init_ctx = Arc::new(
+            AppContext::with_messenger(parent_dir, Arc::clone(&shared_messenger))
+                .with_daemon_state_file(serve.daemon_state_path()),
+        );
+        NodeCommand {
+            command: NodeCommands::Init {
+                node_name: NodeName::new(*node_name).expect("valid node name"),
+                to_dir: None,
+                toolchain: Toolchain::Cargo,
+                with_container: false,
+            },
+        }
+        .execute(&init_ctx)
+        .expect("node init command should succeed");
+    }
+
+    // Drop a bogus peppy.json5 under `target/` to verify pruning — the walker
+    // must ignore it. If it did not, `resolve_node_root_dir` would surface a
+    // parse error and this test would fail.
+    let pruned_dir = workspace_path.join("target").join("ghost");
+    std::fs::create_dir_all(&pruned_dir).expect("create pruned dir");
+    std::fs::write(
+        pruned_dir.join("peppy.json5"),
+        r#"{ this is invalid json5 {{{"#,
+    )
+    .expect("write bogus config");
+
+    // Modify every node's peppy.json5 so the fingerprints will change.
+    let mut node_paths: Vec<PathBuf> = Vec::new();
+    let mut expected_fingerprints: Vec<String> = Vec::new();
+    for (parent_dir, node_name) in &node_layouts {
+        let node_path = parent_dir.join(node_name);
+        let peppy_json5_path = node_path.join("peppy.json5");
+        assert!(
+            peppy_json5_path.exists(),
+            "peppy.json5 should exist at {}",
+            peppy_json5_path.display()
+        );
+
+        let old_fingerprint = config::fingerprint::read_codegen_fingerprint(
+            &peppy_json5_path,
+            config::consts::PEPPYGEN_OUTPUT_PATH,
+        )
+        .expect("fingerprint should be readable");
+
+        add_emitted_topic(&peppy_json5_path);
+
+        let expected_fingerprint =
+            config::runtime::RuntimeConfig::generate_peppy_config_fingerprint(&peppy_json5_path)
+                .expect("peppy.json5 fingerprint should generate");
+        assert_ne!(
+            expected_fingerprint, old_fingerprint,
+            "fingerprint should change after modifying peppy.json5 for {}",
+            node_name
+        );
+
+        node_paths.push(node_path);
+        expected_fingerprints.push(expected_fingerprint);
+    }
+
+    // Run `sync --all` from the workspace root.
+    let sync_ctx = Arc::new(
+        AppContext::with_messenger(workspace_path, Arc::clone(&shared_messenger))
+            .with_daemon_state_file(serve.daemon_state_path()),
+    );
+    NodeCommand {
+        command: NodeCommands::Sync {
+            path: None,
+            all: true,
+        },
+    }
+    .execute(&sync_ctx)
+    .expect("node sync --all command should succeed");
+
+    // Verify each node's fingerprint was updated.
+    for (node_path, expected_fingerprint) in node_paths.iter().zip(expected_fingerprints.iter()) {
+        let peppy_json5_path = node_path.join("peppy.json5");
+        let new_fingerprint = config::fingerprint::read_codegen_fingerprint(
+            &peppy_json5_path,
+            config::consts::PEPPYGEN_OUTPUT_PATH,
+        )
+        .expect("updated fingerprint should be readable");
+        assert_eq!(
+            &new_fingerprint,
+            expected_fingerprint,
+            "fingerprint should be updated for node at {}",
+            node_path.display()
+        );
+    }
+
+    // Verify the logs advertise every synchronized folder — the whole point
+    // of the `--all` flag per the user request.
+    let logs = log_capture.logs();
+    for node_path in &node_paths {
+        let marker = format!("Synced node interfaces at {}", node_path.display());
+        assert!(
+            logs.contains(&marker),
+            "logs should announce sync for {}. Logs:\n{}",
+            node_path.display(),
+            logs
+        );
+    }
+    assert!(
+        logs.contains(&format!("Synced {} node(s)", node_paths.len())),
+        "logs should contain the final sync count. Logs:\n{}",
+        logs
     );
 }

--- a/crates/peppy/tests/node_sync.rs
+++ b/crates/peppy/tests/node_sync.rs
@@ -427,16 +427,25 @@ async fn node_sync_all_succeeds_across_multiple_nodes() {
         .expect("node init command should succeed");
     }
 
-    // Drop a bogus peppy.json5 under `target/` to verify pruning — the walker
-    // must ignore it. If it did not, `resolve_node_root_dir` would surface a
-    // parse error and this test would fail.
+    // Drop a *valid* peppy.json5 under `target/` to verify pruning — the
+    // walker must ignore it. A malformed config wouldn't actually exercise
+    // pruning, since `find_root_node_dirs` already swallows parse errors with
+    // a warning; only a valid root would be added to the sync set if pruning
+    // broke, causing the assertions below to fail.
     let pruned_dir = workspace_path.join("target").join("ghost");
     std::fs::create_dir_all(&pruned_dir).expect("create pruned dir");
     std::fs::write(
         pruned_dir.join("peppy.json5"),
-        r#"{ this is invalid json5 {{{"#,
+        r#"{
+            schema_version: 1,
+            manifest: {
+                name: "ghost",
+                tag: "0.1.0",
+            },
+            execution: { language: "rust", run_cmd: ["./bin"] }
+        }"#,
     )
-    .expect("write bogus config");
+    .expect("write ghost config");
 
     // Modify every node's peppy.json5 so the fingerprints will change.
     let mut node_paths: Vec<PathBuf> = Vec::new();
@@ -516,6 +525,28 @@ async fn node_sync_all_succeeds_across_multiple_nodes() {
     assert!(
         logs.contains(&format!("Synced {} node(s)", node_paths.len())),
         "logs should contain the final sync count. Logs:\n{}",
+        logs
+    );
+
+    // Pruning check: the valid `target/ghost` node must not appear anywhere
+    // in the sync results — not in the logs, and not in the synced count.
+    let ghost_marker = format!("Synced node interfaces at {}", pruned_dir.display());
+    assert!(
+        !logs.contains(&ghost_marker),
+        "ghost node under target/ should be pruned, but logs contain '{}'. Logs:\n{}",
+        ghost_marker,
+        logs
+    );
+    let ghost_syncing_marker = format!("Syncing node at {}", pruned_dir.display());
+    assert!(
+        !logs.contains(&ghost_syncing_marker),
+        "ghost node under target/ should be pruned, but logs contain '{}'. Logs:\n{}",
+        ghost_syncing_marker,
+        logs
+    );
+    assert!(
+        !logs.contains(&format!("Synced {} node(s)", node_paths.len() + 1)),
+        "ghost node under target/ should be pruned, but the sync count includes it. Logs:\n{}",
         logs
     );
 }

--- a/crates/peppy/tests/node_sync_all_dependency_order.rs
+++ b/crates/peppy/tests/node_sync_all_dependency_order.rs
@@ -1,0 +1,366 @@
+//! Integration tests for `peppy node sync -a` dependency ordering.
+//!
+//! These tests verify that the in-memory `VirtualDeptree` built by
+//! `sync_all_nodes_async` (in `crates/peppy/src/commands/node/sync.rs`)
+//! correctly orders nodes so that dependencies are synced before their
+//! dependants, and that the daemon resolves the deps via the `local_peers`
+//! protocol field — without ever touching the persistent node stack.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use config::consts::NODE_CONFIG_FILE;
+use peppy::commands::Command;
+use peppy::commands::node::{NodeCommand, NodeCommands};
+use peppy::context::AppContext;
+use peppy::test_support::{LogCapture, ServeCommandEmulation};
+
+/// Writes a minimal Rust node config to `<dir>/peppy.json5`. `deps` is a list
+/// of `(name, tag)` pairs that go into the manifest's `depends_on.nodes`.
+/// `consumes` is a list of `(local_id, topic_name)` pairs that go into
+/// `interfaces.topics.consumes` (matched against the dep's emitted topics).
+fn write_node(
+    dir: &Path,
+    name: &str,
+    deps: &[(&str, &str)],
+    consumes: &[(&str, &str)],
+    emits: &[&str],
+) {
+    std::fs::create_dir_all(dir).expect("create node dir");
+
+    let depends_on_block = if deps.is_empty() {
+        String::new()
+    } else {
+        let entries = deps
+            .iter()
+            .map(|(n, t)| format!(r#"{{ name: "{n}", tag: "{t}", local_id: "{n}" }}"#))
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("depends_on: {{ nodes: [{entries}] }},")
+    };
+
+    let consumes_block = if consumes.is_empty() {
+        String::new()
+    } else {
+        let entries = consumes
+            .iter()
+            .map(|(local_id, topic)| {
+                format!(r#"{{ local_node_id: "{local_id}", name: "{topic}" }}"#)
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("consumes: [{entries}],")
+    };
+
+    let emits_block = if emits.is_empty() {
+        "emits: [],".to_string()
+    } else {
+        let entries = emits
+            .iter()
+            .map(|topic| {
+                format!(
+                    r#"{{ name: "{topic}", qos_profile: "standard", message_format: {{ payload: "string" }} }}"#
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("emits: [{entries}],")
+    };
+
+    let json5 = format!(
+        r#"{{
+            schema_version: 1,
+            manifest: {{
+                name: "{name}",
+                tag: "0.1.0",
+                {depends_on_block}
+            }},
+            interfaces: {{
+                topics: {{
+                    {emits_block}
+                    {consumes_block}
+                }},
+                services: {{ exposes: [] }},
+                actions: {{ exposes: [] }},
+            }},
+            execution: {{
+                language: "rust",
+                build_cmd: ["true"],
+                run_cmd: ["./bin"],
+            }},
+        }}"#
+    );
+
+    std::fs::write(dir.join(NODE_CONFIG_FILE), json5).expect("write peppy.json5");
+}
+
+/// Returns the order in which the per-node "Syncing node from <path>" log
+/// lines appear, mapped back to the workspace-relative directory name.
+fn extracted_sync_order(logs: &str, workspace: &Path) -> Vec<String> {
+    let prefix = "Syncing node from ";
+    logs.lines()
+        .filter_map(|line| {
+            let idx = line.find(prefix)?;
+            let after = &line[idx + prefix.len()..];
+            // Strip trailing " via daemon ..." chunk.
+            let path_end = after.find(" via daemon").unwrap_or(after.len());
+            let path = Path::new(&after[..path_end]);
+            path.strip_prefix(workspace)
+                .ok()
+                .map(|p| p.display().to_string())
+        })
+        .collect()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn node_sync_all_resolves_chain_in_dependency_order() {
+    let serve = ServeCommandEmulation::with_mock()
+        .await
+        .expect("serve mock");
+    let messenger = serve.messenger();
+
+    let workspace = tempfile::tempdir().expect("workspace tempdir");
+    let workspace_path = workspace.path();
+
+    let log_capture = LogCapture::new();
+    let subscriber = tracing_subscriber::fmt()
+        .with_ansi(false)
+        .without_time()
+        .with_writer(log_capture.clone())
+        .finish();
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    // Chain: a -> b -> c. Listed alphabetically a/b/c, but we explicitly
+    // verify ordering even though that order coincides with the topo order
+    // here. The cycle test below proves the order isn't a coincidence.
+    write_node(&workspace_path.join("a"), "a", &[], &[], &["topic_a"]);
+    write_node(
+        &workspace_path.join("b"),
+        "b",
+        &[("a", "0.1.0")],
+        &[("a", "topic_a")],
+        &["topic_b"],
+    );
+    write_node(
+        &workspace_path.join("c"),
+        "c",
+        &[("b", "0.1.0")],
+        &[("b", "topic_b")],
+        &[],
+    );
+
+    let ctx = Arc::new(
+        AppContext::with_messenger(workspace_path, Arc::clone(&messenger))
+            .with_daemon_state_file(serve.daemon_state_path()),
+    );
+    NodeCommand {
+        command: NodeCommands::Sync {
+            path: None,
+            all: true,
+        },
+    }
+    .execute(&ctx)
+    .expect("node sync -a should succeed");
+
+    let logs = log_capture.logs();
+    assert!(
+        logs.contains("Synced 3 node(s)"),
+        "expected 'Synced 3 node(s)' in logs:\n{}",
+        logs
+    );
+
+    // The chain a -> b -> c forces the topological order regardless of how
+    // the FS walker discovers the directories.
+    let order = extracted_sync_order(&logs, workspace_path);
+    assert_eq!(
+        order,
+        vec!["a".to_string(), "b".to_string(), "c".to_string()],
+        "sync order should respect dependency chain. Logs:\n{}",
+        logs
+    );
+
+    // Each peppygen output should exist.
+    for name in ["a", "b", "c"] {
+        let peppy_dir = workspace_path
+            .join(name)
+            .join(config::consts::PEPPY_OUTPUT_DIR);
+        assert!(
+            peppy_dir.exists(),
+            "expected .peppy directory at {}",
+            peppy_dir.display()
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn node_sync_all_resolves_diamond_dependency() {
+    let serve = ServeCommandEmulation::with_mock()
+        .await
+        .expect("serve mock");
+    let messenger = serve.messenger();
+
+    let workspace = tempfile::tempdir().expect("workspace tempdir");
+    let workspace_path = workspace.path();
+
+    let log_capture = LogCapture::new();
+    let subscriber = tracing_subscriber::fmt()
+        .with_ansi(false)
+        .without_time()
+        .with_writer(log_capture.clone())
+        .finish();
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    // Diamond:
+    //          a
+    //         / \
+    //        b   c
+    //         \ /
+    //          d
+    write_node(&workspace_path.join("a"), "a", &[], &[], &["topic_a"]);
+    write_node(
+        &workspace_path.join("b"),
+        "b",
+        &[("a", "0.1.0")],
+        &[("a", "topic_a")],
+        &["topic_b"],
+    );
+    write_node(
+        &workspace_path.join("c"),
+        "c",
+        &[("a", "0.1.0")],
+        &[("a", "topic_a")],
+        &["topic_c"],
+    );
+    write_node(
+        &workspace_path.join("d"),
+        "d",
+        &[("b", "0.1.0"), ("c", "0.1.0")],
+        &[("b", "topic_b"), ("c", "topic_c")],
+        &[],
+    );
+
+    let ctx = Arc::new(
+        AppContext::with_messenger(workspace_path, Arc::clone(&messenger))
+            .with_daemon_state_file(serve.daemon_state_path()),
+    );
+    NodeCommand {
+        command: NodeCommands::Sync {
+            path: None,
+            all: true,
+        },
+    }
+    .execute(&ctx)
+    .expect("node sync -a should succeed");
+
+    let logs = log_capture.logs();
+    assert!(
+        logs.contains("Synced 4 node(s)"),
+        "expected 'Synced 4 node(s)' in logs:\n{}",
+        logs
+    );
+
+    // a must come before b/c, and d must come last.
+    let order = extracted_sync_order(&logs, workspace_path);
+    assert_eq!(order.len(), 4, "expected 4 sync entries, got: {:?}", order);
+    assert_eq!(order.first().unwrap(), "a", "a must be synced first");
+    assert_eq!(order.last().unwrap(), "d", "d must be synced last");
+    let middle: Vec<&String> = order.iter().skip(1).take(2).collect();
+    assert!(
+        middle.iter().any(|s| s.as_str() == "b") && middle.iter().any(|s| s.as_str() == "c"),
+        "b and c must appear between a and d, got: {:?}",
+        order
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn node_sync_all_reports_cycle() {
+    let serve = ServeCommandEmulation::with_mock()
+        .await
+        .expect("serve mock");
+    let messenger = serve.messenger();
+
+    let workspace = tempfile::tempdir().expect("workspace tempdir");
+    let workspace_path = workspace.path();
+
+    let log_capture = LogCapture::new();
+    let subscriber = tracing_subscriber::fmt()
+        .with_ansi(false)
+        .without_time()
+        .with_writer(log_capture.clone())
+        .finish();
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    // a depends on b, b depends on a → cycle.
+    write_node(&workspace_path.join("a"), "a", &[("b", "0.1.0")], &[], &[]);
+    write_node(&workspace_path.join("b"), "b", &[("a", "0.1.0")], &[], &[]);
+
+    let ctx = Arc::new(
+        AppContext::with_messenger(workspace_path, Arc::clone(&messenger))
+            .with_daemon_state_file(serve.daemon_state_path()),
+    );
+    let err = NodeCommand {
+        command: NodeCommands::Sync {
+            path: None,
+            all: true,
+        },
+    }
+    .execute(&ctx)
+    .expect_err("node sync -a should fail on a cycle");
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("cycle"),
+        "expected error to mention cycle, got: {}",
+        msg
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn node_sync_all_missing_external_dep_fails_at_daemon() {
+    let serve = ServeCommandEmulation::with_mock()
+        .await
+        .expect("serve mock");
+    let messenger = serve.messenger();
+
+    let workspace = tempfile::tempdir().expect("workspace tempdir");
+    let workspace_path = workspace.path();
+
+    let log_capture = LogCapture::new();
+    let subscriber = tracing_subscriber::fmt()
+        .with_ansi(false)
+        .without_time()
+        .with_writer(log_capture.clone())
+        .finish();
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    // `lonely` depends on `nowhere:0.1.0`, which is neither on disk nor in
+    // the daemon's persistent stack — the daemon must reject the sync with
+    // its standard "depends on ... does not exist in the stack" message.
+    write_node(
+        &workspace_path.join("lonely"),
+        "lonely",
+        &[("nowhere", "0.1.0")],
+        &[],
+        &[],
+    );
+
+    let ctx = Arc::new(
+        AppContext::with_messenger(workspace_path, Arc::clone(&messenger))
+            .with_daemon_state_file(serve.daemon_state_path()),
+    );
+    let err = NodeCommand {
+        command: NodeCommands::Sync {
+            path: None,
+            all: true,
+        },
+    }
+    .execute(&ctx)
+    .expect_err("node sync -a should fail when an external dep is missing");
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("nowhere") && msg.contains("does not exist in the stack"),
+        "expected daemon-side missing-dep error, got: {}",
+        msg
+    );
+}

--- a/scripts/functions/build.py
+++ b/scripts/functions/build.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import os
 import subprocess
+import sys
 import tarfile
 import tempfile
 import shutil
+from collections import deque
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -28,10 +30,15 @@ def cargo_build(tag: str, target_triple: str, repo_root: Path) -> None:
     Sets PEPPY_GIT_TAG env var for the build.
     Each target triple gets its own directory under target/{triple}/release/,
     so no cargo clean is needed.
+
+    Streams cargo's output live while retaining a bounded tail, so that
+    when the build fails (e.g. a transient sccache crash) the error
+    message includes the actual cargo output — even when the caller
+    captures stdio, as pytest does by default.
     """
     console.print(f"Building peppy for [bold]{target_triple}[/bold]...")
     env = {**os.environ, "PEPPY_GIT_TAG": tag, "PEPPY_CROSS_ARCH": "1"}
-    result = subprocess.run(
+    proc = subprocess.Popen(
         [
             "cargo",
             "build",
@@ -44,9 +51,24 @@ def cargo_build(tag: str, target_triple: str, repo_root: Path) -> None:
         ],
         cwd=repo_root,
         env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
     )
-    if result.returncode != 0:
-        raise ReleaseError(f"cargo build failed (exit {result.returncode})")
+    assert proc.stdout is not None
+    tail: deque[str] = deque(maxlen=200)
+    for line in proc.stdout:
+        sys.stdout.write(line)
+        sys.stdout.flush()
+        tail.append(line)
+    returncode = proc.wait()
+    if returncode != 0:
+        raise ReleaseError(
+            f"cargo build failed (exit {returncode})\n"
+            f"--- last {len(tail)} lines of cargo output ---\n"
+            + "".join(tail)
+        )
 
 
 def _get_target_dir(repo_root: Path) -> Path:

--- a/scripts/functions/build.py
+++ b/scripts/functions/build.py
@@ -38,25 +38,33 @@ def cargo_build(tag: str, target_triple: str, repo_root: Path) -> None:
     """
     console.print(f"Building peppy for [bold]{target_triple}[/bold]...")
     env = {**os.environ, "PEPPY_GIT_TAG": tag, "PEPPY_CROSS_ARCH": "1"}
-    proc = subprocess.Popen(
-        [
-            "cargo",
-            "build",
-            "-p",
-            "peppy",
-            "--release",
-            "--locked",
-            "--target",
-            target_triple,
-        ],
-        cwd=repo_root,
-        env=env,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-        bufsize=1,
-    )
-    assert proc.stdout is not None
+    try:
+        proc = subprocess.Popen(
+            [
+                "cargo",
+                "build",
+                "-p",
+                "peppy",
+                "--release",
+                "--locked",
+                "--target",
+                target_triple,
+            ],
+            cwd=repo_root,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+        )
+    except OSError as exc:
+        raise ReleaseError(
+            f"Failed to start cargo build for {target_triple}: {exc}"
+        ) from exc
+    if proc.stdout is None:
+        raise ReleaseError(
+            "cargo process started but stdout is not available"
+        )
     tail: deque[str] = deque(maxlen=200)
     for line in proc.stdout:
         sys.stdout.write(line)

--- a/scripts/tests/test_install_container.py
+++ b/scripts/tests/test_install_container.py
@@ -133,10 +133,10 @@ def test_container_node_build(lima_vm: VMConfig) -> None:
     )
     assert result.returncode == 0, "node init failed"
 
-    # Add the node (triggers Apptainer container build)
+    # Add the node and build it (triggers Apptainer container build)
     result = run_step(
-        "Node add",
-        f"{env_preamble} && cd /tmp/test-node && peppy node add .",
+        "Node add + build",
+        f"{env_preamble} && cd /tmp/test-node && peppy node add . --build",
         timeout=600,
     )
     assert result.returncode == 0, "node add failed"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Short flags: -f for force, -b/--build for run, -a/--all for sync
  * node run --build will build unbuilt nodes (skips build if already built)
  * node sync --all discovers and syncs multiple node roots in dependency order

* **Bug Fixes / Reliability**
  * Stage-aware run with preflight checks, polling, and shared timeout budgeting
  * Improved discovery, pruning, and per-node error reporting during sync

* **Tests**
  * Added/updated tests for flags, build/run stages, sync discovery, and ordering
<!-- end of auto-generated comment: release notes by coderabbit.ai -->