### PR TITLE
Add sim-clock mode with per-instance framework overrides

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,9 +404,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -872,9 +872,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "der"
@@ -1136,9 +1136,9 @@ dependencies = [
 
 [[package]]
 name = "fancy-regex"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
+checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
 dependencies = [
  "bit-set",
  "regex-automata",
@@ -1465,9 +1465,9 @@ dependencies = [
 
 [[package]]
 name = "gix-path"
-version = "0.11.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09c31d4373bda7fab9eb01822927b55185a378d6e1bf737e0a54c743ad806658"
+checksum = "671a6059e8a4c1b7f406e24716499cefa3926e060876fb1959ef225efeee346e"
 dependencies = [
  "bstr",
  "gix-trace",
@@ -1477,15 +1477,15 @@ dependencies = [
 
 [[package]]
 name = "gix-trace"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f69a13643b8437d4ca6845e08143e847a36ca82903eed13303475d0ae8b162e0"
+checksum = "6f23569e55f2ffaf958617353b9734a7d52a7c19c439eeaa5e3efc217fd2270e"
 
 [[package]]
 name = "gix-url"
-version = "0.35.2"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d28e8af3d42581190da884f013caf254d2fd4d6ab102408f08d21bfa11de6c8d"
+checksum = "35842d099e813f6f6bba529e88d4670572149c3df79b7a412952259887721ece"
 dependencies = [
  "bstr",
  "gix-path",
@@ -1495,9 +1495,9 @@ dependencies = [
 
 [[package]]
 name = "gix-validate"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec1eff98d91941f47766367cba1be746bab662bad761d9891ae6f7882f7840b"
+checksum = "e26ac2602b43eadfdca0560b81d3341944162a3c9f64ccdeef8fc501ad80dad5"
 dependencies = [
  "bstr",
 ]
@@ -1700,9 +1700,9 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
 dependencies = [
  "typenum",
 ]
@@ -1898,9 +1898,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -2017,6 +2017,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2056,9 +2086,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2079,9 +2109,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.46.2"
+version = "0.46.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50180452e7808015fe083eae3efcf1ec98b89b45dd8cc204f7b4a6b7b81ea675"
+checksum = "cbe92a2f8b00686061eab5cdcfd6f382c27f2084456e7be90ae9f0fe4a30552a"
 dependencies = [
  "ahash",
  "bytecount",
@@ -3040,9 +3070,9 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plist"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
+checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
 dependencies = [
  "base64",
  "indexmap 2.14.0",
@@ -3257,9 +3287,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
+version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
 dependencies = [
  "memchr",
 ]
@@ -3299,7 +3329,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
- "rustls-platform-verifier",
+ "rustls-platform-verifier 0.6.2",
  "slab",
  "thiserror 2.0.18",
  "tinyvec",
@@ -3514,9 +3544,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.46.2"
+version = "0.46.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acb0c66c7b78c1da928bee668b5cc638c678642ff587faff6e6222f797be9d4c"
+checksum = "e125f10bdcd507598c702daada18c47fe5bfba4d7a9545b015b5d432f7168ca3"
 dependencies = [
  "ahash",
  "fluent-uri",
@@ -3560,9 +3590,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
  "base64",
  "bytes",
@@ -3582,7 +3612,7 @@ dependencies = [
  "pin-project-lite",
  "rustls",
  "rustls-pki-types",
- "rustls-platform-verifier",
+ "rustls-platform-verifier 0.7.0",
  "serde",
  "serde_json",
  "sync_wrapper",
@@ -3742,9 +3772,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.39"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -3779,9 +3809,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -3795,7 +3825,28 @@ checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
  "core-foundation",
  "core-foundation-sys",
- "jni",
+ "jni 0.21.1",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni 0.22.4",
  "log",
  "once_cell",
  "rustls",
@@ -4215,6 +4266,22 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
@@ -5093,9 +5160,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5106,9 +5173,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5116,9 +5183,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5126,9 +5193,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5139,9 +5206,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
 ]
@@ -5182,9 +5249,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6380,9 +6447,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "8.5.1"
+version = "8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcab981e19633ebcf0b001ddd37dd802996098bc1864f90b7c5d970ce76c1d59"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
 dependencies = [
  "crc32fast",
  "flate2",

--- a/crates/config-internal/src/launcher.rs
+++ b/crates/config-internal/src/launcher.rs
@@ -5,7 +5,7 @@ mod types;
 pub use parse::PeppyLauncherParser;
 pub use types::{
     CURRENT_SCHEMA_VERSION, Deployment, DeploymentGitSource, DeploymentInstance,
-    DeploymentLocalSource, DeploymentRepoSource, DeploymentSource, DeploymentUrlSource, Name,
-    PeppyLauncher, SchemaVersion, VariantGitSource, VariantNameSource, VariantSource,
-    VariantUrlSource,
+    DeploymentLocalSource, DeploymentRepoSource, DeploymentSource, DeploymentUrlSource,
+    FrameworkOverrides, Name, PeppyLauncher, SchemaVersion, VariantGitSource, VariantNameSource,
+    VariantSource, VariantUrlSource,
 };

--- a/crates/config-internal/src/launcher/types.rs
+++ b/crates/config-internal/src/launcher/types.rs
@@ -41,6 +41,20 @@ pub struct DeploymentInstance {
     pub arguments: BTreeMap<String, AnyType>,
     #[serde(default)]
     pub env_vars: BTreeMap<String, String>,
+    #[serde(default)]
+    pub framework: FrameworkOverrides,
+}
+
+/// Per-instance framework knobs. Distinct from `arguments`: those are
+/// declared by the node author and validated against a per-node parameter
+/// schema; framework knobs are owned by peppylib, fixed-shape, and applied
+/// uniformly to every node. Each field is optional so the daemon can fall
+/// through to its own default when the instance omits the override.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct FrameworkOverrides {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub use_sim_time: Option<bool>,
 }
 
 fn deserialize_instances<'de, D>(deserializer: D) -> Result<Vec<DeploymentInstance>, D::Error>
@@ -204,8 +218,9 @@ mod tests {
         assert_eq!(duplicate, "camera_front");
     }
 
-    /// Verifies that optional fields (`arguments`, `env_vars`) default to empty
-    /// when omitted, and that partially specified instances deserialize correctly.
+    /// Verifies that optional fields (`arguments`, `env_vars`, `framework`)
+    /// default to empty when omitted, and that partially specified instances
+    /// deserialize correctly.
     #[test]
     fn deployment_instance_defaults() {
         let instance: DeploymentInstance =
@@ -213,6 +228,7 @@ mod tests {
         assert_eq!(instance.instance_id, "camera_front");
         assert!(instance.arguments.is_empty());
         assert!(instance.env_vars.is_empty());
+        assert_eq!(instance.framework.use_sim_time, None);
 
         let with_env: DeploymentInstance = serde_json5::from_str(
             "{ instance_id: \"esp32_1\", env_vars: { ESP32_DEVICE: \"/dev/ttyUSB0\" } }",
@@ -223,5 +239,39 @@ mod tests {
             with_env.env_vars.get("ESP32_DEVICE").map(String::as_str),
             Some("/dev/ttyUSB0")
         );
+    }
+
+    /// Per-instance framework overrides parse cleanly and round-trip back
+    /// to JSON5. Both the explicit-true and explicit-false cases must be
+    /// distinguishable from "absent" so the daemon's precedence (per-instance
+    /// > daemon CLI flag > default) has a value to gate on.
+    #[test]
+    fn deployment_instance_framework_overrides_round_trip() {
+        let with_sim: DeploymentInstance = serde_json5::from_str(
+            "{ instance_id: \"camera_front\", framework: { use_sim_time: true } }",
+        )
+        .unwrap();
+        assert_eq!(with_sim.framework.use_sim_time, Some(true));
+
+        let with_wall: DeploymentInstance = serde_json5::from_str(
+            "{ instance_id: \"camera_front\", framework: { use_sim_time: false } }",
+        )
+        .unwrap();
+        assert_eq!(with_wall.framework.use_sim_time, Some(false));
+
+        let serialized = serde_json5::to_string(&with_sim).unwrap();
+        let reparsed: DeploymentInstance = serde_json5::from_str(&serialized).unwrap();
+        assert_eq!(reparsed.framework.use_sim_time, Some(true));
+    }
+
+    /// The launcher rejects unknown framework keys so a typo (e.g.
+    /// `use_simulation_time`) does not silently fall through to wall mode.
+    #[test]
+    fn deployment_instance_framework_rejects_unknown_keys() {
+        let err = serde_json5::from_str::<DeploymentInstance>(
+            "{ instance_id: \"camera_front\", framework: { unknown_knob: true } }",
+        )
+        .expect_err("unknown framework key should be rejected");
+        assert!(err.to_string().contains("unknown_knob"));
     }
 }

--- a/crates/config-internal/src/lib.rs
+++ b/crates/config-internal/src/lib.rs
@@ -77,16 +77,18 @@ pub mod node {
 
 // -- runtime --
 pub mod runtime {
-    pub use crate::internal::runtime::{LauncherRuntimeConfig, NodeInstanceConfig, RuntimeConfig};
+    pub use crate::internal::runtime::{
+        LauncherRuntimeConfig, NodeInstanceConfig, ResolvedFramework, RuntimeConfig,
+    };
 }
 
 // -- launcher --
 pub mod launcher {
     pub use crate::internal::launcher::{
         CURRENT_SCHEMA_VERSION, Deployment, DeploymentGitSource, DeploymentInstance,
-        DeploymentLocalSource, DeploymentRepoSource, DeploymentSource, DeploymentUrlSource, Name,
-        PeppyLauncher, PeppyLauncherParser, SchemaVersion, VariantGitSource, VariantNameSource,
-        VariantSource, VariantUrlSource,
+        DeploymentLocalSource, DeploymentRepoSource, DeploymentSource, DeploymentUrlSource,
+        FrameworkOverrides, Name, PeppyLauncher, PeppyLauncherParser, SchemaVersion,
+        VariantGitSource, VariantNameSource, VariantSource, VariantUrlSource,
     };
 }
 

--- a/crates/config-internal/src/runtime.rs
+++ b/crates/config-internal/src/runtime.rs
@@ -16,6 +16,19 @@ pub struct NodeInstanceConfig {
     pub instance_id: Name,
     #[serde(default)]
     pub arguments: BTreeMap<String, AnyType>,
+    #[serde(default)]
+    pub framework: ResolvedFramework,
+}
+
+/// Framework knobs already resolved by the daemon. Distinct from
+/// `launcher::FrameworkOverrides` so the type system enforces "resolution
+/// happens once": the launcher form carries optional overrides; this form
+/// carries concrete values the spawned node reads without further fallback.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ResolvedFramework {
+    #[serde(default)]
+    pub use_sim_time: bool,
 }
 
 /// Configuration for the launcher to know how to configure spawned nodes' messaging.
@@ -124,6 +137,34 @@ mod tests {
             .replace("$MESSAGING_HOST", "127.0.0.1")
             .replace("$MESSAGING_PORT", "7448");
         serde_json5::from_str(&populated).map_err(|err| Error::Parsing(err.into()))
+    }
+
+    /// `use_sim_time` round-trips through serialize/deserialize, and a
+    /// runtime config written before this field existed (no `framework` key)
+    /// still parses cleanly with `use_sim_time = false`.
+    #[test]
+    fn resolved_framework_round_trip_and_back_compat() {
+        let with_sim: RuntimeConfig = serde_json5::from_str(
+            r#"{
+                messaging_host: "127.0.0.1",
+                messaging_port: 7448,
+                node_instance: {
+                    instance_id: "camera_front",
+                    framework: { use_sim_time: true }
+                },
+                node_name: "camera",
+                bound_core_node: "core_node"
+            }"#,
+        )
+        .unwrap();
+        assert!(with_sim.node_instance.framework.use_sim_time);
+
+        let serialized = serde_json5::to_string(&with_sim).unwrap();
+        let reparsed: RuntimeConfig = serde_json5::from_str(&serialized).unwrap();
+        assert!(reparsed.node_instance.framework.use_sim_time);
+
+        let legacy = runtime_config_from_json("camera_front").unwrap();
+        assert!(!legacy.node_instance.framework.use_sim_time);
     }
 
     #[test]

--- a/crates/core-node-api/Cargo.toml
+++ b/crates/core-node-api/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = "1.0"
 serde_json5 = "0.2"
 thiserror = "2.0"
 url = "2"
-gix-url = "0.35"
+gix-url = "0.36"
 
 [build-dependencies]
 build-helpers = { path = "../build-helpers-internal" }

--- a/crates/core-node-internal/Cargo.toml
+++ b/crates/core-node-internal/Cargo.toml
@@ -36,7 +36,7 @@ tokio-util = "0.7"
 tracing = "0.1"
 askama = "0.15"
 rust-embed = { version = "8", features = ["include-exclude"] }
-gix-url = "0.35"
+gix-url = "0.36"
 git2 = { version = "0.20", features = ["vendored-openssl"] }
 url = "2"
 ureq = "3.1"

--- a/crates/core-node-internal/src/services.rs
+++ b/crates/core-node-internal/src/services.rs
@@ -6,6 +6,8 @@ mod ping;
 mod repo;
 mod stack;
 
+use clock::{ClockSource, SimClockSource, WallClockSource};
+
 pub use node::FORBIDDEN_ENV_KEYS;
 
 use crate::Result;
@@ -27,6 +29,7 @@ use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
 use std::time::{Duration, Instant};
 use tokio::sync::{Mutex, oneshot};
 use tokio::task::JoinHandle;
@@ -57,6 +60,10 @@ pub struct CoreNodeArguments {
     pub health_monitor_timeout: Duration,
     pub health_monitor_max_failures: u32,
     pub clock_publish_interval: Duration,
+    /// Daemon-wide default for the framework `use_sim_time` flag. Per-instance
+    /// launcher overrides win over this; when an instance omits the override,
+    /// the spawned node's `framework.use_sim_time` is set to this value.
+    pub daemon_use_sim_time: bool,
 }
 
 impl CoreNodeArguments {
@@ -87,6 +94,7 @@ pub struct CoreNode {
     health_monitor_timeout: Duration,
     health_monitor_max_failures: u32,
     clock_publish_interval: Duration,
+    daemon_use_sim_time: bool,
 }
 
 /// Pre-flight checks that run once at daemon startup. Exits with a
@@ -151,6 +159,7 @@ impl CoreNode {
         let health_monitor_timeout = node_arguments.health_monitor_timeout;
         let health_monitor_max_failures = node_arguments.health_monitor_max_failures;
         let clock_publish_interval = node_arguments.clock_publish_interval;
+        let daemon_use_sim_time = node_arguments.daemon_use_sim_time;
 
         let node_config = NodeConfig {
             schema_version: CURRENT_SCHEMA_VERSION,
@@ -191,6 +200,7 @@ impl CoreNode {
             health_monitor_timeout,
             health_monitor_max_failures,
             clock_publish_interval,
+            daemon_use_sim_time,
         }
     }
 
@@ -227,6 +237,16 @@ impl CoreNode {
             self.node_name(),
             self.instance_id(),
         );
+        // Build the clock source up front so the service handler and the
+        // tick feeder share a single cache in sim mode. The cache is unused
+        // (and the WallClockSource ignores it) in wall mode, but allocating
+        // it unconditionally keeps the branch below readable.
+        let clock_cache = Arc::new(AtomicU64::new(0));
+        let clock_source: Arc<dyn ClockSource> = if self.daemon_use_sim_time {
+            Arc::new(SimClockSource::new(Arc::clone(&clock_cache)))
+        } else {
+            Arc::new(WallClockSource)
+        };
         // Set up all listeners concurrently so startup latency is bounded by
         // the slowest single listener, not the sum of all 19. They're
         // independent — no listener depends on another being registered first.
@@ -243,16 +263,29 @@ impl CoreNode {
                 core_node_name,
                 self.instance_id(),
                 self.node_name(),
+                Arc::clone(&clock_source),
             )
             .boxed(),
-            clock::publish_clock(
-                self.messenger.clone(),
-                core_node_name,
-                self.instance_id(),
-                self.node_name(),
-                self.clock_publish_interval,
-            )
-            .boxed(),
+            if self.daemon_use_sim_time {
+                clock::subscribe_external_clock(
+                    self.messenger.clone(),
+                    core_node_name,
+                    self.instance_id(),
+                    self.node_name(),
+                    Arc::clone(&clock_cache),
+                )
+                .boxed()
+            } else {
+                clock::publish_clock(
+                    self.messenger.clone(),
+                    core_node_name,
+                    self.instance_id(),
+                    self.node_name(),
+                    self.clock_publish_interval,
+                    Arc::clone(&clock_source),
+                )
+                .boxed()
+            },
             info::listen_for_info(
                 &self.messenger,
                 core_node_name,
@@ -269,12 +302,15 @@ impl CoreNode {
                 self.node_name(),
                 Arc::clone(&self.node_stack),
                 self.peppy_dirs.clone(),
-                stack::StackLaunchTimeouts {
-                    node_startup: self.node_startup_timeout,
-                    node_start_health: self.node_start_health_timeout,
-                    health_monitor_interval: self.health_monitor_interval,
-                    health_monitor_timeout: self.health_monitor_timeout,
-                    health_monitor_max_failures: self.health_monitor_max_failures,
+                stack::StackLaunchDefaults {
+                    timeouts: stack::StackLaunchTimeouts {
+                        node_startup: self.node_startup_timeout,
+                        node_start_health: self.node_start_health_timeout,
+                        health_monitor_interval: self.health_monitor_interval,
+                        health_monitor_timeout: self.health_monitor_timeout,
+                        health_monitor_max_failures: self.health_monitor_max_failures,
+                    },
+                    use_sim_time: self.daemon_use_sim_time,
                 },
             )
             .boxed(),

--- a/crates/core-node-internal/src/services/clock.rs
+++ b/crates/core-node-internal/src/services/clock.rs
@@ -2,18 +2,70 @@ use crate::Result;
 use crate::names;
 use config::node::QoSProfile;
 use core_node_api::encoding::{ClockRequest, ClockResponse, ClockTick, wall_now_ns};
-use peppylib::messaging::{ServiceRequestContext, TopicPublisher};
+use peppylib::messaging::{ServiceRequestContext, Subscription, TopicPublisher};
 use peppylib::types::Payload;
 use peppylib::{MessengerHandle, PeppyError, PeppyResult, ServiceMessenger, TopicMessenger};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 use tokio::task::JoinHandle;
 use tracing::{debug, warn};
+
+/// Failures observable from a [`ClockSource`]. Wall mode propagates a system
+/// clock error; sim mode reports a missing first tick.
+#[derive(Debug, thiserror::Error)]
+pub enum ClockSourceError {
+    #[error("system clock unavailable: {0}")]
+    Wall(String),
+    #[error("clock not ready: no external tick observed yet (sim mode)")]
+    NotReady,
+}
+
+/// Daemon-internal abstraction over "what time is it". The clock service
+/// handler and the periodic publisher both go through this trait so the
+/// daemon can serve sim/replay timestamps without changing the wire.
+pub trait ClockSource: Send + Sync {
+    fn now_ns(&self) -> std::result::Result<u64, ClockSourceError>;
+}
+
+/// Reads OS wall time. Used when the daemon resolves the clock source to
+/// `wall` (the default).
+pub struct WallClockSource;
+
+impl ClockSource for WallClockSource {
+    fn now_ns(&self) -> std::result::Result<u64, ClockSourceError> {
+        wall_now_ns().map_err(|e| ClockSourceError::Wall(e.to_string()))
+    }
+}
+
+/// Serves timestamps from a daemon-internal cache fed by a subscription to
+/// the `clock` topic. `0` is reserved as "no tick observed yet" so the
+/// handler can return `NotReady` instead of a misleading zero timestamp.
+pub struct SimClockSource {
+    cache: Arc<AtomicU64>,
+}
+
+impl SimClockSource {
+    pub fn new(cache: Arc<AtomicU64>) -> Self {
+        Self { cache }
+    }
+}
+
+impl ClockSource for SimClockSource {
+    fn now_ns(&self) -> std::result::Result<u64, ClockSourceError> {
+        match self.cache.load(Ordering::Relaxed) {
+            0 => Err(ClockSourceError::NotReady),
+            ns => Ok(ns),
+        }
+    }
+}
 
 pub async fn listen_for_clock(
     messenger: &MessengerHandle,
     core_node_node: &str,
     instance_id: &str,
     node_name: &str,
+    source: Arc<dyn ClockSource>,
 ) -> Result<JoinHandle<Result<()>>> {
     let mut endpoint = ServiceMessenger::listen(
         messenger,
@@ -26,7 +78,10 @@ pub async fn listen_for_clock(
 
     let handle = tokio::spawn(async move {
         endpoint
-            .handle_requests(handle_clock_request)
+            .handle_requests(move |context| {
+                let source = Arc::clone(&source);
+                async move { handle_clock_request(source.as_ref(), context) }
+            })
             .await
             .map_err(Into::into)
     });
@@ -34,15 +89,20 @@ pub async fn listen_for_clock(
     Ok(handle)
 }
 
-async fn handle_clock_request(context: ServiceRequestContext) -> PeppyResult<Payload> {
+fn handle_clock_request(
+    source: &dyn ClockSource,
+    context: ServiceRequestContext,
+) -> PeppyResult<Payload> {
     // Stamp t1 first — every line after this point inflates server processing
     // time and corrupts the offset estimate the client computes.
-    let server_recv_time = wall_now_ns().map_err(|e| PeppyError::InvalidServiceRequest {
-        identifier: context.message().instance_id().to_string(),
-        reason: format!("server clock unavailable: {e}"),
-    })?;
+    let server_recv_time = source
+        .now_ns()
+        .map_err(|e| PeppyError::InvalidServiceRequest {
+            identifier: context.message().instance_id().to_string(),
+            reason: e.to_string(),
+        })?;
     let instance_id = context.message().instance_id().to_string();
-    handle_clock_request_inner(&context, server_recv_time).map_err(|e| {
+    handle_clock_request_inner(source, &context, server_recv_time).map_err(|e| {
         PeppyError::InvalidServiceRequest {
             identifier: instance_id,
             reason: e.to_string(),
@@ -51,6 +111,7 @@ async fn handle_clock_request(context: ServiceRequestContext) -> PeppyResult<Pay
 }
 
 fn handle_clock_request_inner(
+    source: &dyn ClockSource,
     context: &ServiceRequestContext,
     server_recv_time: u64,
 ) -> Result<Payload> {
@@ -64,7 +125,12 @@ fn handle_clock_request_inner(
 
     // Stamp t2 last — the response encode + send happens after this point and
     // is part of the round-trip delay the client measures, not server time.
-    let server_send_time = wall_now_ns()?;
+    let server_send_time = source
+        .now_ns()
+        .map_err(|e| PeppyError::InvalidServiceRequest {
+            identifier: context.message().instance_id().to_string(),
+            reason: e.to_string(),
+        })?;
 
     ClockResponse::new(request.client_send_time, server_recv_time, server_send_time)
         .encode()
@@ -77,12 +143,17 @@ fn handle_clock_request_inner(
 ///
 /// Pre-binds a [`TopicPublisher`] outside the loop: the wire key is formatted
 /// once at startup, and per-tick `publish` skips the central messenger mutex.
+///
+/// Wall mode only. In sim mode the daemon does not publish; an external
+/// simulator does, and the daemon merely subscribes (see
+/// [`subscribe_external_clock`]).
 pub async fn publish_clock(
     messenger: MessengerHandle,
     core_node_name: &str,
     instance_id: &str,
     node_name: &str,
     interval: Duration,
+    source: Arc<dyn ClockSource>,
 ) -> Result<JoinHandle<Result<()>>> {
     let publisher = TopicMessenger::declare_publisher(
         &messenger,
@@ -93,10 +164,16 @@ pub async fn publish_clock(
         QoSProfile::SensorData,
     )
     .await?;
-    Ok(tokio::spawn(run_clock_publisher(publisher, interval)))
+    Ok(tokio::spawn(run_clock_publisher(
+        publisher, interval, source,
+    )))
 }
 
-async fn run_clock_publisher(publisher: TopicPublisher, interval: Duration) -> Result<()> {
+async fn run_clock_publisher(
+    publisher: TopicPublisher,
+    interval: Duration,
+    source: Arc<dyn ClockSource>,
+) -> Result<()> {
     let mut ticker = tokio::time::interval(interval);
     // Skip catch-up bursts after a backlog (e.g. test pause / GC stall).
     // A clock-tick ten ticks late is uninteresting — we want fresh time.
@@ -104,10 +181,10 @@ async fn run_clock_publisher(publisher: TopicPublisher, interval: Duration) -> R
 
     loop {
         ticker.tick().await;
-        let now_ns = match wall_now_ns() {
+        let now_ns = match source.now_ns() {
             Ok(t) => t,
             Err(e) => {
-                warn!("clock tick skipped, system clock unavailable: {e}");
+                warn!("clock tick skipped, {e}");
                 continue;
             }
         };
@@ -121,5 +198,75 @@ async fn run_clock_publisher(publisher: TopicPublisher, interval: Duration) -> R
         if let Err(e) = publisher.publish(payload).await {
             warn!("clock tick emit failed: {e}");
         }
+    }
+}
+
+/// Subscribes to the `clock` topic and feeds the latest observed timestamp
+/// into `cache`. Spawned in sim mode in lieu of [`publish_clock`]: the daemon
+/// is one of many subscribers to the external simulator's tick stream, and
+/// uses the cached value to answer `synchronize` requests via
+/// [`SimClockSource`].
+///
+/// `cache` is shared with the `SimClockSource` instance handed to
+/// [`listen_for_clock`]. The two halves are decoupled — this task can fall
+/// behind without blocking the service handler, which simply observes a
+/// stale (or missing) value.
+pub async fn subscribe_external_clock(
+    messenger: MessengerHandle,
+    core_node_name: &str,
+    instance_id: &str,
+    node_name: &str,
+    cache: Arc<AtomicU64>,
+) -> Result<JoinHandle<Result<()>>> {
+    let mut subscription: Subscription = TopicMessenger::subscribe(
+        &messenger,
+        core_node_name,
+        instance_id,
+        node_name,
+        names::CLOCK,
+        Some(core_node_name),
+        None,
+        QoSProfile::SensorData,
+    )
+    .await?;
+
+    Ok(tokio::spawn(async move {
+        while let Some(message) = subscription.on_next_message().await {
+            match ClockTick::decode(message.payload().as_ref()) {
+                Ok(tick) => {
+                    // `0` is reserved as "not ready" — a simulator publishing
+                    // a literal zero would be a bug, and clamping it to 1 is a
+                    // safer surprise than silently masking the not-ready state.
+                    let stored = if tick.time == 0 { 1 } else { tick.time };
+                    cache.store(stored, Ordering::Relaxed);
+                }
+                Err(e) => warn!("dropped malformed clock tick: {e}"),
+            }
+        }
+        Ok(())
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wall_clock_source_returns_a_value() {
+        let now = WallClockSource.now_ns().expect("system clock available");
+        assert!(now > 0);
+    }
+
+    #[test]
+    fn sim_clock_source_reports_not_ready_until_first_tick() {
+        let cache = Arc::new(AtomicU64::new(0));
+        let source = SimClockSource::new(Arc::clone(&cache));
+        let err = source
+            .now_ns()
+            .expect_err("empty cache must surface NotReady");
+        assert!(matches!(err, ClockSourceError::NotReady));
+
+        cache.store(42, Ordering::Relaxed);
+        assert_eq!(source.now_ns().expect("cache populated"), 42);
     }
 }

--- a/crates/core-node-internal/src/services/stack.rs
+++ b/crates/core-node-internal/src/services/stack.rs
@@ -3,7 +3,7 @@ mod list;
 mod reset;
 
 pub use launch::STACK_LAUNCH_GIT_HASH;
-pub use launch::StackLaunchTimeouts;
+pub use launch::{StackLaunchDefaults, StackLaunchTimeouts};
 pub use launch::listen_for_stack_launch;
 pub use list::listen_for_stack_list;
 pub use reset::listen_for_stack_reset;

--- a/crates/core-node-internal/src/services/stack.rs
+++ b/crates/core-node-internal/src/services/stack.rs
@@ -3,7 +3,7 @@ mod list;
 mod reset;
 
 pub use launch::STACK_LAUNCH_GIT_HASH;
-pub use launch::{StackLaunchDefaults, StackLaunchTimeouts};
 pub use launch::listen_for_stack_launch;
+pub use launch::{StackLaunchDefaults, StackLaunchTimeouts};
 pub use list::listen_for_stack_list;
 pub use reset::listen_for_stack_reset;

--- a/crates/core-node-internal/src/services/stack/launch.rs
+++ b/crates/core-node-internal/src/services/stack/launch.rs
@@ -73,6 +73,15 @@ pub struct StackLaunchTimeouts {
     pub health_monitor_max_failures: u32,
 }
 
+/// Daemon-wide defaults the stack launcher applies to every spawned
+/// instance. Pairs with launcher overrides (`FrameworkOverrides`) and the
+/// per-instance resolved values (`ResolvedFramework`); this struct is the
+/// "what the daemon would pick when the instance omits the override" half.
+pub struct StackLaunchDefaults {
+    pub timeouts: StackLaunchTimeouts,
+    pub use_sim_time: bool,
+}
+
 pub async fn listen_for_stack_launch(
     messenger: &MessengerHandle,
     core_node_name: &str,
@@ -80,7 +89,7 @@ pub async fn listen_for_stack_launch(
     node_name: &str,
     node_stack: Arc<NodeStack>,
     peppy_dirs: PeppyDirs,
-    timeouts: StackLaunchTimeouts,
+    defaults: StackLaunchDefaults,
 ) -> Result<JoinHandle<Result<()>>> {
     let action = ActionMessenger::expose(
         messenger,
@@ -91,6 +100,10 @@ pub async fn listen_for_stack_launch(
     )
     .await?;
 
+    let StackLaunchDefaults {
+        timeouts,
+        use_sim_time: daemon_use_sim_time,
+    } = defaults;
     let handler = LaunchGoalHandler {
         context: LaunchActionContext {
             node_stack,
@@ -99,6 +112,7 @@ pub async fn listen_for_stack_launch(
             core_instance_id: instance_id.to_string(),
             peppy_dirs,
             timeouts,
+            daemon_use_sim_time,
         },
     };
 
@@ -150,6 +164,9 @@ struct ProcessLaunchContext {
     /// are enforced.
     launch_deadline: Option<Instant>,
     idle_timeouts: IdleTimeouts,
+    /// Daemon-wide default for `framework.use_sim_time` applied to instances
+    /// that omit the per-instance override.
+    daemon_use_sim_time: bool,
 }
 
 #[derive(Clone)]
@@ -160,6 +177,7 @@ struct LaunchActionContext {
     core_instance_id: String,
     peppy_dirs: PeppyDirs,
     timeouts: StackLaunchTimeouts,
+    daemon_use_sim_time: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -285,6 +303,21 @@ fn variant_source_to_node_source(
 /// and generates fresh peppygen files. This allows stack_launch to work with
 /// local filesystem sources without requiring `peppy node sync` beforehand.
 pub const STACK_LAUNCH_GIT_HASH: &str = "stack-launch";
+
+/// Collapse a per-instance launcher override and the daemon-wide default
+/// into a single resolved framework block. Centralizes the "per-instance
+/// value > daemon default > wall" precedence so the spawned node receives
+/// one concrete value and never has to re-implement the fallback.
+fn resolve_framework(
+    overrides: &config::launcher::FrameworkOverrides,
+    daemon_default_use_sim_time: bool,
+) -> config::runtime::ResolvedFramework {
+    config::runtime::ResolvedFramework {
+        use_sim_time: overrides
+            .use_sim_time
+            .unwrap_or(daemon_default_use_sim_time),
+    }
+}
 
 async fn publish_feedback(ctx: &ProcessLaunchContext, feedback: LaunchFeedback) {
     {
@@ -1248,6 +1281,7 @@ async fn start_node_instances(
             let node_instance = config::runtime::NodeInstanceConfig {
                 instance_id: instance.instance_id.clone(),
                 arguments: instance.arguments.clone(),
+                framework: resolve_framework(&instance.framework, ctx.daemon_use_sim_time),
             };
             let runtime_config = match RuntimeConfig::new(
                 messaging_host.as_str(),
@@ -1435,6 +1469,7 @@ async fn handle_goal_request(
             node_stack,
             peppy_dirs,
             timeouts,
+            daemon_use_sim_time,
         } = action_context;
         let env_vars = goal.env_vars.clone();
         // Compute the launch deadline once. `None` => no overall deadline (idle-only).
@@ -1458,6 +1493,7 @@ async fn handle_goal_request(
                 build: Duration::from_secs(goal.node_build_idle_timeout_secs),
                 run: Duration::from_secs(goal.node_run_idle_timeout_secs),
             },
+            daemon_use_sim_time,
         };
         let result = process_launch(goal, ctx).await;
         let mut state_guard = state_clone.lock().await;
@@ -1678,5 +1714,29 @@ mod tests {
             !token.is_cancelled(),
             "happy path must not cancel the token",
         );
+    }
+
+    /// Per-instance override beats the daemon default in either direction.
+    /// `Some(true)` forces sim even when the daemon default is wall;
+    /// `Some(false)` forces wall even when the daemon default is sim.
+    #[test]
+    fn resolve_framework_per_instance_wins() {
+        let force_sim = config::launcher::FrameworkOverrides {
+            use_sim_time: Some(true),
+        };
+        assert!(resolve_framework(&force_sim, false).use_sim_time);
+
+        let force_wall = config::launcher::FrameworkOverrides {
+            use_sim_time: Some(false),
+        };
+        assert!(!resolve_framework(&force_wall, true).use_sim_time);
+    }
+
+    /// When the instance omits the override, the daemon default decides.
+    #[test]
+    fn resolve_framework_falls_through_to_daemon_default() {
+        let none = config::launcher::FrameworkOverrides::default();
+        assert!(!resolve_framework(&none, false).use_sim_time);
+        assert!(resolve_framework(&none, true).use_sim_time);
     }
 }

--- a/crates/core-node-internal/src/services/tests.rs
+++ b/crates/core-node-internal/src/services/tests.rs
@@ -22,6 +22,7 @@ fn test_node_arguments() -> CoreNodeArguments {
         health_monitor_timeout: Duration::from_secs(3),
         health_monitor_max_failures: 3,
         clock_publish_interval: Duration::from_millis(100),
+        daemon_use_sim_time: false,
     }
 }
 

--- a/crates/core-node-internal/tests/common.rs
+++ b/crates/core-node-internal/tests/common.rs
@@ -249,6 +249,7 @@ pub fn build_runtime_config_json5(
         config::runtime::NodeInstanceConfig {
             instance_id: config::launcher::Name::new(instance_id).expect("valid instance id"),
             arguments,
+            framework: Default::default(),
         },
         node_name,
         core_node_name,
@@ -1288,6 +1289,7 @@ fn default_node_arguments() -> CoreNodeArguments {
         // Faster than the production default (100 ms) so publish_clock tests
         // observe several ticks within a small fixed budget without flaking.
         clock_publish_interval: Duration::from_millis(50),
+        daemon_use_sim_time: false,
     }
 }
 
@@ -1301,6 +1303,18 @@ pub async fn start_core_node_with_mock_messenger() -> StartedCoreNode {
         peppy_dirs,
     )
     .await
+}
+
+/// Boots the core node with `daemon_use_sim_time: true`. The daemon stops
+/// publishing wall ticks and instead subscribes to the `clock` topic to fill
+/// its internal cache, mirroring the production flow where an external
+/// simulator drives the clock.
+pub async fn start_core_node_with_sim_clock() -> StartedCoreNode {
+    let (data_dir, peppy_dirs) = init_test_data_dir();
+    let shared_messenger = create_mock_messenger().await;
+    let mut args = default_node_arguments();
+    args.daemon_use_sim_time = true;
+    start_core_node_with_messenger(shared_messenger, args, data_dir, peppy_dirs).await
 }
 
 pub async fn start_core_node_with_real_messenger() -> StartedCoreNode {

--- a/crates/core-node-internal/tests/sim_clock.rs
+++ b/crates/core-node-internal/tests/sim_clock.rs
@@ -13,7 +13,7 @@ use config::node::QoSProfile;
 use core_node::names;
 use core_node_api::encoding::{ClockRequest, ClockResponse, ClockTick};
 use peppylib::{ServiceMessenger, TopicMessenger};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn sim_clock_service_returns_not_ready_until_first_tick() {
@@ -64,8 +64,11 @@ async fn sim_clock_service_serves_external_tick_after_publish() {
         .expect("publish external tick");
 
     // The daemon's subscriber needs a beat to update its cache before the
-    // service handler picks up the new value. Wait briefly, then poll.
+    // service handler picks up the new value. Poll until success, but bound
+    // the loop so a stuck cache fails the test with diagnostics instead of
+    // hanging the test runner.
     let mut last_err = None;
+    let deadline = Instant::now() + Duration::from_secs(5);
     let response = loop {
         let request_payload = ClockRequest::new(0).encode().expect("encode request");
         let attempt = ServiceMessenger::poll(
@@ -84,12 +87,17 @@ async fn sim_clock_service_serves_external_tick_after_publish() {
             Ok(resp) => break resp,
             Err(e) => {
                 last_err = Some(e);
+                if Instant::now() >= deadline {
+                    panic!(
+                        "sim clock service did not return a cached tick within 5s; last error: {:?}",
+                        last_err
+                    );
+                }
                 tokio::time::sleep(Duration::from_millis(50)).await;
                 continue;
             }
         }
     };
-    drop(last_err);
 
     let decoded = ClockResponse::decode(&response.payload()).expect("decode response");
     assert_eq!(

--- a/crates/core-node-internal/tests/sim_clock.rs
+++ b/crates/core-node-internal/tests/sim_clock.rs
@@ -1,0 +1,103 @@
+//! Sim-clock integration tests.
+//!
+//! In sim mode the daemon stops publishing wall ticks and instead subscribes
+//! to the `clock` topic, caching the latest external tick. The clock service
+//! reads from that cache, so requests before the first observed tick must
+//! surface a "not ready" error rather than silently returning zero or
+//! falling back to wall time.
+
+mod common;
+
+use common::{CALLER_INSTANCE_ID, start_core_node_with_sim_clock};
+use config::node::QoSProfile;
+use core_node::names;
+use core_node_api::encoding::{ClockRequest, ClockResponse, ClockTick};
+use peppylib::{ServiceMessenger, TopicMessenger};
+use std::time::Duration;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn sim_clock_service_returns_not_ready_until_first_tick() {
+    let started = start_core_node_with_sim_clock().await;
+
+    let request_payload = ClockRequest::new(0).encode().expect("encode succeeds");
+    let response = ServiceMessenger::poll(
+        &started.caller_handle,
+        &started.core_node_name,
+        CALLER_INSTANCE_ID,
+        &started.core_node_name,
+        names::CLOCK,
+        Some(&started.core_node_name),
+        None,
+        request_payload,
+        Duration::from_secs(2),
+    )
+    .await;
+
+    let err = response.expect_err("empty cache must reject the synchronize request");
+    let message = err.to_string();
+    assert!(
+        message.contains("clock not ready"),
+        "expected 'clock not ready' surface; got: {message}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn sim_clock_service_serves_external_tick_after_publish() {
+    let started = start_core_node_with_sim_clock().await;
+
+    let publisher = TopicMessenger::declare_publisher(
+        &started.caller_handle,
+        &started.core_node_name,
+        CALLER_INSTANCE_ID,
+        &started.core_node_name,
+        names::CLOCK,
+        QoSProfile::SensorData,
+    )
+    .await
+    .expect("external publisher declares against the clock topic");
+
+    // Drive a deterministic value so the response can be checked exactly.
+    const SIM_NS: u64 = 42_000_000_000;
+    publisher
+        .publish(ClockTick::new(SIM_NS).encode().expect("encode tick"))
+        .await
+        .expect("publish external tick");
+
+    // The daemon's subscriber needs a beat to update its cache before the
+    // service handler picks up the new value. Wait briefly, then poll.
+    let mut last_err = None;
+    let response = loop {
+        let request_payload = ClockRequest::new(0).encode().expect("encode request");
+        let attempt = ServiceMessenger::poll(
+            &started.caller_handle,
+            &started.core_node_name,
+            CALLER_INSTANCE_ID,
+            &started.core_node_name,
+            names::CLOCK,
+            Some(&started.core_node_name),
+            None,
+            request_payload,
+            Duration::from_secs(2),
+        )
+        .await;
+        match attempt {
+            Ok(resp) => break resp,
+            Err(e) => {
+                last_err = Some(e);
+                tokio::time::sleep(Duration::from_millis(50)).await;
+                continue;
+            }
+        }
+    };
+    drop(last_err);
+
+    let decoded = ClockResponse::decode(&response.payload()).expect("decode response");
+    assert_eq!(
+        decoded.server_recv_time, SIM_NS,
+        "sim mode must answer from the cached external tick"
+    );
+    assert_eq!(
+        decoded.server_send_time, SIM_NS,
+        "both stamps come from the same cached value within a single request"
+    );
+}

--- a/crates/core-node-internal/tests/sim_clock.rs
+++ b/crates/core-node-internal/tests/sim_clock.rs
@@ -66,10 +66,14 @@ async fn sim_clock_service_serves_external_tick_after_publish() {
     // The daemon's subscriber needs a beat to update its cache before the
     // service handler picks up the new value. Poll until success, but bound
     // the loop so a stuck cache fails the test with diagnostics instead of
-    // hanging the test runner.
-    let mut last_err = None;
+    // hanging the test runner. Each attempt's timeout is capped by the
+    // remaining budget so a stuck poll cannot push wall time past the
+    // deadline.
     let deadline = Instant::now() + Duration::from_secs(5);
     let response = loop {
+        let attempt_timeout = deadline
+            .saturating_duration_since(Instant::now())
+            .min(Duration::from_secs(2));
         let request_payload = ClockRequest::new(0).encode().expect("encode request");
         let attempt = ServiceMessenger::poll(
             &started.caller_handle,
@@ -80,21 +84,18 @@ async fn sim_clock_service_serves_external_tick_after_publish() {
             Some(&started.core_node_name),
             None,
             request_payload,
-            Duration::from_secs(2),
+            attempt_timeout,
         )
         .await;
         match attempt {
             Ok(resp) => break resp,
             Err(e) => {
-                last_err = Some(e);
                 if Instant::now() >= deadline {
                     panic!(
-                        "sim clock service did not return a cached tick within 5s; last error: {:?}",
-                        last_err
+                        "sim clock service did not return a cached tick within 5s; last error: {e:?}"
                     );
                 }
                 tokio::time::sleep(Duration::from_millis(50)).await;
-                continue;
             }
         }
     };

--- a/crates/generator-internal/templates/peppygen/python/peppygen/__init__.py
+++ b/crates/generator-internal/templates/peppygen/python/peppygen/__init__.py
@@ -1,3 +1,4 @@
+from . import clock
 from . import parameters
 from . import emitted_topics
 from . import consumed_topics

--- a/crates/generator-internal/templates/peppygen/python/peppygen/clock.py
+++ b/crates/generator-internal/templates/peppygen/python/peppygen/clock.py
@@ -1,0 +1,44 @@
+"""Pre-bound clock for the generated peppygen module.
+
+Wraps :func:`peppylib.clock_for_node` so user code can read the
+daemon-resolved time with a single call::
+
+    await peppygen.clock.init(node_runner)
+    t = peppygen.clock.now_ns()
+
+``init`` must be called once before any ``now_ns`` call. Subsequent
+``init`` calls are no-ops, so it is safe to call from both top-level setup
+and helper functions that may be invoked first.
+
+In wall mode ``init`` is a no-op wrapper. In sim mode it opens a
+subscription to the ``clock`` topic so the first ``now_ns`` after a tick
+is delivered returns immediately.
+"""
+
+from typing import Optional
+
+import peppylib
+
+_clock: Optional["peppylib.PeppyClock"] = None
+
+
+async def init(node_runner: "peppylib.NodeRunner") -> None:
+    """Build the pre-bound clock for ``node_runner``. Idempotent."""
+    global _clock
+    if _clock is not None:
+        return
+    _clock = await peppylib.clock_for_node(node_runner)
+
+
+def now_ns() -> int:
+    """Read the current core-node-aligned time in nanoseconds since the
+    Unix epoch.
+
+    Raises ``RuntimeError`` if ``init`` has not run, or in sim mode if no
+    ``ClockTick`` has been observed yet.
+    """
+    if _clock is None:
+        raise RuntimeError(
+            "peppygen.clock.init must be called before now_ns"
+        )
+    return _clock.now_ns()

--- a/crates/generator-internal/templates/peppygen/rust/src/clock.rs
+++ b/crates/generator-internal/templates/peppygen/rust/src/clock.rs
@@ -1,0 +1,41 @@
+//! Pre-bound clock for the generated peppygen module.
+//!
+//! Wraps `peppylib::clock_for_node` so user code can read the
+//! daemon-resolved time with a single call:
+//!
+//! ```ignore
+//! peppygen::clock::init(&node_runner).await?;
+//! let t = peppygen::clock::now_ns()?;
+//! ```
+//!
+//! `init` must be called once before any `now_ns` call. The framework
+//! treats subsequent `init` calls as no-ops, so it is safe to call from
+//! both top-level setup and helper functions that may be invoked first.
+
+use std::sync::OnceLock;
+
+use peppylib::runtime::NodeRunner;
+use peppylib::{PeppyClock, PeppyError, PeppyResult, clock_for_node};
+
+static CLOCK: OnceLock<PeppyClock> = OnceLock::new();
+
+/// Build the pre-bound clock for `node_runner`. Idempotent.
+///
+/// In wall mode this is a thin wrapper that does nothing observable; in
+/// sim mode it opens a subscription to the `clock` topic so the first
+/// `now_ns` call after a tick is delivered returns immediately.
+pub async fn init(node_runner: &NodeRunner) -> PeppyResult<()> {
+    if CLOCK.get().is_some() {
+        return Ok(());
+    }
+    let clock = clock_for_node(node_runner).await?;
+    let _ = CLOCK.set(clock);
+    Ok(())
+}
+
+/// Read the current core-node-aligned time in nanoseconds since the Unix
+/// epoch. Returns `Err(PeppyError::ClockNotReady)` if `init` has not run
+/// or, in sim mode, if no `ClockTick` has been observed yet.
+pub fn now_ns() -> PeppyResult<u64> {
+    CLOCK.get().ok_or(PeppyError::ClockNotReady)?.now_ns()
+}

--- a/crates/generator-internal/templates/peppygen/rust/src/lib.rs
+++ b/crates/generator-internal/templates/peppygen/rust/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod clock;
 pub mod parameters;
 
 pub mod capnp;

--- a/crates/generator-internal/tests/python/actions_communication.rs
+++ b/crates/generator-internal/tests/python/actions_communication.rs
@@ -178,6 +178,7 @@ async fn actions_communication() {
         NodeInstanceConfig {
             instance_id: Name::new(consumer_instance_id).unwrap(),
             arguments: Default::default(),
+            framework: Default::default(),
         },
         CONSUMER_NODE_NAME,
         TEST_CORE_NODE,
@@ -248,6 +249,7 @@ if __name__ == "__main__":
         NodeInstanceConfig {
             instance_id: Name::new(exposer_instance_id).unwrap(),
             arguments: Default::default(),
+            framework: Default::default(),
         },
         BRAIN_NODE_NAME, // Must match the node name expected by the consumer
         TEST_CORE_NODE,
@@ -505,6 +507,7 @@ async fn actions_communication_cancel_goal() {
         NodeInstanceConfig {
             instance_id: Name::new(consumer_instance_id).unwrap(),
             arguments: Default::default(),
+            framework: Default::default(),
         },
         CONSUMER_NODE_NAME,
         TEST_CORE_NODE,
@@ -572,6 +575,7 @@ if __name__ == "__main__":
         NodeInstanceConfig {
             instance_id: Name::new(exposer_instance_id).unwrap(),
             arguments: Default::default(),
+            framework: Default::default(),
         },
         BRAIN_NODE_NAME, // Must match the node name expected by the consumer
         TEST_CORE_NODE,

--- a/crates/generator-internal/tests/python/generate_lib.rs
+++ b/crates/generator-internal/tests/python/generate_lib.rs
@@ -87,6 +87,39 @@ fn generate_peppygen_lib_uv() {
     );
 }
 
+/// The clock helper is part of the generated library: `peppygen.clock`
+/// must be a real module exposing both `init` and `now_ns`, and
+/// `peppygen/__init__.py` must import it so user code can call
+/// `peppygen.clock.*` directly.
+#[test]
+fn generate_peppygen_lib_emits_clock_module() {
+    let (_temp_dir, peppygen_dir) =
+        helpers::run_generate_peppygen_lib_test(PeppygenLanguage::Python, PEPPY_JSON5_CONFIG);
+
+    let clock_py = peppygen_dir.join("peppygen/clock.py");
+    assert!(
+        clock_py.exists(),
+        "peppygen/clock.py should be emitted at {}",
+        clock_py.display()
+    );
+    let clock_contents = fs::read_to_string(&clock_py).expect("failed to read clock.py");
+    assert!(
+        clock_contents.contains("async def init"),
+        "clock.py must expose `init`"
+    );
+    assert!(
+        clock_contents.contains("def now_ns"),
+        "clock.py must expose `now_ns`"
+    );
+
+    let init_py = peppygen_dir.join("peppygen/__init__.py");
+    let init_contents = fs::read_to_string(&init_py).expect("failed to read __init__.py");
+    assert!(
+        init_contents.contains("from . import clock"),
+        "__init__.py must import the clock module"
+    );
+}
+
 #[test]
 fn generate_peppygen_lib_minimal_config() {
     let temp_dir = TempDir::new().expect("failed to create temp directory");

--- a/crates/generator-internal/tests/python/services_communication.rs
+++ b/crates/generator-internal/tests/python/services_communication.rs
@@ -130,6 +130,7 @@ async fn services_communication_no_target_instance_id() {
         NodeInstanceConfig {
             instance_id: Name::new(consumer_instance_id).unwrap(),
             arguments: Default::default(),
+            framework: Default::default(),
         },
         CONSUMER_NODE_NAME,
         TEST_CORE_NODE,
@@ -190,6 +191,7 @@ if __name__ == "__main__":
         NodeInstanceConfig {
             instance_id: Name::new(exposer_instance_id).unwrap(),
             arguments: Default::default(),
+            framework: Default::default(),
         },
         UVC_CAMERA_NODE_NAME,
         TEST_CORE_NODE,
@@ -418,6 +420,7 @@ async fn services_communication_exposed_service_without_request_body() {
         NodeInstanceConfig {
             instance_id: Name::new(consumer_instance_id).unwrap(),
             arguments: Default::default(),
+            framework: Default::default(),
         },
         CONSUMER_NODE_NAME,
         TEST_CORE_NODE,
@@ -477,6 +480,7 @@ if __name__ == "__main__":
         NodeInstanceConfig {
             instance_id: Name::new(exposer_instance_id).unwrap(),
             arguments: Default::default(),
+            framework: Default::default(),
         },
         UVC_CAMERA_NODE_NAME,
         TEST_CORE_NODE,
@@ -687,6 +691,7 @@ async fn services_communication_multiple_exposed_instances_same_service_not_targ
         NodeInstanceConfig {
             instance_id: Name::new(consumer_instance_id).unwrap(),
             arguments: Default::default(),
+            framework: Default::default(),
         },
         CONSUMER_NODE_NAME,
         TEST_CORE_NODE,
@@ -747,6 +752,7 @@ if __name__ == "__main__":
         NodeInstanceConfig {
             instance_id: Name::new(exposer1_instance_id).unwrap(),
             arguments: Default::default(),
+            framework: Default::default(),
         },
         UVC_CAMERA_NODE_NAME,
         TEST_CORE_NODE,
@@ -811,6 +817,7 @@ if __name__ == "__main__":
         NodeInstanceConfig {
             instance_id: Name::new(exposer2_instance_id).unwrap(),
             arguments: Default::default(),
+            framework: Default::default(),
         },
         UVC_CAMERA_NODE_NAME,
         TEST_CORE_NODE,

--- a/crates/generator-internal/tests/python/topics_communication.rs
+++ b/crates/generator-internal/tests/python/topics_communication.rs
@@ -115,6 +115,7 @@ async fn topics_communication() {
         NodeInstanceConfig {
             instance_id: Name::new(receiver_instance_id).unwrap(),
             arguments: Default::default(),
+            framework: Default::default(),
         },
         RECEIVER_NODE_NAME,
         TEST_CORE_NODE,
@@ -197,6 +198,7 @@ if __name__ == "__main__":
         NodeInstanceConfig {
             instance_id: Name::new(emitter_instance_id).unwrap(),
             arguments: serde_json5::from_str(r#"{ frequency: 10.0 }"#).unwrap(),
+            framework: Default::default(),
         },
         UVC_CAMERA_NODE_NAME, // Must match the node name expected by the receiver
         TEST_CORE_NODE,

--- a/crates/generator-internal/tests/rust/actions_communication.rs
+++ b/crates/generator-internal/tests/rust/actions_communication.rs
@@ -163,6 +163,7 @@ async fn actions_communication() {
         NodeInstanceConfig {
             instance_id: Name::new(consumer_instance_id).unwrap(),
             arguments: Default::default(),
+            framework: Default::default(),
         },
         CONSUMER_NODE_NAME,
         TEST_CORE_NODE,
@@ -242,6 +243,7 @@ fn main() -> Result<()> {
         NodeInstanceConfig {
             instance_id: Name::new(exposer_instance_id).unwrap(),
             arguments: Default::default(),
+            framework: Default::default(),
         },
         BRAIN_NODE_NAME, // Must match the node name expected by the consumer
         TEST_CORE_NODE,
@@ -480,6 +482,7 @@ async fn actions_communication_cancel_goal() {
         NodeInstanceConfig {
             instance_id: Name::new(consumer_instance_id).unwrap(),
             arguments: Default::default(),
+            framework: Default::default(),
         },
         CONSUMER_NODE_NAME,
         TEST_CORE_NODE,
@@ -555,6 +558,7 @@ fn main() -> Result<()> {
         NodeInstanceConfig {
             instance_id: Name::new(exposer_instance_id).unwrap(),
             arguments: Default::default(),
+            framework: Default::default(),
         },
         BRAIN_NODE_NAME, // Must match the node name expected by the consumer
         TEST_CORE_NODE,

--- a/crates/generator-internal/tests/rust/generate_lib.rs
+++ b/crates/generator-internal/tests/rust/generate_lib.rs
@@ -207,6 +207,38 @@ fn generate_peppygen_lib_cargo() {
     );
 }
 
+/// The clock helper is part of the generated library: `peppygen::clock`
+/// must be a real module exposing both `init` and `now_ns`, and the
+/// crate root must declare it so user code can call `peppygen::clock::*`.
+#[test]
+fn generate_peppygen_lib_emits_clock_module() {
+    let (_temp_dir, peppygen_dir) =
+        helpers::run_generate_peppygen_lib_test(PeppygenLanguage::Rust, PEPPY_JSON5_CONFIG);
+
+    let clock_rs = peppygen_dir.join("src/clock.rs");
+    assert!(
+        clock_rs.exists(),
+        "src/clock.rs should be emitted at {}",
+        clock_rs.display()
+    );
+    let clock_contents = fs::read_to_string(&clock_rs).expect("failed to read clock.rs");
+    assert!(
+        clock_contents.contains("pub async fn init"),
+        "clock.rs must expose `init`"
+    );
+    assert!(
+        clock_contents.contains("pub fn now_ns"),
+        "clock.rs must expose `now_ns`"
+    );
+
+    let lib_rs = peppygen_dir.join("src/lib.rs");
+    let lib_contents = fs::read_to_string(&lib_rs).expect("failed to read lib.rs");
+    assert!(
+        lib_contents.contains("pub mod clock"),
+        "lib.rs must declare the clock module"
+    );
+}
+
 #[test]
 fn generate_peppygen_lib_missing_config() {
     let temp_dir = TempDir::new().expect("failed to create temp directory");

--- a/crates/generator-internal/tests/rust/services_communication.rs
+++ b/crates/generator-internal/tests/rust/services_communication.rs
@@ -129,6 +129,7 @@ async fn services_communication_no_target_instance_id() {
         NodeInstanceConfig {
             instance_id: Name::new(consumer_instance_id).unwrap(),
             arguments: Default::default(),
+            framework: Default::default(),
         },
         CONSUMER_NODE_NAME,
         TEST_CORE_NODE,
@@ -189,6 +190,7 @@ fn main() -> Result<()> {
         NodeInstanceConfig {
             instance_id: Name::new(exposer_instance_id).unwrap(),
             arguments: Default::default(),
+            framework: Default::default(),
         },
         UVC_CAMERA_NODE_NAME,
         TEST_CORE_NODE,
@@ -403,6 +405,7 @@ async fn services_communication_exposed_service_without_request_body() {
         NodeInstanceConfig {
             instance_id: Name::new(consumer_instance_id).unwrap(),
             arguments: Default::default(),
+            framework: Default::default(),
         },
         CONSUMER_NODE_NAME,
         TEST_CORE_NODE,
@@ -460,6 +463,7 @@ fn main() -> Result<()> {
         NodeInstanceConfig {
             instance_id: Name::new(exposer_instance_id).unwrap(),
             arguments: Default::default(),
+            framework: Default::default(),
         },
         UVC_CAMERA_NODE_NAME,
         TEST_CORE_NODE,
@@ -665,6 +669,7 @@ async fn services_communication_multiple_exposed_instances_same_service_not_targ
         NodeInstanceConfig {
             instance_id: Name::new(consumer_instance_id).unwrap(),
             arguments: Default::default(),
+            framework: Default::default(),
         },
         CONSUMER_NODE_NAME,
         TEST_CORE_NODE,
@@ -724,6 +729,7 @@ fn main() -> Result<()> {
         NodeInstanceConfig {
             instance_id: Name::new(exposer1_instance_id).unwrap(),
             arguments: Default::default(),
+            framework: Default::default(),
         },
         UVC_CAMERA_NODE_NAME,
         TEST_CORE_NODE,
@@ -783,6 +789,7 @@ fn main() -> Result<()> {
         NodeInstanceConfig {
             instance_id: Name::new(exposer2_instance_id).unwrap(),
             arguments: Default::default(),
+            framework: Default::default(),
         },
         UVC_CAMERA_NODE_NAME,
         TEST_CORE_NODE,

--- a/crates/generator-internal/tests/rust/topics_communication.rs
+++ b/crates/generator-internal/tests/rust/topics_communication.rs
@@ -104,6 +104,7 @@ async fn topics_communication() {
         NodeInstanceConfig {
             instance_id: Name::new(receiver_instance_id).unwrap(),
             arguments: Default::default(),
+            framework: Default::default(),
         },
         RECEIVER_NODE_NAME,
         TEST_CORE_NODE,
@@ -171,6 +172,7 @@ fn main() -> Result<()> {
         NodeInstanceConfig {
             instance_id: Name::new(emitter_instance_id).unwrap(),
             arguments: serde_json5::from_str(r#"{ frequency: 10.0 }"#).unwrap(),
+            framework: Default::default(),
         },
         UVC_CAMERA_NODE_NAME, // Must match the node name expected by the receiver
         TEST_CORE_NODE,

--- a/crates/peppy/Cargo.toml
+++ b/crates/peppy/Cargo.toml
@@ -16,7 +16,7 @@ bytes = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 askama = "0.15"
-gix-url = "0.35"
+gix-url = "0.36"
 url = "2"
 # https://docs.rs/quote/latest/quote/
 clap = { version = "4.5", features = ["derive"] }

--- a/crates/peppy/src/commands/node/run.rs
+++ b/crates/peppy/src/commands/node/run.rs
@@ -302,6 +302,7 @@ pub async fn run_instance_async(
             instance_id: Name::new(instance_id.clone())
                 .map_err(|e| Error::PeppyConfig(e.into()))?,
             arguments,
+            framework: Default::default(),
         },
         node_name,
         core_node_name,

--- a/crates/peppy/src/commands/node/runtime_config.rs
+++ b/crates/peppy/src/commands/node/runtime_config.rs
@@ -104,6 +104,7 @@ async fn print_runtime_config_async(
         NodeInstanceConfig {
             instance_id: Name::new(instance_id).map_err(|e| Error::PeppyConfig(e.into()))?,
             arguments: args_to_node_arguments(&args),
+            framework: Default::default(),
         },
         node_name,
         conn.core_node_name,

--- a/crates/peppy/src/commands/service.rs
+++ b/crates/peppy/src/commands/service.rs
@@ -8,8 +8,28 @@ pub mod serve;
 
 use super::Command;
 use crate::{context::AppContext, error::Error as CommandError};
-use clap::Subcommand;
+use clap::{Subcommand, ValueEnum};
 use std::sync::Arc;
+
+/// Daemon-wide default for the time source nodes read through `PeppyClock`.
+/// Per-instance launcher overrides win over this; this is the fallback for
+/// instances that omit the framework block.
+#[derive(Copy, Clone, Debug, ValueEnum, Default, PartialEq, Eq)]
+pub enum ClockSource {
+    /// Read OS wall time (`SystemTime::now()`-equivalent).
+    #[default]
+    Wall,
+    /// Read timestamps from the daemon's cache, fed by an external publisher
+    /// on the `clock` topic. Use this for simulators and bag replay.
+    Sim,
+}
+
+impl ClockSource {
+    /// Convenience: `true` when the daemon should treat sim as the default.
+    pub fn use_sim_time(self) -> bool {
+        matches!(self, ClockSource::Sim)
+    }
+}
 
 #[derive(Subcommand)]
 pub enum ServiceCommands {
@@ -22,6 +42,10 @@ pub enum ServiceCommands {
         /// Optional name for the core node
         #[arg(long)]
         core_node_name: Option<String>,
+        /// Daemon-wide clock source. Per-instance `framework.use_sim_time`
+        /// overrides this. Defaults to `wall`.
+        #[arg(long, value_enum, default_value_t = ClockSource::Wall)]
+        clock_source: ClockSource,
     },
     /// Install the peppy daemon as a background service (user-level by default; run with sudo for system-wide).
     Install {},
@@ -43,9 +67,11 @@ impl Command for ServiceCommand {
             ServiceCommands::Serve {
                 messaging_engine,
                 core_node_name,
+                clock_source,
             } => serve::ServeCommand {
                 messaging_engine,
                 core_node_name,
+                clock_source,
                 shutdown_token: None,
             }
             .execute(app_ctx),

--- a/crates/peppy/src/commands/service/builder.rs
+++ b/crates/peppy/src/commands/service/builder.rs
@@ -26,6 +26,7 @@ pub struct ServeCommandBuilder {
     messaging_ready: Option<watch::Receiver<bool>>,
     core_node_requested: bool,
     core_node_name: Option<String>,
+    clock_source: super::ClockSource,
     shutdown_token: Option<CancellationToken>,
     root_dir: PathBuf,
 }
@@ -38,6 +39,7 @@ impl ServeCommandBuilder {
             messaging_ready: None,
             core_node_requested: false,
             core_node_name: None,
+            clock_source: super::ClockSource::default(),
             shutdown_token: None,
             root_dir: root_dir.into(),
         })
@@ -77,9 +79,14 @@ impl ServeCommandBuilder {
         Ok(self)
     }
 
-    pub fn with_core_node(mut self, core_node_name: Option<String>) -> Result<Self> {
+    pub fn with_core_node(
+        mut self,
+        core_node_name: Option<String>,
+        clock_source: super::ClockSource,
+    ) -> Result<Self> {
         self.core_node_requested = true;
         self.core_node_name = core_node_name;
+        self.clock_source = clock_source;
         Ok(self)
     }
 
@@ -93,6 +100,7 @@ impl ServeCommandBuilder {
                     DEFAULT_NODE_START_HEALTH_TIMEOUT,
                     self.root_dir.clone(),
                     self.messaging_ready.clone(),
+                    self.clock_source,
                 );
 
                 // Write the daemon state file with the core node name

--- a/crates/peppy/src/commands/service/core_node.rs
+++ b/crates/peppy/src/commands/service/core_node.rs
@@ -22,6 +22,7 @@ impl CoreNodeRunner {
         node_start_health_timeout: Duration,
         root_dir: PathBuf,
         messaging_ready: Option<watch::Receiver<bool>>,
+        clock_source: super::ClockSource,
     ) -> Self {
         let node_arguments = CoreNodeArguments {
             node_startup_timeout,
@@ -32,6 +33,7 @@ impl CoreNodeRunner {
             // 10 Hz: high enough to correlate logs across nodes, low enough to
             // avoid flooding the bus.
             clock_publish_interval: Duration::from_millis(100),
+            daemon_use_sim_time: clock_source.use_sim_time(),
         };
         let peppy_dirs = PeppyDirs::default();
         let core_node = CoreNode::new(

--- a/crates/peppy/src/commands/service/serve.rs
+++ b/crates/peppy/src/commands/service/serve.rs
@@ -183,6 +183,7 @@ impl Serve {
 pub struct ServeCommand {
     pub messaging_engine: String,
     pub core_node_name: Option<String>,
+    pub clock_source: super::ClockSource,
     pub shutdown_token: Option<CancellationToken>,
 }
 
@@ -190,7 +191,7 @@ impl Command for ServeCommand {
     fn execute(self, ctx: &Arc<AppContext>) -> Result<()> {
         let mut builder = ServeCommandBuilder::new(&ctx.root_dir)?
             .with_messaging_router(self.messaging_engine)?
-            .with_core_node(self.core_node_name)?;
+            .with_core_node(self.core_node_name, self.clock_source)?;
 
         if let Some(token) = self.shutdown_token {
             builder = builder.with_shutdown_token(token);

--- a/crates/peppy/src/test_support.rs
+++ b/crates/peppy/src/test_support.rs
@@ -183,6 +183,7 @@ impl ServeCommandEmulation {
                 health_monitor_timeout: Duration::from_secs(3),
                 health_monitor_max_failures: 3,
                 clock_publish_interval: Duration::from_millis(100),
+                daemon_use_sim_time: false,
             },
             temp_dir.path().to_path_buf(),
             peppy_dirs,

--- a/crates/peppy/tests/service_serve.rs
+++ b/crates/peppy/tests/service_serve.rs
@@ -3,6 +3,7 @@ use std::thread;
 use std::time::Duration;
 
 use peppy::commands::Command;
+use peppy::commands::service::ClockSource;
 use peppy::commands::service::serve::CancellationToken;
 use peppy::commands::service::serve::ServeCommand;
 use peppy::context::AppContext;
@@ -29,6 +30,7 @@ fn serve_command() {
     ServeCommand {
         messaging_engine: "mock".to_string(),
         core_node_name: Some("core-node".to_string()),
+        clock_source: ClockSource::Wall,
         shutdown_token: Some(shutdown_token),
     }
     .execute(&ctx)

--- a/crates/peppylib-py/src/clock.rs
+++ b/crates/peppylib-py/src/clock.rs
@@ -7,7 +7,7 @@
 use std::sync::Arc;
 
 use core_node_api::encoding::{ClockRequest, ClockResponse, ClockTick};
-use peppylib::core_node::clock::{ClockSync, subscribe, synchronize};
+use peppylib::core_node::clock::{ClockSync, PeppyClock, clock_for_node, subscribe, synchronize};
 use peppylib::messaging::Subscription;
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
@@ -274,6 +274,43 @@ fn subscribe_clock_py<'py>(
     })
 }
 
+/// User-facing clock handle. Mirrors
+/// [`peppylib::core_node::clock::PeppyClock`]: hides whether the node was
+/// launched in wall or sim mode and exposes a sync `now_ns()` for hot paths.
+///
+/// Build via [`clock_for_node_py`]. In sim mode the constructor opens the
+/// `clock` subscription up front so subsequent `now_ns()` reads from the
+/// in-memory cache.
+#[pyclass(name = "PeppyClock")]
+pub struct PyPeppyClock {
+    inner: PeppyClock,
+}
+
+#[pymethods]
+impl PyPeppyClock {
+    /// Read the current core-node-aligned time in nanoseconds since the
+    /// Unix epoch. Raises `RuntimeError` in sim mode if no `ClockTick` has
+    /// been observed yet.
+    fn now_ns(&self) -> PyResult<u64> {
+        self.inner.now_ns().map_err(to_py_err)
+    }
+}
+
+/// Build a [`PyPeppyClock`] for `node_runner`. Reads the daemon-resolved
+/// `framework.use_sim_time` flag and installs the matching backend.
+#[pyfunction]
+#[pyo3(name = "clock_for_node")]
+fn clock_for_node_py<'py>(
+    py: Python<'py>,
+    node_runner: &PyNodeRunner,
+) -> PyResult<Bound<'py, PyAny>> {
+    let runner = node_runner.inner.clone();
+    pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        let clock = clock_for_node(&runner).await.map_err(to_py_err)?;
+        Ok(PyPeppyClock { inner: clock })
+    })
+}
+
 /// Add the clock wire-type wrappers and `synchronize` to the parent
 /// `core_node` Python submodule.
 pub(crate) fn register_into(module: &Bound<'_, PyModule>) -> PyResult<()> {
@@ -282,7 +319,9 @@ pub(crate) fn register_into(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_class::<PyClockTick>()?;
     module.add_class::<PyClockSync>()?;
     module.add_class::<PyClockSubscription>()?;
+    module.add_class::<PyPeppyClock>()?;
     module.add_function(wrap_pyfunction!(synchronize_clock, module)?)?;
     module.add_function(wrap_pyfunction!(subscribe_clock_py, module)?)?;
+    module.add_function(wrap_pyfunction!(clock_for_node_py, module)?)?;
     Ok(())
 }

--- a/crates/peppylib/src/core_node/clock.rs
+++ b/crates/peppylib/src/core_node/clock.rs
@@ -11,6 +11,8 @@
 //! timestamp stamping through by hand, this layer takes a [`NodeRunner`]
 //! directly and performs the t0/t3 stamping itself.
 
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use config::node::QoSProfile;
@@ -18,9 +20,9 @@ use core_node_api::encoding::{ClockRequest, ClockResponse, ClockTick, wall_now_n
 use core_node_api::names;
 
 use crate::core_node::transport::poll_clock;
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::messaging::{Subscription, TopicMessenger};
-use crate::runtime::NodeRunner;
+use crate::runtime::{NodeRunner, TaskHandle, spawn};
 
 const DEFAULT_RESPONSE_TIMEOUT: Duration = Duration::from_secs(10);
 
@@ -93,6 +95,90 @@ impl ClockSubscription {
     }
 }
 
+/// User-facing clock handle used by hot-path code that needs "what time is
+/// it now" without knowing whether the node was launched in wall or sim
+/// mode. `now_ns` is sync, allocation-free, and safe to call repeatedly.
+///
+/// Build via [`clock_for_node`]; the constructor decides which underlying
+/// source to install based on the daemon's resolved
+/// `framework.use_sim_time`. The generator emits a pre-bound
+/// `peppygen::clock::now_ns()` free function so user code never has to
+/// thread a `PeppyClock` instance around.
+pub struct PeppyClock {
+    inner: PeppyClockInner,
+}
+
+enum PeppyClockInner {
+    Wall,
+    Sim {
+        cache: Arc<AtomicU64>,
+        // Held to keep the background subscriber alive for as long as the
+        // clock handle exists. Aborted on drop so the task exits cleanly
+        // when the user cancels their node.
+        _feeder: TaskHandle<Result<()>>,
+    },
+}
+
+impl PeppyClock {
+    /// Read the current core-node-aligned time in nanoseconds since the
+    /// Unix epoch. In wall mode this is the local OS clock. In sim mode
+    /// this is the most recently observed `ClockTick`, or
+    /// [`Error::ClockNotReady`] if no tick has arrived yet.
+    pub fn now_ns(&self) -> Result<u64> {
+        match &self.inner {
+            PeppyClockInner::Wall => Ok(wall_now_ns()?),
+            PeppyClockInner::Sim { cache, .. } => match cache.load(Ordering::Relaxed) {
+                0 => Err(Error::ClockNotReady),
+                ns => Ok(ns),
+            },
+        }
+    }
+}
+
+/// Build a [`PeppyClock`] for `node_runner`. Reads
+/// `framework.use_sim_time` off the daemon-resolved runtime config and
+/// installs either a wall-clock wrapper or a sim-clock subscriber.
+///
+/// In sim mode the constructor opens the `clock` subscription up front so
+/// the first `now_ns()` call after a tick has been published returns
+/// immediately without setup latency. The async surface is part of the
+/// constructor so the hot-path read stays sync.
+pub async fn clock_for_node(node_runner: &NodeRunner) -> Result<PeppyClock> {
+    if !node_runner.processor().use_sim_time() {
+        return Ok(PeppyClock {
+            inner: PeppyClockInner::Wall,
+        });
+    }
+
+    let cache = Arc::new(AtomicU64::new(0));
+    let mut subscription = subscribe(node_runner).await?.into_inner();
+    let feeder_cache = Arc::clone(&cache);
+    // The subscriber is detached: subscription drop happens via the
+    // TaskHandle field on PeppyClock, which aborts the task and walks the
+    // Subscription destructor.
+    let feeder = spawn(async move {
+        while let Some(message) = subscription.on_next_message().await {
+            match ClockTick::decode(message.payload().as_ref()) {
+                Ok(tick) => {
+                    // 0 is the not-ready sentinel, so clamp to 1 if a
+                    // simulator ever publishes a literal zero.
+                    let stored = if tick.time == 0 { 1 } else { tick.time };
+                    feeder_cache.store(stored, Ordering::Relaxed);
+                }
+                Err(_) => continue,
+            }
+        }
+        Ok(())
+    });
+
+    Ok(PeppyClock {
+        inner: PeppyClockInner::Sim {
+            cache,
+            _feeder: feeder,
+        },
+    })
+}
+
 /// Subscribe to the periodic `clock` topic on `node_runner`'s bound core node.
 pub async fn subscribe(node_runner: &NodeRunner) -> Result<ClockSubscription> {
     let processor = node_runner.processor();
@@ -127,6 +213,47 @@ fn compute_sync(t0: u64, t1: u64, t2: u64, t3: u64) -> (i64, u64) {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
+    #[test]
+    fn peppy_clock_wall_returns_a_value() {
+        let clock = PeppyClock {
+            inner: PeppyClockInner::Wall,
+        };
+        let now = clock.now_ns().expect("wall should always succeed");
+        assert!(now > 0);
+    }
+
+    #[tokio::test]
+    async fn peppy_clock_sim_reports_not_ready_until_first_tick() {
+        // Construct a sim clock without spawning a feeder by skipping
+        // `clock_for_node`. The `_feeder` slot is filled with a parked
+        // task that keeps the type signature consistent.
+        let cache = Arc::new(AtomicU64::new(0));
+        let cache_clone = Arc::clone(&cache);
+        let feeder = spawn(async move {
+            std::future::pending::<()>().await;
+            Ok(())
+        });
+        let clock = PeppyClock {
+            inner: PeppyClockInner::Sim {
+                cache: cache_clone,
+                _feeder: feeder,
+            },
+        };
+
+        let err = clock
+            .now_ns()
+            .expect_err("empty cache must surface ClockNotReady");
+        assert!(matches!(err, Error::ClockNotReady), "got {err:?}");
+
+        cache.store(42, Ordering::Relaxed);
+        assert_eq!(clock.now_ns().expect("populated cache reads ok"), 42);
+    }
+}
+
+#[cfg(test)]
+mod compute_sync_tests {
     use super::compute_sync;
 
     #[test]

--- a/crates/peppylib/src/core_node/clock.rs
+++ b/crates/peppylib/src/core_node/clock.rs
@@ -113,10 +113,20 @@ enum PeppyClockInner {
     Sim {
         cache: Arc<AtomicU64>,
         // Held to keep the background subscriber alive for as long as the
-        // clock handle exists. Aborted on drop so the task exits cleanly
-        // when the user cancels their node.
-        _feeder: TaskHandle<Result<()>>,
+        // clock handle exists. The `Drop` impl on `PeppyClock` aborts this
+        // handle so the feeder exits when the clock is released; tokio's
+        // `JoinHandle` only detaches on drop, so an explicit abort is
+        // required to actually cancel the task.
+        feeder: TaskHandle<Result<()>>,
     },
+}
+
+impl Drop for PeppyClock {
+    fn drop(&mut self) {
+        if let PeppyClockInner::Sim { feeder, .. } = &self.inner {
+            feeder.abort();
+        }
+    }
 }
 
 impl PeppyClock {
@@ -172,10 +182,7 @@ pub async fn clock_for_node(node_runner: &NodeRunner) -> Result<PeppyClock> {
     });
 
     Ok(PeppyClock {
-        inner: PeppyClockInner::Sim {
-            cache,
-            _feeder: feeder,
-        },
+        inner: PeppyClockInner::Sim { cache, feeder },
     })
 }
 
@@ -226,9 +233,9 @@ mod tests {
 
     #[tokio::test]
     async fn peppy_clock_sim_reports_not_ready_until_first_tick() {
-        // Construct a sim clock without spawning a feeder by skipping
-        // `clock_for_node`. The `_feeder` slot is filled with a parked
-        // task that keeps the type signature consistent.
+        // Construct a sim clock without spawning a real subscriber by
+        // skipping `clock_for_node`. The feeder slot is filled with a
+        // parked task that keeps the type signature consistent.
         let cache = Arc::new(AtomicU64::new(0));
         let cache_clone = Arc::clone(&cache);
         let feeder = spawn(async move {
@@ -238,7 +245,7 @@ mod tests {
         let clock = PeppyClock {
             inner: PeppyClockInner::Sim {
                 cache: cache_clone,
-                _feeder: feeder,
+                feeder,
             },
         };
 

--- a/crates/peppylib/src/core_node/clock.rs
+++ b/crates/peppylib/src/core_node/clock.rs
@@ -112,19 +112,17 @@ enum PeppyClockInner {
     Wall,
     Sim {
         cache: Arc<AtomicU64>,
-        // Held to keep the background subscriber alive for as long as the
-        // clock handle exists. The `Drop` impl on `PeppyClock` aborts this
-        // handle so the feeder exits when the clock is released; tokio's
-        // `JoinHandle` only detaches on drop, so an explicit abort is
-        // required to actually cancel the task.
+        // tokio's `JoinHandle` only detaches on drop, so the `Drop` impl
+        // below must `abort()` to actually cancel the subscriber task.
         feeder: TaskHandle<Result<()>>,
     },
 }
 
-impl Drop for PeppyClock {
+impl Drop for PeppyClockInner {
     fn drop(&mut self) {
-        if let PeppyClockInner::Sim { feeder, .. } = &self.inner {
-            feeder.abort();
+        match self {
+            PeppyClockInner::Wall => {}
+            PeppyClockInner::Sim { feeder, .. } => feeder.abort(),
         }
     }
 }

--- a/crates/peppylib/src/error.rs
+++ b/crates/peppylib/src/error.rs
@@ -96,6 +96,9 @@ pub enum Error {
     #[error("invalid service request '{identifier}': {reason}")]
     InvalidServiceRequest { identifier: String, reason: String },
 
+    #[error("clock not ready: no external tick observed yet on the `clock` topic (sim mode)")]
+    ClockNotReady,
+
     #[error("internal encoding error for '{identifier}': {reason}")]
     InternalEncodingError { identifier: String, reason: String },
 

--- a/crates/peppylib/src/lib.rs
+++ b/crates/peppylib/src/lib.rs
@@ -15,7 +15,10 @@ pub mod types;
 
 // Core node functions
 pub use core_node::{
-    clock::{ClockSubscription, ClockSync, subscribe as subscribe_clock, synchronize},
+    clock::{
+        ClockSubscription, ClockSync, PeppyClock, clock_for_node, subscribe as subscribe_clock,
+        synchronize,
+    },
     info::info,
     stack::{StackList, stack_list},
 };

--- a/crates/peppylib/src/runtime/processor.rs
+++ b/crates/peppylib/src/runtime/processor.rs
@@ -111,6 +111,7 @@ impl Processor {
             NodeInstanceConfig {
                 instance_id: instance_id_name,
                 arguments: BTreeMap::new(),
+                framework: Default::default(),
             },
             &node_name,
             "standalone-core",
@@ -168,6 +169,13 @@ impl Processor {
 
     pub fn messaging_port(&self) -> u16 {
         self.runtime_config.messaging_port
+    }
+
+    /// Daemon-resolved framework `use_sim_time` flag for this instance.
+    /// Read by [`crate::core_node::clock::clock_for_node`] to pick between
+    /// the wall-time and sim-time `PeppyClock` implementations.
+    pub fn use_sim_time(&self) -> bool {
+        self.runtime_config.node_instance.framework.use_sim_time
     }
 }
 

--- a/crates/peppylib/tests/runner.rs
+++ b/crates/peppylib/tests/runner.rs
@@ -130,6 +130,7 @@ async fn daemon_runner_succeed() {
             instance_id: Name::new(TEST_INSTANCE_ID).expect("instance id should be valid"),
             arguments: serde_json5::from_str(&format!("{{ frequency_hz: {TEST_FREQUENCY_HZ} }}"))
                 .expect("runtime args should parse"),
+            framework: Default::default(),
         },
         TEST_NODE_NAME,
         TEST_CORE_NODE,
@@ -333,6 +334,7 @@ async fn node_ready_but_not_healthy() {
             instance_id: Name::new(TEST_INSTANCE_ID).expect("instance id should be valid"),
             arguments: serde_json5::from_str(&format!("{{ frequency_hz: {TEST_FREQUENCY_HZ} }}"))
                 .expect("runtime args should parse"),
+            framework: Default::default(),
         },
         TEST_NODE_NAME,
         TEST_CORE_NODE,
@@ -585,6 +587,7 @@ async fn daemon_cancellation_token_cancelled_on_shutdown() {
             instance_id: Name::new(TEST_INSTANCE_ID).expect("instance id should be valid"),
             arguments: serde_json5::from_str(&format!("{{ frequency_hz: {TEST_FREQUENCY_HZ} }}"))
                 .expect("runtime args should parse"),
+            framework: Default::default(),
         },
         TEST_NODE_NAME,
         TEST_CORE_NODE,

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -8,7 +8,7 @@
       "name": "squalid-ellipse",
       "version": "0.0.1",
       "dependencies": {
-        "@astrojs/rss": "4.0.17",
+        "@astrojs/rss": "^4.0.18",
         "@astrojs/starlight": "^0.38.2",
         "astro": "^6.0.0",
         "entities": "^8.0.0",
@@ -24,21 +24,21 @@
       "license": "MIT"
     },
     "node_modules/@astrojs/internal-helpers": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.8.0.tgz",
-      "integrity": "sha512-J56GrhEiV+4dmrGLPNOl2pZjpHXAndWVyiVDYGDuw6MWKpBSEMLdFxHzeM/6sqaknw9M+HFfHZAcvi3OfT3D/w==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.9.0.tgz",
+      "integrity": "sha512-GdYkzR26re8izmyYlBqf4z2s7zNngmWLFuxw0UKiPNqHraZGS6GKWIwSHgS22RDlu2ePFJ8bzmpBcUszut/SDg==",
       "license": "MIT",
       "dependencies": {
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       }
     },
     "node_modules/@astrojs/markdown-remark": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.1.0.tgz",
-      "integrity": "sha512-P+HnCsu2js3BoTc8kFmu+E9gOcFeMdPris75g+Zl4sY8+bBRbSQV6xzcBDbZ27eE7yBGEGQoqjpChx+KJYIPYQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.1.1.tgz",
+      "integrity": "sha512-C6e9BnLGlbdv6bV8MYGeHpHxsUHrCrB4OuRLqi5LI7oiBVcBcqfUN06zpwFQdHgV48QCCrMmLpyqBr7VqC+swA==",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/internal-helpers": "0.8.0",
+        "@astrojs/internal-helpers": "0.9.0",
         "@astrojs/prism": "4.0.1",
         "github-slugger": "^2.0.0",
         "hast-util-from-html": "^2.0.3",
@@ -62,12 +62,12 @@
       }
     },
     "node_modules/@astrojs/mdx": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-5.0.3.tgz",
-      "integrity": "sha512-zv/OlM5sZZvyjHqJjR3FjJvoCgbxdqj3t4jO/gSEUNcck3BjdtMgNQw8UgPfAGe4yySdG4vjZ3OC5wUxhu7ckg==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-5.0.4.tgz",
+      "integrity": "sha512-tSbuuYueNODiFAFaME7pjHY5lOLoxBYJi1cKd6scw9+a4ZO7C7UGdafEoVAQvOV2eO8a6RaHSAJYGVPL1w8BPA==",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/markdown-remark": "7.1.0",
+        "@astrojs/markdown-remark": "7.1.1",
         "@mdx-js/mdx": "^3.1.1",
         "acorn": "^8.16.0",
         "es-module-lexer": "^2.0.0",
@@ -101,12 +101,12 @@
       }
     },
     "node_modules/@astrojs/rss": {
-      "version": "4.0.17",
-      "resolved": "https://registry.npmjs.org/@astrojs/rss/-/rss-4.0.17.tgz",
-      "integrity": "sha512-eV+wdMbeVKC9+sPaV0LN8JL1LGo9YAh3GKl4Ou4nzMNLmXM/aswYpSGxVEAuHilgBZ6/++/Pv08ICmuOqX107w==",
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@astrojs/rss/-/rss-4.0.18.tgz",
+      "integrity": "sha512-wc5DwKlbTEdgVAWnHy8krFTeQ42t1v/DJqeq5HtulYK3FYHE4krtRGjoyhS3eXXgfdV6Raoz2RU3wrMTFAitRg==",
       "license": "MIT",
       "dependencies": {
-        "fast-xml-parser": "5.4.1",
+        "fast-xml-parser": "^5.5.7",
         "piccolore": "^0.1.3",
         "zod": "^4.3.6"
       }
@@ -132,9 +132,9 @@
       }
     },
     "node_modules/@astrojs/starlight": {
-      "version": "0.38.3",
-      "resolved": "https://registry.npmjs.org/@astrojs/starlight/-/starlight-0.38.3.tgz",
-      "integrity": "sha512-kDlJPlUDdQFWYmyFM2yUPo66yws7v067AEK+/rQjjoVyqehL3DabuOJuy6UJFFTFyGbHxYcBms/ITEgdW7tphw==",
+      "version": "0.38.4",
+      "resolved": "https://registry.npmjs.org/@astrojs/starlight/-/starlight-0.38.4.tgz",
+      "integrity": "sha512-TGFIr2aVC+gcZCPQzJOO4ZnA/yL3jRnsUDcKlVdEhxhxaOQnWr9lZ9MRScg9zU6uh3HVeZAmmjkLCdTlHdcaZA==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/markdown-remark": "^7.0.0",
@@ -171,17 +171,16 @@
       }
     },
     "node_modules/@astrojs/telemetry": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.0.tgz",
-      "integrity": "sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.1.tgz",
+      "integrity": "sha512-7fcIxXS9J4ls5tr8b3ww9rbAIz2+HrhNJYZdkAhhB4za/I5IZ/60g+Bs8q7zwG0tOIZfNB4JWhVJ1Qkl/OrNCw==",
       "license": "MIT",
       "dependencies": {
-        "ci-info": "^4.2.0",
-        "debug": "^4.4.0",
+        "ci-info": "^4.4.0",
         "dlv": "^1.1.3",
         "dset": "^3.1.4",
-        "is-docker": "^3.0.0",
-        "is-wsl": "^3.1.0",
+        "is-docker": "^4.0.0",
+        "is-wsl": "^3.1.1",
         "which-pm-runs": "^1.1.0"
       },
       "engines": {
@@ -926,9 +925,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -944,9 +940,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -964,9 +957,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -982,9 +972,6 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1002,9 +989,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1020,9 +1004,6 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1040,9 +1021,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1059,9 +1037,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1077,9 +1052,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1103,9 +1075,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1127,9 +1096,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1153,9 +1119,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1177,9 +1140,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1203,9 +1163,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1228,9 +1185,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1252,9 +1206,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1390,6 +1341,18 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@oslojs/encoding": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
@@ -1522,9 +1485,9 @@
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
-      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
       "cpu": [
         "arm"
       ],
@@ -1535,9 +1498,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
-      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
       "cpu": [
         "arm64"
       ],
@@ -1548,9 +1511,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
-      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
       "cpu": [
         "arm64"
       ],
@@ -1561,9 +1524,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
-      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
       "cpu": [
         "x64"
       ],
@@ -1574,9 +1537,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
-      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
       "cpu": [
         "arm64"
       ],
@@ -1587,9 +1550,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
-      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
       "cpu": [
         "x64"
       ],
@@ -1600,14 +1563,11 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
-      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -1616,14 +1576,11 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
-      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1632,14 +1589,11 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
-      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -1648,14 +1602,11 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
-      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1664,14 +1615,11 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
-      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -1680,14 +1628,11 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
-      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1696,14 +1641,11 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
-      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -1712,14 +1654,11 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
-      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1728,14 +1667,11 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
-      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -1744,14 +1680,11 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
-      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1760,14 +1693,11 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
-      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -1776,14 +1706,11 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
-      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -1792,14 +1719,11 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
-      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1808,9 +1732,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
-      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
       "cpu": [
         "x64"
       ],
@@ -1821,9 +1745,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
-      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
       "cpu": [
         "arm64"
       ],
@@ -1834,9 +1758,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
-      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
       "cpu": [
         "arm64"
       ],
@@ -1847,9 +1771,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
-      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
       "cpu": [
         "ia32"
       ],
@@ -1860,9 +1784,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
-      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
       "cpu": [
         "x64"
       ],
@@ -1873,9 +1797,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
-      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
       "cpu": [
         "x64"
       ],
@@ -2186,15 +2110,15 @@
       }
     },
     "node_modules/astro": {
-      "version": "6.1.7",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-6.1.7.tgz",
-      "integrity": "sha512-pvZysIUV2C2nRv8N7cXAkCLcfDQz/axAxF09SqiTz1B+xnvbhy6KzL2I6J15ZBXk8k0TfMD75dJ151QyQmAqZA==",
+      "version": "6.1.10",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-6.1.10.tgz",
+      "integrity": "sha512-jQAIki6c862oxRr7OXXC+h3n4wg1EpmKgCH3vv1FtXM9VFmD2iTjlaxrfb0I6eQCwtUjSBxfJBFBDSXHu7Wing==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler": "^3.0.1",
-        "@astrojs/internal-helpers": "0.8.0",
-        "@astrojs/markdown-remark": "7.1.0",
-        "@astrojs/telemetry": "3.3.0",
+        "@astrojs/internal-helpers": "0.9.0",
+        "@astrojs/markdown-remark": "7.1.1",
+        "@astrojs/telemetry": "3.3.1",
         "@capsizecss/unpack": "^4.0.0",
         "@clack/prompts": "^1.1.0",
         "@oslojs/encoding": "^1.1.0",
@@ -2225,7 +2149,7 @@
         "p-queue": "^9.1.0",
         "package-manager-detector": "^1.6.0",
         "piccolore": "^0.1.3",
-        "picomatch": "^4.0.3",
+        "picomatch": "^4.0.4",
         "rehype": "^13.0.2",
         "semver": "^7.7.4",
         "shiki": "^4.0.2",
@@ -2238,9 +2162,9 @@
         "ultrahtml": "^1.6.0",
         "unifont": "~0.7.4",
         "unist-util-visit": "^5.1.0",
-        "unstorage": "^1.17.4",
+        "unstorage": "^1.17.5",
         "vfile": "^6.0.3",
-        "vite": "^7.3.1",
+        "vite": "^7.3.2",
         "vitefu": "^1.1.2",
         "xxhash-wasm": "^1.1.0",
         "yargs-parser": "^22.0.0",
@@ -2789,9 +2713,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
-      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "license": "MIT"
     },
     "node_modules/esast-util-from-estree": {
@@ -3019,9 +2943,9 @@
       }
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
-      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
       "funding": [
         {
           "type": "github",
@@ -3034,9 +2958,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.4.1.tgz",
-      "integrity": "sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
+      "integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
       "funding": [
         {
           "type": "github",
@@ -3045,8 +2969,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fast-xml-builder": "^1.0.0",
-        "strnum": "^2.1.2"
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -3644,15 +3570,15 @@
       }
     },
     "node_modules/is-docker": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
-      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-4.0.0.tgz",
+      "integrity": "sha512-LHE+wROyG/Y/0ZnbktRCoTix2c1RhgWaZraMZ8o1Q7zCh0VSrICJQO5oqIIISrcSBtrXv0o233w1IYwsWCjTzA==",
       "license": "MIT",
       "bin": {
         "is-docker": "cli.js"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3681,6 +3607,21 @@
       },
       "engines": {
         "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container/node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -5022,18 +4963,18 @@
       "license": "MIT"
     },
     "node_modules/oniguruma-parser": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.1.tgz",
-      "integrity": "sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==",
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
+      "integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
       "license": "MIT"
     },
     "node_modules/oniguruma-to-es": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.5.tgz",
-      "integrity": "sha512-Zjygswjpsewa0NLTsiizVuMQZbp0MDyM6lIt66OxsF21npUDlzpHi1Mgb/qhQdkb+dWFTzJmFbEWdvZgRho8eQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
+      "integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
       "license": "MIT",
       "dependencies": {
-        "oniguruma-parser": "^0.12.1",
+        "oniguruma-parser": "^0.12.2",
         "regex": "^6.1.0",
         "regex-recursion": "^6.0.2"
       }
@@ -5054,12 +4995,12 @@
       }
     },
     "node_modules/p-queue": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.1.2.tgz",
-      "integrity": "sha512-ktsDOALzTYTWWF1PbkNVg2rOt+HaOaMWJMUnt7T3qf5tvZ1L8dBW3tObzprBcXNMKkwj+yFSLqHso0x+UFcJXw==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.2.0.tgz",
+      "integrity": "sha512-dWgLE8AH0HjQ9fe74pUkKkvzzYT18Inp4zra3lKHnnwqGvcfcUBrvF2EAVX+envufDNBOzpPq/IBUONDbI7+3g==",
       "license": "MIT",
       "dependencies": {
-        "eventemitter3": "^5.0.1",
+        "eventemitter3": "^5.0.4",
         "p-timeout": "^7.0.0"
       },
       "engines": {
@@ -5212,9 +5153,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "funding": [
         {
           "type": "opencollective",
@@ -5709,9 +5650,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
-      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -5724,31 +5665,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.60.1",
-        "@rollup/rollup-android-arm64": "4.60.1",
-        "@rollup/rollup-darwin-arm64": "4.60.1",
-        "@rollup/rollup-darwin-x64": "4.60.1",
-        "@rollup/rollup-freebsd-arm64": "4.60.1",
-        "@rollup/rollup-freebsd-x64": "4.60.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
-        "@rollup/rollup-linux-arm64-musl": "4.60.1",
-        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
-        "@rollup/rollup-linux-loong64-musl": "4.60.1",
-        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
-        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
-        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
-        "@rollup/rollup-linux-x64-gnu": "4.60.1",
-        "@rollup/rollup-linux-x64-musl": "4.60.1",
-        "@rollup/rollup-openbsd-x64": "4.60.1",
-        "@rollup/rollup-openharmony-arm64": "4.60.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
-        "@rollup/rollup-win32-x64-gnu": "4.60.1",
-        "@rollup/rollup-win32-x64-msvc": "4.60.1",
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
         "fsevents": "~2.3.2"
       }
     },
@@ -5908,12 +5849,12 @@
       }
     },
     "node_modules/starlight-llms-txt": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/starlight-llms-txt/-/starlight-llms-txt-0.8.0.tgz",
-      "integrity": "sha512-SyENqKy5SMms0/RsEPLv1wLI3EvqZeVgVKQZ6umBR4PXEiIg9iisxXPD3lXOdoxEr+ro4Z/9z731UVOgz8LGKA==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/starlight-llms-txt/-/starlight-llms-txt-0.8.1.tgz",
+      "integrity": "sha512-bRMck9OGNiKXyeJzA6Qy2N/gqC40aERpucOOagl+dPz5s/XeY+9p5dx4wBk3Qiicy3dF/F62Zt9iPPff/POpvA==",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/mdx": "^5.0.0",
+        "@astrojs/mdx": "^5.0.3",
         "@types/hast": "^3.0.4",
         "@types/micromatch": "^4.0.10",
         "github-slugger": "^2.0.0",
@@ -6022,9 +5963,9 @@
       }
     },
     "node_modules/tinyexec": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
-      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -6116,9 +6057,9 @@
       "optional": true
     },
     "node_modules/ufo": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
-      "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
       "license": "MIT"
     },
     "node_modules/ultrahtml": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -10,7 +10,7 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@astrojs/rss": "4.0.17",
+    "@astrojs/rss": "^4.0.18",
     "@astrojs/starlight": "^0.38.2",
     "astro": "^6.0.0",
     "entities": "^8.0.0",

--- a/docs/src/content/docs/advanced_guides/system_clock.mdx
+++ b/docs/src/content/docs/advanced_guides/system_clock.mdx
@@ -187,7 +187,8 @@ Resolution order, applied once in the daemon before each spawned node receives i
 1. The instance's `framework.use_sim_time` if it is set.
 2. The daemon's `--clock-source` flag (`wall` is the default).
 
-The wire format does not change. `ClockTick` and `ClockResponse` carry only timestamps; the daemon decides internally which source feeds them. In wall mode the daemon stamps every `t1`/`t2` and every published tick from its own OS clock. In sim mode the daemon stops publishing, subscribes to the `clock` topic, and answers `synchronize` from a cache populated by an external publisher (the simulator or a bag player). Subscribers see the same shape either way.
+The wire format does not change. `ClockTick` and `ClockResponse` carry only timestamps; the daemon decides internally which source feeds them. In wall mode the daemon stamps every `t1`/`t2` and every published tick from its own OS clock. In sim mode the daemon stops publishing, subscribes to the `clock` topic, and answers `synchronize` from a cache populated by an external publisher. 
+Subscribers see the same shape either way.
 
 ### Launcher syntax
 
@@ -225,11 +226,19 @@ For hot-path code that just wants "what time is it now" without caring whether t
 
 
     async def setup(_params: Parameters, node_runner: NodeRunner) -> None:
+        # Idempotent. No-op in wall mode; in sim mode this opens a
+        # `clock` subscription so the background feeder is already
+        # running before `now_ns()` is called below.
         await clock.init(node_runner)
         try:
+            # Wall mode always returns the local OS time. Sim mode
+            # raises RuntimeError until the feeder has cached at least
+            # one ClockTick from the topic.
             now = clock.now_ns()
             print(f"core-node-aligned time: {now} ns")
         except RuntimeError:
+            # Only reachable in sim mode, and only before the first
+            # tick lands. Real apps would retry or wait on a tick.
             print("clock not ready yet")
 
 
@@ -247,9 +256,17 @@ For hot-path code that just wants "what time is it now" without caring whether t
 
     fn main() -> Result<()> {
         NodeBuilder::new().run(|_args: Parameters, node_runner| async move {
+            // Idempotent. No-op in wall mode; in sim mode this opens a
+            // `clock` subscription so the background feeder is already
+            // running before `now_ns()` is called below.
             peppygen::clock::init(&node_runner).await?;
             match peppygen::clock::now_ns() {
+                // Wall mode always lands here. Sim mode reaches this
+                // arm once at least one ClockTick has been observed.
                 Ok(t) => println!("core-node-aligned time: {t} ns"),
+                // Only reachable in sim mode, and only before the
+                // first tick lands. Real apps would retry or wait on
+                // a tick.
                 Err(e) => println!("clock not ready yet: {e}"),
             }
             Ok(())

--- a/docs/src/content/docs/advanced_guides/system_clock.mdx
+++ b/docs/src/content/docs/advanced_guides/system_clock.mdx
@@ -259,4 +259,4 @@ For hot-path code that just wants "what time is it now" without caring whether t
   </TabItem>
 </Tabs>
 
-Use `synchronize` instead of `PeppyClock` when you need a bounded-staleness offset (it observes a round trip and reports the RTT). Use `subscribe_clock` when you want every raw tick. Use `peppygen::clock::now_ns` for everything else.
+Prefer `synchronize` over `PeppyClock` when you need a bounded-staleness offset, since it observes a round trip and reports the RTT. `subscribe_clock` is the right pick if you want every raw tick. For everything else, reach for `peppygen::clock::now_ns`.

--- a/docs/src/content/docs/advanced_guides/system_clock.mdx
+++ b/docs/src/content/docs/advanced_guides/system_clock.mdx
@@ -174,3 +174,89 @@ Each `ClockTick` carries a single field, `time` (`u64`): nanoseconds since the U
 - **`synchronize` is hardened against a misbehaving server.** Offset and delay are computed in widened arithmetic and saturated when narrowed back to `i64` / `u64`, so a peer returning extreme `t1`/`t2` cannot wrap the result or flip its sign.
 - **`on_next_tick` returning `None` is terminal.** Treat it as "core node went away" and rebuild the subscription if you need to keep listening.
 - **Default timeout for `synchronize` is 10 seconds.** Pass an explicit timeout from latency-sensitive paths so a slow or unreachable core node does not stall your node.
+
+## Sim and replay clocks
+
+Most of the time the core node feeds these helpers from its own OS wall time. For simulators and bag replay you usually want the same node binaries to read a virtual clock instead, without rebuilding. peppy makes this a deployment-time choice through two knobs:
+
+- A typed `framework` block on each per-instance launcher entry, sibling to `arguments` and `env_vars`.
+- A daemon-wide CLI flag `--clock-source=wall|sim` that decides the default for instances that omit the override.
+
+Resolution order, applied once in the daemon before each spawned node receives its runtime config:
+
+1. The instance's `framework.use_sim_time` if it is set.
+2. The daemon's `--clock-source` flag (`wall` is the default).
+
+The wire format does not change. `ClockTick` and `ClockResponse` carry only timestamps; the daemon decides internally which source feeds them. In wall mode the daemon stamps every `t1`/`t2` and every published tick from its own OS clock. In sim mode the daemon stops publishing, subscribes to the `clock` topic, and answers `synchronize` from a cache populated by an external publisher (the simulator or a bag player). Subscribers see the same shape either way.
+
+### Launcher syntax
+
+```json5 title="peppy_launcher.json5"
+{
+  deployments: [
+    {
+      source: { local: "./uvc_camera" },
+      instances: [
+        {
+          instance_id: "camera_front",
+          arguments: { device: "/dev/video0" },
+          framework: { use_sim_time: true },
+        },
+      ],
+    },
+  ],
+}
+```
+
+Omit `framework` (or omit `use_sim_time` inside it) to fall through to the daemon default. Setting `use_sim_time: false` on an instance forces wall mode even when the daemon flag is `--clock-source=sim`.
+
+### `PeppyClock` and `peppygen::clock`
+
+For hot-path code that just wants "what time is it now" without caring whether the node was launched in wall or sim mode, peppylib exposes `PeppyClock` and the generator emits a pre-bound `peppygen::clock` module:
+
+- `init(node_runner)` — async; opens a `clock` subscription in sim mode (a no-op in wall mode) so the first `now_ns` after a tick lands returns immediately. Idempotent. Call it once at the top of your setup function.
+- `now_ns()` — sync; reads the current core-node-aligned time. Returns `Err(PeppyError::ClockNotReady)` (Rust) or raises `RuntimeError` (Python) before `init`, and in sim mode before any `ClockTick` has been observed.
+
+<Tabs>
+  <TabItem label="Python">
+    ```python title="src/my_node/__main__.py"
+    from peppygen import NodeBuilder, NodeRunner, clock
+    from peppygen.parameters import Parameters
+
+
+    async def setup(_params: Parameters, node_runner: NodeRunner) -> None:
+        await clock.init(node_runner)
+        try:
+            now = clock.now_ns()
+            print(f"core-node-aligned time: {now} ns")
+        except RuntimeError:
+            print("clock not ready yet")
+
+
+    def main():
+        NodeBuilder().run(setup)
+
+
+    if __name__ == "__main__":
+        main()
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust title="src/main.rs"
+    use peppygen::{NodeBuilder, NodeRunner, Parameters, Result};
+
+    fn main() -> Result<()> {
+        NodeBuilder::new().run(|_args: Parameters, node_runner| async move {
+            peppygen::clock::init(&node_runner).await?;
+            match peppygen::clock::now_ns() {
+                Ok(t) => println!("core-node-aligned time: {t} ns"),
+                Err(e) => println!("clock not ready yet: {e}"),
+            }
+            Ok(())
+        })
+    }
+    ```
+  </TabItem>
+</Tabs>
+
+Use `synchronize` instead of `PeppyClock` when you need a bounded-staleness offset (it observes a round trip and reports the RTT). Use `subscribe_clock` when you want every raw tick. Use `peppygen::clock::now_ns` for everything else.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Simulated-clock support with daemon default and per-instance override; daemon CLI to select wall or sim.
  * New synchronous now_ns() and async init() clock APIs surfaced to runtimes, generated libraries, and Python bindings.
  * Generated helper clock module exported for consumers.

* **Bug Fixes / Tests**
  * Tests for sim-clock readiness, override precedence, serialization/round-trip, and generated library exports.

* **Documentation**
  * System clock guide covering behavior, precedence, and API usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->