### PR TITLE
Add ability to use `stack launch` with nodes from repositories

### DIFF
--- a/crates/config-internal/src/launcher.rs
+++ b/crates/config-internal/src/launcher.rs
@@ -5,6 +5,7 @@ mod types;
 pub use parse::PeppyLauncherParser;
 pub use types::{
     CURRENT_SCHEMA_VERSION, Deployment, DeploymentGitSource, DeploymentInstance,
-    DeploymentLocalSource, DeploymentSource, DeploymentUrlSource, Name, PeppyLauncher,
-    SchemaVersion, VariantGitSource, VariantNameSource, VariantSource, VariantUrlSource,
+    DeploymentLocalSource, DeploymentRepoSource, DeploymentSource, DeploymentUrlSource, Name,
+    PeppyLauncher, SchemaVersion, VariantGitSource, VariantNameSource, VariantSource,
+    VariantUrlSource,
 };

--- a/crates/config-internal/src/launcher/types.rs
+++ b/crates/config-internal/src/launcher/types.rs
@@ -9,8 +9,8 @@ use std::{
 };
 
 pub use crate::source::{
-    DeploymentGitSource, DeploymentLocalSource, DeploymentSource, DeploymentUrlSource,
-    VariantGitSource, VariantNameSource, VariantSource, VariantUrlSource,
+    DeploymentGitSource, DeploymentLocalSource, DeploymentRepoSource, DeploymentSource,
+    DeploymentUrlSource, VariantGitSource, VariantNameSource, VariantSource, VariantUrlSource,
 };
 
 /// Version identifier embedded in node `peppy.json5` manifests.

--- a/crates/config-internal/src/lib.rs
+++ b/crates/config-internal/src/lib.rs
@@ -12,6 +12,7 @@ mod internal {
     pub mod fingerprint;
     pub mod launcher;
     pub mod node;
+    pub mod repo_node_id;
     pub mod runtime;
     pub mod source;
 }
