### PR TITLE
docs: sync with PR #165

### DIFF
--- a/docs/src/content/docs/advanced_guides/repositories.mdx
+++ b/docs/src/content/docs/advanced_guides/repositories.mdx
@@ -69,7 +69,7 @@ When multiple repositories provide the same `name:tag` pair, the repository with
 ### Add a repository
 
 ```sh
-peppy repo add <source> [--ref <tag-or-branch>]
+peppy repo add <source> [--ref <tag-or-branch>] [--top]
 ```
 
 Adds a new repository to `repositories.json5`. The source format is auto-detected:
@@ -86,9 +86,12 @@ peppy repo add https://github.com/org/repo.git --ref v2.0
 
 # Plain URL
 peppy repo add https://example.com/packages
+
+# Give the new repo top priority (lower `id` than every existing entry)
+peppy repo add /path/to/my/nodes --top
 ```
 
-The `--ref` flag is only valid for git sources.
+The `--ref` flag is only valid for git sources. By default the new repository is appended with `id = max(existing ids) + 1`, so it has the lowest priority among configured repositories; pass `--top` to assign it an `id` just below the current minimum, giving it the highest priority. The priority `id` decides which repository wins when several of them provide the same `name:tag` (see [Refresh the index](#refresh-the-index)).
 
 ### Remove a repository
 

--- a/docs/src/content/docs/guides/node_stack.mdx
+++ b/docs/src/content/docs/guides/node_stack.mdx
@@ -147,8 +147,8 @@ Run cmd:   uv run hello_world
 
 Node Stack Status
 --------------------------------------------------
-Status:    In node stack
 Stage:     Ready
+Variant:   default
 Instances: 2 tracked
            - inst-abc  [running]
            - inst-def  [starting]
@@ -163,6 +163,8 @@ hello_world:0.1.0
 ```
 
 This is usually the fastest way to answer "is my node built yet?" and "where is the log for this specific instance?". The `Add log` path is what `peppy node add` writes to; per-instance run logs are what `peppy node run` writes to. Build logs live under `~/.peppy/logs/build/` and are surfaced by `peppy node build` directly when it runs.
+
+The `Variant:` line shows the variant that was selected when the node was added. It prints `default` both when no variant override was passed (auto-resolved default variant) and when the node declares no variants at all (the root's own `execution` section is the default).
 
 ## Stopping your node
 


### PR DESCRIPTION
Automated doc update generated by `scripts/docs/update_docs.py`
in response to code changes in #165.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented new `--top` flag for `peppy repo add` command to control repository priority order.
  * Added `Variant:` field to `peppy node info` output documentation, displaying the variant selected during node setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->