### PR TITLE
Fix stack launch timeouts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2400,6 +2400,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "no-std-net"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2415,6 +2427,7 @@ dependencies = [
  "names-generator2",
  "parking_lot",
  "petgraph",
+ "process-wrap",
  "rand 0.10.1",
  "serde",
  "serde_json5",
@@ -3107,6 +3120,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "process-wrap"
+version = "9.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e842efad9119158434d193c6682e2ebee4b44d6ad801d7b349623b3f57cdf55"
+dependencies = [
+ "futures",
+ "indexmap 2.14.0",
+ "nix 0.31.2",
+ "tokio",
+ "tracing",
+ "windows",
 ]
 
 [[package]]
@@ -6034,7 +6061,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09f2b7f60cdb5ad771d1a4f8e2eda15529e96dbe81c0ad2c1015b4c194347676"
 dependencies = [
  "async-trait",
- "nix",
+ "nix 0.29.0",
  "tokio",
  "tokio-util",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,9 +244,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.2"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -254,9 +254,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
  "cc",
  "cmake",
@@ -302,9 +302,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 dependencies = [
  "serde_core",
 ]
@@ -386,9 +386,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "capnp"
-version = "0.25.3"
+version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1c82ec25a9501d60e22eef4be1b2c271769b5a96e224d0875baef28529cf30"
+checksum = "63da65e5e9ffc3b8f993d4ad222a548152549351a643f6b850a7773cb6ff2809"
 dependencies = [
  "embedded-io",
 ]
@@ -440,7 +440,7 @@ checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -469,9 +469,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -491,9 +491,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -587,11 +587,12 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "const_format"
-version = "0.2.35"
+version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7faa7469a93a566e9ccc1c73fe783b4a65c274c5ace346038dca9c39fe0030ad"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
 dependencies = [
  "const_format_proc_macros",
+ "konst",
 ]
 
 [[package]]
@@ -1134,7 +1135,7 @@ checksum = "4e7f34442dbe69c60fe8eaf58a8cafff81a1f278816d8ab4db255b3bef4ac3c4"
 dependencies = [
  "getrandom 0.3.4",
  "libm",
- "rand 0.9.3",
+ "rand 0.9.4",
  "siphasher",
 ]
 
@@ -1230,9 +1231,9 @@ dependencies = [
 
 [[package]]
 name = "fraction"
-version = "0.15.3"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f158e3ff0a1b334408dc9fb811cd99b446986f4d8b741bb08f9df1604085ae7"
+checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
 dependencies = [
  "lazy_static",
  "num",
@@ -1404,7 +1405,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1712,15 +1713,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -2061,9 +2061,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.46.0"
+version = "0.46.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84695c6689b01384700a3d93acecbd07231ee6fff1bf22ae980b4c307e6ddfd5"
+checksum = "50180452e7808015fe083eae3efcf1ec98b89b45dd8cc204f7b4a6b7b81ea675"
 dependencies = [
  "ahash",
  "bytecount",
@@ -2107,6 +2107,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "konst"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2123,9 +2138,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libgit2-sys"
@@ -2321,7 +2336,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "980249d06e11bc023ff3b555de7161d6b211ab3e3b146a42102d83ea30d373ae"
 dependencies = [
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2512,7 +2527,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
@@ -2696,9 +2711,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.112"
+version = "0.9.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
 dependencies = [
  "cc",
  "libc",
@@ -2991,9 +3006,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plain"
@@ -3257,7 +3272,7 @@ dependencies = [
  "fastbloom",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.3",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3307,9 +3322,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -3318,9 +3333,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -3334,7 +3349,7 @@ checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3377,15 +3392,15 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -3477,9 +3492,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.46.0"
+version = "0.46.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2d5554bf79f4acf770dc3193b44b2d63b348f5f7b7448a0ea1191b37b620728"
+checksum = "acb0c66c7b78c1da928bee668b5cc638c678642ff587faff6e6222f797be9d4c"
 dependencies = [
  "ahash",
  "fluent-uri",
@@ -3705,9 +3720,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -3779,9 +3794,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.11"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -4100,9 +4115,9 @@ checksum = "5f179d4e11094a893b82fff208f74d448a7512f99f5a0acbd5c679b705f83ed9"
 
 [[package]]
 name = "sha3"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
 dependencies = [
  "digest 0.10.7",
  "keccak",
@@ -4273,7 +4288,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "rand 0.8.5",
+ "rand 0.8.6",
  "syn 1.0.109",
 ]
 
@@ -4518,9 +4533,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.51.1"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -4770,7 +4785,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.8.5",
+ "rand 0.8.6",
  "sha1",
  "thiserror 1.0.69",
  "utf-8",
@@ -4800,9 +4815,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "ucd-trie"
@@ -4819,7 +4834,7 @@ dependencies = [
  "humantime",
  "lazy_static",
  "log",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "spin 0.10.0",
 ]
@@ -4938,9 +4953,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -5038,11 +5053,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -5051,7 +5066,7 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -5165,18 +5180,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5578,9 +5593,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
 ]
@@ -5593,6 +5608,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"
@@ -5767,7 +5788,7 @@ dependencies = [
  "once_cell",
  "petgraph",
  "phf",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rustc_version",
  "serde",
  "serde_json",
@@ -5871,7 +5892,7 @@ checksum = "44b80a042fc71419fc4952a90c9cbcfb323c0ced048125d8b44fd362f184045f"
 dependencies = [
  "aes",
  "hmac",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_chacha 0.3.1",
  "sha3",
  "zenoh-result",
@@ -5886,7 +5907,7 @@ dependencies = [
  "getrandom 0.2.17",
  "hashbrown 0.16.1",
  "keyed-set",
- "rand 0.8.5",
+ "rand 0.8.6",
  "schemars 1.2.1",
  "serde",
  "token-cell",
@@ -6131,7 +6152,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eeab45020bbecc077f14f06ee8f5aee65ce760af72481e663cac58b5dbfa66dd"
 dependencies = [
  "const_format",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "uhlc",
  "zenoh-buffers",
@@ -6205,7 +6226,7 @@ dependencies = [
  "futures",
  "lazy_static",
  "lz4_flex",
- "rand 0.8.5",
+ "rand 0.8.6",
  "ringbuffer-spsc",
  "rsa",
  "serde",

--- a/crates/core-node-internal/Cargo.toml
+++ b/crates/core-node-internal/Cargo.toml
@@ -57,7 +57,7 @@ libc = "0.2"
 node-stack = { path = "../node-stack-internal" }
 config = { path = "../config-internal", features = ["test_helpers"] }
 tempfile = "3.10"
-tokio = { version = "1.47", features = ["full"] }
+tokio = { version = "1.47", features = ["full", "test-util"] }
 httptest = "0.16.3"
 
 [features]

--- a/crates/core-node-internal/schemas/launch.capnp
+++ b/crates/core-node-internal/schemas/launch.capnp
@@ -12,12 +12,14 @@ struct LaunchGoal {
     peppyLaunchFilePath @0 :Text;
     # Environment variables to apply when executing build_cmd and run_cmd (e.g. PATH)
     envVars @1 :List(EnvVar);
-    # Idle timeout in seconds for each node add operation (resets on feedback)
+    # Idle timeout in seconds for the node add phase (resets on git/http progress or sub-process output)
     nodeAddIdleTimeoutSecs @2 :UInt64;
-    # Idle timeout in seconds for each node run operation (resets on feedback)
+    # Idle timeout in seconds for the node run-startup phase (resets on subprocess output until the node signals ready)
     nodeRunIdleTimeoutSecs @3 :UInt64;
-    # Absolute max timeout in seconds per operation (0 = default 3600s)
+    # Absolute max timeout in seconds for the entire launch; 0 = unset, no overall deadline (idle timeouts still apply)
     maxTimeoutSecs @4 :UInt64;
+    # Idle timeout in seconds for the node build phase (resets on build_cmd output)
+    nodeBuildIdleTimeoutSecs @5 :UInt64;
 }
 
 struct LaunchGoalResponse {

--- a/crates/core-node-internal/src/encoding/node/add.rs
+++ b/crates/core-node-internal/src/encoding/node/add.rs
@@ -221,6 +221,14 @@ impl NodeAddGoal {
         ))
     }
 
+    /// Builds a goal for in-process execution that bypasses the action-loop
+    /// gate (see `services::stack::launch::add_node_directly`). The
+    /// `timeout_secs` field feeds the gate's busy-reporting and is unread on
+    /// this path, so it is zero by construction.
+    pub fn for_internal_execution(source: NodeSource, git_hash: impl Into<String>) -> Self {
+        Self::from_source(source, git_hash, 0)
+    }
+
     pub fn with_env_vars(mut self, env_vars: Vec<(String, String)>) -> Self {
         self.env_vars = env_vars;
         self

--- a/crates/core-node-internal/src/encoding/node/run.rs
+++ b/crates/core-node-internal/src/encoding/node/run.rs
@@ -46,6 +46,18 @@ impl NodeRunGoal {
         self
     }
 
+    /// Builds a goal for in-process execution that bypasses the action-loop
+    /// gate (see `services::stack::launch::start_node_directly`). The
+    /// `timeout_secs` field feeds the gate's busy-reporting and is unread on
+    /// this path, so it is zero by construction.
+    pub fn for_internal_execution(
+        runtime_config_json5: impl Into<String>,
+        node_name: impl Into<String>,
+        tag: impl Into<String>,
+    ) -> Self {
+        Self::new(runtime_config_json5, node_name, tag, 0)
+    }
+
     pub fn encode(&self) -> Result<Payload> {
         let mut builder = Builder::new_default();
         {

--- a/crates/core-node-internal/src/encoding/stack/launch.rs
+++ b/crates/core-node-internal/src/encoding/stack/launch.rs
@@ -197,12 +197,25 @@ impl LaunchGoalResponse {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LaunchFeedbackStep {
     LauncherStep,
     AddingNode,
     RunningNode,
     BuildingNode,
+}
+
+impl LaunchFeedbackStep {
+    /// Short user-facing label for the phase this step represents. Used by timeout error
+    /// messages so the surfaced string stays aligned with the feedback stream.
+    pub fn phase_label(self) -> &'static str {
+        match self {
+            Self::LauncherStep => "launch",
+            Self::AddingNode => "add",
+            Self::BuildingNode => "build",
+            Self::RunningNode => "run",
+        }
+    }
 }
 /// Feedback message for the Launch action.
 /// Represents a single line of output from the launch process.

--- a/crates/core-node-internal/src/encoding/stack/launch.rs
+++ b/crates/core-node-internal/src/encoding/stack/launch.rs
@@ -15,10 +15,9 @@ use crate::names;
 
 use crate::encoding::{decode_message, encode_message, optional_text};
 
-/// Default idle timeout in seconds for operations (used as fallback when 0 is received on the wire).
+/// Default idle timeout in seconds for the add/build/run phases (used as fallback when 0 is
+/// received on the wire — Cap'n Proto defaults unset `UInt64` to 0).
 const DEFAULT_IDLE_TIMEOUT_SECS: u64 = 600;
-/// Default max timeout in seconds for operations (used as fallback when 0 is received on the wire).
-const DEFAULT_MAX_TIMEOUT_SECS: u64 = 3600;
 
 /// Applies a default value when a timeout field is 0 (Cap'n Proto defaults unset UInt64 to 0).
 fn with_timeout_default(value: u64, default: u64) -> u64 {
@@ -31,21 +30,26 @@ pub struct LaunchGoal {
     pub peppy_launch_file_path: PathBuf,
     pub env_vars: Vec<(String, String)>,
     pub node_add_idle_timeout_secs: u64,
+    pub node_build_idle_timeout_secs: u64,
     pub node_run_idle_timeout_secs: u64,
-    pub max_timeout_secs: u64,
+    /// Whole-launch deadline. `None` means no overall deadline is enforced (only idle timeouts
+    /// apply). Wire encoding uses 0 as the sentinel for `None`.
+    pub max_timeout_secs: Option<u64>,
 }
 
 impl LaunchGoal {
     pub fn new(
         peppy_launch_file_path: impl Into<PathBuf>,
         node_add_idle_timeout_secs: u64,
+        node_build_idle_timeout_secs: u64,
         node_run_idle_timeout_secs: u64,
-        max_timeout_secs: u64,
+        max_timeout_secs: Option<u64>,
     ) -> Self {
         Self {
             peppy_launch_file_path: peppy_launch_file_path.into(),
             env_vars: Vec::new(),
             node_add_idle_timeout_secs,
+            node_build_idle_timeout_secs,
             node_run_idle_timeout_secs,
             max_timeout_secs,
         }
@@ -72,8 +76,12 @@ impl LaunchGoal {
             goal.reborrow()
                 .set_node_add_idle_timeout_secs(self.node_add_idle_timeout_secs);
             goal.reborrow()
+                .set_node_build_idle_timeout_secs(self.node_build_idle_timeout_secs);
+            goal.reborrow()
                 .set_node_run_idle_timeout_secs(self.node_run_idle_timeout_secs);
-            goal.reborrow().set_max_timeout_secs(self.max_timeout_secs);
+            // 0 on the wire means "unset" (no overall deadline).
+            goal.reborrow()
+                .set_max_timeout_secs(self.max_timeout_secs.unwrap_or(0));
         }
         encode_message(&builder)
     }
@@ -92,6 +100,7 @@ impl LaunchGoal {
             ));
         }
 
+        let raw_max = goal.get_max_timeout_secs();
         Ok(Self {
             peppy_launch_file_path: PathBuf::from(goal.get_peppy_launch_file_path()?.to_str()?),
             env_vars,
@@ -99,14 +108,15 @@ impl LaunchGoal {
                 goal.get_node_add_idle_timeout_secs(),
                 DEFAULT_IDLE_TIMEOUT_SECS,
             ),
+            node_build_idle_timeout_secs: with_timeout_default(
+                goal.get_node_build_idle_timeout_secs(),
+                DEFAULT_IDLE_TIMEOUT_SECS,
+            ),
             node_run_idle_timeout_secs: with_timeout_default(
                 goal.get_node_run_idle_timeout_secs(),
                 DEFAULT_IDLE_TIMEOUT_SECS,
             ),
-            max_timeout_secs: with_timeout_default(
-                goal.get_max_timeout_secs(),
-                DEFAULT_MAX_TIMEOUT_SECS,
-            ),
+            max_timeout_secs: if raw_max == 0 { None } else { Some(raw_max) },
         })
     }
 

--- a/crates/core-node-internal/src/services/node/run.rs
+++ b/crates/core-node-internal/src/services/node/run.rs
@@ -27,6 +27,7 @@ use std::time::{Duration, Instant};
 use tokio::process::Child;
 use tokio::sync::{Mutex, Notify, mpsc};
 use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
 use tracing::debug;
 
 const STARTUP_OUTPUT_MAX_WAIT: Duration = Duration::from_millis(100);
@@ -329,6 +330,14 @@ impl node_stack::OutputReaderHooks for FeedbackSync {
 ///
 /// This is the shared implementation used by both the action-server path
 /// ([`handle_goal_request`]) and the direct-call path from `stack_launch`.
+///
+/// `cancel_token` lets an outer orchestrator (currently `stack_launch`'s
+/// idle/max-timeout watchdog) request an in-flight abort. When cancelled after
+/// the child process has been spawned but before the `Starting → Started`
+/// commit, the pipeline explicitly calls `abort_started` to SIGKILL the child
+/// and tear down its `Starting` entry; if cancelled before the spawn, it
+/// returns without starting anything. Callers that don't need cancellation
+/// pass `CancellationToken::new()` and never trigger it.
 pub(crate) async fn run_node_run(
     goal: NodeRunGoal,
     runtime_config: RuntimeConfig,
@@ -336,6 +345,7 @@ pub(crate) async fn run_node_run(
     feedback_tx: mpsc::UnboundedSender<FeedbackLine>,
     log_file: Arc<StdMutex<File>>,
     sender_instance_id: String,
+    cancel_token: CancellationToken,
 ) -> NodeRunResult {
     let log_file_for_panic = log_file.clone();
 
@@ -345,9 +355,14 @@ pub(crate) async fn run_node_run(
         log_file,
         sender_instance_id,
     };
-    match AssertUnwindSafe(process_node_run(goal, runtime_config, process_context))
-        .catch_unwind()
-        .await
+    match AssertUnwindSafe(process_node_run(
+        goal,
+        runtime_config,
+        process_context,
+        cancel_token,
+    ))
+    .catch_unwind()
+    .await
     {
         Ok(result) => result,
         Err(panic_payload) => {
@@ -437,6 +452,8 @@ async fn handle_goal_request(
                 NodeRunFeedback::from_stream(line.stream, &line.line).encode()
             });
 
+        // Action-server path has no outer cancellation source; the internal
+        // per-step timeouts inside `run_node_run` remain the only way out.
         let result = run_node_run(
             goal,
             runtime_config,
@@ -444,6 +461,7 @@ async fn handle_goal_request(
             feedback_tx,
             log_file,
             sender_instance_id,
+            CancellationToken::new(),
         )
         .await;
 
@@ -468,6 +486,7 @@ async fn process_node_run(
     goal: NodeRunGoal,
     runtime_config: RuntimeConfig,
     ctx: ProcessNodeRunContext,
+    cancel_token: CancellationToken,
 ) -> NodeRunResult {
     let sender_instance_id = ctx.sender_instance_id.as_str();
     let NodeRunGoal {
@@ -636,6 +655,16 @@ async fn process_node_run(
             hooks: Arc::new(feedback_sync.clone()),
         },
     };
+    // Reject early if an outer orchestrator already cancelled us — avoids
+    // spawning a child process we're only going to tear down on the next line.
+    if cancel_token.is_cancelled() {
+        let msg = "cancelled before node process spawn".to_string();
+        write_error_to_log(&ctx.log_file, &msg);
+        feedback_sync.flush_or_warn(instance_id_str).await;
+        publish_enabled.store(false, Ordering::Release);
+        return NodeRunResult::failure(msg);
+    }
+
     let (mut child, started_ctx) =
         match node_stack::NodeEntity::prepare_and_spawn(&entity_handle, start_ctx).await {
             Ok(t) => t,
@@ -663,19 +692,31 @@ async fn process_node_run(
         ctx.action.node_startup_timeout.as_secs()
     );
 
-    let ready_result =
-        wait_for_ready_signal(&signal_target, ctx.action.node_startup_timeout, &mut child).await;
+    // Race the ready-signal wait against external cancellation. If the outer
+    // idle/max-timeout watchdog cancels while the node is quietly starting,
+    // we must SIGKILL the child and unregister the `Starting` instance —
+    // otherwise the OS process outlives the launch failure.
+    let ready_outcome = tokio::select! {
+        biased;
+        _ = cancel_token.cancelled() => StartupOutcome::Cancelled,
+        res = wait_for_ready_signal(&signal_target, ctx.action.node_startup_timeout, &mut child) => {
+            match res {
+                Ok(()) => StartupOutcome::Ok,
+                Err(e) => StartupOutcome::Failed(e),
+            }
+        }
+    };
 
-    if let Err(e) = ready_result {
+    if let Some(reason) = startup_abort_reason(&ready_outcome) {
         debug!(
-            "Ready signal failed for node instance '{}': {}, killing process",
-            instance_id_str, e
+            "Aborting node instance '{}' during ready wait: {}",
+            instance_id_str, reason
         );
         let msg = node_stack::NodeEntity::abort_started(
             &entity_handle,
             child,
             started_ctx,
-            e,
+            reason.to_string(),
             &instance_id,
         )
         .await;
@@ -689,19 +730,44 @@ async fn process_node_run(
         instance_id_str
     );
 
-    let health_result = perform_health_check(
-        &signal_target,
-        ctx.action.node_start_health_timeout,
-        &mut child,
-    )
-    .await;
+    let health_outcome = tokio::select! {
+        biased;
+        _ = cancel_token.cancelled() => StartupOutcome::Cancelled,
+        res = perform_health_check(&signal_target, ctx.action.node_start_health_timeout, &mut child) => {
+            match res {
+                Ok(()) => StartupOutcome::Ok,
+                Err(e) => StartupOutcome::Failed(e),
+            }
+        }
+    };
 
-    match health_result {
-        Ok(()) => {
+    match health_outcome {
+        StartupOutcome::Ok => {
             debug!(
                 "Health check passed for node instance '{}'",
                 instance_id_str
             );
+            // Last chance to bail out cleanly — once `commit_started` succeeds
+            // the child is owned by the stack and a late cancel would have to
+            // go through the normal stop path instead of abort_started.
+            if cancel_token.is_cancelled() {
+                let reason = "cancelled before commit".to_string();
+                debug!(
+                    "Aborting node instance '{}' after health check: {}",
+                    instance_id_str, reason
+                );
+                let msg = node_stack::NodeEntity::abort_started(
+                    &entity_handle,
+                    child,
+                    started_ctx,
+                    reason,
+                    &instance_id,
+                )
+                .await;
+                feedback_sync.flush_or_warn(instance_id_str).await;
+                publish_enabled.store(false, Ordering::Release);
+                return NodeRunResult::failure(msg);
+            }
             let pid = child.id().unwrap_or(0);
             let commit_result = node_stack::NodeEntity::commit_started(
                 &entity_handle,
@@ -752,16 +818,21 @@ async fn process_node_run(
                 }
             }
         }
-        Err(e) => {
+        StartupOutcome::Cancelled | StartupOutcome::Failed(_) => {
+            let reason = match health_outcome {
+                StartupOutcome::Cancelled => "cancelled during health check".to_string(),
+                StartupOutcome::Failed(e) => e,
+                StartupOutcome::Ok => unreachable!(),
+            };
             debug!(
-                "Health check failed for node instance '{}': {}, killing process",
-                instance_id_str, e
+                "Aborting node instance '{}' during health check: {}",
+                instance_id_str, reason
             );
             let msg = node_stack::NodeEntity::abort_started(
                 &entity_handle,
                 child,
                 started_ctx,
-                e,
+                reason,
                 &instance_id,
             )
             .await;
@@ -769,6 +840,22 @@ async fn process_node_run(
             publish_enabled.store(false, Ordering::Release);
             NodeRunResult::failure(msg)
         }
+    }
+}
+
+/// Outcome of a startup step (ready-signal wait or health check) racing
+/// against external cancellation.
+enum StartupOutcome {
+    Ok,
+    Cancelled,
+    Failed(String),
+}
+
+fn startup_abort_reason(outcome: &StartupOutcome) -> Option<&str> {
+    match outcome {
+        StartupOutcome::Ok => None,
+        StartupOutcome::Cancelled => Some("cancelled during ready-signal wait"),
+        StartupOutcome::Failed(msg) => Some(msg.as_str()),
     }
 }
 

--- a/crates/core-node-internal/src/services/stack/launch.rs
+++ b/crates/core-node-internal/src/services/stack/launch.rs
@@ -29,7 +29,13 @@ use std::time::Duration;
 use tokio::sync::{Mutex, Notify, mpsc};
 use tokio::task::JoinHandle;
 use tokio::time::Instant;
+use tokio_util::sync::CancellationToken;
 use tracing::debug;
+
+/// Upper bound on how long a run-phase future may spend in its cancellation
+/// cleanup (SIGKILL the child + unregister the `Starting` instance + clear
+/// temp files). Keeps a misbehaving cleanup from stalling the launch failure.
+const RUN_PHASE_CANCEL_CLEANUP_BUDGET: Duration = Duration::from_secs(30);
 
 /// Watches for an idle period: returns when no `notify_one()` arrives for `idle_timeout`.
 /// Each call to `notify_one()` on `notify` resets the clock.
@@ -368,11 +374,47 @@ fn spawn_feedback_forwarder(
 /// - `IdleTimeout` if `idle_timeout` elapsed without subprocess activity
 /// - `MaxTimeout` if the launch deadline fired
 ///
-/// Cancellation safety: when the phase future is dropped, `stream_child_output`'s `KillGuard`
-/// (in node-stack-internal/src/build_io.rs) sends SIGKILL to the child on Drop — no zombies.
-/// For the add phase's git2 clone (synchronous inside its callback callsite), the next
-/// progress callback returns the cancellation status and git2 aborts.
+/// Cancellation semantics differ per phase:
+/// - **add** relies on git2's progress callback returning the cancellation status when the
+///   future is dropped, and on the http downloader's drop-safe streaming reader.
+/// - **build** relies on `stream_child_output`'s `KillGuard` (in
+///   `node-stack-internal/src/build_io.rs`), which SIGKILLs the child process group on drop.
+/// - **run** cannot rely on drop alone: `prepare_and_spawn` returns a raw
+///   `tokio::process::Child` held on the phase future's stack with no `kill_on_drop`, so
+///   dropping it leaves the OS process and its `Starting` stack entry behind. Callers that
+///   need run-phase cancellation pass `cancel_and_drain = Some(token)`; on timeout the
+///   runner signals the token and awaits the phase future's cooperative cleanup (bounded by
+///   `RUN_PHASE_CANCEL_CLEANUP_BUDGET`) instead of dropping it.
 async fn run_phase_with_timeouts<F, T>(
+    phase: F,
+    activity_notify: Arc<Notify>,
+    idle_timeout: Duration,
+    launch_deadline: Option<Instant>,
+    cancel_and_drain: Option<CancellationToken>,
+) -> PhaseOutcome<T>
+where
+    F: std::future::Future<Output = T>,
+{
+    match cancel_and_drain {
+        None => {
+            run_phase_drop_on_timeout(phase, activity_notify, idle_timeout, launch_deadline).await
+        }
+        Some(token) => {
+            run_phase_cancel_on_timeout(
+                phase,
+                activity_notify,
+                idle_timeout,
+                launch_deadline,
+                token,
+            )
+            .await
+        }
+    }
+}
+
+/// Timeout behavior for phases whose futures are cancellation-safe via `Drop`
+/// (currently: add, build).
+async fn run_phase_drop_on_timeout<F, T>(
     phase: F,
     activity_notify: Arc<Notify>,
     idle_timeout: Duration,
@@ -402,10 +444,59 @@ where
     }
 }
 
+/// Timeout behavior for phases that own resources (e.g. a spawned child
+/// process) not reaped by `Drop`. On timeout, signals `cancel_token` and
+/// awaits the phase future for up to `RUN_PHASE_CANCEL_CLEANUP_BUDGET` so it
+/// can run its own teardown (SIGKILL the child, unregister the `Starting`
+/// instance, remove temp files) before we return the timeout outcome.
+async fn run_phase_cancel_on_timeout<F, T>(
+    phase: F,
+    activity_notify: Arc<Notify>,
+    idle_timeout: Duration,
+    launch_deadline: Option<Instant>,
+    cancel_token: CancellationToken,
+) -> PhaseOutcome<T>
+where
+    F: std::future::Future<Output = T>,
+{
+    tokio::pin!(phase);
+
+    // `sleep_until(past-instant)` resolves immediately, so we model "no
+    // deadline" as a far-future sleep and let idle/phase race win.
+    let deadline_sleep = async {
+        match launch_deadline {
+            Some(deadline) => tokio::time::sleep_until(deadline).await,
+            None => std::future::pending::<()>().await,
+        }
+    };
+    tokio::pin!(deadline_sleep);
+
+    let timeout_kind = tokio::select! {
+        biased;
+        result = &mut phase => return PhaseOutcome::Completed(result),
+        _ = watch_idle(activity_notify, idle_timeout) => PhaseOutcome::IdleTimeout,
+        _ = &mut deadline_sleep => PhaseOutcome::MaxTimeout,
+    };
+
+    // Timeout fired. Ask the phase to tear itself down, then drive it to
+    // completion so its cleanup (kill child, remove `Starting` entry, delete
+    // instance dir) actually runs. If cleanup stalls past the budget we drop
+    // the future as a last resort — still strictly better than today, since
+    // the run phase would have been dropped immediately in that branch.
+    cancel_token.cancel();
+    let _ = tokio::time::timeout(RUN_PHASE_CANCEL_CLEANUP_BUDGET, phase.as_mut()).await;
+
+    timeout_kind
+}
+
 /// Runs a phase future under idle + (optional) deadline bounds and, on timeout, writes the
 /// reason to `log_file` and builds a caller-specified failure result. `build_failure`
 /// receives the same string that was logged so phase-specific failure types (differing in
 /// whether they carry a `log_path`) can embed it verbatim.
+///
+/// `cancel_and_drain` controls what happens to the phase future on timeout — see
+/// [`run_phase_with_timeouts`] for the per-phase rationale.
+#[allow(clippy::too_many_arguments)] // All args serve distinct, unrelated roles; grouping them adds noise.
 async fn run_phase<F, T>(
     phase: F,
     activity_notify: Arc<Notify>,
@@ -414,11 +505,20 @@ async fn run_phase<F, T>(
     log_file: &Arc<StdMutex<File>>,
     step: LaunchFeedbackStep,
     build_failure: impl FnOnce(String) -> T,
+    cancel_and_drain: Option<CancellationToken>,
 ) -> T
 where
     F: std::future::Future<Output = T>,
 {
-    match run_phase_with_timeouts(phase, activity_notify, idle_timeout, launch_deadline).await {
+    match run_phase_with_timeouts(
+        phase,
+        activity_notify,
+        idle_timeout,
+        launch_deadline,
+        cancel_and_drain,
+    )
+    .await
+    {
         PhaseOutcome::Completed(result) => result,
         PhaseOutcome::IdleTimeout => {
             let reason = format!(
@@ -485,6 +585,7 @@ async fn add_node_directly(
         &log_file_for_timeout,
         LaunchFeedbackStep::AddingNode,
         |reason| NodeAddResult::failure(&log_path_for_timeout, reason),
+        None,
     )
     .await;
 
@@ -551,6 +652,7 @@ async fn build_node_directly(
         &log_file_for_timeout,
         LaunchFeedbackStep::BuildingNode,
         |reason| crate::encoding::NodeBuildResult::failure(&log_path_for_timeout, reason),
+        None,
     )
     .await;
 
@@ -598,6 +700,11 @@ async fn start_node_directly(
 
     let log_file_for_timeout = log_file.clone();
 
+    // Token triggered by `run_phase_with_timeouts` on idle/max timeout; observed
+    // inside `run_node_run` to abort a half-spawned node instance (SIGKILL the
+    // child + unregister its `Starting` entry) before we return the failure.
+    let run_cancel_token = CancellationToken::new();
+
     let result = run_phase(
         run_node_run(
             node_run_goal,
@@ -606,6 +713,7 @@ async fn start_node_directly(
             feedback_tx,
             log_file,
             ctx.core_instance_id.clone(),
+            run_cancel_token.clone(),
         ),
         activity_notify,
         ctx.idle_timeouts.run,
@@ -613,6 +721,7 @@ async fn start_node_directly(
         &log_file_for_timeout,
         LaunchFeedbackStep::RunningNode,
         NodeRunResult::failure,
+        Some(run_cancel_token),
     )
     .await;
 
@@ -1454,4 +1563,120 @@ async fn process_launch(goal: LaunchGoal, ctx: ProcessLaunchContext) -> LaunchRe
         build_log_paths,
         run_log_paths,
     )
+}
+
+/// Regression tests for the run-phase cancel-and-drain contract.
+///
+/// The invariant under test: when a run-phase timeout fires,
+/// `run_phase_cancel_on_timeout` must signal the cancel token *and* drive the
+/// phase future to completion so its cleanup runs — not drop it. Using
+/// `tokio::time::pause()` + manual advancement so these tests are
+/// deterministic (no wall-clock dependency, no risk of CI flake).
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    /// Builds a phase future that signals `cleanup_ran` iff it observes the
+    /// cancel token — simulating `run_node_run`'s `abort_started` branch.
+    /// If instead the outer runner drops this future, the flag stays false
+    /// and the test fails, matching the real-world orphan bug.
+    async fn cancellable_phase(
+        cancel: CancellationToken,
+        cleanup_ran: Arc<AtomicBool>,
+    ) -> &'static str {
+        tokio::select! {
+            _ = cancel.cancelled() => {
+                cleanup_ran.store(true, Ordering::SeqCst);
+                "cleaned_up"
+            }
+            _ = std::future::pending::<()>() => unreachable!("phase should never complete on its own in these tests"),
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn cancel_on_timeout_awaits_cleanup_on_idle_timeout() {
+        let notify = Arc::new(Notify::new());
+        let token = CancellationToken::new();
+        let cleanup_ran = Arc::new(AtomicBool::new(false));
+
+        let outcome = run_phase_cancel_on_timeout(
+            cancellable_phase(token.clone(), Arc::clone(&cleanup_ran)),
+            Arc::clone(&notify),
+            Duration::from_millis(100),
+            None,
+            token,
+        )
+        .await;
+
+        assert!(
+            matches!(outcome, PhaseOutcome::IdleTimeout),
+            "idle timeout branch expected",
+        );
+        assert!(
+            cleanup_ran.load(Ordering::SeqCst),
+            "phase future must be awaited after cancel so cleanup runs; \
+             dropping it would leave this flag false (the orphan-process bug)",
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn cancel_on_timeout_awaits_cleanup_on_max_deadline() {
+        let notify = Arc::new(Notify::new());
+        let token = CancellationToken::new();
+        let cleanup_ran = Arc::new(AtomicBool::new(false));
+
+        let deadline = Instant::now() + Duration::from_millis(50);
+        let outcome = run_phase_cancel_on_timeout(
+            cancellable_phase(token.clone(), Arc::clone(&cleanup_ran)),
+            Arc::clone(&notify),
+            // Idle much larger than max so only the deadline branch can fire.
+            Duration::from_secs(600),
+            Some(deadline),
+            token,
+        )
+        .await;
+
+        assert!(
+            matches!(outcome, PhaseOutcome::MaxTimeout),
+            "max timeout branch expected",
+        );
+        assert!(
+            cleanup_ran.load(Ordering::SeqCst),
+            "phase future must be awaited after max-deadline cancel so cleanup runs",
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn cancel_on_timeout_returns_value_when_phase_completes_first() {
+        let notify = Arc::new(Notify::new());
+        let token = CancellationToken::new();
+        let cleanup_ran = Arc::new(AtomicBool::new(false));
+        let cleanup_ran_for_phase = Arc::clone(&cleanup_ran);
+
+        // Phase completes immediately with a value — no timeout should fire.
+        let phase = async move {
+            // Reset-like ping proves we keep the happy-path contract (no cancel signal).
+            let _ = cleanup_ran_for_phase;
+            "ok"
+        };
+
+        let outcome = run_phase_cancel_on_timeout(
+            phase,
+            Arc::clone(&notify),
+            Duration::from_millis(100),
+            Some(Instant::now() + Duration::from_millis(100)),
+            token.clone(),
+        )
+        .await;
+
+        match outcome {
+            PhaseOutcome::Completed(v) => assert_eq!(v, "ok"),
+            _ => panic!("phase should complete before any timeout fires"),
+        }
+        assert!(
+            !token.is_cancelled(),
+            "happy path must not cancel the token",
+        );
+    }
 }

--- a/crates/core-node-internal/src/services/stack/launch.rs
+++ b/crates/core-node-internal/src/services/stack/launch.rs
@@ -26,9 +26,28 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::{Mutex, mpsc};
+use tokio::sync::{Mutex, Notify, mpsc};
 use tokio::task::JoinHandle;
+use tokio::time::Instant;
 use tracing::debug;
+
+/// Watches for an idle period: returns when no `notify_one()` arrives for `idle_timeout`.
+/// Each call to `notify_one()` on `notify` resets the clock.
+async fn watch_idle(notify: Arc<Notify>, idle_timeout: Duration) {
+    loop {
+        match tokio::time::timeout(idle_timeout, notify.notified()).await {
+            Ok(()) => continue,
+            Err(_) => return,
+        }
+    }
+}
+
+/// Outcome of a per-phase operation wrapped with idle + (optional) launch-deadline enforcement.
+enum PhaseOutcome<T> {
+    Completed(T),
+    IdleTimeout,
+    MaxTimeout,
+}
 
 #[derive(Clone, Copy)]
 pub struct StackLaunchTimeouts {
@@ -112,7 +131,12 @@ struct ProcessLaunchContext {
     log_path: PathBuf,
     env_vars: Vec<(String, String)>,
     timeouts: StackLaunchTimeouts,
-    max_timeout_secs: u64,
+    /// Whole-launch deadline. `None` means the user did not opt into a max — only idle timeouts
+    /// are enforced.
+    launch_deadline: Option<Instant>,
+    node_add_idle_timeout: Duration,
+    node_build_idle_timeout: Duration,
+    node_run_idle_timeout: Duration,
 }
 
 #[derive(Clone)]
@@ -284,6 +308,13 @@ async fn publish_stderr(
 /// Spawns a feedback forwarding task that reads `FeedbackLine` values from the
 /// channel and publishes them as `LaunchFeedback` to the launch feedback topic.
 ///
+/// Each line received also pings `activity_notify` (if provided), which the per-phase idle
+/// watcher uses to reset its idle clock. The notify is the single seam where real subprocess /
+/// git2 / http-downloader output (which all flow through this mpsc) gets observed; launcher
+/// orchestration messages (`publish_stdout` / `publish_stderr`) bypass this channel and so do
+/// NOT reset the idle clock — which is the right behavior, since they're operator narration,
+/// not subprocess liveness.
+///
 /// Returns the sender end (to pass into the process context) and a join handle
 /// for the consumer task. Drop the sender to signal completion, then await the
 /// handle to drain remaining messages.
@@ -291,12 +322,17 @@ fn spawn_feedback_forwarder(
     feedback_publisher: &TopicPublisher,
     step: LaunchFeedbackStep,
     log_file: &Arc<StdMutex<File>>,
+    activity_notify: Option<Arc<Notify>>,
 ) -> (mpsc::UnboundedSender<FeedbackLine>, JoinHandle<()>) {
     let (feedback_tx, mut feedback_rx) = mpsc::unbounded_channel::<FeedbackLine>();
     let publisher = feedback_publisher.clone();
     let log_file = Arc::clone(log_file);
     let handle = tokio::spawn(async move {
         while let Some(line) = feedback_rx.recv().await {
+            if let Some(notify) = &activity_notify {
+                notify.notify_one();
+            }
+
             node_stack::build_io::write_feedback_log_line(&log_file, line.stream, &line.line);
 
             let launch_feedback = match line.stream {
@@ -317,6 +353,48 @@ fn spawn_feedback_forwarder(
     (feedback_tx, handle)
 }
 
+/// Wraps a phase future with idle-timeout enforcement and an optional whole-launch deadline.
+///
+/// The idle watcher always runs (idle protection is always on); the deadline only wraps when
+/// `launch_deadline` is `Some`. Returns:
+/// - `Completed(T)` if the phase finished within both bounds
+/// - `IdleTimeout` if `idle_timeout` elapsed without subprocess activity
+/// - `MaxTimeout` if the launch deadline fired
+///
+/// Cancellation safety: when the phase future is dropped, `stream_child_output`'s `KillGuard`
+/// (in node-stack-internal/src/build_io.rs) sends SIGKILL to the child on Drop — no zombies.
+/// For the add phase's git2 clone (synchronous inside its callback callsite), the next
+/// progress callback returns the cancellation status and git2 aborts.
+async fn run_phase_with_timeouts<F, T>(
+    phase: F,
+    activity_notify: Arc<Notify>,
+    idle_timeout: Duration,
+    launch_deadline: Option<Instant>,
+) -> PhaseOutcome<T>
+where
+    F: std::future::Future<Output = T>,
+{
+    let inner = async {
+        tokio::select! {
+            biased;
+            _ = watch_idle(activity_notify, idle_timeout) => None,
+            result = phase => Some(result),
+        }
+    };
+
+    match launch_deadline {
+        Some(deadline) => match tokio::time::timeout_at(deadline, inner).await {
+            Ok(Some(value)) => PhaseOutcome::Completed(value),
+            Ok(None) => PhaseOutcome::IdleTimeout,
+            Err(_) => PhaseOutcome::MaxTimeout,
+        },
+        None => match inner.await {
+            Some(value) => PhaseOutcome::Completed(value),
+            None => PhaseOutcome::IdleTimeout,
+        },
+    }
+}
+
 async fn add_node_directly(
     ctx: &ProcessLaunchContext,
     node_add_goal: NodeAddGoal,
@@ -331,10 +409,12 @@ async fn add_node_directly(
         Err(e) => return (Err(e), None),
     };
 
+    let activity_notify = Arc::new(Notify::new());
     let (feedback_tx, forwarder_handle) = spawn_feedback_forwarder(
         &ctx.feedback_publisher,
         LaunchFeedbackStep::AddingNode,
         &ctx.log_file,
+        Some(Arc::clone(&activity_notify)),
     );
 
     let action_context = NodeAddActionContext {
@@ -347,10 +427,9 @@ async fn add_node_directly(
 
     let log_file_for_timeout = log_file.clone();
     let log_path_for_timeout = log_path.clone();
-    let max_timeout = Duration::from_secs(ctx.max_timeout_secs);
+    let idle_secs = ctx.node_add_idle_timeout.as_secs();
 
-    let result = match tokio::time::timeout(
-        max_timeout,
+    let result = match run_phase_with_timeouts(
         run_node_add(
             node_add_goal,
             action_context,
@@ -359,13 +438,24 @@ async fn add_node_directly(
             log_path,
             timestamp,
         ),
+        activity_notify,
+        ctx.node_add_idle_timeout,
+        ctx.launch_deadline,
     )
     .await
     {
-        Ok(result) => result,
-        Err(_) => {
-            write_error_to_log(&log_file_for_timeout, "max timeout exceeded");
-            NodeAddResult::failure(&log_path_for_timeout, "timeout: max timeout exceeded")
+        PhaseOutcome::Completed(result) => result,
+        PhaseOutcome::IdleTimeout => {
+            let msg = format!("add idle timeout exceeded ({idle_secs}s without output)");
+            write_error_to_log(&log_file_for_timeout, &format!("timeout: {msg}"));
+            NodeAddResult::failure(&log_path_for_timeout, format!("timeout: {msg}"))
+        }
+        PhaseOutcome::MaxTimeout => {
+            write_error_to_log(&log_file_for_timeout, "max launch timeout exceeded");
+            NodeAddResult::failure(
+                &log_path_for_timeout,
+                "timeout: max launch timeout exceeded",
+            )
         }
     };
 
@@ -400,10 +490,12 @@ async fn build_node_directly(
 
     let final_log_path = log_path.clone();
 
+    let activity_notify = Arc::new(Notify::new());
     let (feedback_tx, forwarder_handle) = spawn_feedback_forwarder(
         &ctx.feedback_publisher,
         LaunchFeedbackStep::BuildingNode,
         &ctx.log_file,
+        Some(Arc::clone(&activity_notify)),
     );
 
     let action_context = NodeBuildActionContext {
@@ -411,12 +503,11 @@ async fn build_node_directly(
         peppy_dirs: ctx.peppy_dirs.clone(),
     };
 
-    let max_timeout = Duration::from_secs(ctx.max_timeout_secs);
     let log_file_for_timeout = log_file.clone();
     let log_path_for_timeout = log_path.clone();
+    let idle_secs = ctx.node_build_idle_timeout.as_secs();
 
-    let result = match tokio::time::timeout(
-        max_timeout,
+    let result = match run_phase_with_timeouts(
         run_node_build_for_entity(
             node_name.clone(),
             node_tag.clone(),
@@ -426,15 +517,26 @@ async fn build_node_directly(
             log_file,
             log_path,
         ),
+        activity_notify,
+        ctx.node_build_idle_timeout,
+        ctx.launch_deadline,
     )
     .await
     {
-        Ok(result) => result,
-        Err(_) => {
-            write_error_to_log(&log_file_for_timeout, "max timeout exceeded");
+        PhaseOutcome::Completed(result) => result,
+        PhaseOutcome::IdleTimeout => {
+            let msg = format!("build idle timeout exceeded ({idle_secs}s without output)");
+            write_error_to_log(&log_file_for_timeout, &format!("timeout: {msg}"));
             crate::encoding::NodeBuildResult::failure(
                 &log_path_for_timeout,
-                "timeout: max timeout exceeded",
+                format!("timeout: {msg}"),
+            )
+        }
+        PhaseOutcome::MaxTimeout => {
+            write_error_to_log(&log_file_for_timeout, "max launch timeout exceeded");
+            crate::encoding::NodeBuildResult::failure(
+                &log_path_for_timeout,
+                "timeout: max launch timeout exceeded",
             )
         }
     };
@@ -460,10 +562,12 @@ async fn start_node_directly(
     log_path: PathBuf,
     log_file: Arc<StdMutex<File>>,
 ) -> (std::result::Result<NodeRunResult, String>, Option<PathBuf>) {
+    let activity_notify = Arc::new(Notify::new());
     let (feedback_tx, _forwarder_handle) = spawn_feedback_forwarder(
         &ctx.feedback_publisher,
         LaunchFeedbackStep::RunningNode,
         &ctx.log_file,
+        Some(Arc::clone(&activity_notify)),
     );
 
     let action_context = NodeRunActionContext {
@@ -480,10 +584,9 @@ async fn start_node_directly(
     };
 
     let log_file_for_timeout = log_file.clone();
-    let max_timeout = Duration::from_secs(ctx.max_timeout_secs);
+    let idle_secs = ctx.node_run_idle_timeout.as_secs();
 
-    let result = match tokio::time::timeout(
-        max_timeout,
+    let result = match run_phase_with_timeouts(
         run_node_run(
             node_run_goal,
             runtime_config,
@@ -492,13 +595,21 @@ async fn start_node_directly(
             log_file,
             ctx.core_instance_id.clone(),
         ),
+        activity_notify,
+        ctx.node_run_idle_timeout,
+        ctx.launch_deadline,
     )
     .await
     {
-        Ok(result) => result,
-        Err(_) => {
-            write_error_to_log(&log_file_for_timeout, "max timeout exceeded");
-            NodeRunResult::failure("timeout: max timeout exceeded")
+        PhaseOutcome::Completed(result) => result,
+        PhaseOutcome::IdleTimeout => {
+            let msg = format!("run idle timeout exceeded ({idle_secs}s without output)");
+            write_error_to_log(&log_file_for_timeout, &format!("timeout: {msg}"));
+            NodeRunResult::failure(format!("timeout: {msg}"))
+        }
+        PhaseOutcome::MaxTimeout => {
+            write_error_to_log(&log_file_for_timeout, "max launch timeout exceeded");
+            NodeRunResult::failure("timeout: max launch timeout exceeded")
         }
     };
 
@@ -921,6 +1032,20 @@ async fn add_nodes_to_stack(
             continue;
         };
 
+        // Short-circuit between iterations if the launch deadline has passed. Catches the case
+        // where many fast adds collectively blow the budget without any single one tripping
+        // `timeout_at` mid-flight.
+        if let Some(deadline) = ctx.launch_deadline
+            && Instant::now() >= deadline
+        {
+            return Err(restore_stack(
+                ctx,
+                backup_stack,
+                "timeout: max launch timeout exceeded".to_string(),
+            )
+            .await);
+        }
+
         publish_stdout(
             ctx,
             format!("Adding {}", key.label()),
@@ -928,8 +1053,10 @@ async fn add_nodes_to_stack(
         )
         .await;
 
-        // Pass max_timeout_secs to the goal for daemon-side busy reporting
-        let goal_timeout_secs = ctx.max_timeout_secs;
+        // The goal's `timeout_secs` field is used by the action-loop gate elsewhere; in the
+        // stack-launch path `add_node_directly` skips the gate entirely, so this value is
+        // effectively unused. Pass 0 to make that explicit.
+        let goal_timeout_secs = 0;
         let node_add_goal = match &item.source {
             NodeSource::Fs(path) => {
                 NodeAddGoal::new(path.clone(), STACK_LAUNCH_GIT_HASH, goal_timeout_secs)
@@ -1078,12 +1205,13 @@ async fn start_node_instances(
                 }
             };
 
-            // Pass max_timeout_secs to the goal for daemon-side busy reporting
+            // The goal's `timeout_secs` field is unused on the stack-launch path
+            // (start_node_directly skips the action-loop gate). Pass 0 to make that explicit.
             let node_run_goal = NodeRunGoal::new(
                 &runtime_config_json5,
                 item.node_name.as_str(),
                 item.node_tag.as_str(),
-                ctx.max_timeout_secs,
+                0,
             )
             .with_env_vars(ctx.env_vars.clone());
 
@@ -1164,7 +1292,7 @@ async fn handle_goal_request(
         }
     }
 
-    // Decode the goal before marking as Running so we can use max_timeout_secs
+    // Decode the goal before marking as Running so we can capture the user-supplied timeouts
     let goal = match LaunchGoal::decode(payload.as_ref()) {
         Ok(g) => g,
         Err(e) => {
@@ -1180,12 +1308,13 @@ async fn handle_goal_request(
         }
     };
 
-    // Now mark as Running with the actual timeout from the goal
+    // Now mark as Running. `timeout_secs` is gate-reporting only; 0 indicates "no enforced
+    // budget" (when --max-timeout-secs is unset).
     {
         let mut state_guard = state.lock().await;
         *state_guard = ActionState::Running {
             started_at: std::time::Instant::now(),
-            timeout_secs: goal.max_timeout_secs,
+            timeout_secs: goal.max_timeout_secs.unwrap_or(0),
         };
     }
 
@@ -1242,7 +1371,10 @@ async fn handle_goal_request(
             timeouts,
         } = action_context;
         let env_vars = goal.env_vars.clone();
-        let max_timeout_secs = goal.max_timeout_secs;
+        // Compute the launch deadline once. `None` => no overall deadline (idle-only).
+        let launch_deadline = goal
+            .max_timeout_secs
+            .map(|n| Instant::now() + Duration::from_secs(n));
         let ctx = ProcessLaunchContext {
             messenger,
             bound_core_node,
@@ -1254,7 +1386,10 @@ async fn handle_goal_request(
             log_path: log_path_clone.clone(),
             env_vars,
             timeouts,
-            max_timeout_secs,
+            launch_deadline,
+            node_add_idle_timeout: Duration::from_secs(goal.node_add_idle_timeout_secs),
+            node_build_idle_timeout: Duration::from_secs(goal.node_build_idle_timeout_secs),
+            node_run_idle_timeout: Duration::from_secs(goal.node_run_idle_timeout_secs),
         };
         let result = process_launch(goal, ctx).await;
         let mut state_guard = state_clone.lock().await;

--- a/crates/core-node-internal/src/services/stack/launch.rs
+++ b/crates/core-node-internal/src/services/stack/launch.rs
@@ -49,6 +49,15 @@ enum PhaseOutcome<T> {
     MaxTimeout,
 }
 
+/// Per-phase idle timeouts, sourced from the `LaunchGoal` payload. Each phase's clock resets
+/// only on genuine subprocess/git/http activity (see `spawn_feedback_forwarder`).
+#[derive(Clone, Copy)]
+struct IdleTimeouts {
+    add: Duration,
+    build: Duration,
+    run: Duration,
+}
+
 #[derive(Clone, Copy)]
 pub struct StackLaunchTimeouts {
     pub node_startup: Duration,
@@ -134,9 +143,7 @@ struct ProcessLaunchContext {
     /// Whole-launch deadline. `None` means the user did not opt into a max — only idle timeouts
     /// are enforced.
     launch_deadline: Option<Instant>,
-    node_add_idle_timeout: Duration,
-    node_build_idle_timeout: Duration,
-    node_run_idle_timeout: Duration,
+    idle_timeouts: IdleTimeouts,
 }
 
 #[derive(Clone)]
@@ -336,8 +343,8 @@ fn spawn_feedback_forwarder(
             node_stack::build_io::write_feedback_log_line(&log_file, line.stream, &line.line);
 
             let launch_feedback = match line.stream {
-                FeedbackStream::Stdout => LaunchFeedback::stdout(&line.line, step.clone()),
-                FeedbackStream::Stderr => LaunchFeedback::stderr(&line.line, step.clone()),
+                FeedbackStream::Stdout => LaunchFeedback::stdout(&line.line, step),
+                FeedbackStream::Stderr => LaunchFeedback::stderr(&line.line, step),
                 // Warnings bypass the per-node scrolling step and surface as
                 // persistent LauncherStep stderr lines so the operator sees
                 // them even after the step buffer scrolls past.
@@ -395,6 +402,41 @@ where
     }
 }
 
+/// Runs a phase future under idle + (optional) deadline bounds and, on timeout, writes the
+/// reason to `log_file` and builds a caller-specified failure result. `build_failure`
+/// receives the same string that was logged so phase-specific failure types (differing in
+/// whether they carry a `log_path`) can embed it verbatim.
+async fn run_phase<F, T>(
+    phase: F,
+    activity_notify: Arc<Notify>,
+    idle_timeout: Duration,
+    launch_deadline: Option<Instant>,
+    log_file: &Arc<StdMutex<File>>,
+    step: LaunchFeedbackStep,
+    build_failure: impl FnOnce(String) -> T,
+) -> T
+where
+    F: std::future::Future<Output = T>,
+{
+    match run_phase_with_timeouts(phase, activity_notify, idle_timeout, launch_deadline).await {
+        PhaseOutcome::Completed(result) => result,
+        PhaseOutcome::IdleTimeout => {
+            let reason = format!(
+                "timeout: {} idle timeout exceeded ({}s without output)",
+                step.phase_label(),
+                idle_timeout.as_secs()
+            );
+            write_error_to_log(log_file, &reason);
+            build_failure(reason)
+        }
+        PhaseOutcome::MaxTimeout => {
+            let reason = "timeout: max launch timeout exceeded".to_string();
+            write_error_to_log(log_file, &reason);
+            build_failure(reason)
+        }
+    }
+}
+
 async fn add_node_directly(
     ctx: &ProcessLaunchContext,
     node_add_goal: NodeAddGoal,
@@ -427,9 +469,8 @@ async fn add_node_directly(
 
     let log_file_for_timeout = log_file.clone();
     let log_path_for_timeout = log_path.clone();
-    let idle_secs = ctx.node_add_idle_timeout.as_secs();
 
-    let result = match run_phase_with_timeouts(
+    let result = run_phase(
         run_node_add(
             node_add_goal,
             action_context,
@@ -439,25 +480,13 @@ async fn add_node_directly(
             timestamp,
         ),
         activity_notify,
-        ctx.node_add_idle_timeout,
+        ctx.idle_timeouts.add,
         ctx.launch_deadline,
+        &log_file_for_timeout,
+        LaunchFeedbackStep::AddingNode,
+        |reason| NodeAddResult::failure(&log_path_for_timeout, reason),
     )
-    .await
-    {
-        PhaseOutcome::Completed(result) => result,
-        PhaseOutcome::IdleTimeout => {
-            let msg = format!("add idle timeout exceeded ({idle_secs}s without output)");
-            write_error_to_log(&log_file_for_timeout, &format!("timeout: {msg}"));
-            NodeAddResult::failure(&log_path_for_timeout, format!("timeout: {msg}"))
-        }
-        PhaseOutcome::MaxTimeout => {
-            write_error_to_log(&log_file_for_timeout, "max launch timeout exceeded");
-            NodeAddResult::failure(
-                &log_path_for_timeout,
-                "timeout: max launch timeout exceeded",
-            )
-        }
-    };
+    .await;
 
     // Wait for feedback forwarder to drain.
     let _ = forwarder_handle.await;
@@ -505,9 +534,8 @@ async fn build_node_directly(
 
     let log_file_for_timeout = log_file.clone();
     let log_path_for_timeout = log_path.clone();
-    let idle_secs = ctx.node_build_idle_timeout.as_secs();
 
-    let result = match run_phase_with_timeouts(
+    let result = run_phase(
         run_node_build_for_entity(
             node_name.clone(),
             node_tag.clone(),
@@ -518,28 +546,13 @@ async fn build_node_directly(
             log_path,
         ),
         activity_notify,
-        ctx.node_build_idle_timeout,
+        ctx.idle_timeouts.build,
         ctx.launch_deadline,
+        &log_file_for_timeout,
+        LaunchFeedbackStep::BuildingNode,
+        |reason| crate::encoding::NodeBuildResult::failure(&log_path_for_timeout, reason),
     )
-    .await
-    {
-        PhaseOutcome::Completed(result) => result,
-        PhaseOutcome::IdleTimeout => {
-            let msg = format!("build idle timeout exceeded ({idle_secs}s without output)");
-            write_error_to_log(&log_file_for_timeout, &format!("timeout: {msg}"));
-            crate::encoding::NodeBuildResult::failure(
-                &log_path_for_timeout,
-                format!("timeout: {msg}"),
-            )
-        }
-        PhaseOutcome::MaxTimeout => {
-            write_error_to_log(&log_file_for_timeout, "max launch timeout exceeded");
-            crate::encoding::NodeBuildResult::failure(
-                &log_path_for_timeout,
-                "timeout: max launch timeout exceeded",
-            )
-        }
-    };
+    .await;
 
     let _ = forwarder_handle.await;
 
@@ -584,9 +597,8 @@ async fn start_node_directly(
     };
 
     let log_file_for_timeout = log_file.clone();
-    let idle_secs = ctx.node_run_idle_timeout.as_secs();
 
-    let result = match run_phase_with_timeouts(
+    let result = run_phase(
         run_node_run(
             node_run_goal,
             runtime_config,
@@ -596,22 +608,13 @@ async fn start_node_directly(
             ctx.core_instance_id.clone(),
         ),
         activity_notify,
-        ctx.node_run_idle_timeout,
+        ctx.idle_timeouts.run,
         ctx.launch_deadline,
+        &log_file_for_timeout,
+        LaunchFeedbackStep::RunningNode,
+        NodeRunResult::failure,
     )
-    .await
-    {
-        PhaseOutcome::Completed(result) => result,
-        PhaseOutcome::IdleTimeout => {
-            let msg = format!("run idle timeout exceeded ({idle_secs}s without output)");
-            write_error_to_log(&log_file_for_timeout, &format!("timeout: {msg}"));
-            NodeRunResult::failure(format!("timeout: {msg}"))
-        }
-        PhaseOutcome::MaxTimeout => {
-            write_error_to_log(&log_file_for_timeout, "max launch timeout exceeded");
-            NodeRunResult::failure("timeout: max launch timeout exceeded")
-        }
-    };
+    .await;
 
     // Don't await _forwarder_handle — the node process is still running and
     // output readers keep the internal channel alive.
@@ -1039,36 +1042,9 @@ async fn add_nodes_to_stack(
         )
         .await;
 
-        // `timeout_secs` drives the action-loop gate, which `add_node_directly` bypasses.
-        let goal_timeout_secs = 0;
-        let node_add_goal = match &item.source {
-            NodeSource::Fs(path) => {
-                NodeAddGoal::new(path.clone(), STACK_LAUNCH_GIT_HASH, goal_timeout_secs)
-            }
-            NodeSource::Git {
-                repo_url,
-                repo_path,
-                repo_ref,
-            } => NodeAddGoal::new_git(
-                repo_url.clone(),
-                repo_path.clone(),
-                repo_ref.clone(),
-                STACK_LAUNCH_GIT_HASH,
-                goal_timeout_secs,
-            ),
-            NodeSource::Http { url, sha256 } => NodeAddGoal::new_http(
-                url.clone(),
-                sha256.clone(),
-                STACK_LAUNCH_GIT_HASH,
-                goal_timeout_secs,
-            ),
-            NodeSource::RepoNode { .. } => NodeAddGoal::from_source(
-                item.source.clone(),
-                STACK_LAUNCH_GIT_HASH,
-                goal_timeout_secs,
-            ),
-        }
-        .with_env_vars(ctx.env_vars.clone());
+        let node_add_goal =
+            NodeAddGoal::for_internal_execution(item.source.clone(), STACK_LAUNCH_GIT_HASH)
+                .with_env_vars(ctx.env_vars.clone());
 
         let node_add_goal = match item.variant {
             Some(ref variant) => node_add_goal.with_variant_source(variant.clone()),
@@ -1189,12 +1165,10 @@ async fn start_node_instances(
                 }
             };
 
-            // `timeout_secs` drives the action-loop gate, which `start_node_directly` bypasses.
-            let node_run_goal = NodeRunGoal::new(
+            let node_run_goal = NodeRunGoal::for_internal_execution(
                 &runtime_config_json5,
                 item.node_name.as_str(),
                 item.node_tag.as_str(),
-                0,
             )
             .with_env_vars(ctx.env_vars.clone());
 
@@ -1370,9 +1344,11 @@ async fn handle_goal_request(
             env_vars,
             timeouts,
             launch_deadline,
-            node_add_idle_timeout: Duration::from_secs(goal.node_add_idle_timeout_secs),
-            node_build_idle_timeout: Duration::from_secs(goal.node_build_idle_timeout_secs),
-            node_run_idle_timeout: Duration::from_secs(goal.node_run_idle_timeout_secs),
+            idle_timeouts: IdleTimeouts {
+                add: Duration::from_secs(goal.node_add_idle_timeout_secs),
+                build: Duration::from_secs(goal.node_build_idle_timeout_secs),
+                run: Duration::from_secs(goal.node_run_idle_timeout_secs),
+            },
         };
         let result = process_launch(goal, ctx).await;
         let mut state_guard = state_clone.lock().await;

--- a/crates/core-node-internal/src/services/stack/launch.rs
+++ b/crates/core-node-internal/src/services/stack/launch.rs
@@ -1032,20 +1032,6 @@ async fn add_nodes_to_stack(
             continue;
         };
 
-        // Short-circuit between iterations if the launch deadline has passed. Catches the case
-        // where many fast adds collectively blow the budget without any single one tripping
-        // `timeout_at` mid-flight.
-        if let Some(deadline) = ctx.launch_deadline
-            && Instant::now() >= deadline
-        {
-            return Err(restore_stack(
-                ctx,
-                backup_stack,
-                "timeout: max launch timeout exceeded".to_string(),
-            )
-            .await);
-        }
-
         publish_stdout(
             ctx,
             format!("Adding {}", key.label()),
@@ -1053,9 +1039,7 @@ async fn add_nodes_to_stack(
         )
         .await;
 
-        // The goal's `timeout_secs` field is used by the action-loop gate elsewhere; in the
-        // stack-launch path `add_node_directly` skips the gate entirely, so this value is
-        // effectively unused. Pass 0 to make that explicit.
+        // `timeout_secs` drives the action-loop gate, which `add_node_directly` bypasses.
         let goal_timeout_secs = 0;
         let node_add_goal = match &item.source {
             NodeSource::Fs(path) => {
@@ -1205,8 +1189,7 @@ async fn start_node_instances(
                 }
             };
 
-            // The goal's `timeout_secs` field is unused on the stack-launch path
-            // (start_node_directly skips the action-loop gate). Pass 0 to make that explicit.
+            // `timeout_secs` drives the action-loop gate, which `start_node_directly` bypasses.
             let node_run_goal = NodeRunGoal::new(
                 &runtime_config_json5,
                 item.node_name.as_str(),

--- a/crates/core-node-internal/tests/listen_for_launch.rs
+++ b/crates/core-node-internal/tests/listen_for_launch.rs
@@ -318,7 +318,8 @@ async fn send_node_launch_and_wait_with_env(
     result_timeout: Duration,
     env_vars: Vec<(String, String)>,
 ) -> Result<(LaunchGoalResponse, LaunchResult), String> {
-    let goal = LaunchGoal::new(peppy_launch_file_path, 300, 300, 3600).with_env_vars(env_vars);
+    let goal =
+        LaunchGoal::new(peppy_launch_file_path, 300, 300, 300, Some(3600)).with_env_vars(env_vars);
     let goal_payload = goal
         .encode()
         .map_err(|e| format!("Failed to encode launch goal: {e}"))?;

--- a/crates/node-stack-internal/Cargo.toml
+++ b/crates/node-stack-internal/Cargo.toml
@@ -19,6 +19,7 @@ chrono = "0.4"
 tracing = "0.1"
 parking_lot = { workspace = true }
 tempfile = "3.10"
+process-wrap = { version = "9.1.0", features = ["tokio1", "process-group"] }
 
 
 [dev-dependencies]

--- a/crates/node-stack-internal/src/build_io.rs
+++ b/crates/node-stack-internal/src/build_io.rs
@@ -133,21 +133,24 @@ pub fn push_stderr_line(buffer: &Arc<StdMutex<VecDeque<String>>>, line: &str) {
     guard.push_back(line.to_string());
 }
 
-/// Re-exports of the [`process_wrap`] tokio API used by the build path.
+pub use process_wrap::tokio::ChildWrapper;
+use process_wrap::tokio::{CommandWrap, ProcessGroup};
+
+/// Spawns `cmd` as a process-group leader so [`stream_child_output`]'s
+/// `KillGuard` can signal the entire subprocess tree on cancellation.
 ///
-/// **Why callers must use these:** if the daemon forcibly cancels a child
-/// (e.g. an idle/max timeout fires inside [`stream_child_output`]'s
-/// `KillGuard`), a single-pid kill would only reach the immediate child. Any
-/// descendants — e.g. `sleep` spawned by a `sh -c "..."` wrapper, or `cargo`
-/// spawned by a `make` target — would be orphaned and keep the daemon's
-/// stdout/stderr pipes open until they exit naturally, stalling the
-/// cancellation.
-///
-/// Wrapping the spawn with [`ProcessGroup::leader()`] makes the child its own
-/// process-group leader (PGID == its PID); the `KillGuard`'s
-/// `start_kill()` then signals the entire group, killing the whole subprocess
-/// tree atomically.
-pub use process_wrap::tokio::{ChildWrapper, CommandWrap, ProcessGroup};
+/// A single-pid kill would only reach the immediate child; descendants — e.g.
+/// `sleep` inside a `sh -c "..."` wrapper, or `cargo` under a `make` target —
+/// would be orphaned and keep the daemon's stdio pipes open until they exit
+/// naturally, stalling cancellation. Making the child its own process-group
+/// leader (PGID == its PID) lets `start_kill()` signal the whole group.
+pub fn spawn_in_process_group(
+    cmd: tokio::process::Command,
+) -> std::io::Result<Box<dyn ChildWrapper>> {
+    let mut wrap = CommandWrap::from(cmd);
+    wrap.wrap(ProcessGroup::leader());
+    wrap.spawn()
+}
 
 /// Streams stdout/stderr from a spawned child process to both the feedback
 /// publisher and the log file. Optionally collects the last [`STDERR_TAIL_LINES`]
@@ -156,12 +159,10 @@ pub use process_wrap::tokio::{ChildWrapper, CommandWrap, ProcessGroup};
 /// Returns the process exit status and (if `collect_stderr_tail` is true) the
 /// collected stderr tail lines.
 ///
-/// **Cancellation contract:** the child must be spawned via a [`CommandWrap`]
-/// wrapped with [`ProcessGroup::leader()`] (i.e. as a process-group leader),
-/// so that if this future is dropped before the child exits, the internal
-/// `KillGuard` can SIGKILL the entire subprocess tree. Without group spawning,
-/// descendants would be orphaned and keep the daemon's pipes open until they
-/// exit naturally.
+/// **Cancellation contract:** the child must have been spawned via
+/// [`spawn_in_process_group`] so that if this future is dropped before the
+/// child exits, the internal `KillGuard` can SIGKILL the entire subprocess
+/// tree.
 pub async fn stream_child_output(
     mut child: Box<dyn ChildWrapper>,
     feedback_tx: &mpsc::UnboundedSender<FeedbackLine>,
@@ -209,13 +210,9 @@ pub async fn stream_child_output(
     }
 
     // Cancellation safety: if this future is dropped before `child.wait()`
-    // returns (e.g. the task is cancelled), `KillGuard::drop` calls
-    // `ChildWrapper::start_kill`, which (when wrapped with `ProcessGroup`)
-    // signals the entire process group. Targeting the group (not just the
-    // immediate child) is what makes `sh -c "..."` wrappers cancellable —
-    // otherwise the shell dies but its descendants keep the stdio pipes open
-    // until they exit naturally. Requires the child to have been spawned via
-    // a `CommandWrap` wrapped with `ProcessGroup::leader()`.
+    // returns, `KillGuard::drop` calls `start_kill`, which targets the whole
+    // process group (see `spawn_in_process_group`) so `sh -c "..."` wrappers
+    // and their descendants all die together.
     struct KillGuard<'a> {
         child: &'a mut dyn ChildWrapper,
         completed: bool,

--- a/crates/node-stack-internal/src/build_io.rs
+++ b/crates/node-stack-internal/src/build_io.rs
@@ -133,14 +133,37 @@ pub fn push_stderr_line(buffer: &Arc<StdMutex<VecDeque<String>>>, line: &str) {
     guard.push_back(line.to_string());
 }
 
+/// Re-exports of the [`process_wrap`] tokio API used by the build path.
+///
+/// **Why callers must use these:** if the daemon forcibly cancels a child
+/// (e.g. an idle/max timeout fires inside [`stream_child_output`]'s
+/// `KillGuard`), a single-pid kill would only reach the immediate child. Any
+/// descendants — e.g. `sleep` spawned by a `sh -c "..."` wrapper, or `cargo`
+/// spawned by a `make` target — would be orphaned and keep the daemon's
+/// stdout/stderr pipes open until they exit naturally, stalling the
+/// cancellation.
+///
+/// Wrapping the spawn with [`ProcessGroup::leader()`] makes the child its own
+/// process-group leader (PGID == its PID); the `KillGuard`'s
+/// `start_kill()` then signals the entire group, killing the whole subprocess
+/// tree atomically.
+pub use process_wrap::tokio::{ChildWrapper, CommandWrap, ProcessGroup};
+
 /// Streams stdout/stderr from a spawned child process to both the feedback
 /// publisher and the log file. Optionally collects the last [`STDERR_TAIL_LINES`]
 /// lines of stderr for error diagnostics.
 ///
 /// Returns the process exit status and (if `collect_stderr_tail` is true) the
 /// collected stderr tail lines.
+///
+/// **Cancellation contract:** the child must be spawned via a [`CommandWrap`]
+/// wrapped with [`ProcessGroup::leader()`] (i.e. as a process-group leader),
+/// so that if this future is dropped before the child exits, the internal
+/// `KillGuard` can SIGKILL the entire subprocess tree. Without group spawning,
+/// descendants would be orphaned and keep the daemon's pipes open until they
+/// exit naturally.
 pub async fn stream_child_output(
-    mut child: tokio::process::Child,
+    mut child: Box<dyn ChildWrapper>,
     feedback_tx: &mpsc::UnboundedSender<FeedbackLine>,
     log_file: Arc<StdMutex<File>>,
     collect_stderr_tail: bool,
@@ -161,7 +184,7 @@ pub async fn stream_child_output(
     // build path has no quiescence tracking and no publish gate.
     let publish_enabled = Arc::new(AtomicBool::new(true));
     let hooks: Arc<dyn OutputReaderHooks> = Arc::new(NoOpHooks);
-    if let Some(stdout) = child.stdout.take() {
+    if let Some(stdout) = child.stdout().take() {
         reader_handles.push(spawn_output_reader_async(
             stdout,
             feedback_tx.clone(),
@@ -173,7 +196,7 @@ pub async fn stream_child_output(
         ));
     }
 
-    if let Some(stderr) = child.stderr.take() {
+    if let Some(stderr) = child.stderr().take() {
         reader_handles.push(spawn_output_reader_async(
             stderr,
             feedback_tx.clone(),
@@ -186,11 +209,15 @@ pub async fn stream_child_output(
     }
 
     // Cancellation safety: if this future is dropped before `child.wait()`
-    // returns (e.g. the task is cancelled), kill the child synchronously
-    // from the Drop impl so the OS process does not orphan. tokio::process
-    // does not enable kill_on_drop by default.
+    // returns (e.g. the task is cancelled), `KillGuard::drop` calls
+    // `ChildWrapper::start_kill`, which (when wrapped with `ProcessGroup`)
+    // signals the entire process group. Targeting the group (not just the
+    // immediate child) is what makes `sh -c "..."` wrappers cancellable —
+    // otherwise the shell dies but its descendants keep the stdio pipes open
+    // until they exit naturally. Requires the child to have been spawned via
+    // a `CommandWrap` wrapped with `ProcessGroup::leader()`.
     struct KillGuard<'a> {
-        child: &'a mut tokio::process::Child,
+        child: &'a mut dyn ChildWrapper,
         completed: bool,
     }
     impl Drop for KillGuard<'_> {
@@ -201,7 +228,7 @@ pub async fn stream_child_output(
         }
     }
     let mut guard = KillGuard {
-        child: &mut child,
+        child: child.as_mut(),
         completed: false,
     };
     let status = guard

--- a/crates/node-stack-internal/src/node_stack/build_steps.rs
+++ b/crates/node-stack-internal/src/node_stack/build_steps.rs
@@ -11,7 +11,9 @@ use tokio::sync::mpsc;
 use tracing::debug;
 use zstd::stream::write::Encoder as ZstdEncoder;
 
-use crate::build_io::{FeedbackLine, FeedbackStream, stream_child_output};
+use crate::build_io::{
+    CommandWrap, FeedbackLine, FeedbackStream, ProcessGroup, stream_child_output,
+};
 
 /// Per-process counter used to make build-staging tmp filenames unique so
 /// concurrent builds for the same node:tag cannot clobber each other.
@@ -195,7 +197,12 @@ pub(super) async fn build_container_image(
     cmd.stderr(Stdio::piped());
     cmd.stdin(Stdio::null());
 
-    let child = cmd
+    // Spawn as a process-group leader so a cancelled build can SIGKILL the
+    // whole subprocess tree (apptainer shells out to `lima` / nested commands
+    // — a single-pid kill would orphan them and stall the daemon's pipes).
+    let mut wrap = CommandWrap::from(cmd);
+    wrap.wrap(ProcessGroup::leader());
+    let child = wrap
         .spawn()
         .map_err(|e| format!("Failed to spawn apptainer build: {}", e))?;
 
@@ -324,7 +331,14 @@ pub(super) async fn run_build_cmd(
     for (key, value) in env_vars {
         command.env(key, value);
     }
-    let child = command
+    // Spawn as a process-group leader so cancellation (idle/max timeout, future
+    // --force) can SIGKILL the whole subprocess tree. A user `build_cmd` like
+    // `sh -c "make all"` spawns shell descendants that would otherwise be
+    // orphaned by a single-pid kill and would keep the daemon's stdio pipes
+    // open until they exit naturally.
+    let mut wrap = CommandWrap::from(command);
+    wrap.wrap(ProcessGroup::leader());
+    let child = wrap
         .spawn()
         .map_err(|e| format!("failed to execute build_cmd `{}`: {}", full_cmd_display, e))?;
 

--- a/crates/node-stack-internal/src/node_stack/build_steps.rs
+++ b/crates/node-stack-internal/src/node_stack/build_steps.rs
@@ -11,9 +11,7 @@ use tokio::sync::mpsc;
 use tracing::debug;
 use zstd::stream::write::Encoder as ZstdEncoder;
 
-use crate::build_io::{
-    CommandWrap, FeedbackLine, FeedbackStream, ProcessGroup, stream_child_output,
-};
+use crate::build_io::{FeedbackLine, FeedbackStream, spawn_in_process_group, stream_child_output};
 
 /// Per-process counter used to make build-staging tmp filenames unique so
 /// concurrent builds for the same node:tag cannot clobber each other.
@@ -197,13 +195,7 @@ pub(super) async fn build_container_image(
     cmd.stderr(Stdio::piped());
     cmd.stdin(Stdio::null());
 
-    // Spawn as a process-group leader so a cancelled build can SIGKILL the
-    // whole subprocess tree (apptainer shells out to `lima` / nested commands
-    // — a single-pid kill would orphan them and stall the daemon's pipes).
-    let mut wrap = CommandWrap::from(cmd);
-    wrap.wrap(ProcessGroup::leader());
-    let child = wrap
-        .spawn()
+    let child = spawn_in_process_group(cmd)
         .map_err(|e| format!("Failed to spawn apptainer build: {}", e))?;
 
     let (status, stderr_tail) =
@@ -331,15 +323,7 @@ pub(super) async fn run_build_cmd(
     for (key, value) in env_vars {
         command.env(key, value);
     }
-    // Spawn as a process-group leader so cancellation (idle/max timeout, future
-    // --force) can SIGKILL the whole subprocess tree. A user `build_cmd` like
-    // `sh -c "make all"` spawns shell descendants that would otherwise be
-    // orphaned by a single-pid kill and would keep the daemon's stdio pipes
-    // open until they exit naturally.
-    let mut wrap = CommandWrap::from(command);
-    wrap.wrap(ProcessGroup::leader());
-    let child = wrap
-        .spawn()
+    let child = spawn_in_process_group(command)
         .map_err(|e| format!("failed to execute build_cmd `{}`: {}", full_cmd_display, e))?;
 
     let (status, _) = stream_child_output(child, feedback_tx, log_file, false).await?;

--- a/crates/peppy/src/commands/stack.rs
+++ b/crates/peppy/src/commands/stack.rs
@@ -10,7 +10,7 @@ use clap::Subcommand;
 use tracing::info;
 
 use super::Command;
-use super::node::{DEFAULT_IDLE_TIMEOUT_SECS, DEFAULT_MAX_TIMEOUT_SECS};
+use super::node::DEFAULT_IDLE_TIMEOUT_SECS;
 use crate::{context::AppContext, error::Error as CommandError};
 
 #[derive(Subcommand)]
@@ -19,15 +19,18 @@ pub enum StackCommands {
     Launch {
         /// Path to the peppy launcher configuration file
         launcher_config_path: PathBuf,
-        /// Idle timeout in seconds for each node add operation (resets on output)
+        /// Idle timeout in seconds for the node add phase (resets on git/http progress or sub-process output)
         #[arg(long, default_value_t = DEFAULT_IDLE_TIMEOUT_SECS)]
         node_add_idle_timeout_secs: u64,
-        /// Idle timeout in seconds for each node run operation (resets on output)
+        /// Idle timeout in seconds for the node build phase (resets on build_cmd output)
+        #[arg(long, default_value_t = DEFAULT_IDLE_TIMEOUT_SECS)]
+        node_build_idle_timeout_secs: u64,
+        /// Idle timeout in seconds for the node run-startup phase (resets on subprocess output until the node signals ready)
         #[arg(long, default_value_t = DEFAULT_IDLE_TIMEOUT_SECS)]
         node_run_idle_timeout_secs: u64,
-        /// Absolute max timeout in seconds per operation (safety net)
-        #[arg(long, default_value_t = DEFAULT_MAX_TIMEOUT_SECS)]
-        max_timeout_secs: u64,
+        /// Optional absolute max timeout in seconds for the entire launch. If unset, only idle timeouts apply.
+        #[arg(long)]
+        max_timeout_secs: Option<u64>,
     },
     /// List the nodes in the current node stack
     List {
@@ -47,6 +50,7 @@ impl Command for StackCommand {
             StackCommands::Launch {
                 launcher_config_path,
                 node_add_idle_timeout_secs,
+                node_build_idle_timeout_secs,
                 node_run_idle_timeout_secs,
                 max_timeout_secs,
             } => {
@@ -55,6 +59,7 @@ impl Command for StackCommand {
                     ctx,
                     launcher_config_path,
                     node_add_idle_timeout_secs,
+                    node_build_idle_timeout_secs,
                     node_run_idle_timeout_secs,
                     max_timeout_secs,
                 )

--- a/crates/peppy/src/commands/stack/launch.rs
+++ b/crates/peppy/src/commands/stack/launch.rs
@@ -16,10 +16,10 @@ use crate::context::AppContext;
 use crate::error::{Error, Result};
 use crate::terminal::ScrollingOutput;
 
-// CLI-side floor for the overall safety net when the user does not pass `--max-timeout-secs`.
-// When they do pass it, we use `max_timeout_secs + DAEMON_RESPONSE_GRACE` (or this floor,
-// whichever is greater) so the daemon's own deadline always fires first and surfaces a clean
-// error before this fallback.
+// Minimum CLI fallback ceiling when the user opts into `--max-timeout-secs`. Ensures the CLI's
+// safety net never fires before the daemon's own per-phase timeout, so users see a precise
+// daemon-side error rather than a generic CLI fallback. When the user omits the flag, no CLI
+// ceiling is installed — the contract is idle-only (daemon-side `max_timeout_secs = None`).
 const CLI_MAX_TIMEOUT_FLOOR: Duration = Duration::from_secs(7200);
 // Headroom granted to the daemon to surface its own timeout error before the CLI's fallback
 // ceiling fires. Keeps the error the user sees specific ("build idle timeout exceeded...") rather
@@ -27,6 +27,17 @@ const CLI_MAX_TIMEOUT_FLOOR: Duration = Duration::from_secs(7200);
 const DAEMON_RESPONSE_GRACE: Duration = Duration::from_secs(60);
 const FEEDBACK_DRAIN_TIMEOUT: Duration = Duration::from_millis(50);
 const RESULT_POLL_TIMEOUT: Duration = Duration::from_millis(200);
+
+// CLI wall-clock fallback ceiling. `None` means idle-only (daemon-side contract honored).
+// When the user opts into `--max-timeout-secs`, add DAEMON_RESPONSE_GRACE and enforce
+// CLI_MAX_TIMEOUT_FLOOR so the daemon's per-phase error fires first.
+fn compute_cli_max_timeout(max_timeout_secs: Option<u64>) -> Option<Duration> {
+    max_timeout_secs.map(|n| {
+        Duration::from_secs(n)
+            .saturating_add(DAEMON_RESPONSE_GRACE)
+            .max(CLI_MAX_TIMEOUT_FLOOR)
+    })
+}
 
 fn display_node_log_files(
     add_logs: &[NodeAddLogEntry],
@@ -172,13 +183,8 @@ async fn launch_async(
 
     // CLI fallback ceiling: when the user opts into a max we grant the daemon a response-grace
     // window to surface its own error first, but never less than the absolute floor in case the
-    // daemon hangs entirely.
-    let cli_max_timeout = match max_timeout_secs {
-        Some(n) => Duration::from_secs(n)
-            .saturating_add(DAEMON_RESPONSE_GRACE)
-            .max(CLI_MAX_TIMEOUT_FLOOR),
-        None => CLI_MAX_TIMEOUT_FLOOR,
-    };
+    // daemon hangs entirely. `None` honors the daemon's idle-only contract — no CLI ceiling.
+    let cli_max_timeout: Option<Duration> = compute_cli_max_timeout(max_timeout_secs);
 
     // CLI-side liveness watchdog: trips if no feedback arrives from any phase. Must cover the
     // longest per-phase idle budget (only one phase runs at a time) plus a grace window so the
@@ -220,7 +226,8 @@ async fn launch_async(
         goal_response.log_path.display()
     );
 
-    let absolute_deadline = tokio::time::Instant::now() + cli_max_timeout;
+    let absolute_deadline: Option<tokio::time::Instant> =
+        cli_max_timeout.map(|d| tokio::time::Instant::now() + d);
     let mut last_activity = tokio::time::Instant::now();
     let mut scrolling_output: Option<ScrollingOutput> = None;
     let mut current_scrolling_step: Option<LaunchFeedbackStep> = None;
@@ -229,7 +236,9 @@ async fn launch_async(
         // Drain feedback so the subscriber channel doesn't fill up and block publication.
         loop {
             let now = tokio::time::Instant::now();
-            if now >= absolute_deadline {
+            if let Some(deadline) = absolute_deadline
+                && now >= deadline
+            {
                 if let Some(output) = scrolling_output.as_mut() {
                     output.clear();
                 }
@@ -269,7 +278,9 @@ async fn launch_async(
         }
 
         let now = tokio::time::Instant::now();
-        if now >= absolute_deadline {
+        if let Some(deadline) = absolute_deadline
+            && now >= deadline
+        {
             return Err(Error::ExecutionFailed(format!(
                 "Launch timed out: max timeout exceeded. Log file: {}",
                 goal_response.log_path.display()
@@ -350,5 +361,34 @@ async fn launch_async(
         }
 
         tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn none_preserves_idle_only_contract() {
+        assert_eq!(compute_cli_max_timeout(None), None);
+    }
+
+    #[test]
+    fn small_value_hits_the_floor() {
+        let got = compute_cli_max_timeout(Some(60)).expect("some");
+        assert_eq!(got, CLI_MAX_TIMEOUT_FLOOR);
+    }
+
+    #[test]
+    fn large_value_dominates_the_floor() {
+        let n = CLI_MAX_TIMEOUT_FLOOR.as_secs() * 2;
+        let got = compute_cli_max_timeout(Some(n)).expect("some");
+        assert_eq!(got, Duration::from_secs(n) + DAEMON_RESPONSE_GRACE);
+    }
+
+    #[test]
+    fn saturating_add_does_not_panic_at_u64_max() {
+        let got = compute_cli_max_timeout(Some(u64::MAX)).expect("some");
+        assert_eq!(got, Duration::MAX);
     }
 }

--- a/crates/peppy/src/commands/stack/launch.rs
+++ b/crates/peppy/src/commands/stack/launch.rs
@@ -10,15 +10,12 @@ use core_node::encoding::{
 use peppylib::{ActionMessenger, PeppyError};
 use tracing::info;
 
-use crate::commands::node::{DEFAULT_IDLE_TIMEOUT_SECS, caller_env_overrides};
+use crate::commands::node::caller_env_overrides;
 use crate::commands::{CALLER_INSTANCE_ID, GOAL_TIMEOUT, SCROLLING_OUTPUT_LINES};
 use crate::context::AppContext;
 use crate::error::{Error, Result};
 use crate::terminal::ScrollingOutput;
 
-// CLI-side liveness timeout: how long we wait without any feedback from the daemon before giving
-// up on it as hung. Independent of the daemon's own per-phase idle timeouts.
-const IDLE_TIMEOUT: Duration = Duration::from_secs(DEFAULT_IDLE_TIMEOUT_SECS);
 // CLI-side floor for the overall safety net when the user does not pass `--max-timeout-secs`.
 // When they do pass it, we use `max_timeout_secs + DAEMON_RESPONSE_GRACE` (or this floor,
 // whichever is greater) so the daemon's own deadline always fires first and surfaces a clean
@@ -183,6 +180,16 @@ async fn launch_async(
         None => CLI_MAX_TIMEOUT_FLOOR,
     };
 
+    // CLI-side liveness watchdog: trips if no feedback arrives from any phase. Must cover the
+    // longest per-phase idle budget (only one phase runs at a time) plus a grace window so the
+    // daemon's phase-specific timeout always fires first and surfaces a precise error.
+    let cli_idle_timeout = Duration::from_secs(
+        node_add_idle_timeout_secs
+            .max(node_build_idle_timeout_secs)
+            .max(node_run_idle_timeout_secs),
+    )
+    .saturating_add(DAEMON_RESPONSE_GRACE);
+
     let mut action_handle = goal
         .send_goal(
             conn.messenger,
@@ -231,13 +238,13 @@ async fn launch_async(
                     goal_response.log_path.display()
                 )));
             }
-            if now.duration_since(last_activity) >= IDLE_TIMEOUT {
+            if now.duration_since(last_activity) >= cli_idle_timeout {
                 if let Some(output) = scrolling_output.as_mut() {
                     output.clear();
                 }
                 return Err(Error::ExecutionFailed(format!(
                     "Launch timed out: no output received for {}s. Log file: {}",
-                    IDLE_TIMEOUT.as_secs(),
+                    cli_idle_timeout.as_secs(),
                     goal_response.log_path.display()
                 )));
             }
@@ -268,10 +275,10 @@ async fn launch_async(
                 goal_response.log_path.display()
             )));
         }
-        if now.duration_since(last_activity) >= IDLE_TIMEOUT {
+        if now.duration_since(last_activity) >= cli_idle_timeout {
             return Err(Error::ExecutionFailed(format!(
                 "Launch timed out: no output received for {}s. Log file: {}",
-                IDLE_TIMEOUT.as_secs(),
+                cli_idle_timeout.as_secs(),
                 goal_response.log_path.display()
             )));
         }

--- a/crates/peppy/src/commands/stack/launch.rs
+++ b/crates/peppy/src/commands/stack/launch.rs
@@ -227,7 +227,7 @@ async fn launch_async(
     );
 
     let absolute_deadline: Option<tokio::time::Instant> =
-        cli_max_timeout.map(|d| tokio::time::Instant::now() + d);
+        cli_max_timeout.and_then(|d| tokio::time::Instant::now().checked_add(d));
     let mut last_activity = tokio::time::Instant::now();
     let mut scrolling_output: Option<ScrollingOutput> = None;
     let mut current_scrolling_step: Option<LaunchFeedbackStep> = None;

--- a/crates/peppy/src/commands/stack/launch.rs
+++ b/crates/peppy/src/commands/stack/launch.rs
@@ -16,10 +16,13 @@ use crate::context::AppContext;
 use crate::error::{Error, Result};
 use crate::terminal::ScrollingOutput;
 
-// Idle timeout for the overall launch result (resets on feedback from daemon)
+// CLI-side liveness timeout: how long we wait without any feedback from the daemon before giving
+// up on it as hung. Independent of the daemon's own per-phase idle timeouts.
 const IDLE_TIMEOUT: Duration = Duration::from_secs(DEFAULT_IDLE_TIMEOUT_SECS);
-// Absolute max timeout for the entire launch operation (2x per-operation max to allow for multi-node sequential processing)
-const MAX_TIMEOUT: Duration = Duration::from_secs(7200);
+// CLI-side floor for the overall safety net when the user does not pass `--max-timeout-secs`.
+// When they do pass it, we use `max_timeout_secs + 60` (or this floor, whichever is greater) so
+// the daemon's own deadline always fires first and surfaces a clean error before this fallback.
+const CLI_MAX_TIMEOUT_FLOOR: Duration = Duration::from_secs(7200);
 const FEEDBACK_DRAIN_TIMEOUT: Duration = Duration::from_millis(50);
 const RESULT_POLL_TIMEOUT: Duration = Duration::from_millis(200);
 
@@ -115,13 +118,15 @@ pub fn launch(
     ctx: &Arc<AppContext>,
     launcher_config_path: PathBuf,
     node_add_idle_timeout_secs: u64,
+    node_build_idle_timeout_secs: u64,
     node_run_idle_timeout_secs: u64,
-    max_timeout_secs: u64,
+    max_timeout_secs: Option<u64>,
 ) -> Result<()> {
     crate::commands::block_on(launch_async(
         ctx,
         launcher_config_path,
         node_add_idle_timeout_secs,
+        node_build_idle_timeout_secs,
         node_run_idle_timeout_secs,
         max_timeout_secs,
     ))
@@ -131,8 +136,9 @@ async fn launch_async(
     ctx: &Arc<AppContext>,
     launcher_config_path: PathBuf,
     node_add_idle_timeout_secs: u64,
+    node_build_idle_timeout_secs: u64,
     node_run_idle_timeout_secs: u64,
-    max_timeout_secs: u64,
+    max_timeout_secs: Option<u64>,
 ) -> Result<()> {
     // Canonicalize the path so the core node can find the file regardless of its working directory
     let launcher_config_path = launcher_config_path.canonicalize().map_err(|e| {
@@ -156,10 +162,19 @@ async fn launch_async(
     let goal = LaunchGoal::new(
         &launcher_config_path,
         node_add_idle_timeout_secs,
+        node_build_idle_timeout_secs,
         node_run_idle_timeout_secs,
         max_timeout_secs,
     )
     .with_env_vars(caller_env_overrides());
+
+    // CLI fallback ceiling: when the user opts into a max we give the daemon `max + 60s` to
+    // surface its own error first, but never less than the absolute floor in case the daemon
+    // hangs entirely.
+    let cli_max_timeout = match max_timeout_secs {
+        Some(n) => Duration::from_secs(n.saturating_add(60)).max(CLI_MAX_TIMEOUT_FLOOR),
+        None => CLI_MAX_TIMEOUT_FLOOR,
+    };
 
     let mut action_handle = goal
         .send_goal(
@@ -191,7 +206,7 @@ async fn launch_async(
         goal_response.log_path.display()
     );
 
-    let absolute_deadline = tokio::time::Instant::now() + MAX_TIMEOUT;
+    let absolute_deadline = tokio::time::Instant::now() + cli_max_timeout;
     let mut last_activity = tokio::time::Instant::now();
     let mut scrolling_output: Option<ScrollingOutput> = None;
     let mut current_scrolling_step: Option<LaunchFeedbackStep> = None;

--- a/crates/peppy/src/commands/stack/launch.rs
+++ b/crates/peppy/src/commands/stack/launch.rs
@@ -20,9 +20,14 @@ use crate::terminal::ScrollingOutput;
 // up on it as hung. Independent of the daemon's own per-phase idle timeouts.
 const IDLE_TIMEOUT: Duration = Duration::from_secs(DEFAULT_IDLE_TIMEOUT_SECS);
 // CLI-side floor for the overall safety net when the user does not pass `--max-timeout-secs`.
-// When they do pass it, we use `max_timeout_secs + 60` (or this floor, whichever is greater) so
-// the daemon's own deadline always fires first and surfaces a clean error before this fallback.
+// When they do pass it, we use `max_timeout_secs + DAEMON_RESPONSE_GRACE` (or this floor,
+// whichever is greater) so the daemon's own deadline always fires first and surfaces a clean
+// error before this fallback.
 const CLI_MAX_TIMEOUT_FLOOR: Duration = Duration::from_secs(7200);
+// Headroom granted to the daemon to surface its own timeout error before the CLI's fallback
+// ceiling fires. Keeps the error the user sees specific ("build idle timeout exceeded...") rather
+// than a generic CLI-side "daemon hung" message.
+const DAEMON_RESPONSE_GRACE: Duration = Duration::from_secs(60);
 const FEEDBACK_DRAIN_TIMEOUT: Duration = Duration::from_millis(50);
 const RESULT_POLL_TIMEOUT: Duration = Duration::from_millis(200);
 
@@ -168,11 +173,13 @@ async fn launch_async(
     )
     .with_env_vars(caller_env_overrides());
 
-    // CLI fallback ceiling: when the user opts into a max we give the daemon `max + 60s` to
-    // surface its own error first, but never less than the absolute floor in case the daemon
-    // hangs entirely.
+    // CLI fallback ceiling: when the user opts into a max we grant the daemon a response-grace
+    // window to surface its own error first, but never less than the absolute floor in case the
+    // daemon hangs entirely.
     let cli_max_timeout = match max_timeout_secs {
-        Some(n) => Duration::from_secs(n.saturating_add(60)).max(CLI_MAX_TIMEOUT_FLOOR),
+        Some(n) => Duration::from_secs(n)
+            .saturating_add(DAEMON_RESPONSE_GRACE)
+            .max(CLI_MAX_TIMEOUT_FLOOR),
         None => CLI_MAX_TIMEOUT_FLOOR,
     };
 

--- a/crates/peppy/src/commands/stack/launch.rs
+++ b/crates/peppy/src/commands/stack/launch.rs
@@ -98,7 +98,7 @@ fn handle_feedback(
             output.clear();
             *scrolling_output = None;
         }
-        *current_scrolling_step = Some(feedback.step.clone());
+        *current_scrolling_step = Some(feedback.step);
     }
 
     match &feedback.step {

--- a/crates/peppy/src/test_support.rs
+++ b/crates/peppy/src/test_support.rs
@@ -43,6 +43,26 @@ pub fn disable_build_cmd(peppy_json5: &Path) {
     });
 }
 
+/// Overrides the node `build_cmd` to the given command, used by timeout tests that need a
+/// long/quiet/loud build subprocess.
+pub fn override_build_cmd(peppy_json5: &Path, cmd: Vec<String>) {
+    modify_node_config(peppy_json5, |cfg| {
+        cfg.execution.build_cmd = Some(cmd);
+    });
+}
+
+/// Overrides the node `run_cmd` to a long, silent binary (`sleep 30`) and clears `build_cmd`.
+/// Used by the run-idle timeout test: the process never produces output and never registers
+/// itself with the messaging layer, so it never becomes "ready". Direct-binary form is used
+/// so SIGKILL from KillGuard targets `sleep` directly — `sh -c "sleep N"` would orphan the
+/// child `sleep` process and keep the daemon's stdio pipes open for the full sleep duration.
+pub fn override_run_cmd_silent(peppy_json5: &Path) {
+    modify_node_config(peppy_json5, |cfg| {
+        cfg.execution.run_cmd = Some(vec!["sleep".to_string(), "30".to_string()]);
+        cfg.execution.build_cmd = None;
+    });
+}
+
 #[derive(Clone, Default)]
 pub struct LogCapture {
     buffer: Arc<parking_lot::Mutex<Vec<u8>>>,

--- a/crates/peppy/src/test_support.rs
+++ b/crates/peppy/src/test_support.rs
@@ -54,8 +54,10 @@ pub fn override_build_cmd(peppy_json5: &Path, cmd: Vec<String>) {
 /// Overrides the node `run_cmd` to a long, silent binary (`sleep 30`) and clears `build_cmd`.
 /// Used by the run-idle timeout test: the process never produces output and never registers
 /// itself with the messaging layer, so it never becomes "ready". Direct-binary form is used
-/// so SIGKILL from KillGuard targets `sleep` directly — `sh -c "sleep N"` would orphan the
-/// child `sleep` process and keep the daemon's stdio pipes open for the full sleep duration.
+/// so the cancellation SIGKILL (sent via `abort_started → kill_child` when the run-phase
+/// idle timeout trips the cancel token) targets `sleep` directly — `sh -c "sleep N"` would
+/// orphan the grandchild `sleep` and keep the daemon's stdio pipes open for the full sleep
+/// duration.
 pub fn override_run_cmd_silent(peppy_json5: &Path) {
     modify_node_config(peppy_json5, |cfg| {
         cfg.execution.run_cmd = Some(vec!["sleep".to_string(), "30".to_string()]);

--- a/crates/peppy/tests/stack_launch.rs
+++ b/crates/peppy/tests/stack_launch.rs
@@ -543,13 +543,17 @@ async fn node_launch_fails_when_node_build_idle_timeout_is_hit() {
     }
     .execute(&harness.ctx);
 
+    let elapsed = started.elapsed();
     let err_msg = result
         .expect_err("launch should fail when build idle timeout fires")
         .to_string();
     assert!(
-        started.elapsed() < Duration::from_secs(20),
-        "launch should fail in well under 30s; took {:?}",
-        started.elapsed()
+        elapsed >= Duration::from_secs(1),
+        "build idle timeout (1s) cannot fire earlier than its configured duration; took {elapsed:?}",
+    );
+    assert!(
+        elapsed < Duration::from_secs(20),
+        "launch should fail in well under 30s; took {elapsed:?}",
     );
     assert!(
         err_msg.contains("timeout") && err_msg.contains("build"),
@@ -576,13 +580,17 @@ async fn node_launch_fails_when_node_run_idle_timeout_is_hit() {
     }
     .execute(&harness.ctx);
 
+    let elapsed = started.elapsed();
     let err_msg = result
         .expect_err("launch should fail when run idle timeout fires")
         .to_string();
     assert!(
-        started.elapsed() < Duration::from_secs(20),
-        "launch should fail in well under 30s; took {:?}",
-        started.elapsed()
+        elapsed >= Duration::from_secs(1),
+        "run idle timeout (1s) cannot fire earlier than its configured duration; took {elapsed:?}",
+    );
+    assert!(
+        elapsed < Duration::from_secs(20),
+        "launch should fail in well under 30s; took {elapsed:?}",
     );
     assert!(
         err_msg.contains("timeout") && err_msg.contains("run"),
@@ -617,13 +625,17 @@ async fn node_launch_fails_when_max_timeout_is_hit() {
     }
     .execute(&harness.ctx);
 
+    let elapsed = started.elapsed();
     let err_msg = result
         .expect_err("launch should fail when max launch timeout fires")
         .to_string();
     assert!(
-        started.elapsed() < Duration::from_secs(20),
-        "launch should fail in well under 30s; took {:?}",
-        started.elapsed()
+        elapsed >= Duration::from_secs(2),
+        "max timeout (2s) cannot fire earlier than its configured duration; took {elapsed:?}",
+    );
+    assert!(
+        elapsed < Duration::from_secs(20),
+        "launch should fail in well under 30s; took {elapsed:?}",
     );
     assert!(
         err_msg.contains("timeout") && err_msg.contains("max"),

--- a/crates/peppy/tests/stack_launch.rs
+++ b/crates/peppy/tests/stack_launch.rs
@@ -1,9 +1,11 @@
 use config::node::Toolchain;
-use peppy::test_support::{LogCapture, ServeCommandEmulation};
+use peppy::test_support::{
+    LogCapture, ServeCommandEmulation, override_build_cmd, override_run_cmd_silent,
+};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use config::consts::{NODE_CONFIG_FILE, PEPPY_OUTPUT_DIR, PEPPYGEN_OUTPUT_PATH};
 use core_node::encoding::StackListRequest;
@@ -208,8 +210,9 @@ async fn node_launch_command_succeed() {
         command: StackCommands::Launch {
             launcher_config_path: launcher_path,
             node_add_idle_timeout_secs: 60,
+            node_build_idle_timeout_secs: 60,
             node_run_idle_timeout_secs: 60,
-            max_timeout_secs: 3600,
+            max_timeout_secs: Some(3600),
         },
     }
     .execute(&ctx)
@@ -412,8 +415,9 @@ async fn node_launch_command_fails_when_node_never_becomes_healthy() {
         command: StackCommands::Launch {
             launcher_config_path: launcher_path,
             node_add_idle_timeout_secs: 60,
+            node_build_idle_timeout_secs: 60,
             node_run_idle_timeout_secs: 60,
-            max_timeout_secs: 3600,
+            max_timeout_secs: Some(3600),
         },
     }
     .execute(&ctx);
@@ -453,5 +457,180 @@ async fn node_launch_command_fails_when_node_never_becomes_healthy() {
             .any(|n| n.label().contains(&format!("{node_b_name}:{node_tag}"))),
         "graph should not contain node_b after failed launch. Got: {:?}",
         graph.nodes.iter().map(|n| n.label()).collect::<Vec<_>>()
+    );
+}
+
+/// Common setup for the timeout-firing tests. Returns the launcher path and the temp node
+/// peppy.json5, with node_b initialized via `node init` so the caller can `override_*_cmd`
+/// before launch. The error message bubbles up via the returned `Result` from
+/// `StackCommand::execute`, so we don't need a `LogCapture` here.
+struct TimeoutTestHarness {
+    ctx: Arc<AppContext>,
+    launcher_path: PathBuf,
+    node_b_peppy_json5: PathBuf,
+    _serve: ServeCommandEmulation,
+}
+
+async fn setup_timeout_test(node_b_name: &'static str) -> TimeoutTestHarness {
+    let serve = ServeCommandEmulation::with_mock()
+        .await
+        .expect("failed to create serve emulation");
+    let shared_messenger = serve.messenger();
+    let nodes_dir = tempfile::tempdir().expect("failed to create temp nodes directory");
+    // Leak the tempdir so it survives for the duration of the test (the harness holds the
+    // serve emulation, which already owns its own tempdir; we keep this one alive via the
+    // launcher path it contains).
+    let nodes_dir_path = nodes_dir.keep();
+
+    let ctx = Arc::new(
+        AppContext::with_messenger(&nodes_dir_path, Arc::clone(&shared_messenger))
+            .with_daemon_state_file(serve.daemon_state_path()),
+    );
+
+    NodeCommand {
+        command: NodeCommands::Init {
+            node_name: peppy::commands::node::NodeName::new(node_b_name).expect("valid node name"),
+            to_dir: None,
+            toolchain: Toolchain::Cargo,
+            with_container: false,
+        },
+    }
+    .execute(&ctx)
+    .expect("node init command should succeed");
+
+    let node_b_path = nodes_dir_path.join(node_b_name);
+    let node_b_peppy_json5 = node_b_path.join(NODE_CONFIG_FILE);
+    let launcher_path = nodes_dir_path.join("peppy_launcher.json5");
+    let launcher_json5 = format!(
+        r#"{{
+            deployments: [
+                {{
+                    source: {{ local: "{}" }},
+                    instances: [{{ instance_id: "node_b_instance" }}]
+                }}
+            ]
+        }}"#,
+        node_b_path.display()
+    );
+    fs::write(&launcher_path, launcher_json5).expect("launcher config should be writable");
+
+    TimeoutTestHarness {
+        ctx,
+        launcher_path,
+        node_b_peppy_json5,
+        _serve: serve,
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn node_launch_fails_when_node_build_idle_timeout_is_hit() {
+    let harness = setup_timeout_test("build_idle_node_b").await;
+
+    // Silent build that produces no output. Use direct binary form so the SIGKILL from
+    // KillGuard targets `sleep` directly — wrapping in `sh -c` would orphan a child `sleep`
+    // process that keeps the daemon's stdout/stderr pipes open for the full sleep duration,
+    // causing forwarder_handle.await to block.
+    override_build_cmd(
+        &harness.node_b_peppy_json5,
+        vec!["sleep".to_string(), "30".to_string()],
+    );
+
+    let started = Instant::now();
+    let result = StackCommand {
+        command: StackCommands::Launch {
+            launcher_config_path: harness.launcher_path.clone(),
+            node_add_idle_timeout_secs: 60,
+            node_build_idle_timeout_secs: 1,
+            node_run_idle_timeout_secs: 60,
+            max_timeout_secs: None,
+        },
+    }
+    .execute(&harness.ctx);
+
+    let err_msg = result
+        .expect_err("launch should fail when build idle timeout fires")
+        .to_string();
+    assert!(
+        started.elapsed() < Duration::from_secs(20),
+        "launch should fail in well under 30s; took {:?}",
+        started.elapsed()
+    );
+    assert!(
+        err_msg.contains("timeout") && err_msg.contains("build"),
+        "error message should mention 'timeout' and 'build' on build idle failure. Got: {err_msg}",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn node_launch_fails_when_node_run_idle_timeout_is_hit() {
+    let harness = setup_timeout_test("run_idle_node_b").await;
+
+    // Silent run command that never produces output and never becomes ready.
+    override_run_cmd_silent(&harness.node_b_peppy_json5);
+
+    let started = Instant::now();
+    let result = StackCommand {
+        command: StackCommands::Launch {
+            launcher_config_path: harness.launcher_path.clone(),
+            node_add_idle_timeout_secs: 60,
+            node_build_idle_timeout_secs: 60,
+            node_run_idle_timeout_secs: 1,
+            max_timeout_secs: None,
+        },
+    }
+    .execute(&harness.ctx);
+
+    let err_msg = result
+        .expect_err("launch should fail when run idle timeout fires")
+        .to_string();
+    assert!(
+        started.elapsed() < Duration::from_secs(20),
+        "launch should fail in well under 30s; took {:?}",
+        started.elapsed()
+    );
+    assert!(
+        err_msg.contains("timeout") && err_msg.contains("run"),
+        "error message should mention 'timeout' and 'run' on run idle failure. Got: {err_msg}",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn node_launch_fails_when_max_timeout_is_hit() {
+    let harness = setup_timeout_test("max_timeout_node_b").await;
+
+    // Continuous output for ~10s so idle never fires, but `max_timeout_secs=2` does.
+    // POSIX-portable shell loop (`seq` is bash-only).
+    override_build_cmd(
+        &harness.node_b_peppy_json5,
+        vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            "i=0; while [ $i -lt 50 ]; do echo step-$i; i=$((i+1)); sleep 0.2; done".to_string(),
+        ],
+    );
+
+    let started = Instant::now();
+    let result = StackCommand {
+        command: StackCommands::Launch {
+            launcher_config_path: harness.launcher_path.clone(),
+            node_add_idle_timeout_secs: 60,
+            node_build_idle_timeout_secs: 60,
+            node_run_idle_timeout_secs: 60,
+            max_timeout_secs: Some(2),
+        },
+    }
+    .execute(&harness.ctx);
+
+    let err_msg = result
+        .expect_err("launch should fail when max launch timeout fires")
+        .to_string();
+    assert!(
+        started.elapsed() < Duration::from_secs(20),
+        "launch should fail in well under 30s; took {:?}",
+        started.elapsed()
+    );
+    assert!(
+        err_msg.contains("timeout") && err_msg.contains("max"),
+        "error message should mention 'timeout' and 'max' on max launch failure. Got: {err_msg}",
     );
 }

--- a/crates/peppy/tests/stack_launch.rs
+++ b/crates/peppy/tests/stack_launch.rs
@@ -526,13 +526,14 @@ async fn setup_timeout_test(node_b_name: &'static str) -> TimeoutTestHarness {
 async fn node_launch_fails_when_node_build_idle_timeout_is_hit() {
     let harness = setup_timeout_test("build_idle_node_b").await;
 
-    // Silent build that produces no output. Use direct binary form so the SIGKILL from
-    // KillGuard targets `sleep` directly — wrapping in `sh -c` would orphan a child `sleep`
-    // process that keeps the daemon's stdout/stderr pipes open for the full sleep duration,
-    // causing forwarder_handle.await to block.
+    // Silent shell-wrapped build. The `sh -c "sleep 30"` form is the regression-test shape:
+    // before the process-group fix, KillGuard's SIGKILL only targeted `sh`, leaving an
+    // orphaned `sleep` holding the daemon's stdio pipes open for the full 30s. With
+    // `spawn_in_process_group` + group-kill, SIGKILL hits the entire group and cancellation
+    // returns in milliseconds.
     override_build_cmd(
         &harness.node_b_peppy_json5,
-        vec!["sleep".to_string(), "30".to_string()],
+        vec!["sh".to_string(), "-c".to_string(), "sleep 30".to_string()],
     );
 
     let started = Instant::now();

--- a/crates/peppy/tests/stack_launch.rs
+++ b/crates/peppy/tests/stack_launch.rs
@@ -526,11 +526,6 @@ async fn setup_timeout_test(node_b_name: &'static str) -> TimeoutTestHarness {
 async fn node_launch_fails_when_node_build_idle_timeout_is_hit() {
     let harness = setup_timeout_test("build_idle_node_b").await;
 
-    // Silent shell-wrapped build. The `sh -c "sleep 30"` form is the regression-test shape:
-    // before the process-group fix, KillGuard's SIGKILL only targeted `sh`, leaving an
-    // orphaned `sleep` holding the daemon's stdio pipes open for the full 30s. With
-    // `spawn_in_process_group` + group-kill, SIGKILL hits the entire group and cancellation
-    // returns in milliseconds.
     override_build_cmd(
         &harness.node_b_peppy_json5,
         vec!["sh".to_string(), "-c".to_string(), "sleep 30".to_string()],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-phase idle timeouts for add, build, and run-startup; added build-phase idle timeout
  * Optional overall launch deadline; CLI and launch APIs accept an optional max timeout

* **Bug Fixes**
  * Subprocess cancellation now targets whole subprocess trees and waits for cleanup
  * Timeout reporting now distinguishes which phase timed out (add/build/run/max)

* **Tests**
  * New timeout regression tests and test helpers for build/run overrides and timeout scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->