@@ -83,18 +84,23 @@ pub mod runtime {
 pub mod launcher {
     pub use crate::internal::launcher::{
         CURRENT_SCHEMA_VERSION, Deployment, DeploymentGitSource, DeploymentInstance,
-        DeploymentLocalSource, DeploymentSource, DeploymentUrlSource, Name, PeppyLauncher,
-        PeppyLauncherParser, SchemaVersion, VariantGitSource, VariantNameSource, VariantSource,
-        VariantUrlSource,
+        DeploymentLocalSource, DeploymentRepoSource, DeploymentSource, DeploymentUrlSource, Name,
+        PeppyLauncher, PeppyLauncherParser, SchemaVersion, VariantGitSource, VariantNameSource,
+        VariantSource, VariantUrlSource,
     };
 }
 
 // -- source --
 pub mod source {
     pub use crate::internal::source::{
-        DeploymentGitSource, DeploymentLocalSource, DeploymentSource, DeploymentUrlSource,
-        VariantGitSource, VariantNameSource, VariantSource, VariantUrlSource,
+        DeploymentGitSource, DeploymentLocalSource, DeploymentRepoSource, DeploymentSource,
+        DeploymentUrlSource, VariantGitSource, VariantNameSource, VariantSource, VariantUrlSource,
     };
+}
+
+// -- repo node id --
+pub mod repo_node_id {
+    pub use crate::internal::repo_node_id::{validate_repo_node_name, validate_repo_node_tag};
 }
 
 #[cfg(feature = "test_helpers")]

--- a/crates/config-internal/src/repo_node_id.rs
+++ b/crates/config-internal/src/repo_node_id.rs
@@ -1,0 +1,83 @@
+//! Shared name/tag validation for repo-backed node identifiers.
+//!
+//! Used both by the launch-file parser (where a deployment source can be
+//! `{ name, tag }`) and by the node-add encoding (where `NodeSource::RepoNode`
+//! carries the same identifiers). Returning `Result<(), String>` lets each
+//! caller wrap the detail into its own error type.
+
+use crate::internal::node::Name;
+
+pub fn validate_repo_node_name(value: &str, label: &str) -> Result<(), String> {
+    Name::try_from(value.to_owned())
+        .map(|_| ())
+        .map_err(|e| format!("invalid {label}: {e}"))
+}
+
+pub fn validate_repo_node_tag(tag: &str, label: &str) -> Result<(), String> {
+    if tag.is_empty() {
+        return Err(format!("empty {label}"));
+    }
+    if tag == "." || tag == ".." || tag.starts_with('.') {
+        return Err(format!("{label} must not start with '.': {tag}"));
+    }
+    if tag.contains("..") {
+        return Err(format!("{label} must not contain '..': {tag}"));
+    }
+    for c in tag.chars() {
+        let ok = c.is_ascii_alphanumeric() || c == '.' || c == '_' || c == '-';
+        if !ok {
+            return Err(format!(
+                "{label} contains disallowed character {c:?}: {tag}"
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_valid_name() {
+        assert!(validate_repo_node_name("robot_brain", "name").is_ok());
+        assert!(validate_repo_node_name("Camera-V2", "name").is_ok());
+    }
+
+    #[test]
+    fn rejects_empty_name() {
+        assert!(validate_repo_node_name("", "name").is_err());
+    }
+
+    #[test]
+    fn rejects_name_with_slash() {
+        assert!(validate_repo_node_name("foo/bar", "name").is_err());
+    }
+
+    #[test]
+    fn accepts_valid_tag() {
+        assert!(validate_repo_node_tag("0.1.0", "tag").is_ok());
+        assert!(validate_repo_node_tag("v1", "tag").is_ok());
+        assert!(validate_repo_node_tag("1.2.3-rc1", "tag").is_ok());
+    }
+
+    #[test]
+    fn rejects_empty_tag() {
+        let err = validate_repo_node_tag("", "tag").unwrap_err();
+        assert_eq!(err, "empty tag");
+    }
+
+    #[test]
+    fn rejects_traversal_tag() {
+        assert!(validate_repo_node_tag("..", "tag").is_err());
+        assert!(validate_repo_node_tag("..something", "tag").is_err());
+        assert!(validate_repo_node_tag(".hidden", "tag").is_err());
+        assert!(validate_repo_node_tag("a..b", "tag").is_err());
+    }
+
+    #[test]
+    fn rejects_disallowed_chars_in_tag() {
+        assert!(validate_repo_node_tag("1.0/2", "tag").is_err());
+        assert!(validate_repo_node_tag("1.0 beta", "tag").is_err());
+    }
+}

--- a/crates/config-internal/src/repo_node_id.rs
+++ b/crates/config-internal/src/repo_node_id.rs
@@ -15,7 +15,7 @@ pub fn validate_repo_node_tag(tag: &str, label: &str) -> Result<(), String> {
     if tag.is_empty() {
         return Err(format!("empty {label}"));
     }
-    if tag == "." || tag == ".." || tag.starts_with('.') {
+    if tag.starts_with('.') {
         return Err(format!("{label} must not start with '.': {tag}"));
     }
     if tag.contains("..") {

--- a/crates/config-internal/src/repo_node_id.rs
+++ b/crates/config-internal/src/repo_node_id.rs
@@ -1,9 +1,7 @@
 //! Shared name/tag validation for repo-backed node identifiers.
 //!
-//! Used both by the launch-file parser (where a deployment source can be
-//! `{ name, tag }`) and by the node-add encoding (where `NodeSource::RepoNode`
-//! carries the same identifiers). Returning `Result<(), String>` lets each
-//! caller wrap the detail into its own error type.
+//! Returning `Result<(), String>` lets each caller wrap the detail into its
+//! own error type.
 
 use crate::internal::node::Name;
 

--- a/crates/config-internal/src/source.rs
+++ b/crates/config-internal/src/source.rs
@@ -405,7 +405,7 @@ impl<'de> Deserialize<'de> for DeploymentSource {
                 }))
             }
             _ => Err(invalid_deployment_source::<D::Error>(
-                "source must be one of: { local }, { repo, path, ref }, { url [, sha256] }, { name, tag }",
+                "source must be one of: { local }, { repo, path, ref }, { url, sha256 }, { name, tag }",
             )),
         }
     }

--- a/crates/config-internal/src/source.rs
+++ b/crates/config-internal/src/source.rs
@@ -10,6 +10,7 @@ pub enum DeploymentSource {
     Local(DeploymentLocalSource),
     Git(DeploymentGitSource),
     Url(DeploymentUrlSource),
+    Repo(DeploymentRepoSource),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -33,6 +34,17 @@ pub struct DeploymentGitSource {
 pub struct DeploymentUrlSource {
     pub url: String,
     pub sha256: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub variant: Option<VariantSource>,
+}
+
+/// Deployment source that resolves a node through the user's repo cache
+/// (`~/.peppy/cache/packages.json5`). Accepts `{ name, tag }` or the
+/// combined `{ name: "<name>:<tag>" }` shorthand.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct DeploymentRepoSource {
+    pub name: String,
+    pub tag: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub variant: Option<VariantSource>,
 }
@@ -76,6 +88,7 @@ impl DeploymentSource {
             DeploymentSource::Local(s) => s.variant.as_ref(),
             DeploymentSource::Git(s) => s.variant.as_ref(),
             DeploymentSource::Url(s) => s.variant.as_ref(),
+            DeploymentSource::Repo(s) => s.variant.as_ref(),
         }
     }
 }
@@ -180,6 +193,57 @@ where
     Ok(trimmed.to_ascii_lowercase())
 }
 
+/// Resolves a repo-source `name` field into a validated `(name, tag)` pair.
+///
+/// Accepts either a bare name combined with an explicit `tag` field, or the
+/// shorthand `"<name>:<tag>"` (in which case no separate `tag` field may be
+/// supplied). Both components run through
+/// [`crate::repo_node_id`] so invalid characters are rejected at parse time.
+fn split_repo_name_and_tag<E>(
+    raw_name: String,
+    raw_tag: Option<&str>,
+) -> Result<(String, String), E>
+where
+    E: de::Error,
+{
+    let name_trimmed = raw_name.trim();
+    if name_trimmed.is_empty() {
+        return Err(invalid_deployment_source::<E>(
+            "repo source name cannot be empty",
+        ));
+    }
+
+    let (name, tag) = if name_trimmed.contains(':') {
+        if raw_tag.is_some() {
+            return Err(invalid_deployment_source::<E>(
+                "repo source cannot combine `name: \"<name>:<tag>\"` with a separate `tag` field",
+            ));
+        }
+        let parts: Vec<&str> = name_trimmed.split(':').collect();
+        if parts.len() != 2 {
+            return Err(invalid_deployment_source::<E>(
+                "repo source `name` must contain at most one ':' separating name and tag",
+            ));
+        }
+        (parts[0].trim().to_owned(), parts[1].trim().to_owned())
+    } else {
+        let tag = raw_tag.map(str::trim).unwrap_or("");
+        if tag.is_empty() {
+            return Err(invalid_deployment_source::<E>(
+                "repo source requires a non-empty `tag` (or the combined `name: \"<name>:<tag>\"` form)",
+            ));
+        }
+        (name_trimmed.to_owned(), tag.to_owned())
+    };
+
+    crate::internal::repo_node_id::validate_repo_node_name(&name, "repo source name")
+        .map_err(invalid_deployment_source::<E>)?;
+    crate::internal::repo_node_id::validate_repo_node_tag(&tag, "repo source tag")
+        .map_err(invalid_deployment_source::<E>)?;
+
+    Ok((name, tag))
+}
+
 impl<'de> Deserialize<'de> for VariantSource {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -268,6 +332,10 @@ impl<'de> Deserialize<'de> for DeploymentSource {
             #[serde(default)]
             sha256: Option<String>,
             #[serde(default)]
+            name: Option<String>,
+            #[serde(default)]
+            tag: Option<String>,
+            #[serde(default)]
             variant: Option<VariantSource>,
         }
 
@@ -275,9 +343,22 @@ impl<'de> Deserialize<'de> for DeploymentSource {
         let has_local = raw.local.is_some();
         let has_git = raw.repo.is_some() || raw.path.is_some() || raw.ref_.is_some();
         let has_url = raw.url.is_some() || raw.sha256.is_some();
+        let has_repo = raw.name.is_some() || raw.tag.is_some();
 
-        match (has_local, has_git, has_url) {
-            (true, false, false) => {
+        match (has_local, has_git, has_url, has_repo) {
+            (false, false, false, true) => {
+                let name_raw = raw.name.ok_or_else(|| {
+                    invalid_deployment_source::<D::Error>("repo source requires `name`")
+                })?;
+                let (name, tag) =
+                    split_repo_name_and_tag::<D::Error>(name_raw, raw.tag.as_deref())?;
+                Ok(DeploymentSource::Repo(DeploymentRepoSource {
+                    name,
+                    tag,
+                    variant: raw.variant,
+                }))
+            }
+            (true, false, false, false) => {
                 let local = trim_non_empty::<D::Error>(
                     raw.local.expect("local is present"),
                     "local path cannot be empty",
@@ -291,7 +372,7 @@ impl<'de> Deserialize<'de> for DeploymentSource {
                     variant: raw.variant,
                 }))
             }
-            (false, true, false) => {
+            (false, true, false, false) => {
                 let repo = raw.repo.ok_or_else(|| {
                     invalid_deployment_source::<D::Error>("git source requires `repo`")
                 })?;
@@ -313,7 +394,7 @@ impl<'de> Deserialize<'de> for DeploymentSource {
                     variant: raw.variant,
                 }))
             }
-            (false, false, true) => {
+            (false, false, true, false) => {
                 let url = raw.url.ok_or_else(|| {
                     invalid_deployment_source::<D::Error>("url source requires `url`")
                 })?;
@@ -331,7 +412,7 @@ impl<'de> Deserialize<'de> for DeploymentSource {
                 }))
             }
             _ => Err(invalid_deployment_source::<D::Error>(
-                "source must be one of: { local }, { repo, path, ref }, { url, sha256 }",
+                "source must be one of: { local }, { repo, path, ref }, { url, sha256 }, { name, tag }",
             )),
         }
     }
@@ -668,6 +749,125 @@ mod tests {
     fn deployment_source_without_variant_is_none() {
         let src: DeploymentSource = serde_json5::from_str("{ local: \"./uvc_camera\" }").unwrap();
         assert!(src.variant().is_none());
+    }
+
+    // -- DeploymentRepoSource tests --
+
+    #[test]
+    fn repo_source_parses_name_and_tag_fields() {
+        let src: DeploymentSource =
+            serde_json5::from_str("{ name: \"robot_brain\", tag: \"0.1.0\" }").unwrap();
+        let DeploymentSource::Repo(repo) = src else {
+            panic!("expected repo source");
+        };
+        assert_eq!(repo.name, "robot_brain");
+        assert_eq!(repo.tag, "0.1.0");
+        assert!(repo.variant.is_none());
+    }
+
+    #[test]
+    fn repo_source_parses_combined_name_tag() {
+        let src: DeploymentSource =
+            serde_json5::from_str("{ name: \"robot_brain:0.1.0\" }").unwrap();
+        let DeploymentSource::Repo(repo) = src else {
+            panic!("expected repo source");
+        };
+        assert_eq!(repo.name, "robot_brain");
+        assert_eq!(repo.tag, "0.1.0");
+    }
+
+    #[test]
+    fn repo_source_parses_with_name_variant() {
+        let src: DeploymentSource = serde_json5::from_str(
+            "{ name: \"robot_brain\", tag: \"0.1.0\", variant: { name: \"mock-python\" } }",
+        )
+        .unwrap();
+        let DeploymentSource::Repo(repo) = src else {
+            panic!("expected repo source");
+        };
+        let Some(VariantSource::Name(v)) = repo.variant else {
+            panic!("expected name variant");
+        };
+        assert_eq!(v.name, "mock-python");
+    }
+
+    #[test]
+    fn repo_source_rejects_name_without_tag() {
+        let err: serde_json5::Error =
+            serde_json5::from_str::<DeploymentSource>("{ name: \"foo\" }").unwrap_err();
+        let ParsingError::InvalidDeploymentSource(msg) = err.into() else {
+            panic!("expected InvalidDeploymentSource");
+        };
+        assert!(msg.contains("non-empty `tag`"), "unexpected: {msg}");
+    }
+
+    #[test]
+    fn repo_source_rejects_empty_name() {
+        let err: serde_json5::Error =
+            serde_json5::from_str::<DeploymentSource>("{ name: \"\", tag: \"0.1.0\" }")
+                .unwrap_err();
+        let ParsingError::InvalidDeploymentSource(msg) = err.into() else {
+            panic!("expected InvalidDeploymentSource");
+        };
+        assert_eq!(msg, "repo source name cannot be empty");
+    }
+
+    #[test]
+    fn repo_source_rejects_combined_with_separate_tag() {
+        let err: serde_json5::Error =
+            serde_json5::from_str::<DeploymentSource>("{ name: \"foo:0.1.0\", tag: \"0.1.0\" }")
+                .unwrap_err();
+        let ParsingError::InvalidDeploymentSource(msg) = err.into() else {
+            panic!("expected InvalidDeploymentSource");
+        };
+        assert!(msg.contains("cannot combine"), "unexpected: {msg}");
+    }
+
+    #[test]
+    fn repo_source_rejects_multiple_colons() {
+        let err: serde_json5::Error =
+            serde_json5::from_str::<DeploymentSource>("{ name: \"foo:0.1:extra\" }").unwrap_err();
+        let ParsingError::InvalidDeploymentSource(msg) = err.into() else {
+            panic!("expected InvalidDeploymentSource");
+        };
+        assert!(msg.contains("at most one ':'"), "unexpected: {msg}");
+    }
+
+    #[test]
+    fn repo_source_rejects_traversal_tag() {
+        let err: serde_json5::Error =
+            serde_json5::from_str::<DeploymentSource>("{ name: \"foo\", tag: \"..\" }")
+                .unwrap_err();
+        let ParsingError::InvalidDeploymentSource(msg) = err.into() else {
+            panic!("expected InvalidDeploymentSource");
+        };
+        assert!(msg.contains("must not start with '.'"), "unexpected: {msg}");
+    }
+
+    #[test]
+    fn repo_source_rejects_invalid_name_char() {
+        let err: serde_json5::Error =
+            serde_json5::from_str::<DeploymentSource>("{ name: \"foo/bar\", tag: \"0.1.0\" }")
+                .unwrap_err();
+        let ParsingError::InvalidDeploymentSource(msg) = err.into() else {
+            panic!("expected InvalidDeploymentSource");
+        };
+        assert!(
+            msg.contains("invalid repo source name"),
+            "unexpected: {msg}"
+        );
+    }
+
+    #[test]
+    fn repo_source_rejects_mixed_with_local() {
+        let err: serde_json5::Error = serde_json5::from_str::<DeploymentSource>(
+            "{ name: \"foo\", tag: \"0.1.0\", local: \"./x\" }",
+        )
+        .unwrap_err();
+        let ParsingError::InvalidDeploymentSource(msg) = err.into() else {
+            panic!("expected InvalidDeploymentSource");
+        };
+        assert!(msg.contains("source must be one of"), "unexpected: {msg}");
     }
 
     #[test]

--- a/crates/config-internal/src/source.rs
+++ b/crates/config-internal/src/source.rs
@@ -193,12 +193,6 @@ where
     Ok(trimmed.to_ascii_lowercase())
 }
 
-/// Resolves a repo-source `name` field into a validated `(name, tag)` pair.
-///
-/// Accepts either a bare name combined with an explicit `tag` field, or the
-/// shorthand `"<name>:<tag>"` (in which case no separate `tag` field may be
-/// supplied). Both components run through
-/// [`crate::repo_node_id`] so invalid characters are rejected at parse time.
 fn split_repo_name_and_tag<E>(
     raw_name: String,
     raw_tag: Option<&str>,
@@ -213,19 +207,18 @@ where
         ));
     }
 
