### PR TITLE
docs: sync with PR #170

### DIFF
--- a/docs/src/content/docs/guides/launch_files.mdx
+++ b/docs/src/content/docs/guides/launch_files.mdx
@@ -153,6 +153,27 @@ PeppyOS automatically inspects the `name` and `tag` of each node, verifies that 
 Running the `peppy stack launch` command clears the existing node stack and stops all running instances
 :::
 
+### Timeout Configuration
+
+`peppy stack launch` supports per-phase idle timeouts that reset whenever the corresponding phase produces output, plus an optional absolute deadline for the entire launch:
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--node-add-idle-timeout-secs` | 600 | Idle timeout for the **add** phase. Resets on git/http progress or sub-process output. |
+| `--node-build-idle-timeout-secs` | 600 | Idle timeout for the **build** phase. Resets on `build_cmd` output. |
+| `--node-run-idle-timeout-secs` | 600 | Idle timeout for the **run-startup** phase. Resets on subprocess output until the node signals ready. |
+| `--max-timeout-secs` | *(unset)* | Optional absolute max timeout in seconds for the entire launch. If omitted, only idle timeouts apply. |
+
+For example, to launch with a short build idle timeout and an overall 30-minute deadline:
+
+```sh
+peppy stack launch ./peppy_launcher.json5 \
+  --node-build-idle-timeout-secs 120 \
+  --max-timeout-secs 1800
+```
+
+When a per-phase idle timeout fires, the error message identifies which phase timed out (e.g. `"timeout: build idle timeout exceeded"`). When the overall deadline fires, the error reports `"timeout: max launch timeout exceeded"`.
+
 Verify that the node stack was configured correctly:
 ```
 $ peppy stack list

--- a/docs/src/content/docs/guides/launch_files.mdx
+++ b/docs/src/content/docs/guides/launch_files.mdx
@@ -172,7 +172,7 @@ peppy stack launch ./peppy_launcher.json5 \
   --max-timeout-secs 1800
 ```
 
-When a per-phase idle timeout fires, the error message identifies which phase timed out (e.g. `"timeout: build idle timeout exceeded"`). When the overall deadline fires, the error reports `"timeout: max launch timeout exceeded"`.
+When a per-phase idle timeout fires, the error message identifies which phase timed out (e.g. `"timeout: build idle timeout exceeded"`). When the overall deadline fires, the error reports `"Launch timed out: max timeout exceeded. Log file: ..."`.
 
 Verify that the node stack was configured correctly:
 ```


### PR DESCRIPTION
Automated doc update generated by `scripts/docs/update_docs.py`
in response to code changes in #170.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added "Timeout Configuration" to the launch guide: documents three per-phase idle timeouts (add, build, run-startup) that reset on phase activity, an optional overall max-deadline, command-line usage examples (including shorter build idle with a 30-minute max), and distinct error message descriptions for per-phase vs overall deadline failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->