### PR TITLE
docs: sync with PR #184

### DIFF
--- a/docs/src/content/docs/advanced_guides/system_clock.mdx
+++ b/docs/src/content/docs/advanced_guides/system_clock.mdx
@@ -194,6 +194,7 @@ Subscribers see the same shape either way.
 
 ```json5 title="peppy_launcher.json5"
 {
+  peppy_schema: "launcher_v1",
   deployments: [
     {
       source: { local: "./uvc_camera" },

--- a/docs/src/content/docs/guides/launch_files.mdx
+++ b/docs/src/content/docs/guides/launch_files.mdx
@@ -158,7 +158,7 @@ Launchers discovered by `peppy repo refresh` (see [Repositories](/advanced_guide
 peppy stack launch openarm01_sim_teleop
 ```
 
-Peppy treats the argument as a repository launcher when it has no path separator and no `.json5` extension; otherwise it is resolved as a filesystem path. The repository form looks the launcher up in `~/.peppy/cache/launchers.json5`, so run `peppy repo refresh` first to ensure the cache is populated. If the name does not exist in the cache, the launch fails with an explicit "not found" error.
+An argument that contains a path separator or ends in `.json5` is always resolved as a filesystem path. A bare name (no separator, no extension) is first tried on disk as `<name>.json5` next to your current directory, and only falls back to the repository cache at `~/.peppy/cache/launchers.json5` when no such file exists. Run `peppy repo refresh` first to ensure the launcher cache is populated. If the name resolves neither to a file nor to a cached launcher, the launch fails with an explicit "not found" error.
 
 :::caution
 Running the `peppy stack launch` command clears the existing node stack and stops all running instances


### PR DESCRIPTION
Automated doc update generated by `scripts/docs/update_docs.py`
in response to code changes in #184.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation of the new `peppy_schema: "launcher_v1"` field in Launcher syntax examples.
  * Clarified argument resolution rules for repository launches: arguments containing path separators or `.json5` extensions are treated as filesystem paths; bare names check local files before the cached launcher index.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->