-    let (name, tag) = if name_trimmed.contains(':') {
+    let (name, tag) = if let Some((n, t)) = name_trimmed.split_once(':') {
         if raw_tag.is_some() {
             return Err(invalid_deployment_source::<E>(
                 "repo source cannot combine `name: \"<name>:<tag>\"` with a separate `tag` field",
             ));
         }
-        let parts: Vec<&str> = name_trimmed.split(':').collect();
-        if parts.len() != 2 {
+        if t.contains(':') {
             return Err(invalid_deployment_source::<E>(
                 "repo source `name` must contain at most one ':' separating name and tag",
             ));
         }
-        (parts[0].trim().to_owned(), parts[1].trim().to_owned())
+        (n.trim().to_owned(), t.trim().to_owned())
     } else {
         let tag = raw_tag.map(str::trim).unwrap_or("");
         if tag.is_empty() {
@@ -412,7 +405,7 @@ impl<'de> Deserialize<'de> for DeploymentSource {
                 }))
             }
             _ => Err(invalid_deployment_source::<D::Error>(
-                "source must be one of: { local }, { repo, path, ref }, { url, sha256 }, { name, tag }",
+                "source must be one of: { local }, { repo, path, ref }, { url [, sha256] }, { name, tag }",
             )),
         }
     }

--- a/crates/config-internal/src/source.rs
+++ b/crates/config-internal/src/source.rs
@@ -404,9 +404,17 @@ impl<'de> Deserialize<'de> for DeploymentSource {
                     variant: raw.variant,
                 }))
             }
-            _ => Err(invalid_deployment_source::<D::Error>(
-                "source must be one of: { local }, { repo, path, ref }, { url, sha256 }, { name, tag }",
-            )),
+            _ => {
+                if has_git && has_repo {
+                    Err(invalid_deployment_source::<D::Error>(
+                        "cannot mix git fields (`repo`, `path`, `ref`) with repo-source fields (`name`, `tag`); use one source type per deployment",
+                    ))
+                } else {
+                    Err(invalid_deployment_source::<D::Error>(
+                        "source must be one of: { local }, { repo, path, ref }, { url, sha256 }, { name, tag }",
+                    ))
+                }
+            }
         }
     }
 }
@@ -861,6 +869,18 @@ mod tests {
             panic!("expected InvalidDeploymentSource");
         };
         assert!(msg.contains("source must be one of"), "unexpected: {msg}");
+    }
+
+    #[test]
+    fn repo_source_rejects_mixed_with_git_fields() {
+        let err: serde_json5::Error = serde_json5::from_str::<DeploymentSource>(
+            "{ repo: \"https://github.com/org/repo.git\", name: \"foo\", tag: \"0.1.0\" }",
+        )
+        .unwrap_err();
+        let ParsingError::InvalidDeploymentSource(msg) = err.into() else {
+            panic!("expected InvalidDeploymentSource");
+        };
+        assert!(msg.contains("cannot mix git fields"), "unexpected: {msg}");
     }
 
     #[test]

--- a/crates/core-node-internal/src/encoding/node/add.rs
+++ b/crates/core-node-internal/src/encoding/node/add.rs
@@ -4,7 +4,7 @@ use crate::Result;
 use crate::names;
 use crate::node_capnp;
 use capnp::message::Builder;
-use config::node::{Name, QoSProfile};
+use config::node::QoSProfile;
 use gix_url::Url as GitUrl;
 use peppylib::messaging::ActionGoalHandle;
 use peppylib::types::Payload;
@@ -140,41 +140,12 @@ impl NodeSource {
     }
 }
 
-/// Rejects a repo-node name that would be unsafe to splice into a log
-/// filename or to look up in the repo cache. Reuses the manifest `Name`
-/// character set (lowercase/uppercase ASCII letters, digits, `_`, `-`).
 fn validate_repo_node_name(value: &str, label: &str) -> Result<()> {
-    Name::try_from(value.to_owned())
-        .map(|_| ())
-        .map_err(|e| crate::Error::Decoding(format!("invalid {label}: {e}")))
+    config::repo_node_id::validate_repo_node_name(value, label).map_err(crate::Error::Decoding)
 }
 
-/// Rejects a repo-node tag that would be unsafe to splice into a filename
-/// joined under the logs directory (e.g. `../etc/passwd`). Mirrors
-/// `node_stack::build_steps::validate_node_tag`.
 fn validate_repo_node_tag(tag: &str, label: &str) -> Result<()> {
-    if tag.is_empty() {
-        return Err(crate::Error::Decoding(format!("empty {label}")));
-    }
-    if tag == "." || tag == ".." || tag.starts_with('.') {
-        return Err(crate::Error::Decoding(format!(
-            "{label} must not start with '.': {tag}"
-        )));
-    }
-    if tag.contains("..") {
-        return Err(crate::Error::Decoding(format!(
-            "{label} must not contain '..': {tag}"
-        )));
-    }
-    for c in tag.chars() {
-        let ok = c.is_ascii_alphanumeric() || c == '.' || c == '_' || c == '-';
-        if !ok {
-            return Err(crate::Error::Decoding(format!(
-                "{label} contains disallowed character {c:?}: {tag}"
-            )));
-        }
-    }
-    Ok(())
+    config::repo_node_id::validate_repo_node_tag(tag, label).map_err(crate::Error::Decoding)
 }
 
 /// Goal message for the NodeAdd action.

--- a/crates/core-node-internal/src/services/node/info.rs
+++ b/crates/core-node-internal/src/services/node/info.rs
@@ -5,6 +5,7 @@ use super::{
 use crate::Result;
 use crate::encoding::{NodeInfo, NodeInfoRequest, NodeInfoResponse, NodeInstanceInfo, NodeSource};
 use crate::names;
+use crate::services::repo::cache as repo_cache;
 use config::consts::{NODE_CONFIG_FILE, PeppyDirs};
 use config::fingerprint::fingerprint_for_bytes;
 use config::node::{DEFAULT_VARIANT_NAME, NodeConfig, NodeConfigParser, ParsedNodeConfig};
@@ -236,8 +237,12 @@ async fn resolve_node_config_with_source_path(
         NodeSource::Http { url, sha256 } => {
             parse_node_config_from_http_with_path(url, sha256, peppy_dirs).await
         }
-        NodeSource::RepoNode { .. } => {
-            Err("node_info does not support repo-node sources".to_owned())
+        NodeSource::RepoNode { name, tag, .. } => {
+            let resolved = repo_cache::resolve_repo_node_source(&name, &tag, peppy_dirs)?;
+            Box::pin(resolve_node_config_with_source_path(
+                resolved, peppy_dirs, deadline,
+            ))
+            .await
         }
     }
 }

--- a/crates/core-node-internal/src/services/node/info.rs
+++ b/crates/core-node-internal/src/services/node/info.rs
@@ -239,6 +239,14 @@ async fn resolve_node_config_with_source_path(
         }
         NodeSource::RepoNode { name, tag, .. } => {
             let resolved = repo_cache::resolve_repo_node_source(&name, &tag, peppy_dirs)?;
+            // The packages cache only stores Fs/Git/Http entries, so the
+            // resolved source should never be another RepoNode. Guard against
+            // infinite recursion in case that invariant is ever broken.
+            if matches!(resolved, NodeSource::RepoNode { .. }) {
+                return Err(format!(
+                    "repo-node `{name}:{tag}` resolved to another repo-node source; this is a bug in the packages cache"
+                ));
+            }
             Box::pin(resolve_node_config_with_source_path(
                 resolved, peppy_dirs, deadline,
             ))

--- a/crates/core-node-internal/src/services/node/variant.rs
+++ b/crates/core-node-internal/src/services/node/variant.rs
@@ -306,7 +306,7 @@ async fn resolve_variant_deployment_source(
             ))
         }
         DeploymentSource::Repo(_) => Err(format!(
-            "variant '{label}' uses a repo-backed source, which is not supported inside manifest variant entries"
+            "variant '{label}' uses a repo-backed source, which is not supported inside manifest variant entries; use a git, url, or name variant source instead"
         )),
     }
 }

--- a/crates/core-node-internal/src/services/node/variant.rs
+++ b/crates/core-node-internal/src/services/node/variant.rs
@@ -305,6 +305,9 @@ async fn resolve_variant_deployment_source(
                 extracted.cleanup_dir,
             ))
         }
+        DeploymentSource::Repo(_) => Err(format!(
+            "variant '{label}' uses a repo-backed source, which is not supported inside manifest variant entries"
+        )),
     }
 }
 

--- a/crates/core-node-internal/src/services/repo/cache.rs
+++ b/crates/core-node-internal/src/services/repo/cache.rs
@@ -213,10 +213,14 @@ pub(crate) fn resolve_repo_node_source(
                 .ok_or_else(|| format!("cache entry for `{id}` is git but has no source_uri"))?;
             let repo_url = gix_url::Url::try_from(repo_url_str)
                 .map_err(|e| format!("invalid git URL in cache entry for `{id}`: {e}"))?;
+            let repo_ref = entry
+                .resolved_ref
+                .clone()
+                .ok_or_else(|| format!("cache entry for `{id}` is git but has no resolved_ref"))?;
             Ok(NodeSource::Git {
                 repo_url,
                 repo_path: entry.path.clone(),
-                repo_ref: entry.resolved_ref.clone(),
+                repo_ref: Some(repo_ref),
             })
         }
         RepoSourceKind::Url => {
@@ -283,6 +287,61 @@ mod tests {
             variants: vec![],
             duplicate,
             repo_id,
+        }
+    }
+
+    fn mk_fs_entry(name: &str, tag: &str, path: &str) -> PackageEntry {
+        PackageEntry {
+            node_name: name.to_owned(),
+            node_tag: tag.to_owned(),
+            source_type: RepoSourceKind::Fs,
+            source_uri: None,
+            resolved_ref: None,
+            checksum: None,
+            path: path.to_owned(),
+            variants: vec![],
+            duplicate: false,
+            repo_id: 0,
+        }
+    }
+
+    fn mk_git_entry(
+        name: &str,
+        tag: &str,
+        uri: Option<&str>,
+        resolved_ref: Option<&str>,
+    ) -> PackageEntry {
+        PackageEntry {
+            node_name: name.to_owned(),
+            node_tag: tag.to_owned(),
+            source_type: RepoSourceKind::Git,
+            source_uri: uri.map(str::to_owned),
+            resolved_ref: resolved_ref.map(str::to_owned),
+            checksum: None,
+            path: "nodes/example".to_owned(),
+            variants: vec![],
+            duplicate: false,
+            repo_id: 0,
+        }
+    }
+
+    fn mk_url_entry(
+        name: &str,
+        tag: &str,
+        uri: Option<&str>,
+        checksum: Option<&str>,
+    ) -> PackageEntry {
+        PackageEntry {
+            node_name: name.to_owned(),
+            node_tag: tag.to_owned(),
+            source_type: RepoSourceKind::Url,
+            source_uri: uri.map(str::to_owned),
+            resolved_ref: None,
+            checksum: checksum.map(str::to_owned),
+            path: "nodes/example".to_owned(),
+            variants: vec![],
+            duplicate: false,
+            repo_id: 0,
         }
     }
 
@@ -361,5 +420,143 @@ mod tests {
         assert_eq!(loaded[0].resolved_ref.as_deref(), Some("main"));
         assert_eq!(loaded[1].node_name, "b");
         assert!(loaded[1].duplicate);
+    }
+
+    // -- resolve_repo_node_source tests --
+
+    #[test]
+    fn resolve_fs_success() {
+        let tmp = tempfile::tempdir().unwrap();
+        let peppy_dirs = PeppyDirs::new(tmp.path());
+        let entries = vec![mk_fs_entry("mynode", "1.0", "/tmp/mynode")];
+        write_cache(&peppy_dirs, &entries).unwrap();
+
+        let src = resolve_repo_node_source("mynode", "1.0", &peppy_dirs).unwrap();
+        assert_eq!(src, NodeSource::Fs(PathBuf::from("/tmp/mynode")));
+    }
+
+    #[test]
+    fn resolve_git_success() {
+        let tmp = tempfile::tempdir().unwrap();
+        let peppy_dirs = PeppyDirs::new(tmp.path());
+        let entries = vec![mk_git_entry(
+            "g",
+            "1.0",
+            Some("https://example.com/repo.git"),
+            Some("main"),
+        )];
+        write_cache(&peppy_dirs, &entries).unwrap();
+
+        let src = resolve_repo_node_source("g", "1.0", &peppy_dirs).unwrap();
+        match src {
+            NodeSource::Git {
+                repo_url,
+                repo_path,
+                repo_ref,
+            } => {
+                assert!(
+                    repo_url
+                        .to_bstring()
+                        .to_string()
+                        .contains("example.com/repo.git"),
+                    "unexpected repo_url: {repo_url:?}",
+                );
+                assert_eq!(repo_path, "nodes/example");
+                assert_eq!(repo_ref.as_deref(), Some("main"));
+            }
+            other => panic!("expected NodeSource::Git, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_url_success() {
+        let tmp = tempfile::tempdir().unwrap();
+        let peppy_dirs = PeppyDirs::new(tmp.path());
+        let entries = vec![mk_url_entry(
+            "u",
+            "2.0",
+            Some("https://example.com/archive.tzst"),
+            Some("abc123"),
+        )];
+        write_cache(&peppy_dirs, &entries).unwrap();
+
+        let src = resolve_repo_node_source("u", "2.0", &peppy_dirs).unwrap();
+        match src {
+            NodeSource::Http { url, sha256 } => {
+                assert_eq!(url.as_str(), "https://example.com/archive.tzst");
+                assert_eq!(sha256.as_deref(), Some("abc123"));
+            }
+            other => panic!("expected NodeSource::Http, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_git_missing_source_uri() {
+        let tmp = tempfile::tempdir().unwrap();
+        let peppy_dirs = PeppyDirs::new(tmp.path());
+        let entries = vec![mk_git_entry("g", "1.0", None, Some("main"))];
+        write_cache(&peppy_dirs, &entries).unwrap();
+
+        let err = resolve_repo_node_source("g", "1.0", &peppy_dirs).unwrap_err();
+        assert!(err.contains("no source_uri"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn resolve_git_invalid_source_uri() {
+        let tmp = tempfile::tempdir().unwrap();
+        let peppy_dirs = PeppyDirs::new(tmp.path());
+        let entries = vec![mk_git_entry("g", "1.0", Some(""), Some("main"))];
+        write_cache(&peppy_dirs, &entries).unwrap();
+
+        let err = resolve_repo_node_source("g", "1.0", &peppy_dirs).unwrap_err();
+        assert!(err.contains("invalid git URL"), "unexpected error: {err}",);
+    }
+
+    #[test]
+    fn resolve_git_missing_resolved_ref() {
+        let tmp = tempfile::tempdir().unwrap();
+        let peppy_dirs = PeppyDirs::new(tmp.path());
+        let entries = vec![mk_git_entry(
+            "g",
+            "1.0",
+            Some("https://example.com/repo.git"),
+            None,
+        )];
+        write_cache(&peppy_dirs, &entries).unwrap();
+
+        let err = resolve_repo_node_source("g", "1.0", &peppy_dirs).unwrap_err();
+        assert!(err.contains("no resolved_ref"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn resolve_url_missing_source_uri() {
+        let tmp = tempfile::tempdir().unwrap();
+        let peppy_dirs = PeppyDirs::new(tmp.path());
+        let entries = vec![mk_url_entry("u", "1.0", None, None)];
+        write_cache(&peppy_dirs, &entries).unwrap();
+
+        let err = resolve_repo_node_source("u", "1.0", &peppy_dirs).unwrap_err();
+        assert!(err.contains("no source_uri"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn resolve_url_invalid_source_uri() {
+        let tmp = tempfile::tempdir().unwrap();
+        let peppy_dirs = PeppyDirs::new(tmp.path());
+        let entries = vec![mk_url_entry("u", "1.0", Some("not://[invalid"), None)];
+        write_cache(&peppy_dirs, &entries).unwrap();
+
+        let err = resolve_repo_node_source("u", "1.0", &peppy_dirs).unwrap_err();
+        assert!(err.contains("invalid url"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn resolve_not_found() {
+        let tmp = tempfile::tempdir().unwrap();
+        let peppy_dirs = PeppyDirs::new(tmp.path());
+        write_cache(&peppy_dirs, &[]).unwrap();
+
+        let err = resolve_repo_node_source("missing", "0.0", &peppy_dirs).unwrap_err();
+        assert!(err.contains("not found"), "unexpected error: {err}");
     }
 }

--- a/crates/core-node-internal/src/services/repo/cache.rs
+++ b/crates/core-node-internal/src/services/repo/cache.rs
@@ -11,7 +11,7 @@
 //! re-parse the cache file on every request.
 
 use crate::Result;
-use crate::encoding::RepoSourceKind;
+use crate::encoding::{NodeSource, RepoSourceKind};
 use crate::services::repo::refresh::read_or_create_repos;
 use config::consts::PeppyDirs;
 use parking_lot::Mutex;
@@ -184,6 +184,53 @@ pub fn lookup<'a>(entries: &'a [PackageEntry], name: &str, tag: &str) -> Option<
 /// Path to the cache file. Used for user-facing error messages.
 pub fn cache_path(peppy_dirs: &PeppyDirs) -> PathBuf {
     peppy_dirs.cache_dir().join("packages.json5")
+}
+
+/// Looks up `(name, tag)` in the packages cache and translates the matched
+/// entry into a concrete `NodeSource` (Fs / Git / Http) that downstream
+/// resolution can handle directly. Used both by `node_info` and by
+/// `stack_launch` planning to flatten `NodeSource::RepoNode` into its
+/// underlying source kind.
+pub fn resolve_repo_node_source(
+    name: &str,
+    tag: &str,
+    peppy_dirs: &PeppyDirs,
+) -> std::result::Result<NodeSource, String> {
+    let (entries, _) = load_with_generation(peppy_dirs)
+        .map_err(|e| format!("failed to load packages cache: {e}"))?;
+    let entry = lookup(&entries, name, tag).ok_or_else(|| {
+        format!(
+            "repo-node `{name}:{tag}` not found in {}",
+            cache_path(peppy_dirs).display()
+        )
+    })?;
+
+    match entry.source_type {
+        RepoSourceKind::Fs => Ok(NodeSource::Fs(PathBuf::from(&entry.path))),
+        RepoSourceKind::Git => {
+            let repo_url_str = entry.source_uri.as_deref().ok_or_else(|| {
+                format!("cache entry for `{name}:{tag}` is git but has no source_uri")
+            })?;
+            let repo_url = gix_url::Url::try_from(repo_url_str)
+                .map_err(|e| format!("invalid git URL in cache entry for `{name}:{tag}`: {e}"))?;
+            Ok(NodeSource::Git {
+                repo_url,
+                repo_path: entry.path.clone(),
+                repo_ref: entry.resolved_ref.clone(),
+            })
+        }
+        RepoSourceKind::Url => {
+            let url_str = entry.source_uri.as_deref().ok_or_else(|| {
+                format!("cache entry for `{name}:{tag}` is url but has no source_uri")
+            })?;
+            let url = url::Url::parse(url_str)
+                .map_err(|e| format!("invalid url in cache entry for `{name}:{tag}`: {e}"))?;
+            Ok(NodeSource::Http {
+                url,
+                sha256: entry.checksum.clone(),
+            })
+        }
+    }
 }
 
 struct MemoEntry {

--- a/crates/core-node-internal/src/services/repo/cache.rs
+++ b/crates/core-node-internal/src/services/repo/cache.rs
@@ -188,19 +188,18 @@ pub fn cache_path(peppy_dirs: &PeppyDirs) -> PathBuf {
 
 /// Looks up `(name, tag)` in the packages cache and translates the matched
 /// entry into a concrete `NodeSource` (Fs / Git / Http) that downstream
-/// resolution can handle directly. Used both by `node_info` and by
-/// `stack_launch` planning to flatten `NodeSource::RepoNode` into its
-/// underlying source kind.
-pub fn resolve_repo_node_source(
+/// resolution can handle directly.
+pub(crate) fn resolve_repo_node_source(
     name: &str,
     tag: &str,
     peppy_dirs: &PeppyDirs,
 ) -> std::result::Result<NodeSource, String> {
     let (entries, _) = load_with_generation(peppy_dirs)
         .map_err(|e| format!("failed to load packages cache: {e}"))?;
+    let id = format!("{name}:{tag}");
     let entry = lookup(&entries, name, tag).ok_or_else(|| {
         format!(
-            "repo-node `{name}:{tag}` not found in {}",
+            "repo-node `{id}` not found in {}",
             cache_path(peppy_dirs).display()
         )
     })?;
@@ -208,11 +207,12 @@ pub fn resolve_repo_node_source(
     match entry.source_type {
         RepoSourceKind::Fs => Ok(NodeSource::Fs(PathBuf::from(&entry.path))),
         RepoSourceKind::Git => {
-            let repo_url_str = entry.source_uri.as_deref().ok_or_else(|| {
-                format!("cache entry for `{name}:{tag}` is git but has no source_uri")
-            })?;
+            let repo_url_str = entry
+                .source_uri
+                .as_deref()
+                .ok_or_else(|| format!("cache entry for `{id}` is git but has no source_uri"))?;
             let repo_url = gix_url::Url::try_from(repo_url_str)
-                .map_err(|e| format!("invalid git URL in cache entry for `{name}:{tag}`: {e}"))?;
+                .map_err(|e| format!("invalid git URL in cache entry for `{id}`: {e}"))?;
             Ok(NodeSource::Git {
                 repo_url,
                 repo_path: entry.path.clone(),
@@ -220,11 +220,12 @@ pub fn resolve_repo_node_source(
             })
         }
         RepoSourceKind::Url => {
-            let url_str = entry.source_uri.as_deref().ok_or_else(|| {
-                format!("cache entry for `{name}:{tag}` is url but has no source_uri")
-            })?;
+            let url_str = entry
+                .source_uri
+                .as_deref()
+                .ok_or_else(|| format!("cache entry for `{id}` is url but has no source_uri"))?;
             let url = url::Url::parse(url_str)
-                .map_err(|e| format!("invalid url in cache entry for `{name}:{tag}`: {e}"))?;
+                .map_err(|e| format!("invalid url in cache entry for `{id}`: {e}"))?;
             Ok(NodeSource::Http {
                 url,
                 sha256: entry.checksum.clone(),

--- a/crates/core-node-internal/src/services/stack/launch.rs
+++ b/crates/core-node-internal/src/services/stack/launch.rs
@@ -159,6 +159,7 @@ fn deployment_label(deployment: &Deployment) -> String {
         DeploymentSource::Local(spec) => format!("local:{}", spec.local.display()),
         DeploymentSource::Git(spec) => format!("git:{}@{}:{}", spec.repo, spec.ref_, spec.path),
         DeploymentSource::Url(spec) => format!("url:{}", spec.url),
+        DeploymentSource::Repo(spec) => format!("repo:{}:{}", spec.name, spec.tag),
     };
     match deployment.source.variant() {
         Some(VariantSource::Name(v)) => format!("{base} [variant:{name}]", name = v.name),
@@ -177,6 +178,7 @@ fn git_url_from_repo(repo: &str) -> std::result::Result<gix_url::Url, String> {
 fn node_source_from_deployment_source(
     deployment: &Deployment,
     nodes_directory: &std::path::Path,
+    peppy_dirs: &PeppyDirs,
 ) -> std::result::Result<(NodeSource, Option<NodeSource>), String> {
     let source = match &deployment.source {
         DeploymentSource::Local(spec) => {
@@ -203,6 +205,13 @@ fn node_source_from_deployment_source(
                 sha256: Some(spec.sha256.clone()),
             }
         }
+        // Repo-backed sources are flattened to their concrete FS/Git/Http
+        // counterpart at planning time by consulting the user's packages
+        // cache. Downstream add/build/run steps never see `RepoNode` under
+        // a stack launch.
+        DeploymentSource::Repo(spec) => crate::services::repo::cache::resolve_repo_node_source(
+            &spec.name, &spec.tag, peppy_dirs,
+        )?,
     };
 
     let variant = deployment
@@ -616,7 +625,8 @@ async fn resolve_deployments(
         }
 
         let (source, variant) =
-            match node_source_from_deployment_source(&deployment, nodes_directory) {
+            match node_source_from_deployment_source(&deployment, nodes_directory, &ctx.peppy_dirs)
+            {
                 Ok(result) => result,
                 Err(err) => {
                     planning_errors.push(format!(

--- a/crates/core-node-internal/src/services/stack/launch.rs
+++ b/crates/core-node-internal/src/services/stack/launch.rs
@@ -205,10 +205,6 @@ fn node_source_from_deployment_source(
                 sha256: Some(spec.sha256.clone()),
             }
         }
-        // Repo-backed sources are flattened to their concrete FS/Git/Http
-        // counterpart at planning time by consulting the user's packages
-        // cache. Downstream add/build/run steps never see `RepoNode` under
-        // a stack launch.
         DeploymentSource::Repo(spec) => crate::services::repo::cache::resolve_repo_node_source(
             &spec.name, &spec.tag, peppy_dirs,
         )?,

--- a/crates/core-node-internal/tests/listen_for_launch.rs
+++ b/crates/core-node-internal/tests/listen_for_launch.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tempfile::tempdir;
 
-use crate::common::start_core_node_with_mock_messenger;
+use crate::common::{TestPackagesCache, start_core_node_with_mock_messenger};
 
 struct NodeConfigOptions<'a> {
     build_cmd: &'a [&'a str],
@@ -804,6 +804,152 @@ async fn listen_for_launch_configuration_succeed() {
             .map(|e| &e.instance_id)
             .collect::<Vec<_>>()
     );
+}
+
+/// Launch file references nodes by `{ name, tag }` (long form) and
+/// `{ name: "foo:tag" }` (combined form). Both shapes resolve through the
+/// user's packages cache, which we pre-populate with local filesystem
+/// entries so the test needs no network access.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn listen_for_launch_configuration_succeeds_with_repo_sources() {
+    const BRAIN_NODE: &str = "repo_brain";
+    const ARM_NODE: &str = "repo_arm";
+    const NODE_TAG: &str = "0.1.0";
+
+    let started_core_node = start_core_node_with_mock_messenger().await;
+    let node_stack = started_core_node.node_stack.clone();
+    let peppy_dirs = started_core_node.peppy_dirs.clone();
+    let node_messenger =
+        MessengerHandle::from_shared(Arc::clone(&started_core_node.shared_messenger));
+
+    // On-disk node configs referenced by the packages cache.
+    let nodes_dir = tempdir().expect("failed to create temp nodes directory");
+    let brain_dir = write_node_config(
+        nodes_dir.path(),
+        BRAIN_NODE,
+        NODE_TAG,
+        "test-hash",
+        &["sleep", "60"],
+        false,
+        false,
+    );
+    let arm_dir = write_node_config(
+        nodes_dir.path(),
+        ARM_NODE,
+        NODE_TAG,
+        "test-hash",
+        &["sleep", "60"],
+        false,
+        false,
+    );
+
+    // Map both nodes into the user-repo cache. This is what the
+    // `{ name, tag }` launcher shape resolves against.
+    TestPackagesCache::new()
+        .fs_entry(BRAIN_NODE, NODE_TAG, &brain_dir, &[])
+        .fs_entry(ARM_NODE, NODE_TAG, &arm_dir, &[])
+        .write(&peppy_dirs);
+
+    let _ready_brain = AbortOnDrop(
+        listen_for_node_ready(
+            &node_messenger,
+            &started_core_node.core_node_name,
+            "the_brain",
+            BRAIN_NODE,
+        )
+        .await
+        .expect("ready service should start"),
+    );
+    let _health_brain = AbortOnDrop(
+        listen_for_node_health(
+            &node_messenger,
+            &started_core_node.core_node_name,
+            "the_brain",
+            BRAIN_NODE,
+        )
+        .await
+        .expect("health service should start"),
+    );
+    let _ready_arm = AbortOnDrop(
+        listen_for_node_ready(
+            &node_messenger,
+            &started_core_node.core_node_name,
+            "the_arm",
+            ARM_NODE,
+        )
+        .await
+        .expect("ready service should start"),
+    );
+    let _health_arm = AbortOnDrop(
+        listen_for_node_health(
+            &node_messenger,
+            &started_core_node.core_node_name,
+            "the_arm",
+            ARM_NODE,
+        )
+        .await
+        .expect("health service should start"),
+    );
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // Real peppy_launcher.json5 file exercising both the long-form and the
+    // `name:tag` shorthand.
+    let launcher_json5 = format!(
+        r#"{{
+  deployments: [
+    {{
+      source: {{ name: "{BRAIN_NODE}", tag: "{NODE_TAG}" }},
+      instances: [
+        {{ instance_id: "the_brain" }}
+      ]
+    }},
+    {{
+      source: {{ name: "{ARM_NODE}:{NODE_TAG}" }},
+      instances: [
+        {{ instance_id: "the_arm" }}
+      ]
+    }}
+  ]
+}}"#
+    );
+    let launch_file_path = nodes_dir.path().join("peppy_launcher.json5");
+    fs::write(&launch_file_path, &launcher_json5).expect("failed to write launch file");
+
+    let (_goal_response, result) = send_node_launch_and_wait(
+        &started_core_node.caller_handle,
+        &started_core_node.core_node_name,
+        &launch_file_path,
+        GOAL_TIMEOUT,
+        RESULT_TIMEOUT,
+    )
+    .await
+    .expect("launch should complete");
+
+    assert!(
+        result.success,
+        "launch should succeed, got error: {:?}",
+        result.error_message
+    );
+
+    assert!(
+        node_stack.contains(BRAIN_NODE, NODE_TAG),
+        "brain should be in stack"
+    );
+    assert!(
+        node_stack.contains(ARM_NODE, NODE_TAG),
+        "arm should be in stack"
+    );
+    assert_eq!(node_stack.len(), 3, "root + 2 repo-sourced nodes");
+
+    let brain = node_stack
+        .find(BRAIN_NODE, NODE_TAG)
+        .expect("brain should be in stack");
+    assert_eq!(brain.read().instances().len(), 1);
+
+    let arm = node_stack
+        .find(ARM_NODE, NODE_TAG)
+        .expect("arm should be in stack");
+    assert_eq!(arm.read().instances().len(), 1);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/node-stack-internal/src/node_stack/build_steps.rs
+++ b/crates/node-stack-internal/src/node_stack/build_steps.rs
@@ -55,42 +55,12 @@ where
 }
 
 /// Validates that `node_tag` is safe to splice into a filename joined under
-/// the storage directory. Manifest names are constrained by `Name`'s parser,
-/// but `Manifest::tag` is a raw `String` — so we re-validate it here before
+/// the storage directory. Re-validates the raw `Manifest::tag` string before
 /// it ever reaches `storage_dir.join(...)` to prevent path traversal or
 /// absolute-path injection (e.g. a tag like `../etc/passwd`).
 pub(super) fn validate_node_tag(node_tag: &str) -> std::io::Result<()> {
-    if node_tag.is_empty() {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            "node tag must not be empty",
-        ));
-    }
-    if node_tag == "." || node_tag == ".." || node_tag.starts_with('.') {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            format!("node tag must not start with '.': {}", node_tag),
-        ));
-    }
-    if node_tag.contains("..") {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            format!("node tag must not contain '..': {}", node_tag),
-        ));
-    }
-    for c in node_tag.chars() {
-        let ok = c.is_ascii_alphanumeric() || c == '.' || c == '_' || c == '-';
-        if !ok {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                format!(
-                    "node tag contains disallowed character {:?}: {}",
-                    c, node_tag
-                ),
-            ));
-        }
-    }
-    Ok(())
+    config::repo_node_id::validate_repo_node_tag(node_tag, "node tag")
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidInput, e))
 }
 
 /// Archives the contents of `source_dir` into a `.tar.zst` file in the

--- a/docs/src/content/docs/guides/launch_files.mdx
+++ b/docs/src/content/docs/guides/launch_files.mdx
@@ -30,10 +30,11 @@ In the root directory, you'll find a [`peppy_launcher.json5`](https://github.com
  1. All deployments are defined in the `deployments` array
  2. Each deployment requires a `source` and `instances` attribute
 
-The `source` attribute supports three formats:
+The `source` attribute supports four formats:
  - **URL**: A link to a `.tar.zst` archive, requiring both `url` and `sha256` attributes
  - **Git repository**: Requires `repo`, `path` (location within the repo), and `ref` attributes
  - **Local path**: Specified via the `local` key, pointing to a directory on your filesystem. The path can be either absolute or relative to the `peppy_launcher.json5` file
+ - **Repository**: Reference a node that is already registered in your user repositories. Specify `name` and `tag`, or use the combined `name: "<name>:<tag>"` shorthand. The node (and its dependencies) is resolved against your local packages cache at `~/.peppy/cache/packages.json5`, so be sure to run `peppy repo refresh` beforehand.
 
 ### Variants
 
@@ -91,6 +92,33 @@ Examples:
   },
   instances: [
     { instance_id: "my_node_1" }
+  ]
+}
+```
+
+```json5
+// Repository source (long form)
+{
+  source: {
+    name: "openarm01_controller",
+    tag: "0.1.0",
+    variant: { name: "mock-python" }
+  },
+  instances: [
+    { instance_id: "the_nervous_system" }
+  ]
+}
+```
+
+```json5
+// Repository source (combined shorthand — equivalent to the example above)
+{
+  source: {
+    name: "openarm01_controller:0.1.0",
+    variant: { name: "mock-python" }
+  },
+  instances: [
+    { instance_id: "the_nervous_system" }
   ]
 }
 ```

--- a/docs/src/content/docs/guides/launch_files.mdx
+++ b/docs/src/content/docs/guides/launch_files.mdx
@@ -34,7 +34,11 @@ The `source` attribute supports four formats:
  - **URL**: A link to a `.tar.zst` archive, requiring both `url` and `sha256` attributes
  - **Git repository**: Requires `repo`, `path` (location within the repo), and `ref` attributes
  - **Local path**: Specified via the `local` key, pointing to a directory on your filesystem. The path can be either absolute or relative to the `peppy_launcher.json5` file
- - **Repository**: Reference a node that is already registered in your user repositories. Specify `name` and `tag`, or use the combined `name: "<name>:<tag>"` shorthand. The node (and its dependencies) is resolved against your local packages cache at `~/.peppy/cache/packages.json5`, so be sure to run `peppy repo refresh` beforehand.
+ - **Repository**: Reference a node that is already registered in your user repositories. Specify `name` and `tag`, or use the combined `name: "<name>:<tag>"` shorthand. The node is resolved against your local packages cache at `~/.peppy/cache/packages.json5`.
+
+:::note
+The repository source resolves nodes from a locally cached index. Run `peppy repo refresh` before launching to ensure the cache is up to date. If a node or tag is missing from the cache, the launch will fail with a "not found" error.
+:::
 
 ### Variants
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Repository-based deployment sources are supported (name/tag or shorthand name:tag) and resolved from the local cached package index.
  * Launch planning and resolution now accept repo-backed nodes.

* **Bug Fixes**
  * Improved validation and clearer errors for repo node identifiers and for mixing repo vs git/source fields.

* **Documentation**
  * Launch guide updated with repo source examples and cache-refresh instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->