### PR TITLE
[To remove] Variants now are part of the key expression that identify a node in the node stack

### DIFF
--- a/crates/config-internal/src/error.rs
+++ b/crates/config-internal/src/error.rs
@@ -91,6 +91,10 @@ pub enum ParsingError {
     InvalidMountPath(String, String),
     #[error("Invalid parameter reference `${{parameters:{0}}}` in mount path: {1}")]
     InvalidMountPathParameterRef(String, String),
+
+    // -- node identifier parsing
+    #[error("Invalid node reference `{0}`: {1}")]
+    InvalidNodeRef(String, String),
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]

--- a/crates/config-internal/src/lib.rs
+++ b/crates/config-internal/src/lib.rs
@@ -79,11 +79,12 @@ pub mod node {
         ConsumedService, ConsumedTopic, ContainerConfig, DEFAULT_VARIANT_NAME, DependsOn,
         EmittedTopic, Execution, ExposedAction, ExposedService, ExternalConsumedTopic,
         InterfaceKind, Interfaces, LinkedConsumedTopic, Manifest, MergedVariant, MessageFormat,
-        Name, NodeConfig, NodeConfigCreator, NodeConfigParser, NodeDependency, ObjectKind,
+        Name, NodeConfig, NodeConfigCreator, NodeConfigParser, NodeDependency, NodeKey, ObjectKind,
         ObjectSchema, ParsedNodeConfig, PeppyNodeConfig, PeppygenLanguage, PrimitiveSchema,
         QoSProfile, SchemaType, ServiceInterfaces, Toolchain, TopicInterfaces, TypeToken, Variant,
-        VariantConfig, VariantConfigParser, extract_parameter_refs, find_root_node_dir,
-        is_blocked_mount_source, load_standalone_node_config,
+        VariantConfig, VariantConfigParser, default_variant_name, extract_parameter_refs,
+        find_root_node_dir, is_blocked_mount_source, load_standalone_node_config, parse_node_ref,
+        render_node_id,
     };
 }
 

--- a/crates/config-internal/src/lib.rs
+++ b/crates/config-internal/src/lib.rs
@@ -82,9 +82,8 @@ pub mod node {
         Name, NodeConfig, NodeConfigCreator, NodeConfigParser, NodeDependency, NodeKey, ObjectKind,
         ObjectSchema, ParsedNodeConfig, PeppyNodeConfig, PeppygenLanguage, PrimitiveSchema,
         QoSProfile, SchemaType, ServiceInterfaces, Toolchain, TopicInterfaces, TypeToken, Variant,
-        VariantConfig, VariantConfigParser, default_variant_name, extract_parameter_refs,
-        find_root_node_dir, is_blocked_mount_source, load_standalone_node_config, parse_node_ref,
-        render_node_id,
+        VariantConfig, VariantConfigParser, extract_parameter_refs, find_root_node_dir,
+        is_blocked_mount_source, load_standalone_node_config, parse_node_ref, render_node_id,
     };
 }
 

--- a/crates/config-internal/src/node.rs
+++ b/crates/config-internal/src/node.rs
@@ -14,6 +14,6 @@ pub use types::{
     LinkedConsumedTopic, Manifest, MergedVariant, MessageFormat, Name, NodeConfig, NodeDependency,
     NodeKey, ObjectKind, ObjectSchema, ParsedNodeConfig, PeppyNodeConfig, PeppygenLanguage,
     PrimitiveSchema, QoSProfile, SchemaType, ServiceInterfaces, Toolchain, TopicInterfaces,
-    TypeToken, Variant, VariantConfig, default_variant_name, extract_parameter_refs,
-    is_blocked_mount_source, parse_node_ref, render_node_id,
+    TypeToken, Variant, VariantConfig, extract_parameter_refs, is_blocked_mount_source,
+    parse_node_ref, render_node_id,
 };

--- a/crates/config-internal/src/node.rs
+++ b/crates/config-internal/src/node.rs
@@ -12,7 +12,8 @@ pub use types::{
     ConsumedTopic, ContainerConfig, DEFAULT_VARIANT_NAME, DependsOn, EmittedTopic, Execution,
     ExposedAction, ExposedService, ExternalConsumedTopic, InterfaceKind, Interfaces,
     LinkedConsumedTopic, Manifest, MergedVariant, MessageFormat, Name, NodeConfig, NodeDependency,
-    ObjectKind, ObjectSchema, ParsedNodeConfig, PeppyNodeConfig, PeppygenLanguage, PrimitiveSchema,
-    QoSProfile, SchemaType, ServiceInterfaces, Toolchain, TopicInterfaces, TypeToken, Variant,
-    VariantConfig, extract_parameter_refs, is_blocked_mount_source,
+    NodeKey, ObjectKind, ObjectSchema, ParsedNodeConfig, PeppyNodeConfig, PeppygenLanguage,
+    PrimitiveSchema, QoSProfile, SchemaType, ServiceInterfaces, Toolchain, TopicInterfaces,
+    TypeToken, Variant, VariantConfig, default_variant_name, extract_parameter_refs,
+    is_blocked_mount_source, parse_node_ref, render_node_id,
 };

--- a/crates/config-internal/src/node/types.rs
+++ b/crates/config-internal/src/node/types.rs
@@ -92,7 +92,7 @@ where
 pub const DEFAULT_VARIANT_NAME: &str = "default";
 
 /// `serde(default = ...)` helper for fields that default to the `"default"` variant.
-pub fn default_variant_name() -> String {
+fn default_variant_name() -> String {
     DEFAULT_VARIANT_NAME.to_owned()
 }
 

--- a/crates/config-internal/src/node/types.rs
+++ b/crates/config-internal/src/node/types.rs
@@ -91,6 +91,122 @@ where
 /// Name reserved for the default variant.
 pub const DEFAULT_VARIANT_NAME: &str = "default";
 
+/// `serde(default = ...)` helper for fields that default to the `"default"` variant.
+pub fn default_variant_name() -> String {
+    DEFAULT_VARIANT_NAME.to_owned()
+}
+
+/// Triple identifying a single node in a stack: `(name, tag, variant)`.
+///
+/// The variant field is always present — bare `name:tag` references resolve to
+/// `variant == "default"`. Display via [`NodeKey::label`] elides the
+/// `@default` suffix as a display nicety; the on-disk subpath via
+/// [`NodeKey::artifact_subpath`] never elides.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct NodeKey {
+    pub name: String,
+    pub tag: String,
+    pub variant: String,
+}
+
+impl NodeKey {
+    pub fn new(
+        name: impl Into<String>,
+        tag: impl Into<String>,
+        variant: impl Into<String>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            tag: tag.into(),
+            variant: variant.into(),
+        }
+    }
+
+    /// Synthetic-default constructor for callers without explicit variant context.
+    pub fn with_default_variant(name: impl Into<String>, tag: impl Into<String>) -> Self {
+        Self::new(name, tag, DEFAULT_VARIANT_NAME)
+    }
+
+    /// Canonical display string: `name:tag` when variant is `"default"`,
+    /// otherwise `name:tag@variant`.
+    pub fn label(&self) -> String {
+        render_node_id(&self.name, &self.tag, &self.variant)
+    }
+
+    /// On-disk subpath: `<name>/<tag>/<variant>`. Never elides — every variant,
+    /// including `"default"`, gets its own directory tree so artifacts of
+    /// different variants cannot collide.
+    pub fn artifact_subpath(&self) -> std::path::PathBuf {
+        let mut p = std::path::PathBuf::new();
+        p.push(&self.name);
+        p.push(&self.tag);
+        p.push(&self.variant);
+        p
+    }
+}
+
+/// Render a node identity as `name:tag` (when variant is `"default"`) or
+/// `name:tag@variant` otherwise.
+pub fn render_node_id(name: &str, tag: &str, variant: &str) -> String {
+    if variant == DEFAULT_VARIANT_NAME {
+        format!("{name}:{tag}")
+    } else {
+        format!("{name}:{tag}@{variant}")
+    }
+}
+
+/// Parse a node reference string. Accepts:
+/// - `name:tag` → variant defaults to `"default"`
+/// - `name:tag@variant`
+///
+/// Rejects empty parts, multiple `@`, multiple `:`, embedded whitespace, and
+/// references that don't contain a `:`.
+pub fn parse_node_ref(s: &str) -> Result<(String, String, String), ParsingError> {
+    let invalid = |reason: &str| ParsingError::InvalidNodeRef(s.to_owned(), reason.to_owned());
+
+    let trimmed = s.trim();
+    if trimmed.is_empty() {
+        return Err(invalid("empty"));
+    }
+
+    let (left, variant) = match trimmed.split_once('@') {
+        Some((left, variant)) => {
+            if variant.is_empty() {
+                return Err(invalid("variant after `@` is empty"));
+            }
+            if variant.contains('@') {
+                return Err(invalid("variant must not contain `@`"));
+            }
+            if variant.contains(':') {
+                return Err(invalid("variant must not contain `:`"));
+            }
+            if variant.chars().any(char::is_whitespace) {
+                return Err(invalid("variant must not contain whitespace"));
+            }
+            (left, variant.to_owned())
+        }
+        None => (trimmed, DEFAULT_VARIANT_NAME.to_owned()),
+    };
+
+    let Some((name, tag)) = left.split_once(':') else {
+        return Err(invalid("expected `name:tag` (with optional `@variant`)"));
+    };
+    if name.is_empty() {
+        return Err(invalid("name is empty"));
+    }
+    if tag.is_empty() {
+        return Err(invalid("tag is empty"));
+    }
+    if name.contains(':') || tag.contains(':') {
+        return Err(invalid("name and tag must not contain `:`"));
+    }
+    if name.chars().any(char::is_whitespace) || tag.chars().any(char::is_whitespace) {
+        return Err(invalid("name and tag must not contain whitespace"));
+    }
+
+    Ok((name.to_owned(), tag.to_owned(), variant))
+}
+
 impl RawNodeConfig {
     /// Returns `true` if the manifest contains a variant named `"default"`.
     pub(crate) fn has_default_variant(&self) -> bool {
@@ -806,6 +922,8 @@ fn default_action_service_qos_profile() -> QoSProfile {
 pub struct NodeDependency {
     pub name: Name,
     pub tag: String,
+    #[serde(default = "default_variant_name")]
+    pub variant: String,
     pub local_id: String,
 }
 
@@ -2084,5 +2202,106 @@ mod tests {
         let consumes = actions_a.consumes.unwrap();
         assert_eq!(consumes[0].local_node_id, "node_a");
         assert_eq!(consumes[1].local_node_id, "node_b");
+    }
+
+    #[test]
+    fn render_node_id_elides_default_variant() {
+        assert_eq!(render_node_id("foo", "bar", "default"), "foo:bar");
+        assert_eq!(
+            render_node_id("foo", "bar", DEFAULT_VARIANT_NAME),
+            "foo:bar"
+        );
+    }
+
+    #[test]
+    fn render_node_id_includes_non_default_variant() {
+        assert_eq!(render_node_id("foo", "bar", "v1"), "foo:bar@v1");
+        assert_eq!(
+            render_node_id("depth_camera", "0.1.0", "realsense_d435"),
+            "depth_camera:0.1.0@realsense_d435"
+        );
+    }
+
+    #[test]
+    fn parse_node_ref_bare_defaults_to_default_variant() {
+        let (n, t, v) = parse_node_ref("foo:bar").unwrap();
+        assert_eq!(n, "foo");
+        assert_eq!(t, "bar");
+        assert_eq!(v, DEFAULT_VARIANT_NAME);
+    }
+
+    #[test]
+    fn parse_node_ref_with_variant() {
+        let (n, t, v) = parse_node_ref("foo:bar@v1").unwrap();
+        assert_eq!(n, "foo");
+        assert_eq!(t, "bar");
+        assert_eq!(v, "v1");
+    }
+
+    #[test]
+    fn parse_node_ref_rejects_malformed_inputs() {
+        for bad in [
+            "",                 // empty
+            "   ",              // whitespace only
+            "foo",              // missing colon
+            ":bar",             // empty name
+            "foo:",             // empty tag
+            "foo:bar@",         // empty variant
+            "foo:bar@v1@v2",    // multiple `@`
+            "foo:tag:extra@v1", // multiple `:` before `@`
+            "foo bar:tag",      // whitespace in name
+            "foo:tag@v 1",      // whitespace in variant
+            "foo:tag@v:1",      // `:` in variant
+        ] {
+            assert!(
+                parse_node_ref(bad).is_err(),
+                "expected error for input {bad:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_node_ref_round_trips_render_node_id() {
+        for variant in ["default", "v1", "realsense_d435"] {
+            let s = render_node_id("foo", "bar", variant);
+            let (n, t, v) = parse_node_ref(&s).unwrap();
+            assert_eq!(n, "foo");
+            assert_eq!(t, "bar");
+            assert_eq!(v, variant);
+        }
+    }
+
+    #[test]
+    fn node_key_label_matches_render_node_id() {
+        let k = NodeKey::new("foo", "bar", "default");
+        assert_eq!(k.label(), "foo:bar");
+        let k = NodeKey::new("foo", "bar", "v1");
+        assert_eq!(k.label(), "foo:bar@v1");
+    }
+
+    #[test]
+    fn node_key_artifact_subpath_is_three_components() {
+        let k = NodeKey::new("foo", "bar", "v1");
+        let p = k.artifact_subpath();
+        let parts: Vec<_> = p.components().collect();
+        assert_eq!(parts.len(), 3);
+        // Default-variant subpath still has three components (no elision).
+        let k = NodeKey::new("foo", "bar", "default");
+        let p = k.artifact_subpath();
+        assert_eq!(p.components().count(), 3);
+    }
+
+    #[test]
+    fn node_dependency_defaults_variant_when_absent() {
+        let json = r#"{ "name": "foo", "tag": "0.1.0", "local_id": "x" }"#;
+        let dep: NodeDependency = serde_json::from_str(json).unwrap();
+        assert_eq!(dep.variant, DEFAULT_VARIANT_NAME);
+    }
+
+    #[test]
+    fn node_dependency_reads_explicit_variant() {
+        let json = r#"{ "name": "foo", "tag": "0.1.0", "variant": "v1", "local_id": "x" }"#;
+        let dep: NodeDependency = serde_json::from_str(json).unwrap();
+        assert_eq!(dep.variant, "v1");
     }
 }

--- a/crates/core-node-api/schemas/node.capnp
+++ b/crates/core-node-api/schemas/node.capnp
@@ -63,17 +63,7 @@ struct NodeAddRepoNodeSource {
     name @0 :Text;
     # Node tag as it appears in `nodes.json5`
     tag @1 :Text;
-    # Dep-level variant overrides applied when resolving transitive
-    # dependencies. Empty for "use defaults for every dep".
-    depVariantOverrides @2 :List(DepVariantOverride);
-}
-
-struct DepVariantOverride {
-    # Dep node name
-    name @0 :Text;
-    # Dep node tag
-    tag @1 :Text;
-    # Variant name to use when resolving this dep
+    # Variant name to resolve from the manifest. Required.
     variant @2 :Text;
 }
 
@@ -130,6 +120,9 @@ struct NodeAddResult {
     nodeName @3 :Text;
     # Tag of the added node (empty on failure)
     nodeTag @4 :Text;
+    # Variant of the added node. Always populated; the implicit default is
+    # the literal string "default".
+    nodeVariant @5 :Text;
 }
 
 # Node Build Action — drives the build of a previously-added node
@@ -139,6 +132,9 @@ struct NodeBuildGoal {
     envVars @2 :List(EnvVar);
     timeoutSecs @3 :UInt64;
     force @4 :Bool;
+    # Variant identity. Always populated; the implicit default is the
+    # literal string "default".
+    nodeVariant @5 :Text;
 }
 
 struct NodeBuildGoalResponse {
@@ -226,6 +222,9 @@ struct NodeRunGoal {
     envVars @3 :List(EnvVar);
     # Timeout in seconds for the run operation (used to report remaining time when busy)
     timeoutSecs @4 :UInt64;
+    # Variant identity. Always populated; the implicit default is the
+    # literal string "default".
+    nodeVariant @5 :Text;
 }
 
 struct NodeRunGoalResponse {
@@ -273,6 +272,9 @@ struct NodeRemoveRequest {
     stopInstances @1 :Bool;
     # Tag of the node to remove
     tag @2 :Text;
+    # Variant identity. Always populated; the implicit default is the
+    # literal string "default".
+    nodeVariant @3 :Text;
 }
 
 struct NodeRemoveResponse {
@@ -299,6 +301,9 @@ struct NodeInfoRequest {
     nodeName @0 :Text;
     # Tag of the node to look up in the stack
     nodeTag @1 :Text;
+    # Variant identity. Always populated; the implicit default is the
+    # literal string "default".
+    nodeVariant @2 :Text;
 }
 
 struct NodeInstanceInfo {
@@ -336,8 +341,8 @@ struct NodeInfoResponse {
             addLogPath @5 :Text;
             # Per-instance run log paths, aligned with `instances` (same order).
             runLogPaths @6 :List(Text);
-            # Variant label selected at `node add` time. Empty string when
-            # no variant applies (non-variant add paths).
+            # Variant label selected at `node add` time. Always populated;
+            # the implicit default is the literal string "default".
             variantName @7 :Text;
         }
     }

--- a/crates/core-node-api/src/encoding.rs
+++ b/crates/core-node-api/src/encoding.rs
@@ -16,8 +16,8 @@ pub use clock::{ClockRequest, ClockResponse, ClockTick, wall_now_ns};
 pub use info::{ContainerInfo, InfoRequest, InfoResponse};
 pub use node::builder::FeedbackStream;
 pub use node::{
-    add::DepVariantOverride, add::NodeAddFeedback, add::NodeAddGoal, add::NodeAddGoalResponse,
-    add::NodeAddResult, add::NodeSource, builder::NodeBuildFeedback, builder::NodeBuildGoal,
+    add::NodeAddFeedback, add::NodeAddGoal, add::NodeAddGoalResponse, add::NodeAddResult,
+    add::NodeSource, builder::NodeBuildFeedback, builder::NodeBuildGoal,
     builder::NodeBuildGoalResponse, builder::NodeBuildResult, info::NodeInfo,
     info::NodeInfoRequest, info::NodeInfoResponse, info::NodeInstanceInfo, init::NodeInitRequest,
     init::NodeInitResponse, remove::NodeRemoveRequest, remove::NodeRemoveResponse,

--- a/crates/core-node-api/src/encoding/node/add.rs
+++ b/crates/core-node-api/src/encoding/node/add.rs
@@ -22,56 +22,29 @@ pub enum NodeSource {
         url: url::Url,
         sha256: Option<String>,
     },
-    /// Reference a node by `(name, tag)`; the daemon resolves it and
-    /// its transitive dependencies against the repo cache
+    /// Reference a node by `(name, tag, variant)`; the daemon resolves it
+    /// and its transitive dependencies against the repo cache
     /// (`~/.peppy/cache/nodes.json5`) and adds them as one batch.
-    ///
-    /// Dep-level variant overrides travel with the source so they're
-    /// unrepresentable on non-repo sources.
+    /// Dep-level variants are declared on each manifest's `depends_on`
+    /// entry, not routed through the source.
     RepoNode {
         name: String,
         tag: String,
-        dep_variant_overrides: Vec<DepVariantOverride>,
+        variant: String,
     },
 }
 
-/// Per-dependency variant override for `RepoNode` batch adds.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct DepVariantOverride {
-    pub name: String,
-    pub tag: String,
-    pub variant: String,
-}
-
 impl NodeSource {
-    /// Validated convenience constructor for a `RepoNode` with no dep
-    /// overrides. Applies the same name/tag validation as
-    /// [`Self::decode_repo_node`] so callers cannot build an unsafe
-    /// source that would later be rejected on the wire.
-    pub fn repo_node(name: impl AsRef<str>, tag: impl AsRef<str>) -> Result<Self> {
-        Self::decode_repo_node(name.as_ref(), tag.as_ref(), Vec::new())
-    }
-
-    /// Replaces the dep-override list wholesale on a `RepoNode` source,
-    /// validating each override with the same rules as
-    /// [`Self::decode_repo_node`]. No-op for every other source kind.
-    pub fn with_dep_variant_overrides(
-        mut self,
-        overrides: Vec<DepVariantOverride>,
+    /// Validated convenience constructor for a `RepoNode` source. Applies
+    /// the same name/tag/variant validation as [`Self::decode_repo_node`]
+    /// so callers cannot build an unsafe source that would later be
+    /// rejected on the wire.
+    pub fn repo_node(
+        name: impl AsRef<str>,
+        tag: impl AsRef<str>,
+        variant: impl AsRef<str>,
     ) -> Result<Self> {
-        if let Self::RepoNode {
-            ref mut dep_variant_overrides,
-            ..
-        } = self
-        {
-            for ov in &overrides {
-                validate_repo_node_name(&ov.name, "repo-node dep override name")?;
-                validate_repo_node_tag(&ov.tag, "repo-node dep override tag")?;
-                validate_repo_node_name(&ov.variant, "repo-node dep override variant")?;
-            }
-            *dep_variant_overrides = overrides;
-        }
-        Ok(self)
+        Self::decode_repo_node(name.as_ref(), tag.as_ref(), variant.as_ref())
     }
 }
 
@@ -109,22 +82,14 @@ impl NodeSource {
         })
     }
 
-    pub fn decode_repo_node(
-        name: &str,
-        tag: &str,
-        dep_variant_overrides: Vec<DepVariantOverride>,
-    ) -> Result<Self> {
+    pub fn decode_repo_node(name: &str, tag: &str, variant: &str) -> Result<Self> {
         validate_repo_node_name(name, "repo-node name")?;
         validate_repo_node_tag(tag, "repo-node tag")?;
-        for ov in &dep_variant_overrides {
-            validate_repo_node_name(&ov.name, "repo-node dep override name")?;
-            validate_repo_node_tag(&ov.tag, "repo-node dep override tag")?;
-            validate_repo_node_name(&ov.variant, "repo-node dep override variant")?;
-        }
+        validate_repo_node_name(variant, "repo-node variant")?;
         Ok(Self::RepoNode {
             name: name.to_owned(),
             tag: tag.to_owned(),
-            dep_variant_overrides,
+            variant: variant.to_owned(),
         })
     }
 }
@@ -194,17 +159,18 @@ impl NodeAddGoal {
         Self::from_source(NodeSource::Http { url, sha256 }, git_hash, timeout_secs)
     }
 
-    /// Creates a new NodeAddGoal that targets a node by `(name, tag)`
-    /// against the daemon's repo cache (no dep overrides). Returns an
-    /// error when the name or tag fails the repo-node validation rules.
+    /// Creates a new NodeAddGoal that targets a node by `(name, tag, variant)`
+    /// against the daemon's repo cache. Returns an error when any of the
+    /// inputs fail the repo-node validation rules.
     pub fn new_repo_node(
         name: impl AsRef<str>,
         tag: impl AsRef<str>,
+        variant: impl AsRef<str>,
         git_hash: impl Into<String>,
         timeout_secs: u64,
     ) -> Result<Self> {
         Ok(Self::from_source(
-            NodeSource::repo_node(name, tag)?,
+            NodeSource::repo_node(name, tag, variant)?,
             git_hash,
             timeout_secs,
         ))
@@ -272,25 +238,11 @@ impl NodeAddGoal {
                         goal.reborrow().set_http_sha256(&digest);
                     }
                 }
-                NodeSource::RepoNode {
-                    name,
-                    tag,
-                    dep_variant_overrides,
-                } => {
+                NodeSource::RepoNode { name, tag, variant } => {
                     let mut repo = source.init_repo_node();
                     repo.set_name(name);
                     repo.set_tag(tag);
-                    let override_count = capnp_list_len(
-                        dep_variant_overrides.len(),
-                        "NodeAddGoal.dep_variant_overrides",
-                    )?;
-                    let mut overrides = repo.reborrow().init_dep_variant_overrides(override_count);
-                    for (idx, ov) in dep_variant_overrides.iter().enumerate() {
-                        let mut entry = overrides.reborrow().get(idx as u32);
-                        entry.set_name(&ov.name);
-                        entry.set_tag(&ov.tag);
-                        entry.set_variant(&ov.variant);
-                    }
+                    repo.set_variant(variant);
                 }
             }
 
@@ -356,20 +308,10 @@ impl NodeAddGoal {
             }
             Which::RepoNode(repo) => {
                 let repo = repo?;
-                let overrides_reader = repo.get_dep_variant_overrides()?;
-                let mut overrides = Vec::with_capacity(overrides_reader.len() as usize);
-                for idx in 0..overrides_reader.len() {
-                    let entry = overrides_reader.get(idx);
-                    overrides.push(DepVariantOverride {
-                        name: entry.get_name()?.to_str()?.to_owned(),
-                        tag: entry.get_tag()?.to_str()?.to_owned(),
-                        variant: entry.get_variant()?.to_str()?.to_owned(),
-                    });
-                }
                 NodeSource::decode_repo_node(
                     repo.get_name()?.to_str()?,
                     repo.get_tag()?.to_str()?,
-                    overrides,
+                    repo.get_variant()?.to_str()?,
                 )?
             }
         };
@@ -455,6 +397,36 @@ mod tests {
     }
 
     #[test]
+    fn node_add_goal_repo_node_source_roundtrips() {
+        let encoded = NodeAddGoal::new_repo_node("camera", "0.1.0", "default", "hash", 42)
+            .expect("repo_node constructor should accept valid inputs")
+            .encode()
+            .expect("encoding should succeed");
+        let decoded = NodeAddGoal::decode(&encoded).expect("decoding should succeed");
+        assert_eq!(
+            decoded.source,
+            NodeSource::RepoNode {
+                name: "camera".to_owned(),
+                tag: "0.1.0".to_owned(),
+                variant: "default".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn node_add_goal_repo_node_source_carries_variant() {
+        let encoded = NodeAddGoal::new_repo_node("camera", "0.1.0", "realsense_d435", "hash", 42)
+            .expect("repo_node constructor should accept valid inputs")
+            .encode()
+            .expect("encoding should succeed");
+        let decoded = NodeAddGoal::decode(&encoded).expect("decoding should succeed");
+        let NodeSource::RepoNode { variant, .. } = decoded.source else {
+            panic!("expected RepoNode source, got {:?}", decoded.source);
+        };
+        assert_eq!(variant, "realsense_d435");
+    }
+
+    #[test]
     fn node_add_goal_http_source_roundtrips_sha256() {
         let url = url::Url::parse("https://example.com/node.tar.zst").unwrap();
         let sha256 = "a".repeat(64);
@@ -474,102 +446,31 @@ mod tests {
     }
 
     #[test]
-    fn node_add_goal_repo_node_source_roundtrips() {
-        let encoded = NodeAddGoal::new_repo_node("camera", "0.1.0", "hash", 42)
-            .expect("repo_node constructor should accept valid inputs")
-            .encode()
-            .expect("encoding should succeed");
-        let decoded = NodeAddGoal::decode(&encoded).expect("decoding should succeed");
-        assert_eq!(
-            decoded.source,
-            NodeSource::RepoNode {
-                name: "camera".to_owned(),
-                tag: "0.1.0".to_owned(),
-                dep_variant_overrides: vec![],
-            }
-        );
-    }
-
-    #[test]
-    fn node_add_goal_dep_variant_overrides_roundtrip() {
-        let overrides = vec![
-            DepVariantOverride {
-                name: "uvc_camera".to_owned(),
-                tag: "0.1.0".to_owned(),
-                variant: "mock-python".to_owned(),
-            },
-            DepVariantOverride {
-                name: "lidar".to_owned(),
-                tag: "2.0.0".to_owned(),
-                variant: "sim".to_owned(),
-            },
-        ];
-        let source = NodeSource::repo_node("target", "1.0.0")
-            .expect("repo_node constructor should accept valid inputs")
-            .with_dep_variant_overrides(overrides)
-            .expect("with_dep_variant_overrides should accept valid overrides");
-        let encoded = NodeAddGoal::from_source(source, "hash", 42)
-            .encode()
-            .expect("encoding should succeed");
-        let decoded = NodeAddGoal::decode(&encoded).expect("decoding should succeed");
-        let NodeSource::RepoNode {
-            ref dep_variant_overrides,
-            ..
-        } = decoded.source
-        else {
-            panic!("expected RepoNode source, got {:?}", decoded.source);
-        };
-        assert_eq!(dep_variant_overrides.len(), 2);
-        assert_eq!(dep_variant_overrides[0].name, "uvc_camera");
-        assert_eq!(dep_variant_overrides[0].tag, "0.1.0");
-        assert_eq!(dep_variant_overrides[0].variant, "mock-python");
-        assert_eq!(dep_variant_overrides[1].variant, "sim");
-    }
-
-    #[test]
-    fn with_dep_variant_overrides_is_noop_on_non_repo_source() {
-        let overrides = vec![DepVariantOverride {
-            name: "a".to_owned(),
-            tag: "1.0".to_owned(),
-            variant: "v".to_owned(),
-        }];
-        let source = NodeSource::Fs(PathBuf::from("/tmp/x"))
-            .with_dep_variant_overrides(overrides)
-            .expect("non-repo sources skip override validation");
-        assert!(matches!(source, NodeSource::Fs(_)));
-    }
-
-    #[test]
     fn repo_node_rejects_invalid_name() {
-        assert!(NodeSource::repo_node("../etc", "1.0").is_err());
-        assert!(NodeSource::repo_node("bad name", "1.0").is_err());
+        assert!(NodeSource::repo_node("../etc", "1.0", "default").is_err());
+        assert!(NodeSource::repo_node("bad name", "1.0", "default").is_err());
     }
 
     #[test]
     fn repo_node_rejects_invalid_tag() {
-        assert!(NodeSource::repo_node("node", "").is_err());
-        assert!(NodeSource::repo_node("node", "..").is_err());
+        assert!(NodeSource::repo_node("node", "", "default").is_err());
+        assert!(NodeSource::repo_node("node", "..", "default").is_err());
     }
 
     #[test]
-    fn with_dep_variant_overrides_rejects_invalid_override() {
-        let base = NodeSource::repo_node("node", "1.0").expect("valid");
-        let bad = vec![DepVariantOverride {
-            name: "../evil".to_owned(),
-            tag: "0.1.0".to_owned(),
-            variant: "v".to_owned(),
-        }];
-        assert!(base.with_dep_variant_overrides(bad).is_err());
+    fn repo_node_rejects_invalid_variant() {
+        assert!(NodeSource::repo_node("node", "1.0", "../evil").is_err());
+        assert!(NodeSource::repo_node("node", "1.0", "").is_err());
     }
 
     #[test]
     fn decode_repo_node_rejects_empty_name() {
-        assert!(NodeSource::decode_repo_node("", "0.1.0", vec![]).is_err());
+        assert!(NodeSource::decode_repo_node("", "0.1.0", "default").is_err());
     }
 
     #[test]
     fn decode_repo_node_rejects_empty_tag() {
-        assert!(NodeSource::decode_repo_node("node", "", vec![]).is_err());
+        assert!(NodeSource::decode_repo_node("node", "", "default").is_err());
     }
 
     #[test]
@@ -584,7 +485,7 @@ mod tests {
             "name with space",
         ] {
             assert!(
-                NodeSource::decode_repo_node(name, "0.1.0", vec![]).is_err(),
+                NodeSource::decode_repo_node(name, "0.1.0", "default").is_err(),
                 "name `{name}` should be rejected"
             );
         }
@@ -602,20 +503,10 @@ mod tests {
             "tag with space",
         ] {
             assert!(
-                NodeSource::decode_repo_node("node", tag, vec![]).is_err(),
+                NodeSource::decode_repo_node("node", tag, "default").is_err(),
                 "tag `{tag}` should be rejected"
             );
         }
-    }
-
-    #[test]
-    fn decode_repo_node_rejects_unsafe_dep_override() {
-        let overrides = vec![DepVariantOverride {
-            name: "../evil".to_owned(),
-            tag: "0.1.0".to_owned(),
-            variant: "v".to_owned(),
-        }];
-        assert!(NodeSource::decode_repo_node("node", "0.1.0", overrides).is_err());
     }
 
     #[test]
@@ -764,6 +655,9 @@ pub struct NodeAddResult {
     pub error_message: Option<String>,
     pub node_name: Option<String>,
     pub node_tag: Option<String>,
+    /// Variant identity. `None` only on failure; on success, always populated
+    /// (defaulting to `"default"` for non-variant adds).
+    pub node_variant: Option<String>,
 }
 
 impl NodeAddResult {
@@ -771,6 +665,7 @@ impl NodeAddResult {
         log_path: impl Into<PathBuf>,
         node_name: impl Into<String>,
         node_tag: impl Into<String>,
+        node_variant: impl Into<String>,
     ) -> Self {
         Self {
             log_path: log_path.into(),
@@ -778,6 +673,7 @@ impl NodeAddResult {
             error_message: None,
             node_name: Some(node_name.into()),
             node_tag: Some(node_tag.into()),
+            node_variant: Some(node_variant.into()),
         }
     }
 
@@ -788,6 +684,7 @@ impl NodeAddResult {
             error_message: Some(error_message.into()),
             node_name: None,
             node_tag: None,
+            node_variant: None,
         }
     }
 
@@ -806,6 +703,9 @@ impl NodeAddResult {
             if let Some(ref node_tag) = self.node_tag {
                 result.set_node_tag(node_tag);
             }
+            if let Some(ref node_variant) = self.node_variant {
+                result.set_node_variant(node_variant);
+            }
         }
         encode_message(&builder)
     }
@@ -820,6 +720,7 @@ impl NodeAddResult {
             error_message: optional_text(result.get_error_message()?.to_str()?),
             node_name: optional_text(result.get_node_name()?.to_str()?),
             node_tag: optional_text(result.get_node_tag()?.to_str()?),
+            node_variant: optional_text(result.get_node_variant()?.to_str()?),
         })
     }
 }

--- a/crates/core-node-api/src/encoding/node/builder.rs
+++ b/crates/core-node-api/src/encoding/node/builder.rs
@@ -46,6 +46,7 @@ impl FeedbackStream {
 pub struct NodeBuildGoal {
     pub node_name: String,
     pub node_tag: String,
+    pub node_variant: String,
     pub env_vars: Vec<(String, String)>,
     pub timeout_secs: u64,
     pub force: bool,
@@ -55,11 +56,13 @@ impl NodeBuildGoal {
     pub fn new(
         node_name: impl Into<String>,
         node_tag: impl Into<String>,
+        node_variant: impl Into<String>,
         timeout_secs: u64,
     ) -> Self {
         Self {
             node_name: node_name.into(),
             node_tag: node_tag.into(),
+            node_variant: node_variant.into(),
             env_vars: Vec::new(),
             timeout_secs,
             force: false,
@@ -82,6 +85,7 @@ impl NodeBuildGoal {
             let mut goal = builder.init_root::<node_capnp::node_build_goal::Builder>();
             goal.set_node_name(&self.node_name);
             goal.set_node_tag(&self.node_tag);
+            goal.set_node_variant(&self.node_variant);
 
             let env_var_count = capnp_list_len(self.env_vars.len(), "NodeBuildGoal.env_vars")?;
             let mut env_vars = goal.reborrow().init_env_vars(env_var_count);
@@ -114,6 +118,7 @@ impl NodeBuildGoal {
         Ok(Self {
             node_name: goal.get_node_name()?.to_str()?.to_owned(),
             node_tag: goal.get_node_tag()?.to_str()?.to_owned(),
+            node_variant: goal.get_node_variant()?.to_str()?.to_owned(),
             env_vars,
             timeout_secs: goal.get_timeout_secs(),
             force: goal.get_force(),

--- a/crates/core-node-api/src/encoding/node/info.rs
+++ b/crates/core-node-api/src/encoding/node/info.rs
@@ -14,20 +14,26 @@ use crate::encoding::{capnp_list_len, decode_message, encode_message, optional_t
 
 /// Request payload for the `node_info` service.
 ///
-/// Identifies a node already present in the node stack by `(name, tag)`.
+/// Identifies a node already present in the node stack by `(name, tag, variant)`.
 /// Unlike `node_add`, `node_info` does not resolve configs from filesystem,
 /// git, or HTTP sources — it only inspects what is already in the stack.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NodeInfoRequest {
     pub node_name: String,
     pub node_tag: String,
+    pub node_variant: String,
 }
 
 impl NodeInfoRequest {
-    pub fn new(node_name: impl Into<String>, node_tag: impl Into<String>) -> Self {
+    pub fn new(
+        node_name: impl Into<String>,
+        node_tag: impl Into<String>,
+        node_variant: impl Into<String>,
+    ) -> Self {
         Self {
             node_name: node_name.into(),
             node_tag: node_tag.into(),
+            node_variant: node_variant.into(),
         }
     }
 
@@ -37,6 +43,7 @@ impl NodeInfoRequest {
             let mut request = builder.init_root::<node_capnp::node_info_request::Builder>();
             request.set_node_name(&self.node_name);
             request.set_node_tag(&self.node_tag);
+            request.set_node_variant(&self.node_variant);
         }
         encode_message(&builder)
     }
@@ -47,6 +54,7 @@ impl NodeInfoRequest {
         Ok(Self {
             node_name: request.get_node_name()?.to_str()?.to_owned(),
             node_tag: request.get_node_tag()?.to_str()?.to_owned(),
+            node_variant: request.get_node_variant()?.to_str()?.to_owned(),
         })
     }
 }
@@ -73,9 +81,9 @@ pub struct NodeInfo {
     pub add_log_path: Option<PathBuf>,
     /// Per-instance run log paths, aligned with `instances` (same order).
     pub run_log_paths: Vec<PathBuf>,
-    /// Variant label captured at `node add` time, if any. `None` for
-    /// the synthetic root entity and for non-variant add paths.
-    pub variant_name: Option<String>,
+    /// Variant identity. Always populated; the synthetic root entity and
+    /// non-variant add paths use the literal `"default"` string.
+    pub variant: String,
 }
 
 /// Response payload for the `node_info` service.
@@ -138,7 +146,7 @@ impl NodeInfoResponse {
                             paths_builder.set(i as u32, path.to_string_lossy().as_ref());
                         }
                     }
-                    found.set_variant_name(info.variant_name.as_deref().unwrap_or(""));
+                    found.set_variant_name(&info.variant);
                 }
             }
         }
@@ -180,7 +188,7 @@ impl NodeInfoResponse {
                 for i in 0..run_log_paths_reader.len() {
                     run_log_paths.push(PathBuf::from(run_log_paths_reader.get(i)?.to_str()?));
                 }
-                let variant_name = optional_text(found.get_variant_name()?.to_str()?);
+                let variant = found.get_variant_name()?.to_str()?.to_owned();
                 Ok(NodeInfoResponse::Found(Box::new(NodeInfo {
                     config,
                     config_integrity,
@@ -188,7 +196,7 @@ impl NodeInfoResponse {
                     instances,
                     add_log_path,
                     run_log_paths,
-                    variant_name,
+                    variant,
                 })))
             }
         }
@@ -202,13 +210,14 @@ mod tests {
 
     #[test]
     fn node_info_request_roundtrips_name_tag() {
-        let encoded = NodeInfoRequest::new("sensor_node", "0.1.0")
+        let encoded = NodeInfoRequest::new("sensor_node", "0.1.0", "default")
             .encode()
             .expect("encoding should succeed");
         let decoded = NodeInfoRequest::decode(&encoded).expect("decoding should succeed");
 
         assert_eq!(decoded.node_name, "sensor_node");
         assert_eq!(decoded.node_tag, "0.1.0");
+        assert_eq!(decoded.node_variant, "default");
     }
 
     fn sample_config_for_roundtrip() -> NodeConfig {
@@ -226,7 +235,7 @@ mod tests {
             .expect("resolve config")
     }
 
-    fn info_with_variant(variant_name: Option<String>) -> NodeInfo {
+    fn info_with_variant(variant: impl Into<String>) -> NodeInfo {
         NodeInfo {
             config: sample_config_for_roundtrip(),
             config_integrity: "0".repeat(64),
@@ -234,13 +243,13 @@ mod tests {
             instances: vec![],
             add_log_path: None,
             run_log_paths: vec![],
-            variant_name,
+            variant: variant.into(),
         }
     }
 
     #[test]
-    fn node_info_response_roundtrips_variant_name_some() {
-        let info = info_with_variant(Some("macos".to_string()));
+    fn node_info_response_roundtrips_variant_explicit() {
+        let info = info_with_variant("macos");
         let encoded = NodeInfoResponse::Found(Box::new(info))
             .encode()
             .expect("encoding should succeed");
@@ -248,15 +257,15 @@ mod tests {
 
         match decoded {
             NodeInfoResponse::Found(info) => {
-                assert_eq!(info.variant_name.as_deref(), Some("macos"));
+                assert_eq!(info.variant, "macos");
             }
             NodeInfoResponse::NotInStack => panic!("expected Found"),
         }
     }
 
     #[test]
-    fn node_info_response_roundtrips_variant_name_none() {
-        let info = info_with_variant(None);
+    fn node_info_response_roundtrips_variant_default() {
+        let info = info_with_variant("default");
         let encoded = NodeInfoResponse::Found(Box::new(info))
             .encode()
             .expect("encoding should succeed");
@@ -264,7 +273,7 @@ mod tests {
 
         match decoded {
             NodeInfoResponse::Found(info) => {
-                assert!(info.variant_name.is_none());
+                assert_eq!(info.variant, "default");
             }
             NodeInfoResponse::NotInStack => panic!("expected Found"),
         }

--- a/crates/core-node-api/src/encoding/node/remove.rs
+++ b/crates/core-node-api/src/encoding/node/remove.rs
@@ -9,14 +9,20 @@ use crate::encoding::{decode_message, encode_message, optional_text};
 pub struct NodeRemoveRequest {
     pub node_name: String,
     pub tag: String,
+    pub node_variant: String,
     pub stop_instances: bool,
 }
 
 impl NodeRemoveRequest {
-    pub fn new(node_name: impl Into<String>, tag: impl Into<String>) -> Self {
+    pub fn new(
+        node_name: impl Into<String>,
+        tag: impl Into<String>,
+        node_variant: impl Into<String>,
+    ) -> Self {
         Self {
             node_name: node_name.into(),
             tag: tag.into(),
+            node_variant: node_variant.into(),
             stop_instances: false,
         }
     }
@@ -33,6 +39,7 @@ impl NodeRemoveRequest {
             request.set_node_name(&self.node_name);
             request.set_stop_instances(self.stop_instances);
             request.set_tag(&self.tag);
+            request.set_node_variant(&self.node_variant);
         }
         encode_message(&builder)
     }
@@ -43,6 +50,7 @@ impl NodeRemoveRequest {
         Ok(Self {
             node_name: request.get_node_name()?.to_str()?.to_owned(),
             tag: request.get_tag()?.to_str()?.to_owned(),
+            node_variant: request.get_node_variant()?.to_str()?.to_owned(),
             stop_instances: request.get_stop_instances(),
         })
     }

--- a/crates/core-node-api/src/encoding/node/run.rs
+++ b/crates/core-node-api/src/encoding/node/run.rs
@@ -16,6 +16,7 @@ pub struct NodeRunGoal {
     pub runtime_config_json5: String,
     pub node_name: String,
     pub tag: String,
+    pub node_variant: String,
     pub env_vars: Vec<(String, String)>,
     pub timeout_secs: u64,
 }
@@ -25,12 +26,14 @@ impl NodeRunGoal {
         runtime_config_json5: impl Into<String>,
         node_name: impl Into<String>,
         tag: impl Into<String>,
+        node_variant: impl Into<String>,
         timeout_secs: u64,
     ) -> Self {
         Self {
             runtime_config_json5: runtime_config_json5.into(),
             node_name: node_name.into(),
             tag: tag.into(),
+            node_variant: node_variant.into(),
             env_vars: Vec::new(),
             timeout_secs,
         }
@@ -49,8 +52,9 @@ impl NodeRunGoal {
         runtime_config_json5: impl Into<String>,
         node_name: impl Into<String>,
         tag: impl Into<String>,
+        node_variant: impl Into<String>,
     ) -> Self {
-        Self::new(runtime_config_json5, node_name, tag, 0)
+        Self::new(runtime_config_json5, node_name, tag, node_variant, 0)
     }
 
     pub fn encode(&self) -> Result<Payload> {
@@ -60,6 +64,7 @@ impl NodeRunGoal {
             goal.set_runtime_config_json5(&self.runtime_config_json5);
             goal.set_node_name(&self.node_name);
             goal.set_tag(&self.tag);
+            goal.set_node_variant(&self.node_variant);
 
             let env_var_count = capnp_list_len(self.env_vars.len(), "NodeRunGoal.env_vars")?;
             let mut env_vars = goal.reborrow().init_env_vars(env_var_count);
@@ -92,6 +97,7 @@ impl NodeRunGoal {
             runtime_config_json5: goal.get_runtime_config_json5()?.to_str()?.to_owned(),
             node_name: goal.get_node_name()?.to_str()?.to_owned(),
             tag: goal.get_tag()?.to_str()?.to_owned(),
+            node_variant: goal.get_node_variant()?.to_str()?.to_owned(),
             env_vars,
             timeout_secs: goal.get_timeout_secs(),
         })

--- a/crates/core-node-api/src/graph.rs
+++ b/crates/core-node-api/src/graph.rs
@@ -138,11 +138,7 @@ pub struct SerializedNode {
 
 impl SerializedNode {
     pub fn label(&self) -> String {
-        if self.variant == "default" {
-            format!("{}:{}", self.name, self.tag)
-        } else {
-            format!("{}:{}@{}", self.name, self.tag, self.variant)
-        }
+        config::node::render_node_id(&self.name, &self.tag, &self.variant)
     }
 
     /// Externally visible instance ids — the subset of `instances` that have

--- a/crates/core-node-api/src/graph.rs
+++ b/crates/core-node-api/src/graph.rs
@@ -130,15 +130,19 @@ pub struct SerializedNode {
     /// in-flight `Starting` instances.
     #[serde(default)]
     pub instances: Vec<SerializedInstance>,
-    /// Variant label selected at `node add` time, if any. `None` for the
-    /// synthetic root node and for non-variant add paths.
-    #[serde(default)]
-    pub variant_name: Option<String>,
+    /// Variant label captured at `node add` time. Always populated — the
+    /// synthetic root node and non-variant add paths use the literal
+    /// `"default"` string.
+    pub variant: String,
 }
 
 impl SerializedNode {
     pub fn label(&self) -> String {
-        format!("{}:{}", self.name, self.tag)
+        if self.variant == "default" {
+            format!("{}:{}", self.name, self.tag)
+        } else {
+            format!("{}:{}@{}", self.name, self.tag, self.variant)
+        }
     }
 
     /// Externally visible instance ids — the subset of `instances` that have

--- a/crates/core-node-internal/src/services/node/add.rs
+++ b/crates/core-node-internal/src/services/node/add.rs
@@ -832,7 +832,12 @@ pub(crate) async fn run_node_add(
         // Capture the variant label alongside `effective_variant` so it can
         // be persisted on the `NodeEntity` after `push_config` — the daemon
         // reads it back out of the entity when answering `node_info`.
-        let variant_name: Option<String> = effective_variant.as_ref().map(variant_label);
+        // Nodes without a variant context default to the literal "default"
+        // string so identity is always a non-empty triple.
+        let variant: String = effective_variant
+            .as_ref()
+            .map(variant_label)
+            .unwrap_or_else(|| DEFAULT_VARIANT_NAME.to_owned());
 
         // Capture the root source path before variant resolution may overwrite it.
         // The .peppy/git.hash file is written by `peppy node sync` at the root
@@ -979,12 +984,16 @@ pub(crate) async fn run_node_add(
             matches!(&goal.source, NodeSource::Fs(_)) && goal.git_hash != STACK_LAUNCH_GIT_HASH;
         let verify_codegen_fingerprint = is_local_root && variant_source_is_local;
 
-        // Rename log file to the canonical {name}_{tag}_{timestamp}.log format
-        // now that we know the node name and tag from the resolved config.
+        // Move the log file under the canonical
+        // `<logs_add>/<name>/<tag>/<variant>/<timestamp>.log` subtree now that
+        // the resolved node identity (including variant) is known.
         let node_name = node_config.manifest.name.as_str();
         let node_tag = &node_config.manifest.tag;
-        let canonical_filename = format!("{}_{}_{}.log", node_name, node_tag, timestamp);
-        let canonical_log_path = log_dir.join(&canonical_filename);
+        let key = config::node::NodeKey::new(node_name, node_tag, &variant);
+        let canonical_dir = log_dir.join(key.artifact_subpath());
+        let _ = std::fs::create_dir_all(&canonical_dir);
+        let canonical_filename = format!("{}.log", timestamp);
+        let canonical_log_path = canonical_dir.join(&canonical_filename);
         let log_path = if std::fs::rename(&log_path, &canonical_log_path).is_ok() {
             canonical_log_path
         } else {
@@ -1006,7 +1015,7 @@ pub(crate) async fn run_node_add(
             source_path,
             verify_codegen_fingerprint,
             cleanup_dir,
-            variant_name,
+            variant,
             ctx,
         )
         .await
@@ -1158,9 +1167,14 @@ async fn handle_goal_request(
 async fn shutdown_existing_instances(
     node_name: &str,
     node_tag: &str,
+    node_variant: &str,
     ctx: &ProcessNodeAddContext,
 ) -> std::result::Result<(), String> {
-    let Some(entity) = ctx.action.node_stack.find(node_name, node_tag) else {
+    let Some(entity) = ctx
+        .action
+        .node_stack
+        .find(node_name, node_tag, node_variant)
+    else {
         return Ok(());
     };
 
@@ -1205,6 +1219,7 @@ async fn shutdown_existing_instances(
             &ctx.action.node_stack,
             node_name,
             node_tag,
+            node_variant,
             &instance_id,
         )
         .await?;
@@ -1224,7 +1239,7 @@ async fn process_node_add(
     source_path: PathBuf,
     verify_codegen_fingerprint: bool,
     cleanup_dir: Option<PathBuf>,
-    variant_name: Option<String>,
+    variant: String,
     ctx: ProcessNodeAddContext,
 ) -> NodeAddResult {
     // Reject any forbidden env vars early so the user gets a fast failure;
@@ -1323,10 +1338,11 @@ async fn process_node_add(
         &node_config.interfaces,
         &node_name,
         &node_tag,
-        |name, tag| {
+        &variant,
+        |name, tag, variant| {
             ctx.action
                 .node_stack
-                .find(name, tag)
+                .find(name, tag, variant)
                 .map(|e| e.read().config().clone())
         },
     );
@@ -1375,7 +1391,7 @@ async fn process_node_add(
     // config. `push_config` rejects replacements that still have live
     // instances (it would otherwise orphan them), so we shut them down
     // first to satisfy that precondition.
-    if let Err(e) = shutdown_existing_instances(&node_name, &node_tag, &ctx).await {
+    if let Err(e) = shutdown_existing_instances(&node_name, &node_tag, &variant, &ctx).await {
         let msg = format!("Failed to shutdown existing node instances: {}", e);
         write_error_to_log(&ctx.log_file, &msg);
         return NodeAddResult::failure(&ctx.log_path, msg);
@@ -1387,23 +1403,23 @@ async fn process_node_add(
     // clone) that is cleaned up after this function returns. The
     // working_dir persists as long as the entity exists via WorkingDirGuard.
     let config_path_for_stack = working_dir.join(NODE_CONFIG_FILE);
-    if let Err(e) = ctx.action.node_stack.push_config_with_variant(
+    if let Err(e) = ctx.action.node_stack.push_config(
         node_config.clone(),
         false,
         &config_path_for_stack,
-        variant_name.clone(),
+        variant.clone(),
     ) {
         let msg = format!("Failed to add node config: {}", e);
         write_error_to_log(&ctx.log_file, &msg);
         return NodeAddResult::failure(&ctx.log_path, msg);
     }
 
-    let entity_handle = match ctx.action.node_stack.find(&node_name, &node_tag) {
+    let entity_handle = match ctx.action.node_stack.find(&node_name, &node_tag, &variant) {
         Some(handle) => handle,
         None => {
             let msg = format!(
-                "internal error: just-pushed entity {}:{} disappeared from the stack",
-                node_name, node_tag
+                "internal error: just-pushed entity {} disappeared from the stack",
+                config::node::render_node_id(&node_name, &node_tag, &variant)
             );
             write_error_to_log(&ctx.log_file, &msg);
             return NodeAddResult::failure(&ctx.log_path, msg);
@@ -1420,15 +1436,21 @@ async fn process_node_add(
     ));
     {
         let mut guard = entity_handle.write();
-        ctx.action
-            .node_stack
-            .set_add_log_path(&node_name, &node_tag, ctx.log_path.clone());
+        ctx.action.node_stack.set_add_log_path(
+            &node_name,
+            &node_tag,
+            &variant,
+            ctx.log_path.clone(),
+        );
         guard.set_pending_working_dir(Arc::clone(&working_dir_guard));
     }
 
-    debug!("Added node {}:{} (pending build)", node_name, node_tag);
+    debug!(
+        "Added node {} (pending build)",
+        config::node::render_node_id(&node_name, &node_tag, &variant)
+    );
 
-    NodeAddResult::success(&ctx.log_path, node_name, node_tag)
+    NodeAddResult::success(&ctx.log_path, node_name, node_tag, variant)
 }
 
 #[cfg(test)]

--- a/crates/core-node-internal/src/services/node/add.rs
+++ b/crates/core-node-internal/src/services/node/add.rs
@@ -829,11 +829,8 @@ pub(crate) async fn run_node_add(
             None => None,
         };
 
-        // Capture the variant label alongside `effective_variant` so it can
-        // be persisted on the `NodeEntity` after `push_config` — the daemon
-        // reads it back out of the entity when answering `node_info`.
-        // Nodes without a variant context default to the literal "default"
-        // string so identity is always a non-empty triple.
+        // Identity is always a non-empty `(name, tag, variant)` triple — fall
+        // back to the literal "default" when no variant context applies.
         let variant: String = effective_variant
             .as_ref()
             .map(variant_label)

--- a/crates/core-node-internal/src/services/node/add_batch.rs
+++ b/crates/core-node-internal/src/services/node/add_batch.rs
@@ -455,6 +455,7 @@ async fn run_single_batched_add(
         batch_goal.timeout_secs,
     );
 
+    let mut variant_set_via_source = false;
     if node.is_root {
         // Env vars / force / root variant only apply to the root entity.
         sub_goal = sub_goal
@@ -462,10 +463,10 @@ async fn run_single_batched_add(
             .with_force(batch_goal.force);
         if let Some(ref v) = batch_goal.variant {
             sub_goal = sub_goal.with_variant_source(v.clone());
-        } else if node.variant != config::node::DEFAULT_VARIANT_NAME {
-            sub_goal = sub_goal.with_variant_name(node.variant.clone());
+            variant_set_via_source = true;
         }
-    } else if node.variant != config::node::DEFAULT_VARIANT_NAME {
+    }
+    if !variant_set_via_source && node.variant != config::node::DEFAULT_VARIANT_NAME {
         sub_goal = sub_goal.with_variant_name(node.variant.clone());
     }
 

--- a/crates/core-node-internal/src/services/node/add_batch.rs
+++ b/crates/core-node-internal/src/services/node/add_batch.rs
@@ -15,9 +15,7 @@ use super::{FeedbackLine, FeedbackStream, create_action_log_file};
 use chrono::Local;
 use config::consts::PeppyDirs;
 use config::node::ParsedNodeConfig;
-use core_node_api::encoding::{
-    DepVariantOverride, NodeAddGoal, NodeAddResult, NodeSource, RepoSourceKind,
-};
+use core_node_api::encoding::{NodeAddGoal, NodeAddResult, NodeSource, RepoSourceKind};
 use futures::future::BoxFuture;
 use futures::stream::{FuturesUnordered, StreamExt};
 use node_stack::VirtualDeptree;
@@ -46,12 +44,8 @@ pub(crate) async fn run_repo_node_add(
     log_file: Arc<StdMutex<File>>,
     log_path: PathBuf,
 ) -> NodeAddResult {
-    let (root_name, root_tag, dep_variant_overrides) = match &goal.source {
-        NodeSource::RepoNode {
-            name,
-            tag,
-            dep_variant_overrides,
-        } => (name.clone(), tag.clone(), dep_variant_overrides.clone()),
+    let (root_name, root_tag, root_variant) = match &goal.source {
+        NodeSource::RepoNode { name, tag, variant } => (name.clone(), tag.clone(), variant.clone()),
         _ => {
             return NodeAddResult::failure(
                 &log_path,
@@ -60,24 +54,13 @@ pub(crate) async fn run_repo_node_add(
         }
     };
 
-    if let Some(root_override) = dep_variant_overrides
-        .iter()
-        .find(|ov| ov.name == root_name && ov.tag == root_tag)
-    {
-        return fail(
-            &log_file,
-            &log_path,
-            format!(
-                "Dependency variant override {}:{}@{} targets the root repo node; use the root variant field instead",
-                root_override.name, root_override.tag, root_override.variant
-            ),
-        );
-    }
-
     emit(
         &feedback_tx,
         FeedbackStream::Stdout,
-        format!("Resolving {}:{} from repo cache", root_name, root_tag),
+        format!(
+            "Resolving {} from repo cache",
+            config::node::render_node_id(&root_name, &root_tag, &root_variant)
+        ),
     );
 
     let peppy_dirs = action_context.peppy_dirs.clone();
@@ -113,7 +96,7 @@ pub(crate) async fn run_repo_node_add(
         resolution_ctx,
         &root_name,
         &root_tag,
-        &dep_variant_overrides,
+        &root_variant,
     )
     .await
     {
@@ -121,30 +104,18 @@ pub(crate) async fn run_repo_node_add(
         Err(msg) => return fail(&log_file, &log_path, msg),
     };
 
-    // Warn about overrides that targeted nodes not actually in the tree.
-    for ov in &dep_variant_overrides {
-        let in_tree = resolution
-            .to_add
-            .iter()
-            .any(|n| n.name == ov.name && n.tag == ov.tag);
-        if !in_tree {
-            emit(
-                &feedback_tx,
-                FeedbackStream::Warning,
-                format!(
-                    "Dependency variant override for {}:{} ignored — not in the resolved dependency tree",
-                    ov.name, ov.tag
-                ),
-            );
-        }
-    }
-
-    let tree_input: Vec<(PathBuf, config::node::NodeConfig)> = resolution
+    let tree_input: Vec<(PathBuf, config::node::NodeConfig, String)> = resolution
         .to_add
         .iter()
-        .map(|n| (n.root_dir.clone(), n.config_resolved.clone()))
+        .map(|n| {
+            (
+                n.root_dir.clone(),
+                n.config_resolved.clone(),
+                n.variant.clone(),
+            )
+        })
         .collect();
-    let tree = match VirtualDeptree::build(tree_input) {
+    let tree = match VirtualDeptree::build_with_variants(tree_input) {
         Ok(t) => t,
         Err(e) => {
             return fail(
@@ -155,11 +126,11 @@ pub(crate) async fn run_repo_node_add(
         }
     };
 
-    // Build a (name, tag) -> ResolvedBatchNode lookup for variant info.
-    let node_lookup: HashMap<(String, String), &ResolvedBatchNode> = resolution
+    // Build a (name, tag, variant) -> ResolvedBatchNode lookup for variant info.
+    let node_lookup: HashMap<config::node::NodeKey, &ResolvedBatchNode> = resolution
         .to_add
         .iter()
-        .map(|n| ((n.name.clone(), n.tag.clone()), n))
+        .map(|n| (config::node::NodeKey::new(&n.name, &n.tag, &n.variant), n))
         .collect();
 
     emit(
@@ -171,7 +142,7 @@ pub(crate) async fn run_repo_node_add(
             resolution
                 .to_add
                 .iter()
-                .map(|n| format!("{}:{}", n.name, n.tag))
+                .map(|n| config::node::render_node_id(&n.name, &n.tag, &n.variant))
                 .collect::<Vec<_>>()
                 .join(", ")
         ),
@@ -187,8 +158,8 @@ pub(crate) async fn run_repo_node_add(
                 &log_file,
                 &log_path,
                 format!(
-                    "internal error: topological order produced a node not in the batch ({}:{})",
-                    key.0, key.1
+                    "internal error: topological order produced a node not in the batch ({})",
+                    key.label()
                 ),
             );
         };
@@ -197,9 +168,8 @@ pub(crate) async fn run_repo_node_add(
             &feedback_tx,
             FeedbackStream::Stdout,
             format!(
-                "Adding {}:{} ({})",
-                node.name,
-                node.tag,
+                "Adding {} ({})",
+                config::node::render_node_id(&node.name, &node.tag, &node.variant),
                 kind_label(node.source_kind)
             ),
         );
@@ -210,13 +180,13 @@ pub(crate) async fn run_repo_node_add(
         // elsewhere in the batch does not wipe the user's prior state.
         let previous = action_context
             .node_stack
-            .find(&node.name, &node.tag)
+            .find(&node.name, &node.tag, &node.variant)
             .map(|handle| {
                 let guard = handle.read();
                 PreviousConfig {
                     config: guard.config().clone(),
                     config_path: guard.config_path().to_path_buf(),
-                    variant_name: guard.variant_name().map(ToString::to_string),
+                    variant: guard.variant().to_owned(),
                 }
             });
 
@@ -227,7 +197,11 @@ pub(crate) async fn run_repo_node_add(
                     return fail(
                         &log_file,
                         &log_path,
-                        format!("Failed to add {}:{}: {}", node.name, node.tag, msg),
+                        format!(
+                            "Failed to add {}: {}",
+                            config::node::render_node_id(&node.name, &node.tag, &node.variant),
+                            msg
+                        ),
                     );
                 }
             };
@@ -239,7 +213,11 @@ pub(crate) async fn run_repo_node_add(
             return fail(
                 &log_file,
                 &log_path,
-                format!("Failed to add {}:{}: {}", node.name, node.tag, msg),
+                format!(
+                    "Failed to add {}: {}",
+                    config::node::render_node_id(&node.name, &node.tag, &node.variant),
+                    msg
+                ),
             );
         }
 
@@ -247,6 +225,7 @@ pub(crate) async fn run_repo_node_add(
         rollback.added.push(RollbackEntry {
             name: node.name.clone(),
             tag: node.tag.clone(),
+            variant: node.variant.clone(),
             previous,
         });
     }
@@ -264,7 +243,7 @@ pub(crate) async fn run_repo_node_add(
     );
 
     let effective_log = last_sub_log_path.unwrap_or(log_path);
-    NodeAddResult::success(effective_log, root_name, root_tag)
+    NodeAddResult::success(effective_log, root_name, root_tag, root_variant)
 }
 
 fn kind_label(kind: RepoSourceKind) -> &'static str {
@@ -280,11 +259,13 @@ fn kind_label(kind: RepoSourceKind) -> &'static str {
 struct ResolvedBatchNode {
     name: String,
     tag: String,
+    /// Variant identity for this node — taken from the manifest's
+    /// `depends_on[].variant` for transitive deps, or from the root
+    /// goal's `RepoNode.variant` for the entry point.
+    variant: String,
     root_dir: PathBuf,
     config_resolved: config::node::NodeConfig,
     source_kind: RepoSourceKind,
-    /// Caller-requested variant for this node, if any.
-    variant_override: Option<String>,
     /// Only set to `true` for the root of the batch. Controls whether
     /// the env_vars / force / root variant from the original goal apply.
     is_root: bool,
@@ -297,6 +278,7 @@ struct Resolution {
 }
 
 type MaterializeOutput = (
+    String,
     String,
     String,
     bool,
@@ -318,7 +300,7 @@ async fn resolve_transitive_closure<'a>(
     ctx: BatchResolutionCtx<'a>,
     root_name: &str,
     root_tag: &str,
-    dep_overrides: &[DepVariantOverride],
+    root_variant: &str,
 ) -> Result<Resolution, String> {
     let BatchResolutionCtx {
         peppy_dirs,
@@ -326,22 +308,22 @@ async fn resolve_transitive_closure<'a>(
         cache_generation,
         feedback_tx,
     } = ctx;
-    let override_map: HashMap<(String, String), String> = dep_overrides
-        .iter()
-        .map(|o| ((o.name.clone(), o.tag.clone()), o.variant.clone()))
-        .collect();
 
     let mut to_add: Vec<ResolvedBatchNode> = Vec::new();
-    let mut seen: HashSet<(String, String)> = HashSet::new();
+    let mut seen: HashSet<(String, String, String)> = HashSet::new();
     let mut missing: Vec<(String, String)> = Vec::new();
-    let mut pending: Vec<(String, String, bool)> =
-        vec![(root_name.to_owned(), root_tag.to_owned(), true)];
+    let mut pending: Vec<(String, String, String, bool)> = vec![(
+        root_name.to_owned(),
+        root_tag.to_owned(),
+        root_variant.to_owned(),
+        true,
+    )];
     let mut in_flight: FuturesUnordered<BoxFuture<'a, MaterializeOutput>> = FuturesUnordered::new();
     let semaphore = Arc::new(Semaphore::new(MATERIALIZE_CONCURRENCY));
 
     loop {
-        while let Some((name, tag, is_root)) = pending.pop() {
-            let key = (name.clone(), tag.clone());
+        while let Some((name, tag, variant, is_root)) = pending.pop() {
+            let key = (name.clone(), tag.clone(), variant.clone());
             if !seen.insert(key.clone()) {
                 continue;
             }
@@ -350,7 +332,7 @@ async fn resolve_transitive_closure<'a>(
             // keys already in the stack, including the live-instance and
             // dependents safety gates.
             let Some(entry) = cache::lookup(entries, &name, &tag) else {
-                missing.push(key);
+                missing.push((name, tag));
                 continue;
             };
             let entry = entry.clone();
@@ -375,11 +357,12 @@ async fn resolve_transitive_closure<'a>(
                     on_feedback,
                 )
                 .await;
-                (name, tag, is_root, source_kind, result)
+                (name, tag, variant, is_root, source_kind, result)
             }));
         }
 
-        let Some((name, tag, is_root, source_kind, result)) = in_flight.next().await else {
+        let Some((name, tag, variant, is_root, source_kind, result)) = in_flight.next().await
+        else {
             break;
         };
 
@@ -387,28 +370,21 @@ async fn resolve_transitive_closure<'a>(
             Ok(pair) => pair,
             Err(e) => {
                 return Err(format!(
-                    "Failed to materialize {}:{} from repo cache: {}",
-                    name, tag, e
+                    "Failed to materialize {} from repo cache: {}",
+                    config::node::render_node_id(&name, &tag, &variant),
+                    e
                 ));
             }
         };
 
-        // Roots take their variant from goal.variant (handled later in
-        // run_single_batched_add); deps look at override_map.
-        let variant_override = if is_root {
-            None
-        } else {
-            override_map.get(&(name.clone(), tag.clone())).cloned()
-        };
-
-        // Enforce that an override points at a variant declared by this
-        // dep's manifest. (Root variant validation happens inside
-        // run_node_add itself.)
-        if let Some(ref v) = variant_override
-            && !parsed.variant_names().iter().any(|n| n == v)
+        // Enforce that the requested variant is declared by this node's
+        // manifest, except for the implicit "default" variant for nodes
+        // that don't expose a variants block at all.
+        if !is_default_variant_implicit(&variant, &parsed)
+            && !parsed.variant_names().iter().any(|n| n == &variant)
         {
             return Err(format!(
-                "variant '{v}' not declared on dep {name}:{tag} (available: {:?})",
+                "variant '{variant}' not declared on {name}:{tag} (available: {:?})",
                 parsed.variant_names()
             ));
         }
@@ -417,10 +393,11 @@ async fn resolve_transitive_closure<'a>(
             for dep in &deps.nodes {
                 let dep_name = dep.name.as_str().to_owned();
                 let dep_tag = dep.tag.clone();
-                if seen.contains(&(dep_name.clone(), dep_tag.clone())) {
+                let dep_variant = dep.variant.clone();
+                if seen.contains(&(dep_name.clone(), dep_tag.clone(), dep_variant.clone())) {
                     continue;
                 }
-                pending.push((dep_name, dep_tag, false));
+                pending.push((dep_name, dep_tag, dep_variant, false));
             }
         }
 
@@ -434,10 +411,10 @@ async fn resolve_transitive_closure<'a>(
         to_add.push(ResolvedBatchNode {
             name,
             tag,
+            variant,
             root_dir,
             config_resolved,
             source_kind,
-            variant_override,
             is_root,
         });
     }
@@ -455,6 +432,12 @@ async fn resolve_transitive_closure<'a>(
     }
 
     Ok(Resolution { to_add })
+}
+
+/// Returns true when the variant is the implicit `"default"` for a node
+/// whose manifest declares no `variants:` block.
+fn is_default_variant_implicit(variant: &str, parsed: &ParsedNodeConfig) -> bool {
+    variant == config::node::DEFAULT_VARIANT_NAME && !parsed.has_variants()
 }
 
 /// Run a single node-add step inside the batch. Each sub-add gets its
@@ -479,15 +462,21 @@ async fn run_single_batched_add(
             .with_force(batch_goal.force);
         if let Some(ref v) = batch_goal.variant {
             sub_goal = sub_goal.with_variant_source(v.clone());
+        } else if node.variant != config::node::DEFAULT_VARIANT_NAME {
+            sub_goal = sub_goal.with_variant_name(node.variant.clone());
         }
-    } else if let Some(ref v) = node.variant_override {
-        sub_goal = sub_goal.with_variant_name(v.clone());
+    } else if node.variant != config::node::DEFAULT_VARIANT_NAME {
+        sub_goal = sub_goal.with_variant_name(node.variant.clone());
     }
 
-    // Each sub-add gets its own log file derived from `{name}_{tag}`.
-    let log_dir = action_context.peppy_dirs.logs_dir_add();
+    // Each sub-add gets its own log file under the variant-specific subtree.
+    let key = config::node::NodeKey::new(&node.name, &node.tag, &node.variant);
+    let log_dir = action_context
+        .peppy_dirs
+        .logs_dir_add()
+        .join(key.artifact_subpath());
     let timestamp = Local::now().format("%Y%m%d_%H%M%S_%3f").to_string();
-    let log_filename = format!("{}_{}_{}.log", node.name, node.tag, timestamp);
+    let log_filename = format!("{}.log", timestamp);
     let (log_file, log_path) = create_action_log_file(&log_dir, &log_filename)
         .map_err(|e| format!("Failed to create sub-add log: {}", e))?;
 
@@ -523,12 +512,13 @@ async fn run_single_batched_add(
 struct PreviousConfig {
     config: config::node::NodeConfig,
     config_path: PathBuf,
-    variant_name: Option<String>,
+    variant: String,
 }
 
 struct RollbackEntry {
     name: String,
     tag: String,
+    variant: String,
     previous: Option<PreviousConfig>,
 }
 
@@ -566,24 +556,26 @@ impl Drop for RollbackGuard {
             let RollbackEntry {
                 name,
                 tag,
+                variant,
                 previous,
             } = entry;
+            let label = config::node::render_node_id(&name, &tag, &variant);
             match previous {
-                Some(prev) => match self.node_stack.push_config_with_variant(
+                Some(prev) => match self.node_stack.push_config(
                     prev.config,
                     false,
                     prev.config_path,
-                    prev.variant_name,
+                    prev.variant,
                 ) {
-                    Ok(()) => debug!("Rolled back batched replacement of {}:{}", name, tag),
+                    Ok(()) => debug!("Rolled back batched replacement of {}", label),
                     Err(e) => warn!(
-                        "Batch-add rollback (restore previous) failed for {}:{} — {}",
-                        name, tag, e
+                        "Batch-add rollback (restore previous) failed for {} — {}",
+                        label, e
                     ),
                 },
-                None => match self.node_stack.remove_config(&name, &tag) {
-                    Ok(_) => debug!("Rolled back batched add of {}:{}", name, tag),
-                    Err(e) => warn!("Batch-add rollback failed for {}:{} — {}", name, tag, e),
+                None => match self.node_stack.remove_config(&name, &tag, &variant) {
+                    Ok(_) => debug!("Rolled back batched add of {}", label),
+                    Err(e) => warn!("Batch-add rollback failed for {} — {}", label, e),
                 },
             }
         }

--- a/crates/core-node-internal/src/services/node/builder.rs
+++ b/crates/core-node-internal/src/services/node/builder.rs
@@ -67,6 +67,7 @@ impl ActionResult for NodeBuildResult {
 struct NodeBuildRun {
     node_name: String,
     node_tag: String,
+    node_variant: String,
     env_vars: Vec<(String, String)>,
     entity_handle: node_stack::EntityHandle,
     working_dir_guard: Arc<node_stack::WorkingDirGuard>,
@@ -83,16 +84,23 @@ struct NodeBuildRun {
 pub(crate) async fn run_node_build_for_entity(
     node_name: String,
     node_tag: String,
+    node_variant: String,
     env_vars: Vec<(String, String)>,
     action_context: NodeBuildActionContext,
     feedback_tx: mpsc::UnboundedSender<FeedbackLine>,
     log_file: Arc<StdMutex<File>>,
     log_path: PathBuf,
 ) -> NodeBuildResult {
-    let entity_handle = match action_context.node_stack.find(&node_name, &node_tag) {
+    let entity_handle = match action_context
+        .node_stack
+        .find(&node_name, &node_tag, &node_variant)
+    {
         Some(handle) => handle,
         None => {
-            let msg = format!("node `{}:{}` is not in the node stack", node_name, node_tag);
+            let msg = format!(
+                "node `{}` is not in the node stack",
+                config::node::render_node_id(&node_name, &node_tag, &node_variant)
+            );
             write_error_to_log(&log_file, &msg);
             return NodeBuildResult::failure(&log_path, msg);
         }
@@ -102,8 +110,9 @@ pub(crate) async fn run_node_build_for_entity(
         let guard = entity_handle.read();
         if let Err(stage) = guard.stage().ensure_buildable() {
             let msg = format!(
-                "node `{}:{}` is in stage `{}`; cannot build",
-                node_name, node_tag, stage
+                "node `{}` is in stage `{}`; cannot build",
+                config::node::render_node_id(&node_name, &node_tag, &node_variant),
+                stage
             );
             write_error_to_log(&log_file, &msg);
             return NodeBuildResult::failure(&log_path, msg);
@@ -112,8 +121,8 @@ pub(crate) async fn run_node_build_for_entity(
             Some(g) => (g, guard.generation()),
             None => {
                 let msg = format!(
-                    "node `{}:{}` has no staged working directory",
-                    node_name, node_tag
+                    "node `{}` has no staged working directory",
+                    config::node::render_node_id(&node_name, &node_tag, &node_variant)
                 );
                 write_error_to_log(&log_file, &msg);
                 return NodeBuildResult::failure(&log_path, msg);
@@ -124,6 +133,7 @@ pub(crate) async fn run_node_build_for_entity(
     run_node_build(NodeBuildRun {
         node_name,
         node_tag,
+        node_variant,
         env_vars,
         entity_handle,
         working_dir_guard,
@@ -201,25 +211,30 @@ impl NodeBuildGoalHandler {
         }
 
         debug!(
-            "Received `node_build` goal from {sender_instance_id}, target={}:{}",
-            goal.node_name, goal.node_tag
+            "Received `node_build` goal from {sender_instance_id}, target={}",
+            config::node::render_node_id(&goal.node_name, &goal.node_tag, &goal.node_variant)
         );
 
-        let entity_handle = match self
-            .context
-            .node_stack
-            .find(&goal.node_name, &goal.node_tag)
-        {
-            Some(handle) => handle,
-            None => {
-                let mut state_guard = state.lock().await;
-                *state_guard = ActionState::Rejected;
-                return encode_rejected_goal(format!(
-                    "node `{}:{}` is not in the node stack — run `peppy node add` first",
-                    goal.node_name, goal.node_tag
-                ));
-            }
-        };
+        let entity_handle =
+            match self
+                .context
+                .node_stack
+                .find(&goal.node_name, &goal.node_tag, &goal.node_variant)
+            {
+                Some(handle) => handle,
+                None => {
+                    let mut state_guard = state.lock().await;
+                    *state_guard = ActionState::Rejected;
+                    return encode_rejected_goal(format!(
+                        "node `{}` is not in the node stack — run `peppy node add` first",
+                        config::node::render_node_id(
+                            &goal.node_name,
+                            &goal.node_tag,
+                            &goal.node_variant,
+                        )
+                    ));
+                }
+            };
 
         let pending = {
             let guard = entity_handle.read();
@@ -233,25 +248,39 @@ impl NodeBuildGoalHandler {
                 let mut state_guard = state.lock().await;
                 *state_guard = ActionState::Rejected;
                 return encode_rejected_goal(format!(
-                    "node `{}:{}` is in stage `{}`; cannot build",
-                    goal.node_name, goal.node_tag, stage
+                    "node `{}` is in stage `{}`; cannot build",
+                    config::node::render_node_id(
+                        &goal.node_name,
+                        &goal.node_tag,
+                        &goal.node_variant,
+                    ),
+                    stage
                 ));
             }
             Ok((None, _)) => {
                 let mut state_guard = state.lock().await;
                 *state_guard = ActionState::Rejected;
                 return encode_rejected_goal(format!(
-                    "node `{}:{}` has no staged working directory; \
+                    "node `{}` has no staged working directory; \
                      re-run `peppy node add` to stage one",
-                    goal.node_name, goal.node_tag
+                    config::node::render_node_id(
+                        &goal.node_name,
+                        &goal.node_tag,
+                        &goal.node_variant,
+                    )
                 ));
             }
             Ok((Some(g), generation)) => (g, generation),
         };
 
-        let log_dir = self.context.peppy_dirs.logs_dir_build();
+        let key = config::node::NodeKey::new(&goal.node_name, &goal.node_tag, &goal.node_variant);
+        let log_dir = self
+            .context
+            .peppy_dirs
+            .logs_dir_build()
+            .join(key.artifact_subpath());
         let timestamp = Local::now().format("%Y%m%d_%H%M%S_%3f").to_string();
-        let log_filename = format!("{}_{}_{}.log", goal.node_name, goal.node_tag, timestamp);
+        let log_filename = format!("{}.log", timestamp);
         let (log_file, log_path) = match create_action_log_file(&log_dir, &log_filename) {
             Ok(result) => result,
             Err(error_msg) => {
@@ -276,6 +305,7 @@ impl NodeBuildGoalHandler {
         let node_stack_for_cancel = Arc::clone(&self.context.node_stack);
         let node_name_for_cancel = goal.node_name.clone();
         let node_tag_for_cancel = goal.node_tag.clone();
+        let node_variant_for_cancel = goal.node_variant.clone();
         let entity_handle_for_cancel = entity_handle.clone();
         let generation_for_cancel = captured_generation;
         let log_path_for_cancel = log_path.clone();
@@ -292,6 +322,7 @@ impl NodeBuildGoalHandler {
                 result = run_node_build(NodeBuildRun {
                     node_name: goal.node_name,
                     node_tag: goal.node_tag,
+                    node_variant: goal.node_variant,
                     env_vars: goal.env_vars,
                     entity_handle,
                     working_dir_guard,
@@ -305,6 +336,7 @@ impl NodeBuildGoalHandler {
                     let _ = node_stack_for_cancel.remove_config_if_matches(
                         &node_name_for_cancel,
                         &node_tag_for_cancel,
+                        &node_variant_for_cancel,
                         &entity_handle_for_cancel,
                         generation_for_cancel,
                     );
@@ -333,6 +365,7 @@ async fn run_node_build(run: NodeBuildRun) -> NodeBuildResult {
     let NodeBuildRun {
         node_name,
         node_tag,
+        node_variant,
         env_vars: goal_env_vars,
         entity_handle,
         working_dir_guard,
@@ -353,6 +386,7 @@ async fn run_node_build(run: NodeBuildRun) -> NodeBuildResult {
     let node_stack_for_panic = Arc::clone(&action_context.node_stack);
     let node_name_for_panic = node_name.clone();
     let node_tag_for_panic = node_tag.clone();
+    let node_variant_for_panic = node_variant.clone();
     let entity_handle_for_panic = entity_handle.clone();
     let generation_for_panic = captured_generation;
     let working_dir_detached = Arc::new(std::sync::atomic::AtomicBool::new(false));
@@ -391,9 +425,11 @@ async fn run_node_build(run: NodeBuildRun) -> NodeBuildResult {
                 }
                 Err(current_gen) => {
                     let msg = format!(
-                        "node `{}:{}` was replaced by a concurrent push \
+                        "node `{}` was replaced by a concurrent push \
                          (generation {} -> {}); aborting build",
-                        node_name, node_tag, captured_generation, current_gen
+                        config::node::render_node_id(&node_name, &node_tag, &node_variant),
+                        captured_generation,
+                        current_gen
                     );
                     write_error_to_log(&log_file, &msg);
                     return NodeBuildResult::failure(&log_path, msg);
@@ -419,9 +455,8 @@ async fn run_node_build(run: NodeBuildRun) -> NodeBuildResult {
         match build_result {
             Ok(artifact_path) => {
                 debug!(
-                    "Built node {}:{} at {}",
-                    node_name,
-                    node_tag,
+                    "Built node {} at {}",
+                    config::node::render_node_id(&node_name, &node_tag, &node_variant),
                     artifact_path.display()
                 );
                 NodeBuildResult::success(artifact_path, &log_path)
@@ -432,6 +467,7 @@ async fn run_node_build(run: NodeBuildRun) -> NodeBuildResult {
                 let _ = action_context.node_stack.remove_config_if_matches(
                     &node_name,
                     &node_tag,
+                    &node_variant,
                     &entity_handle,
                     expected_generation,
                 );
@@ -458,6 +494,7 @@ async fn run_node_build(run: NodeBuildRun) -> NodeBuildResult {
                 let _ = node_stack_for_panic.remove_config_if_matches(
                     &node_name_for_panic,
                     &node_tag_for_panic,
+                    &node_variant_for_panic,
                     &entity_handle_for_panic,
                     generation_for_panic,
                 );

--- a/crates/core-node-internal/src/services/node/info.rs
+++ b/crates/core-node-internal/src/services/node/info.rs
@@ -119,27 +119,29 @@ async fn handle_node_info_request_inner(
     let request = NodeInfoRequest::decode(payload.as_ref()).map_err(|e| format!("{}", e))?;
 
     debug!(
-        "Received `node_info` request from {sender_instance_id} for {}:{}",
-        request.node_name, request.node_tag
+        "Received `node_info` request from {sender_instance_id} for {}",
+        config::node::render_node_id(&request.node_name, &request.node_tag, &request.node_variant)
     );
 
-    // A missing `(name, tag)` is a *successful* negative lookup, not a
-    // malformed request. Encode it as `NodeInfoResponse::NotInStack` so
-    // callers (e.g. the `peppy node add` preflight) can handle it without
-    // provoking the generic service-handler error log. Malformed requests
-    // (decode failures above) still route to `InfoError::Invalid` and are
-    // the only legitimate caller-fault path through this handler.
-    let Some(entity) = node_stack.find(&request.node_name, &request.node_tag) else {
+    // A missing identity is a *successful* negative lookup, not a malformed
+    // request. Encode it as `NodeInfoResponse::NotInStack` so callers (e.g.
+    // the `peppy node add` preflight) can handle it without provoking the
+    // generic service-handler error log. Malformed requests (decode failures
+    // above) still route to `InfoError::Invalid` and are the only legitimate
+    // caller-fault path through this handler.
+    let Some(entity) =
+        node_stack.find(&request.node_name, &request.node_tag, &request.node_variant)
+    else {
         return NodeInfoResponse::NotInStack
             .encode()
             .map_err(|e| InfoError::Internal(format!("failed to encode NodeInfoResponse: {}", e)));
     };
 
-    let (node_config, stage, instances, run_log_paths, variant_name) = {
+    let (node_config, stage, instances, run_log_paths, variant) = {
         let guard = entity.read();
         let stage = guard.stage().to_serialized();
         let node_config = guard.config().clone();
-        let variant_name = guard.variant_name().map(str::to_owned);
+        let variant = guard.variant().to_owned();
         let tracked = guard.instances();
         let run_log_dir = peppy_dirs.logs_dir_run();
         let mut instances: Vec<NodeInstanceInfo> = Vec::with_capacity(tracked.len());
@@ -152,10 +154,11 @@ async fn handle_node_info_request_inner(
             });
             run_log_paths.push(run_log_dir.join(format!("{}.log", id)));
         }
-        (node_config, stage, instances, run_log_paths, variant_name)
+        (node_config, stage, instances, run_log_paths, variant)
     };
 
-    let add_log_path = node_stack.add_log_path(&request.node_name, &request.node_tag);
+    let add_log_path =
+        node_stack.add_log_path(&request.node_name, &request.node_tag, &request.node_variant);
 
     let config_json = config::json5_pretty::to_string_pretty(&node_config)
         .map_err(|e| InfoError::Internal(format!("failed to serialize node config: {}", e)))?;
@@ -168,7 +171,7 @@ async fn handle_node_info_request_inner(
         instances,
         add_log_path,
         run_log_paths,
-        variant_name,
+        variant,
     }))
     .encode()
     .map_err(|e| InfoError::Internal(format!("failed to encode NodeInfoResponse: {}", e)))
@@ -235,6 +238,9 @@ async fn resolve_node_config_with_source_path(
             parse_node_config_from_http_with_path(url, sha256, peppy_dirs).await
         }
         NodeSource::RepoNode { name, tag, .. } => {
+            // Variant routing happens at the goal level (in add_batch); for
+            // raw config inspection we just resolve the underlying source
+            // entry, which is keyed by `(name, tag)` in the repo cache.
             let resolved = repo_cache::resolve_repo_node_source(&name, &tag, peppy_dirs)?;
             // The packages cache only stores Fs/Git/Http entries, so the
             // resolved source should never be another RepoNode. Guard against

--- a/crates/core-node-internal/src/services/node/remove.rs
+++ b/crates/core-node-internal/src/services/node/remove.rs
@@ -91,14 +91,18 @@ async fn handle_node_remove_request_inner(
     );
 
     let root_handle = node_stack.root();
-    let (root_node_name, root_node_tag) = {
+    let (root_node_name, root_node_tag, root_node_variant) = {
         let guard = root_handle.read();
         (
             guard.config().manifest.name.as_str().to_owned(),
             guard.config().manifest.tag.clone(),
+            guard.variant().to_owned(),
         )
     };
-    if request.node_name == root_node_name && request.tag == root_node_tag {
+    if request.node_name == root_node_name
+        && request.tag == root_node_tag
+        && request.node_variant == root_node_variant
+    {
         return NodeRemoveResponse::failure("Cannot remove the core node from the node stack")
             .encode()
             .map_err(Into::into);
@@ -108,11 +112,12 @@ async fn handle_node_remove_request_inner(
         let guard = handle.read();
         guard.config().manifest.name.as_str() == request.node_name
             && guard.config().manifest.tag == request.tag
+            && guard.variant() == request.node_variant
     });
     let Some(matching_entity) = matching_entity else {
         return NodeRemoveResponse::failure(format!(
-            "Node '{}:{}' not found in node stack",
-            request.node_name, request.tag
+            "Node '{}' not found in node stack",
+            config::node::render_node_id(&request.node_name, &request.tag, &request.node_variant)
         ))
         .encode()
         .map_err(Into::into);
@@ -124,6 +129,7 @@ async fn handle_node_remove_request_inner(
     struct RemovalTarget {
         node_name: String,
         node_tag: String,
+        node_variant: String,
         instance_id: Name,
     }
 
@@ -131,6 +137,7 @@ async fn handle_node_remove_request_inner(
     struct ConfigRemovalTarget {
         node_name: String,
         node_tag: String,
+        node_variant: String,
     }
 
     let mut targets: Vec<RemovalTarget> = Vec::new();
@@ -139,9 +146,11 @@ async fn handle_node_remove_request_inner(
         let guard = handle.read();
         let node_tag = guard.config().manifest.tag.clone();
         let node_name = guard.config().manifest.name.as_str().to_owned();
+        let node_variant = guard.variant().to_owned();
         config_targets.push(ConfigRemovalTarget {
             node_name: node_name.clone(),
             node_tag: node_tag.clone(),
+            node_variant: node_variant.clone(),
         });
         for instance in guard.instances() {
             // Skip Starting instances: they will resolve via the
@@ -153,6 +162,7 @@ async fn handle_node_remove_request_inner(
             targets.push(RemovalTarget {
                 node_name: node_name.clone(),
                 node_tag: node_tag.clone(),
+                node_variant: node_variant.clone(),
                 instance_id: instance.instance_id().clone(),
             });
         }
@@ -272,12 +282,18 @@ async fn handle_node_remove_request_inner(
     }
 
     for target in &targets {
-        let Some(handle) = node_stack.find(&target.node_name, &target.node_tag) else {
+        let Some(handle) =
+            node_stack.find(&target.node_name, &target.node_tag, &target.node_variant)
+        else {
             // Entity was concurrently removed; nothing to stop. Treat as
             // success rather than failing the whole removal request.
             debug!(
-                "Node '{}:{}' already absent from node stack; skipping instance stop",
-                target.node_name, target.node_tag
+                "Node '{}' already absent from node stack; skipping instance stop",
+                config::node::render_node_id(
+                    &target.node_name,
+                    &target.node_tag,
+                    &target.node_variant
+                )
             );
             continue;
         };
@@ -292,19 +308,28 @@ async fn handle_node_remove_request_inner(
     }
 
     for target in &config_targets {
-        match node_stack.remove_config(&target.node_name, &target.node_tag) {
+        match node_stack.remove_config(&target.node_name, &target.node_tag, &target.node_variant) {
             Ok(true) => {}
             Ok(false) => {
                 // Concurrently removed — treat as success.
                 debug!(
-                    "Node '{}:{}' already absent from node stack during remove_config",
-                    target.node_name, target.node_tag
+                    "Node '{}' already absent from node stack during remove_config",
+                    config::node::render_node_id(
+                        &target.node_name,
+                        &target.node_tag,
+                        &target.node_variant
+                    )
                 );
             }
             Err(e) => {
                 return NodeRemoveResponse::failure(format!(
-                    "Failed to remove node config '{}:{}': {}",
-                    target.node_name, target.node_tag, e
+                    "Failed to remove node config '{}': {}",
+                    config::node::render_node_id(
+                        &target.node_name,
+                        &target.node_tag,
+                        &target.node_variant
+                    ),
+                    e
                 ))
                 .encode()
                 .map_err(Into::into);

--- a/crates/core-node-internal/src/services/node/run.rs
+++ b/crates/core-node-internal/src/services/node/run.rs
@@ -436,6 +436,7 @@ async fn process_node_run(
     let NodeRunGoal {
         node_name,
         tag,
+        node_variant,
         env_vars,
         ..
     } = goal;
@@ -463,10 +464,13 @@ async fn process_node_run(
         node_name, tag, instance_id_str
     );
 
-    let entity_handle = match ctx.action.node_stack.find(&node_name, &tag) {
+    let entity_handle = match ctx.action.node_stack.find(&node_name, &tag, &node_variant) {
         Some(entity) => entity,
         None => {
-            let msg = format!("Node '{}:{}' not found in node stack", node_name, tag);
+            let msg = format!(
+                "Node '{}' not found in node stack",
+                config::node::render_node_id(&node_name, &tag, &node_variant)
+            );
             write_error_to_log(&ctx.log_file, &msg);
             return NodeRunResult::failure(msg);
         }

--- a/crates/core-node-internal/src/services/node/stop.rs
+++ b/crates/core-node-internal/src/services/node/stop.rs
@@ -151,23 +151,26 @@ async fn handle_node_stop_request_inner(
     // Get the PID for later verification (if available)
     let pid = instance.pid();
 
-    let (node_name, node_tag) = {
+    let (node_name, node_tag, node_variant) = {
         let guard = entity_handle.read();
         (
             guard.config().manifest.name.as_str().to_owned(),
             guard.config().manifest.tag.clone(),
+            guard.variant().to_owned(),
         )
     };
-    let (root_node_name, root_node_tag) = {
+    let (root_node_name, root_node_tag, root_node_variant) = {
         let root = node_stack.root();
         let guard = root.read();
         (
             guard.config().manifest.name.as_str().to_owned(),
             guard.config().manifest.tag.clone(),
+            guard.variant().to_owned(),
         )
     };
 
-    if node_name == root_node_name && node_tag == root_node_tag {
+    if node_name == root_node_name && node_tag == root_node_tag && node_variant == root_node_variant
+    {
         return NodeStopResponse::failure("Cannot stop the core node")
             .encode()
             .map_err(Into::into);
@@ -212,8 +215,13 @@ async fn handle_node_stop_request_inner(
     }
 
     // Step 3: confirmed termination — now finalize the registry removal.
-    if let Err(e) = remove_instance_from_registry(&node_stack, &node_name, &node_tag, &instance_id)
-    {
+    if let Err(e) = remove_instance_from_registry(
+        &node_stack,
+        &node_name,
+        &node_tag,
+        &node_variant,
+        &instance_id,
+    ) {
         return NodeStopResponse::failure(e).encode().map_err(Into::into);
     }
 
@@ -276,9 +284,10 @@ fn remove_instance_from_registry(
     node_stack: &Arc<NodeStack>,
     node_name: &str,
     node_tag: &str,
+    node_variant: &str,
     instance_id: &Name,
 ) -> std::result::Result<(), String> {
-    let Some(handle) = node_stack.find(node_name, node_tag) else {
+    let Some(handle) = node_stack.find(node_name, node_tag, node_variant) else {
         return Ok(());
     };
     let mut guard = handle.write();
@@ -289,18 +298,16 @@ fn remove_instance_from_registry(
         });
         if starting {
             debug!(
-                "Node instance '{}' is in Starting state on {}:{}; cannot stop via stop_instance \
+                "Node instance '{}' is in Starting state on {}; cannot stop via stop_instance \
                  (will resolve via abort_started)",
                 instance_id.as_str(),
-                node_name,
-                node_tag
+                config::node::render_node_id(node_name, node_tag, node_variant),
             );
         } else {
             debug!(
-                "Node instance '{}' was not tracked in entity {}:{}",
+                "Node instance '{}' was not tracked in entity {}",
                 instance_id.as_str(),
-                node_name,
-                node_tag
+                config::node::render_node_id(node_name, node_tag, node_variant),
             );
         }
     }
@@ -326,6 +333,7 @@ pub(super) async fn stop_instance(
     node_stack: &Arc<NodeStack>,
     node_name: &str,
     node_tag: &str,
+    node_variant: &str,
     instance_id: &Name,
 ) -> std::result::Result<(), String> {
     let instance_id_str = instance_id.as_str();
@@ -334,14 +342,16 @@ pub(super) async fn stop_instance(
     // Reading it from the live entry (rather than after shutdown) avoids a
     // race with any concurrent registry mutation and matches the shape of
     // `handle_node_stop_request_inner`.
-    let pid = node_stack.find(node_name, node_tag).and_then(|handle| {
-        handle
-            .read()
-            .instances()
-            .iter()
-            .find(|inst| inst.instance_id() == instance_id)
-            .and_then(|inst| inst.pid())
-    });
+    let pid = node_stack
+        .find(node_name, node_tag, node_variant)
+        .and_then(|handle| {
+            handle
+                .read()
+                .instances()
+                .iter()
+                .find(|inst| inst.instance_id() == instance_id)
+                .and_then(|inst| inst.pid())
+        });
 
     send_shutdown_signal(
         messenger,
@@ -361,7 +371,7 @@ pub(super) async fn stop_instance(
         ));
     }
 
-    remove_instance_from_registry(node_stack, node_name, node_tag, instance_id)
+    remove_instance_from_registry(node_stack, node_name, node_tag, node_variant, instance_id)
 }
 
 /// Waits for a process to terminate, polling at regular intervals.

--- a/crates/core-node-internal/src/services/node/sync.rs
+++ b/crates/core-node-internal/src/services/node/sync.rs
@@ -253,9 +253,9 @@ async fn handle_node_sync_request_inner(
     // Resolver closure: node stack first, then any repository-materialized
     // deps. Stack always wins — the repo cache is a fallback opt-in via
     // the request's `include_repositories` flag.
-    let resolve_dep = |name: &str, tag: &str| -> Option<config::node::NodeConfig> {
+    let resolve_dep = |name: &str, tag: &str, variant: &str| -> Option<config::node::NodeConfig> {
         node_stack
-            .find(name, tag)
+            .find(name, tag, variant)
             .map(|e| e.read().config().clone())
             .or_else(|| {
                 repo_resolved
@@ -287,6 +287,7 @@ async fn handle_node_sync_request_inner(
                     node_config.interfaces(),
                     node_config.manifest_name(),
                     node_config.manifest_tag(),
+                    config::node::DEFAULT_VARIANT_NAME,
                     resolve_dep,
                 );
 
@@ -423,15 +424,16 @@ async fn handle_node_sync_request_inner(
             .as_ref()
             .map(|d| {
                 let mut acc: Vec<String> = Vec::new();
-                let mut seen: HashSet<(String, String)> = HashSet::new();
+                let mut seen: HashSet<(String, String, String)> = HashSet::new();
                 for dep in &d.nodes {
                     let name = dep.name.as_str().to_owned();
                     let tag = dep.tag.clone();
-                    if !seen.insert((name.clone(), tag.clone())) {
+                    let variant = dep.variant.clone();
+                    if !seen.insert((name.clone(), tag.clone(), variant.clone())) {
                         continue;
                     }
-                    if node_stack.find(&name, &tag).is_some() {
-                        acc.push(format!("{}:{}", name, tag));
+                    if node_stack.find(&name, &tag, &variant).is_some() {
+                        acc.push(config::node::render_node_id(&name, &tag, &variant));
                     }
                 }
                 acc
@@ -722,22 +724,22 @@ async fn materialize_repo_deps(
         Option<std::time::SystemTime>,
     )> = None;
 
-    let mut seen: HashSet<(String, String)> = HashSet::new();
-    let mut pending: Vec<(String, String)> = deps
+    let mut seen: HashSet<(String, String, String)> = HashSet::new();
+    let mut pending: Vec<(String, String, String)> = deps
         .nodes
         .iter()
-        .map(|n| (n.name.as_str().to_owned(), n.tag.clone()))
+        .map(|n| (n.name.as_str().to_owned(), n.tag.clone(), n.variant.clone()))
         .collect();
 
-    while let Some((name, tag)) = pending.pop() {
-        if !seen.insert((name.clone(), tag.clone())) {
+    while let Some((name, tag, variant)) = pending.pop() {
+        if !seen.insert((name.clone(), tag.clone(), variant.clone())) {
             continue;
         }
         // Stack tier wins — record the hit (de-duped via `seen` above)
         // and skip materialization for anything already pushed onto the
         // persistent NodeStack.
-        if node_stack.find(&name, &tag).is_some() {
-            stack_hits.push(format!("{}:{}", name, tag));
+        if node_stack.find(&name, &tag, &variant).is_some() {
+            stack_hits.push(config::node::render_node_id(&name, &tag, &variant));
             continue;
         }
         if cache.is_none() {
@@ -768,7 +770,11 @@ async fn materialize_repo_deps(
         // already plan to visit. Stack-tier shadowing happens at pop time.
         if let Some(child_deps) = parsed.manifest().depends_on.as_ref() {
             for child in &child_deps.nodes {
-                let key = (child.name.as_str().to_owned(), child.tag.clone());
+                let key = (
+                    child.name.as_str().to_owned(),
+                    child.tag.clone(),
+                    child.variant.clone(),
+                );
                 if !seen.contains(&key) {
                     pending.push(key);
                 }
@@ -787,10 +793,11 @@ async fn materialize_repo_deps(
     Ok((resolved, provenance, stack_hits))
 }
 
-/// Builds a lookup from `local_id` → `(dep_name, dep_tag)` using the node's `depends_on.nodes`.
+/// Builds a lookup from `local_id` → `(dep_name, dep_tag, dep_variant)` using
+/// the node's `depends_on.nodes`.
 fn build_dependency_lookup(
     manifest: &config::node::Manifest,
-) -> std::collections::HashMap<String, (String, String)> {
+) -> std::collections::HashMap<String, (String, String, String)> {
     manifest
         .depends_on
         .as_ref()
@@ -800,7 +807,11 @@ fn build_dependency_lookup(
                 .map(|n| {
                     (
                         n.local_id.clone(),
-                        (n.name.as_str().to_string(), n.tag.clone()),
+                        (
+                            n.name.as_str().to_string(),
+                            n.tag.clone(),
+                            n.variant.clone(),
+                        ),
                     )
                 })
                 .collect()
@@ -820,20 +831,22 @@ fn build_dependency_lookup(
 pub fn collect_consumed_interfaces(
     manifest: &config::node::Manifest,
     interfaces_cfg: &config::node::Interfaces,
-    resolve: impl Fn(&str, &str) -> Option<config::node::NodeConfig>,
+    resolve: impl Fn(&str, &str, &str) -> Option<config::node::NodeConfig>,
 ) -> std::result::Result<Vec<DeploymentInterface>, String> {
     let mut interfaces = Vec::new();
     let dep_lookup = build_dependency_lookup(manifest);
 
-    // Pre-resolve each unique (name, tag) into a cloned NodeConfig so the
-    // per-item loops below don't repeatedly hit the resolver (which may take
-    // a NodeStack read lock or do filesystem I/O).
-    let mut dep_configs: std::collections::HashMap<(String, String), config::node::NodeConfig> =
-        std::collections::HashMap::new();
-    for (dep_name, dep_tag) in dep_lookup.values() {
-        let key = (dep_name.clone(), dep_tag.clone());
+    // Pre-resolve each unique (name, tag, variant) into a cloned NodeConfig so
+    // the per-item loops below don't repeatedly hit the resolver (which may
+    // take a NodeStack read lock or do filesystem I/O).
+    let mut dep_configs: std::collections::HashMap<
+        (String, String, String),
+        config::node::NodeConfig,
+    > = std::collections::HashMap::new();
+    for (dep_name, dep_tag, dep_variant) in dep_lookup.values() {
+        let key = (dep_name.clone(), dep_tag.clone(), dep_variant.clone());
         if !dep_configs.contains_key(&key)
-            && let Some(cfg) = resolve(dep_name, dep_tag)
+            && let Some(cfg) = resolve(dep_name, dep_tag, dep_variant)
         {
             dep_configs.insert(key, cfg);
         }
@@ -846,11 +859,13 @@ pub fn collect_consumed_interfaces(
         for consumed_topic in consumed_topics {
             match consumed_topic {
                 config::node::ConsumedTopic::Linked(linked) => {
-                    let Some((dep_name, dep_tag)) = dep_lookup.get(linked.local_node_id.as_str())
+                    let Some((dep_name, dep_tag, dep_variant)) =
+                        dep_lookup.get(linked.local_node_id.as_str())
                     else {
                         continue;
                     };
-                    if let Some(dep_config) = dep_configs.get(&(dep_name.clone(), dep_tag.clone()))
+                    if let Some(dep_config) =
+                        dep_configs.get(&(dep_name.clone(), dep_tag.clone(), dep_variant.clone()))
                         && let Some(dep_topics) = &dep_config.interfaces.topics
                         && let Some(emitted_topics) = &dep_topics.emits
                         && let Some(emitted_topic) = emitted_topics
@@ -884,10 +899,13 @@ pub fn collect_consumed_interfaces(
         && let Some(consumed_services) = &service_interfaces.consumes
     {
         for consumed_service in consumed_services {
-            let Some((dep_name, dep_tag)) = dep_lookup.get(&consumed_service.local_node_id) else {
+            let Some((dep_name, dep_tag, dep_variant)) =
+                dep_lookup.get(&consumed_service.local_node_id)
+            else {
                 continue;
             };
-            if let Some(dep_config) = dep_configs.get(&(dep_name.clone(), dep_tag.clone()))
+            if let Some(dep_config) =
+                dep_configs.get(&(dep_name.clone(), dep_tag.clone(), dep_variant.clone()))
                 && let Some(dep_services) = &dep_config.interfaces.services
                 && let Some(exposed_services) = &dep_services.exposes
                 && let Some(exposed_service) = exposed_services
@@ -917,10 +935,13 @@ pub fn collect_consumed_interfaces(
         && let Some(consumed_actions) = &action_interfaces.consumes
     {
         for consumed_action in consumed_actions {
-            let Some((dep_name, dep_tag)) = dep_lookup.get(&consumed_action.local_node_id) else {
+            let Some((dep_name, dep_tag, dep_variant)) =
+                dep_lookup.get(&consumed_action.local_node_id)
+            else {
                 continue;
             };
-            if let Some(dep_config) = dep_configs.get(&(dep_name.clone(), dep_tag.clone()))
+            if let Some(dep_config) =
+                dep_configs.get(&(dep_name.clone(), dep_tag.clone(), dep_variant.clone()))
                 && let Some(dep_actions) = &dep_config.interfaces.actions
                 && let Some(exposed_actions) = &dep_actions.exposes
                 && let Some(exposed_action) = exposed_actions
@@ -968,10 +989,10 @@ pub fn collect_consumed_interfaces(
 /// the daemon's persistent stack — i.e. `node add` and `auto_sync_if_missing`.
 pub fn stack_resolver(
     node_stack: &NodeStack,
-) -> impl Fn(&str, &str) -> Option<config::node::NodeConfig> + '_ {
-    move |name, tag| {
+) -> impl Fn(&str, &str, &str) -> Option<config::node::NodeConfig> + '_ {
+    move |name, tag, variant| {
         node_stack
-            .find(name, tag)
+            .find(name, tag, variant)
             .map(|e| e.read().config().clone())
     }
 }

--- a/crates/core-node-internal/src/services/node/sync.rs
+++ b/crates/core-node-internal/src/services/node/sync.rs
@@ -299,10 +299,14 @@ async fn handle_node_sync_request_inner(
                         node_stack::NodeStackError::MissingDependency {
                             dependency,
                             dependency_tag,
+                            dependency_variant,
                             ..
                         } => {
-                            missing_dependencies
-                                .insert(format!("{}:{}", dependency, dependency_tag));
+                            missing_dependencies.insert(config::node::render_node_id(
+                                dependency,
+                                dependency_tag,
+                                dependency_variant,
+                            ));
                         }
                         node_stack::NodeStackError::MissingInterface {
                             dependency,

--- a/crates/core-node-internal/src/services/node/variant.rs
+++ b/crates/core-node-internal/src/services/node/variant.rs
@@ -386,7 +386,7 @@ mod tests {
         let root_config =
             config::node::NodeConfigParser::from_path(root.join(NODE_CONFIG_FILE)).unwrap();
 
-        let variant = NodeSource::repo_node("some_dep", "1.2.3").unwrap();
+        let variant = NodeSource::repo_node("some_dep", "1.2.3", "default").unwrap();
         let peppy_dirs = PeppyDirs::default();
 
         match resolve_variant(&variant, &root_config, root, &peppy_dirs, None).await {

--- a/crates/core-node-internal/src/services/stack/launch.rs
+++ b/crates/core-node-internal/src/services/stack/launch.rs
@@ -180,24 +180,7 @@ struct LaunchActionContext {
     daemon_use_sim_time: bool,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-struct NodeKey {
-    name: String,
-    tag: String,
-}
-
-impl NodeKey {
-    fn new(name: impl Into<String>, tag: impl Into<String>) -> Self {
-        Self {
-            name: name.into(),
-            tag: tag.into(),
-        }
-    }
-
-    fn label(&self) -> String {
-        format!("{}:{}", self.name, self.tag)
-    }
-}
+use config::node::NodeKey;
 
 #[derive(Clone)]
 struct PlannedDeployment {
@@ -206,6 +189,7 @@ struct PlannedDeployment {
     variant: Option<NodeSource>,
     node_name: String,
     node_tag: String,
+    node_variant: String,
     config: config::node::NodeConfig,
 }
 
@@ -641,11 +625,13 @@ async fn build_node_directly(
     ctx: &ProcessLaunchContext,
     node_name: String,
     node_tag: String,
+    node_variant: String,
     env_vars: Vec<(String, String)>,
 ) -> (std::result::Result<(), String>, Option<PathBuf>) {
-    let log_dir = ctx.peppy_dirs.logs_dir_build();
+    let key = NodeKey::new(&node_name, &node_tag, &node_variant);
+    let log_dir = ctx.peppy_dirs.logs_dir_build().join(key.artifact_subpath());
     let timestamp = Local::now().format("%Y%m%d_%H%M%S_%3f").to_string();
-    let log_filename = format!("{}_{}_{}.log", node_name, node_tag, timestamp);
+    let log_filename = format!("{}.log", timestamp);
     let (log_file, log_path) = match create_action_log_file(&log_dir, &log_filename) {
         Ok(pair) => pair,
         Err(e) => return (Err(e.to_string()), None),
@@ -673,6 +659,7 @@ async fn build_node_directly(
         run_node_build_for_entity(
             node_name.clone(),
             node_tag.clone(),
+            node_variant.clone(),
             env_vars,
             action_context,
             feedback_tx,
@@ -953,7 +940,19 @@ async fn resolve_deployments(
         let node_name = config.manifest.name.as_str().to_owned();
         let node_tag = config.manifest.tag.clone();
 
-        let key = NodeKey::new(&node_name, &node_tag);
+        // Resolve the variant identity for the planned deployment. Bare
+        // sources (no variant block) and `VariantSource::Name` map directly;
+        // Git/Url variants must point at a manifest-declared `Variant.name`,
+        // which is enforced inside the actual variant resolution path. Here
+        // we record the placeholder identity so duplicate detection works.
+        let node_variant = match deployment.source.variant() {
+            None => config::node::DEFAULT_VARIANT_NAME.to_owned(),
+            Some(VariantSource::Name(v)) => v.name.clone(),
+            Some(VariantSource::Git(v)) => v.path.clone().unwrap_or_else(|| v.repo.clone()),
+            Some(VariantSource::Url(v)) => v.url.clone(),
+        };
+
+        let key = NodeKey::new(&node_name, &node_tag, &node_variant);
         if !planned_keys.insert(key.clone()) {
             planning_errors.push(format!(
                 "duplicate deployment for node {} (resolved from {})",
@@ -966,10 +965,9 @@ async fn resolve_deployments(
         publish_stdout(
             ctx,
             format!(
-                "Deployment {} resolved to {}:{}",
+                "Deployment {} resolved to {}",
                 deployment_label(&deployment),
-                node_name,
-                node_tag
+                key.label()
             ),
             LaunchFeedbackStep::LauncherStep,
         )
@@ -981,6 +979,7 @@ async fn resolve_deployments(
             variant,
             node_name,
             node_tag,
+            node_variant,
             config,
         });
     }
@@ -1010,20 +1009,21 @@ async fn validate_and_order_dependencies(
     let root_key = NodeKey::new(
         root_config.manifest.name.as_str(),
         root_config.manifest.tag.as_str(),
+        config::node::DEFAULT_VARIANT_NAME,
     );
 
     let mut configs_by_key: HashMap<NodeKey, config::node::NodeConfig> = HashMap::new();
     configs_by_key.insert(root_key.clone(), root_config.clone());
     for item in planned {
         configs_by_key.insert(
-            NodeKey::new(&item.node_name, &item.node_tag),
+            NodeKey::new(&item.node_name, &item.node_tag, &item.node_variant),
             item.config.clone(),
         );
     }
 
     let planned_keys: HashSet<NodeKey> = planned
         .iter()
-        .map(|p| NodeKey::new(&p.node_name, &p.node_tag))
+        .map(|p| NodeKey::new(&p.node_name, &p.node_tag, &p.node_variant))
         .collect();
 
     // Validate all dependencies exist and expose the required interfaces.
@@ -1035,7 +1035,12 @@ async fn validate_and_order_dependencies(
                 &item.config.interfaces,
                 &item.node_name,
                 &item.node_tag,
-                |name, tag| configs_by_key.get(&NodeKey::new(name, tag)).cloned(),
+                &item.node_variant,
+                |name, tag, variant| {
+                    configs_by_key
+                        .get(&NodeKey::new(name, tag, variant))
+                        .cloned()
+                },
             )
         })
         .map(|e| e.to_string())
@@ -1050,10 +1055,10 @@ async fn validate_and_order_dependencies(
     // Build the dependency graph for topological ordering.
     let mut deps_for: HashMap<NodeKey, HashSet<NodeKey>> = HashMap::new();
     for item in planned {
-        let dependant_key = NodeKey::new(&item.node_name, &item.node_tag);
+        let dependant_key = NodeKey::new(&item.node_name, &item.node_tag, &item.node_variant);
         let mut deps = HashSet::new();
         for spec in node_stack::collect_dependency_specs(&item.config) {
-            let dep_key = NodeKey::new(&spec.node_name, &spec.node_tag);
+            let dep_key = NodeKey::new(&spec.node_name, &spec.node_tag, &spec.node_variant);
             if dep_key != root_key && planned_keys.contains(&dep_key) {
                 deps.insert(dep_key);
             }
@@ -1092,7 +1097,7 @@ fn topological_sort(
 
     for key in planned
         .iter()
-        .map(|p| NodeKey::new(&p.node_name, &p.node_tag))
+        .map(|p| NodeKey::new(&p.node_name, &p.node_tag, &p.node_variant))
     {
         in_degree.entry(key.clone()).or_insert(0);
         dependents.entry(key).or_default();
@@ -1111,7 +1116,12 @@ fn topological_sort(
     let order_index: HashMap<NodeKey, usize> = planned
         .iter()
         .enumerate()
-        .map(|(idx, p)| (NodeKey::new(&p.node_name, &p.node_tag), idx))
+        .map(|(idx, p)| {
+            (
+                NodeKey::new(&p.node_name, &p.node_tag, &p.node_variant),
+                idx,
+            )
+        })
         .collect();
 
     let mut ready: Vec<NodeKey> = in_degree
@@ -1255,13 +1265,23 @@ async fn add_nodes_to_stack(
                 }
                 let node_name = result.node_name.clone().unwrap_or_else(|| key.name.clone());
                 let node_tag = result.node_tag.clone().unwrap_or_else(|| key.tag.clone());
+                let node_variant = result
+                    .node_variant
+                    .clone()
+                    .unwrap_or_else(|| key.variant.clone());
 
                 // Stack launch chains directly from add into build, since the
                 // launcher's contract is "the stack is up and running" — an
                 // `Added` entity isn't actually buildable from the user's
                 // perspective until `node build` has run.
-                let (build_result, build_log_path) =
-                    build_node_directly(ctx, node_name, node_tag, ctx.env_vars.clone()).await;
+                let (build_result, build_log_path) = build_node_directly(
+                    ctx,
+                    node_name,
+                    node_tag,
+                    node_variant,
+                    ctx.env_vars.clone(),
+                )
+                .await;
 
                 let build_failed = build_result.is_err();
                 if let Some(path) = build_log_path {
@@ -1352,11 +1372,12 @@ async fn start_node_instances(
                 &runtime_config_json5,
                 item.node_name.as_str(),
                 item.node_tag.as_str(),
+                item.node_variant.as_str(),
             )
             .with_env_vars(ctx.env_vars.clone());
 
-            // Create log file for this node start
-            let log_dir = ctx.peppy_dirs.logs_dir_run();
+            // Create log file for this node start under the per-variant subtree.
+            let log_dir = ctx.peppy_dirs.logs_dir_run().join(key.artifact_subpath());
             let log_filename = format!("{}.log", instance_id);
             let (log_file, log_path) = match create_action_log_file(&log_dir, &log_filename) {
                 Ok(r) => r,
@@ -1587,7 +1608,12 @@ async fn process_launch(goal: LaunchGoal, ctx: ProcessLaunchContext) -> LaunchRe
     // Build lookup map
     let planned_by_key: HashMap<NodeKey, PlannedDeployment> = planned
         .into_iter()
-        .map(|item| (NodeKey::new(&item.node_name, &item.node_tag), item))
+        .map(|item| {
+            (
+                NodeKey::new(&item.node_name, &item.node_tag, &item.node_variant),
+                item,
+            )
+        })
         .collect();
 
     let mut add_log_paths: Vec<NodeAddLogEntry> = Vec::new();
@@ -1778,5 +1804,42 @@ mod tests {
         let none = config::launcher::FrameworkOverrides::default();
         assert!(!resolve_framework(&none, false).use_sim_time);
         assert!(resolve_framework(&none, true).use_sim_time);
+    }
+
+    /// The launcher's duplicate detection now keys on the full
+    /// `(name, tag, variant)` triple. Two deployments differing only in
+    /// `variant` must not collide — this is what makes the user's golden
+    /// case (two `depth_camera:0.1.0` deployments for `realsense_d435`
+    /// and `realsense_d405`) work side-by-side.
+    #[test]
+    fn planned_keys_distinguish_deployments_by_variant() {
+        let mut planned: std::collections::HashSet<NodeKey> = std::collections::HashSet::new();
+
+        let k_default = NodeKey::new("depth_camera", "0.1.0", "default");
+        let k_d435 = NodeKey::new("depth_camera", "0.1.0", "realsense_d435");
+        let k_d405 = NodeKey::new("depth_camera", "0.1.0", "realsense_d405");
+
+        assert!(
+            planned.insert(k_d435.clone()),
+            "first variant should insert"
+        );
+        assert!(
+            planned.insert(k_d405.clone()),
+            "second variant of same name:tag must coexist"
+        );
+        assert!(
+            planned.insert(k_default.clone()),
+            "default variant of same name:tag is yet another distinct deployment"
+        );
+        assert!(
+            !planned.insert(k_d435.clone()),
+            "exact-duplicate triple must collide"
+        );
+
+        // Display elision: default-variant labels strip the `@default`,
+        // but on-disk subpaths never elide.
+        assert_eq!(k_default.label(), "depth_camera:0.1.0");
+        assert_eq!(k_d435.label(), "depth_camera:0.1.0@realsense_d435");
+        assert_eq!(k_d435.artifact_subpath().components().count(), 3);
     }
 }

--- a/crates/core-node-internal/tests/common.rs
+++ b/crates/core-node-internal/tests/common.rs
@@ -206,9 +206,13 @@ pub enum NodeAddSource<'a> {
         url: url::Url,
         sha256: Option<String>,
     },
-    /// Add a node by `(name, tag)` against the repo cache — the daemon
+    /// Add a node by `(name, tag, variant)` against the repo cache — the daemon
     /// resolves transitive deps from `~/.peppy/cache/nodes.json5`.
-    RepoNode { name: &'a str, tag: &'a str },
+    RepoNode {
+        name: &'a str,
+        tag: &'a str,
+        variant: &'a str,
+    },
 }
 
 impl<'a> From<&'a Path> for NodeAddSource<'a> {
@@ -313,6 +317,7 @@ async fn send_node_run_and_wait_internal(
         runtime_config_json5,
         node_name,
         tag,
+        "default".to_string(),
         timeouts.result.as_secs(),
     )
     .with_env_vars(env_vars);
@@ -426,7 +431,6 @@ async fn send_node_add_and_wait_internal<'a>(
     core_node_name: &str,
     source: impl Into<NodeAddSource<'a>>,
     variant: Option<NodeSource>,
-    dep_variant_overrides: Vec<core_node_api::encoding::DepVariantOverride>,
     goal_timeout: Duration,
     result_timeout: Duration,
     feedback_tx: Option<UnboundedSender<NodeAddFeedback>>,
@@ -434,17 +438,6 @@ async fn send_node_add_and_wait_internal<'a>(
     force: bool,
 ) -> Result<NodeAddResult, String> {
     let source = source.into();
-
-    // Dep-variant overrides are only representable on RepoNode sources.
-    // If a test supplies them with any other source kind, that is a bug in
-    // the test — fail loudly instead of silently dropping them and
-    // running down the wrong code path.
-    if !dep_variant_overrides.is_empty() && !matches!(source, NodeAddSource::RepoNode { .. }) {
-        return Err(format!(
-            "dep_variant_overrides only allowed with RepoNode sources, got {:?}",
-            source
-        ));
-    }
 
     let mut goal = match &source {
         NodeAddSource::Path(path) => {
@@ -493,14 +486,9 @@ async fn send_node_add_and_wait_internal<'a>(
             TEST_GIT_HASH,
             result_timeout.as_secs(),
         ),
-        NodeAddSource::RepoNode { name, tag } => {
-            let mut src = NodeSource::repo_node(*name, *tag)
+        NodeAddSource::RepoNode { name, tag, variant } => {
+            let src = NodeSource::repo_node(*name, *tag, *variant)
                 .map_err(|e| format!("invalid repo-node source in test: {e}"))?;
-            if !dep_variant_overrides.is_empty() {
-                src = src
-                    .with_dep_variant_overrides(dep_variant_overrides.clone())
-                    .map_err(|e| format!("invalid dep-variant override in test: {e}"))?;
-            }
             NodeAddGoal::from_source(src, TEST_GIT_HASH, result_timeout.as_secs())
         }
     }
@@ -634,8 +622,13 @@ pub async fn send_node_build_and_wait(
     env_vars: Vec<(String, String)>,
     feedback_tx: Option<UnboundedSender<NodeBuildFeedback>>,
 ) -> Result<NodeBuildResult, String> {
-    let goal =
-        NodeBuildGoal::new(node_name, node_tag, result_timeout.as_secs()).with_env_vars(env_vars);
+    let goal = NodeBuildGoal::new(
+        node_name,
+        node_tag,
+        "default".to_string(),
+        result_timeout.as_secs(),
+    )
+    .with_env_vars(env_vars);
     let goal_payload = goal
         .encode()
         .map_err(|e| format!("Failed to encode build goal: {}", e))?;
@@ -762,7 +755,6 @@ pub async fn send_node_add_and_wait<'a>(
         core_node_name,
         source,
         None,
-        Vec::new(),
         goal_timeout,
         result_timeout,
         feedback_tx,
@@ -786,7 +778,6 @@ pub async fn send_node_add_and_wait_with_env<'a>(
         core_node_name,
         source,
         None,
-        Vec::new(),
         goal_timeout,
         result_timeout,
         feedback_tx,
@@ -810,33 +801,6 @@ pub async fn send_node_add_and_wait_with_variant<'a>(
         core_node_name,
         source,
         Some(NodeSource::Fs(PathBuf::from(variant))),
-        Vec::new(),
-        goal_timeout,
-        result_timeout,
-        feedback_tx,
-        Vec::new(),
-        false,
-    )
-    .await
-}
-
-#[allow(clippy::too_many_arguments)]
-pub async fn send_node_add_and_wait_with_dep_overrides<'a>(
-    messenger: &MessengerHandle,
-    core_node_name: &str,
-    source: impl Into<NodeAddSource<'a>>,
-    variant: Option<&str>,
-    dep_overrides: Vec<core_node_api::encoding::DepVariantOverride>,
-    goal_timeout: Duration,
-    result_timeout: Duration,
-    feedback_tx: Option<UnboundedSender<NodeAddFeedback>>,
-) -> Result<NodeAddResult, String> {
-    send_node_add_and_wait_internal(
-        messenger,
-        core_node_name,
-        source,
-        variant.map(|v| NodeSource::Fs(PathBuf::from(v))),
-        dep_overrides,
         goal_timeout,
         result_timeout,
         feedback_tx,
@@ -989,7 +953,6 @@ pub async fn send_node_add_then_build<'a>(
         core_node_name,
         source,
         None,
-        Vec::new(),
         goal_timeout,
         result_timeout,
         None,
@@ -1038,7 +1001,6 @@ pub async fn send_node_add_and_wait_with_force<'a>(
         core_node_name,
         source,
         None,
-        Vec::new(),
         goal_timeout,
         result_timeout,
         feedback_tx,
@@ -1509,7 +1471,7 @@ async fn spawn_real_running_instance_inner(
 ) -> TestRunningInstance {
     let handle = started
         .node_stack
-        .find(name, tag)
+        .find(name, tag, "default")
         .expect("spawn_real_running_instance: entity should exist");
     let (output_sinks, _feedback_tx, drain) =
         make_real_output_sinks(&started.peppy_dirs, instance_id);
@@ -1586,7 +1548,7 @@ pub async fn real_build_and_spawn_instance(
 
     let handle = started
         .node_stack
-        .find(name, tag)
+        .find(name, tag, "default")
         .expect("real_build_and_spawn_instance: entity should exist");
 
     let working_dir = TempDir::new().expect("working_dir tempdir");

--- a/crates/core-node-internal/tests/listen_for_launch.rs
+++ b/crates/core-node-internal/tests/listen_for_launch.rs
@@ -556,13 +556,13 @@ async fn listen_for_launch_configuration_succeed_with_complex_dependencies() {
         result.error_message
     );
 
-    assert!(node_stack.contains(FAKE_UVC_CAMERA, NODE_TAG));
-    assert!(node_stack.contains(FAKE_ROBOT_BRAIN, NODE_TAG));
-    assert!(node_stack.contains(FAKE_OPENARM01_CONTROLLER, NODE_TAG));
+    assert!(node_stack.contains(FAKE_UVC_CAMERA, NODE_TAG, "default"));
+    assert!(node_stack.contains(FAKE_ROBOT_BRAIN, NODE_TAG, "default"));
+    assert!(node_stack.contains(FAKE_OPENARM01_CONTROLLER, NODE_TAG, "default"));
     assert_eq!(node_stack.len(), 4, "root + 3 deployed nodes");
 
     let uvc_camera = node_stack
-        .find(FAKE_UVC_CAMERA, NODE_TAG)
+        .find(FAKE_UVC_CAMERA, NODE_TAG, "default")
         .expect("fake_uvc_camera should be in stack");
     assert_eq!(
         uvc_camera.read().instances().len(),
@@ -571,7 +571,7 @@ async fn listen_for_launch_configuration_succeed_with_complex_dependencies() {
     );
 
     let robot_brain = node_stack
-        .find(FAKE_ROBOT_BRAIN, NODE_TAG)
+        .find(FAKE_ROBOT_BRAIN, NODE_TAG, "default")
         .expect("fake_robot_brain should be in stack");
     assert_eq!(
         robot_brain.read().instances().len(),
@@ -580,7 +580,7 @@ async fn listen_for_launch_configuration_succeed_with_complex_dependencies() {
     );
 
     let controller = node_stack
-        .find(FAKE_OPENARM01_CONTROLLER, NODE_TAG)
+        .find(FAKE_OPENARM01_CONTROLLER, NODE_TAG, "default")
         .expect("fake_openarm01_controller should be in stack");
     assert_eq!(
         controller.read().instances().len(),
@@ -698,12 +698,12 @@ async fn listen_for_launch_configuration_succeed() {
         result.error_message
     );
 
-    assert!(node_stack.contains(UVC_NODE_NAME, NODE_TAG));
-    assert!(node_stack.contains(ROBOT_NODE_NAME, NODE_TAG));
+    assert!(node_stack.contains(UVC_NODE_NAME, NODE_TAG, "default"));
+    assert!(node_stack.contains(ROBOT_NODE_NAME, NODE_TAG, "default"));
     assert_eq!(node_stack.len(), 3, "root + 2 deployed nodes");
 
     let uvc = node_stack
-        .find(UVC_NODE_NAME, NODE_TAG)
+        .find(UVC_NODE_NAME, NODE_TAG, "default")
         .expect("uvc_camera should be in stack");
     assert_eq!(
         uvc.read().instances().len(),
@@ -712,7 +712,7 @@ async fn listen_for_launch_configuration_succeed() {
     );
 
     let brain = node_stack
-        .find(ROBOT_NODE_NAME, NODE_TAG)
+        .find(ROBOT_NODE_NAME, NODE_TAG, "default")
         .expect("robot_brain should be in stack");
     assert_eq!(
         brain.read().instances().len(),
@@ -955,22 +955,22 @@ async fn listen_for_launch_configuration_succeeds_with_repo_sources() {
     );
 
     assert!(
-        node_stack.contains(BRAIN_NODE, NODE_TAG),
+        node_stack.contains(BRAIN_NODE, NODE_TAG, "default"),
         "brain should be in stack"
     );
     assert!(
-        node_stack.contains(ARM_NODE, NODE_TAG),
+        node_stack.contains(ARM_NODE, NODE_TAG, "default"),
         "arm should be in stack"
     );
     assert_eq!(node_stack.len(), 3, "root + 2 repo-sourced nodes");
 
     let brain = node_stack
-        .find(BRAIN_NODE, NODE_TAG)
+        .find(BRAIN_NODE, NODE_TAG, "default")
         .expect("brain should be in stack");
     assert_eq!(brain.read().instances().len(), 1);
 
     let arm = node_stack
-        .find(ARM_NODE, NODE_TAG)
+        .find(ARM_NODE, NODE_TAG, "default")
         .expect("arm should be in stack");
     assert_eq!(arm.read().instances().len(), 1);
 }
@@ -999,7 +999,7 @@ async fn listen_for_launch_configuration_launch_config_invalid_json5_returns_err
         .into_resolved()
         .expect("test config has execution");
     node_stack
-        .push_config(existing_config, false, &existing_path)
+        .push_config(existing_config, false, &existing_path, "default")
         .expect("should seed stack");
 
     let bad_launcher_json5 = r#"{ peppy_schema: "launcher_v1", deployments: [ }"#;
@@ -1018,7 +1018,7 @@ async fn listen_for_launch_configuration_launch_config_invalid_json5_returns_err
 
     assert!(!result.success, "launch should fail for invalid json5");
     assert!(
-        node_stack.contains(EXISTING_NODE, NODE_TAG),
+        node_stack.contains(EXISTING_NODE, NODE_TAG, "default"),
         "stack should not be mutated on invalid json5"
     );
 }
@@ -1046,7 +1046,7 @@ async fn listen_for_launch_configuration_launch_file_path_must_be_a_file() {
         .into_resolved()
         .expect("test config has execution");
     node_stack
-        .push_config(existing_config, false, &existing_path)
+        .push_config(existing_config, false, &existing_path, "default")
         .expect("should seed stack");
 
     // Create a file (not a directory) to use as the "launch file"
@@ -1068,7 +1068,7 @@ async fn listen_for_launch_configuration_launch_file_path_must_be_a_file() {
         "launch should fail when launch file path is a directory"
     );
     assert!(
-        node_stack.contains(EXISTING_NODE, NODE_TAG),
+        node_stack.contains(EXISTING_NODE, NODE_TAG, "default"),
         "stack should not be mutated on invalid launch file path"
     );
 }
@@ -1096,7 +1096,7 @@ async fn listen_for_launch_config_missing_required_deployment_does_not_apply_par
         .into_resolved()
         .expect("test config has execution");
     node_stack
-        .push_config(existing_config, false, &existing_path)
+        .push_config(existing_config, false, &existing_path, "default")
         .expect("should seed stack");
 
     // One deployment exists, the other is missing and required.
@@ -1127,7 +1127,7 @@ async fn listen_for_launch_config_missing_required_deployment_does_not_apply_par
         "launch should fail when a required deployment is missing"
     );
     assert!(
-        node_stack.contains(EXISTING_NODE, NODE_TAG),
+        node_stack.contains(EXISTING_NODE, NODE_TAG, "default"),
         "stack should not apply a partial plan"
     );
 }
@@ -1177,7 +1177,7 @@ async fn listen_for_launch_configuration_launch_config_dependency_errors_are_rej
         .into_resolved()
         .expect("test config has execution");
     node_stack
-        .push_config(existing_config, false, &existing_path)
+        .push_config(existing_config, false, &existing_path, "default")
         .expect("should seed stack");
 
     let launcher_json5 = r#"
@@ -1207,7 +1207,7 @@ async fn listen_for_launch_configuration_launch_config_dependency_errors_are_rej
         "launch should fail due to dependency mismatch"
     );
     assert!(
-        node_stack.contains("existing_node", NODE_TAG),
+        node_stack.contains("existing_node", NODE_TAG, "default"),
         "stack should not be mutated on dependency failure"
     );
 }
@@ -1298,7 +1298,7 @@ async fn listen_for_launch_configuration_launch_config_second_request_replaces_e
     .await
     .expect("first launch should complete");
     assert!(result_a.success, "first launch should succeed");
-    assert!(node_stack.contains("node_a", NODE_TAG));
+    assert!(node_stack.contains("node_a", NODE_TAG, "default"));
 
     let launch_b = r#"
     { peppy_schema: "launcher_v1", deployments: [ { source: { local: "./node_b" }, instances: [ { instance_id: "b1" } ] } ] }
@@ -1317,11 +1317,11 @@ async fn listen_for_launch_configuration_launch_config_second_request_replaces_e
     assert!(result_b.success, "second launch should succeed");
 
     assert!(
-        !node_stack.contains("node_a", NODE_TAG),
+        !node_stack.contains("node_a", NODE_TAG, "default"),
         "second request should replace existing stack (remove node_a)"
     );
     assert!(
-        node_stack.contains("node_b", NODE_TAG),
+        node_stack.contains("node_b", NODE_TAG, "default"),
         "second request should replace existing stack (add node_b)"
     );
 }
@@ -1351,7 +1351,7 @@ async fn listen_for_launch_configuration_fails_when_one_node_never_becomes_healt
         .into_resolved()
         .expect("test config has execution");
     node_stack
-        .push_config(existing_config, false, &existing_path)
+        .push_config(existing_config, false, &existing_path, "default")
         .expect("should seed stack");
 
     // Node to be launched.
@@ -1402,11 +1402,11 @@ async fn listen_for_launch_configuration_fails_when_one_node_never_becomes_healt
     );
 
     assert!(
-        node_stack.contains("existing_node", NODE_TAG),
+        node_stack.contains("existing_node", NODE_TAG, "default"),
         "stack should be restored on failure"
     );
     assert!(
-        !node_stack.contains("node_b", NODE_TAG),
+        !node_stack.contains("node_b", NODE_TAG, "default"),
         "node_b should not be present after failed launch"
     );
 }
@@ -1435,7 +1435,7 @@ async fn listen_for_launch_configuration_fails_when_build_cmd_fails_and_restores
         .into_resolved()
         .expect("test config has execution");
     node_stack
-        .push_config(existing_config, false, &existing_path)
+        .push_config(existing_config, false, &existing_path, "default")
         .expect("should seed stack");
 
     // Node with a failing build_cmd.
@@ -1481,11 +1481,11 @@ async fn listen_for_launch_configuration_fails_when_build_cmd_fails_and_restores
     );
 
     assert!(
-        node_stack.contains("existing_node", NODE_TAG),
+        node_stack.contains("existing_node", NODE_TAG, "default"),
         "stack should be restored on build_cmd failure"
     );
     assert!(
-        !node_stack.contains("failing_node", NODE_TAG),
+        !node_stack.contains("failing_node", NODE_TAG, "default"),
         "failing_node should not be present after failed launch"
     );
 }
@@ -1516,7 +1516,7 @@ async fn listen_for_launch_configuration_fails_when_run_cmd_exits_with_error() {
         .into_resolved()
         .expect("test config has execution");
     node_stack
-        .push_config(existing_config, false, &existing_path)
+        .push_config(existing_config, false, &existing_path, "default")
         .expect("should seed stack");
 
     // Node whose run_cmd exits immediately with a non-zero status.
@@ -1566,11 +1566,11 @@ async fn listen_for_launch_configuration_fails_when_run_cmd_exits_with_error() {
     );
 
     assert!(
-        node_stack.contains("existing_node", NODE_TAG),
+        node_stack.contains("existing_node", NODE_TAG, "default"),
         "stack should be restored on run_cmd failure"
     );
     assert!(
-        !node_stack.contains(NODE_NAME, NODE_TAG),
+        !node_stack.contains(NODE_NAME, NODE_TAG, "default"),
         "{NODE_NAME} should not be present after failed launch"
     );
 
@@ -1841,7 +1841,7 @@ async fn listen_for_launch_resolves_launcher_from_repository_cache() {
         result.error_message
     );
     assert!(
-        node_stack.contains(ROBOT_NODE_NAME, NODE_TAG),
+        node_stack.contains(ROBOT_NODE_NAME, NODE_TAG, "default"),
         "robot_brain_repo should be in stack"
     );
 }

--- a/crates/core-node-internal/tests/listen_for_node_add.rs
+++ b/crates/core-node-internal/tests/listen_for_node_add.rs
@@ -36,7 +36,7 @@ const RESULT_TIMEOUT: Duration = Duration::from_secs(120);
 /// the `read()` + `artifact_path().expect(...)` boilerplate.
 fn entity_artifact_path(node_stack: &node_stack::NodeStack, name: &str, tag: &str) -> PathBuf {
     node_stack
-        .find(name, tag)
+        .find(name, tag, "default")
         .expect("entity should exist")
         .read()
         .artifact_path()
@@ -47,7 +47,7 @@ fn entity_artifact_path(node_stack: &node_stack::NodeStack, name: &str, tag: &st
 /// Returns the number of tracked instances for the entity at `(name, tag)`.
 fn entity_instance_count(node_stack: &node_stack::NodeStack, name: &str, tag: &str) -> usize {
     node_stack
-        .find(name, tag)
+        .find(name, tag, "default")
         .expect("entity should exist")
         .read()
         .instances()

--- a/crates/core-node-internal/tests/listen_for_node_add/basic_sources.rs
+++ b/crates/core-node-internal/tests/listen_for_node_add/basic_sources.rs
@@ -41,7 +41,7 @@ async fn listen_for_node_fs_add_success() {
         add_result.error_message
     );
 
-    assert!(node_stack.contains(TARGET_NODE_NAME, TARGET_NODE_TAG));
+    assert!(node_stack.contains(TARGET_NODE_NAME, TARGET_NODE_TAG, "default"));
     assert_eq!(node_stack.len(), 2, "root + added node");
 
     // `add` only adds the node to the NodeStack but doesn't spawn any instance
@@ -89,7 +89,7 @@ async fn listen_for_node_git_add_success() {
         add_result.error_message
     );
 
-    assert!(node_stack.contains(TARGET_NODE_NAME, TARGET_NODE_TAG));
+    assert!(node_stack.contains(TARGET_NODE_NAME, TARGET_NODE_TAG, "default"));
     assert_eq!(node_stack.len(), 2, "root + added node");
 
     assert_eq!(
@@ -133,7 +133,7 @@ async fn listen_for_node_git_add_with_ref_success() {
         "node_add should succeed, got error: {:?}",
         add_result_head.error_message
     );
-    assert!(node_stack.contains(TARGET_NODE_NAME, "0.2.0"));
+    assert!(node_stack.contains(TARGET_NODE_NAME, "0.2.0", "default"));
 
     let add_result_ref = send_node_add_and_wait(
         &started_core_node.caller_handle,
@@ -155,7 +155,7 @@ async fn listen_for_node_git_add_with_ref_success() {
         "node_add should succeed, got error: {:?}",
         add_result_ref.error_message
     );
-    assert!(node_stack.contains(TARGET_NODE_NAME, "0.1.0"));
+    assert!(node_stack.contains(TARGET_NODE_NAME, "0.1.0", "default"));
 }
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn listen_for_node_http_add_success() {
@@ -240,7 +240,7 @@ async fn listen_for_node_http_add_success() {
         add_result.error_message
     );
 
-    assert!(node_stack.contains(TARGET_NODE_NAME, TARGET_NODE_TAG));
+    assert!(node_stack.contains(TARGET_NODE_NAME, TARGET_NODE_TAG, "default"));
     assert_eq!(node_stack.len(), 2, "root + added node");
 
     assert_eq!(
@@ -290,7 +290,7 @@ async fn listen_for_node_http_add_rejects_wrong_sha256() {
         "error should mention checksum mismatch, got: {:?}",
         add_result.error_message
     );
-    assert!(!node_stack.contains(TARGET_NODE_NAME, TARGET_NODE_TAG));
+    assert!(!node_stack.contains(TARGET_NODE_NAME, TARGET_NODE_TAG, "default"));
 }
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn listen_for_node_http_add_accepts_correct_sha256() {
@@ -329,7 +329,7 @@ async fn listen_for_node_http_add_accepts_correct_sha256() {
         "node_add should succeed with correct sha256, got error: {:?}",
         add_result.error_message
     );
-    assert!(node_stack.contains(TARGET_NODE_NAME, TARGET_NODE_TAG));
+    assert!(node_stack.contains(TARGET_NODE_NAME, TARGET_NODE_TAG, "default"));
 }
 /// Adding a node from a git source whose config has a default variant with a
 /// local deployment source must succeed — fingerprint verification must not
@@ -433,10 +433,10 @@ async fn listen_for_node_git_add_with_default_local_variant_success() {
         add_result.error_message
     );
 
-    assert!(node_stack.contains(ROOT_NODE_NAME, ROOT_NODE_TAG));
+    assert!(node_stack.contains(ROOT_NODE_NAME, ROOT_NODE_TAG, "default"));
 
     let entity = node_stack
-        .find(ROOT_NODE_NAME, ROOT_NODE_TAG)
+        .find(ROOT_NODE_NAME, ROOT_NODE_TAG, "default")
         .expect("node should exist in stack");
     let entity_guard = entity.read();
     let config = entity_guard.config();

--- a/crates/core-node-internal/tests/listen_for_node_add/concurrency_and_force.rs
+++ b/crates/core-node-internal/tests/listen_for_node_add/concurrency_and_force.rs
@@ -184,7 +184,7 @@ async fn listen_for_node_add_force_overrides_in_progress_action() {
     );
 
     assert!(
-        node_stack.contains(SECOND_NODE_NAME, SECOND_NODE_TAG),
+        node_stack.contains(SECOND_NODE_NAME, SECOND_NODE_TAG, "default"),
         "force-added node should be in the stack"
     );
 }

--- a/crates/core-node-internal/tests/listen_for_node_add/failures.rs
+++ b/crates/core-node-internal/tests/listen_for_node_add/failures.rs
@@ -1,8 +1,5 @@
 use super::*;
-use common::{
-    TestPackagesCache, send_node_add_and_wait_with_dep_overrides, write_plain_peppy_json5,
-};
-use core_node_api::encoding::DepVariantOverride;
+use common::{TestPackagesCache, write_plain_peppy_json5};
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn repo_node_add_fails_when_packages_cache_missing() {
@@ -16,6 +13,7 @@ async fn repo_node_add_fails_when_packages_cache_missing() {
         NodeAddSource::RepoNode {
             name: "ghost",
             tag: "0.1.0",
+            variant: "default",
         },
         GOAL_TIMEOUT,
         RESULT_TIMEOUT,
@@ -55,6 +53,7 @@ async fn repo_node_add_fails_when_root_node_unknown() {
         NodeAddSource::RepoNode {
             name: "ghost",
             tag: "0.1.0",
+            variant: "default",
         },
         GOAL_TIMEOUT,
         RESULT_TIMEOUT,
@@ -95,6 +94,7 @@ async fn repo_node_add_fails_when_dep_missing_in_cache() {
         NodeAddSource::RepoNode {
             name: "target",
             tag: "1.0.0",
+            variant: "default",
         },
         GOAL_TIMEOUT,
         RESULT_TIMEOUT,
@@ -140,6 +140,7 @@ async fn repo_node_add_fails_on_cycle() {
         NodeAddSource::RepoNode {
             name: "a",
             tag: "0.1.0",
+            variant: "default",
         },
         GOAL_TIMEOUT,
         RESULT_TIMEOUT,
@@ -152,95 +153,15 @@ async fn repo_node_add_fails_on_cycle() {
     assert_eq!(node_stack.len(), 1, "nothing should have been added");
 }
 
+// TODO: re-express via manifest-declared `NodeDependency.variant`. See failures.rs:151.
+#[ignore = "DepVariantOverride deleted; rewrite via manifest variant field"]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn repo_node_add_fails_on_unknown_dep_variant() {
-    let started = start_core_node_with_mock_messenger().await;
-    let node_stack = started.node_stack.clone();
+async fn repo_node_add_fails_on_unknown_dep_variant() {}
 
-    let tmp = TempDir::new().unwrap();
-    let dep_dir = tmp.path().join("dep");
-    write_plain_peppy_json5(&dep_dir, &minimal_node_config("dep", "0.1.0", &[]));
-    let target_dir = tmp.path().join("target");
-    write_plain_peppy_json5(
-        &target_dir,
-        &minimal_node_config("target", "1.0.0", &[("dep", "0.1.0")]),
-    );
-
-    TestPackagesCache::new()
-        .fs_entry("dep", "0.1.0", &dep_dir, &[])
-        .fs_entry("target", "1.0.0", &target_dir, &[])
-        .write(&started.peppy_dirs);
-
-    let res = send_node_add_and_wait_with_dep_overrides(
-        &started.caller_handle,
-        &started.core_node_name,
-        NodeAddSource::RepoNode {
-            name: "target",
-            tag: "1.0.0",
-        },
-        None,
-        vec![DepVariantOverride {
-            name: "dep".into(),
-            tag: "0.1.0".into(),
-            variant: "nonexistent".into(),
-        }],
-        GOAL_TIMEOUT,
-        RESULT_TIMEOUT,
-        None,
-    )
-    .await
-    .expect("node_add should complete");
-
-    assert!(!res.success, "add should fail for unknown variant override");
-    let err = res.error_message.unwrap_or_default();
-    assert!(
-        err.contains("variant 'nonexistent'") && err.contains("dep:0.1.0"),
-        "expected unknown-variant error; got: {err}"
-    );
-    assert_eq!(node_stack.len(), 1);
-}
-
+// TODO: re-express via manifest-declared `NodeDependency.variant`. See failures.rs:155.
+#[ignore = "DepVariantOverride deleted; rewrite via manifest variant field"]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn repo_node_add_rejects_root_target_dep_variant_override() {
-    let started = start_core_node_with_mock_messenger().await;
-    let node_stack = started.node_stack.clone();
-
-    let tmp = TempDir::new().unwrap();
-    let target_dir = tmp.path().join("target");
-    write_plain_peppy_json5(&target_dir, &minimal_node_config("target", "1.0.0", &[]));
-
-    TestPackagesCache::new()
-        .fs_entry("target", "1.0.0", &target_dir, &[])
-        .write(&started.peppy_dirs);
-
-    let res = send_node_add_and_wait_with_dep_overrides(
-        &started.caller_handle,
-        &started.core_node_name,
-        NodeAddSource::RepoNode {
-            name: "target",
-            tag: "1.0.0",
-        },
-        None,
-        vec![DepVariantOverride {
-            name: "target".into(),
-            tag: "1.0.0".into(),
-            variant: "sim".into(),
-        }],
-        GOAL_TIMEOUT,
-        RESULT_TIMEOUT,
-        None,
-    )
-    .await
-    .expect("node_add should complete");
-
-    assert!(!res.success, "root-target dep override should be rejected");
-    let err = res.error_message.unwrap_or_default();
-    assert!(
-        err.contains("targets the root repo node") && err.contains("target:1.0.0@sim"),
-        "expected root-target override error; got: {err}"
-    );
-    assert_eq!(node_stack.len(), 1);
-}
+async fn repo_node_add_rejects_root_target_dep_variant_override() {}
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn repo_node_add_rolls_back_on_mid_batch_failure() {
@@ -278,6 +199,7 @@ async fn repo_node_add_rolls_back_on_mid_batch_failure() {
         NodeAddSource::RepoNode {
             name: "a",
             tag: "0.1.0",
+            variant: "default",
         },
         GOAL_TIMEOUT,
         RESULT_TIMEOUT,
@@ -289,9 +211,9 @@ async fn repo_node_add_rolls_back_on_mid_batch_failure() {
     assert!(!res.success, "add should fail on missing transitive dep");
     // Stack must be unchanged — no partial add.
     assert_eq!(node_stack.len(), pre_len, "stack should be unchanged");
-    assert!(!node_stack.contains("a", "0.1.0"));
-    assert!(!node_stack.contains("b", "0.1.0"));
-    assert!(!node_stack.contains("c", "0.1.0"));
+    assert!(!node_stack.contains("a", "0.1.0", "default"));
+    assert!(!node_stack.contains("b", "0.1.0", "default"));
+    assert!(!node_stack.contains("c", "0.1.0", "default"));
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -342,7 +264,7 @@ async fn listen_for_node_add_no_config_found() {
         "node_add should not succeed, the config file is missing",
     );
 
-    assert!(!node_stack.contains(TARGET_NODE_NAME, TARGET_NODE_TAG));
+    assert!(!node_stack.contains(TARGET_NODE_NAME, TARGET_NODE_TAG, "default"));
     assert_eq!(node_stack.len(), 1, "root");
 }
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -393,7 +315,7 @@ async fn listen_for_node_add_git_hash_mismatch_fails() {
         "error message should indicate git hash mismatch, got: {:?}",
         add_result.error_message
     );
-    assert!(!node_stack.contains("git_hash_mismatch_node", "0.1.0"));
+    assert!(!node_stack.contains("git_hash_mismatch_node", "0.1.0", "default"));
 }
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn listen_for_node_add_invalid_config_fails() {
@@ -608,7 +530,7 @@ async fn listen_for_node_add_fails_runs_add_cmd_on_missing_node_dependency() {
     );
 
     assert!(
-        !node_stack.contains(TARGET_NODE_NAME, TARGET_NODE_TAG),
+        !node_stack.contains(TARGET_NODE_NAME, TARGET_NODE_TAG, "default"),
         "node should not be added when dependency is missing"
     );
     assert_eq!(node_stack.len(), 1, "only root should exist");
@@ -663,7 +585,7 @@ async fn listen_for_node_add_fails_on_missing_interface_even_when_dependency_exi
         dep_result.error_message
     );
     assert!(
-        node_stack.contains(DEPENDENCY_NODE_NAME, DEPENDENCY_NODE_TAG),
+        node_stack.contains(DEPENDENCY_NODE_NAME, DEPENDENCY_NODE_TAG, "default"),
         "dependency node should be in the stack"
     );
     assert_eq!(node_stack.len(), 2, "root + dependency");
@@ -732,7 +654,7 @@ async fn listen_for_node_add_fails_on_missing_interface_even_when_dependency_exi
     );
 
     assert!(
-        !node_stack.contains(TARGET_NODE_NAME, TARGET_NODE_TAG),
+        !node_stack.contains(TARGET_NODE_NAME, TARGET_NODE_TAG, "default"),
         "dependent node should not be added when interface is missing"
     );
     assert_eq!(node_stack.len(), 2, "root + dependency only");

--- a/crates/core-node-internal/tests/listen_for_node_add/failures.rs
+++ b/crates/core-node-internal/tests/listen_for_node_add/failures.rs
@@ -153,16 +153,6 @@ async fn repo_node_add_fails_on_cycle() {
     assert_eq!(node_stack.len(), 1, "nothing should have been added");
 }
 
-// TODO: re-express via manifest-declared `NodeDependency.variant`. See failures.rs:151.
-#[ignore = "DepVariantOverride deleted; rewrite via manifest variant field"]
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn repo_node_add_fails_on_unknown_dep_variant() {}
-
-// TODO: re-express via manifest-declared `NodeDependency.variant`. See failures.rs:155.
-#[ignore = "DepVariantOverride deleted; rewrite via manifest variant field"]
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn repo_node_add_rejects_root_target_dep_variant_override() {}
-
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn repo_node_add_rolls_back_on_mid_batch_failure() {
     let started = start_core_node_with_mock_messenger().await;

--- a/crates/core-node-internal/tests/listen_for_node_add/replacement_and_lifecycle.rs
+++ b/crates/core-node-internal/tests/listen_for_node_add/replacement_and_lifecycle.rs
@@ -92,7 +92,7 @@ async fn listen_for_node_add_same_node_same_tags_overwrites_when_no_dependents()
 
     assert_eq!(node_stack.len(), 2, "stack should be unchanged");
     let entity = node_stack
-        .find(NODE_NAME, NODE_TAG)
+        .find(NODE_NAME, NODE_TAG, "default")
         .expect("node should exist after v2 overwrite");
     let entity_guard = entity.read();
     assert_eq!(
@@ -269,7 +269,7 @@ async fn listen_for_node_add_same_node_same_tags_fails_when_node_has_dependents(
 
     assert_eq!(node_stack.len(), 3, "stack should be unchanged");
     assert!(
-        node_stack.contains(DEPENDENT_NODE_NAME, DEPENDENT_NODE_TAG),
+        node_stack.contains(DEPENDENT_NODE_NAME, DEPENDENT_NODE_TAG, "default"),
         "dependent node should still exist after failed overwrite"
     );
 
@@ -279,7 +279,7 @@ async fn listen_for_node_add_same_node_same_tags_fails_when_node_has_dependents(
     // truly preserved the original revision rather than just the path.
     {
         let handle = node_stack
-            .find(DEPENDENCY_NODE_NAME, DEPENDENCY_NODE_TAG)
+            .find(DEPENDENCY_NODE_NAME, DEPENDENCY_NODE_TAG, "default")
             .expect("dependency entity should exist");
         let guard = handle.read();
         let services = guard
@@ -392,8 +392,8 @@ async fn listen_for_node_add_same_node_different_tags_create_two_entities() {
     );
 
     assert_eq!(node_stack.len(), 3, "root + two versions");
-    assert!(node_stack.contains(NODE_NAME, "1.0.0"));
-    assert!(node_stack.contains(NODE_NAME, "2.0.0"));
+    assert!(node_stack.contains(NODE_NAME, "1.0.0", "default"));
+    assert!(node_stack.contains(NODE_NAME, "2.0.0", "default"));
 }
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn listen_for_node_add_fingerprint_mismatch() {
@@ -464,7 +464,7 @@ async fn listen_for_node_add_fingerprint_mismatch() {
 
     // Node should not be in the stack
     assert!(
-        !node_stack.contains(TARGET_NODE_NAME, TARGET_NODE_TAG),
+        !node_stack.contains(TARGET_NODE_NAME, TARGET_NODE_TAG, "default"),
         "node should not be added when fingerprint mismatches"
     );
     assert_eq!(node_stack.len(), 1, "only root should exist");
@@ -544,7 +544,7 @@ async fn listen_for_node_add_abandoned_action_does_not_block_next_goal() {
     // separate goal.
     tokio::time::timeout(Duration::from_secs(30), async {
         loop {
-            if let Some(handle) = node_stack.find(FIRST_NODE_NAME, FIRST_NODE_TAG) {
+            if let Some(handle) = node_stack.find(FIRST_NODE_NAME, FIRST_NODE_TAG, "default") {
                 let guard = handle.read();
                 if matches!(guard.stage(), node_stack::NodeStage::Added { .. }) {
                     break;
@@ -593,11 +593,11 @@ async fn listen_for_node_add_abandoned_action_does_not_block_next_goal() {
 
     // Verify both nodes are in the stack
     assert!(
-        node_stack.contains(FIRST_NODE_NAME, FIRST_NODE_TAG),
+        node_stack.contains(FIRST_NODE_NAME, FIRST_NODE_TAG, "default"),
         "first node should be in stack (action completed even though result wasn't polled)"
     );
     assert!(
-        node_stack.contains(SECOND_NODE_NAME, SECOND_NODE_TAG),
+        node_stack.contains(SECOND_NODE_NAME, SECOND_NODE_TAG, "default"),
         "second node should be in stack"
     );
     assert_eq!(node_stack.len(), 3, "root + first + second nodes");
@@ -1054,7 +1054,7 @@ async fn node_add_same_node_with_running_instance_and_dependents_succeeds() {
         "running instance should have been stopped"
     );
     assert!(
-        node_stack.contains(DEPENDENT_NODE_NAME, DEPENDENT_NODE_TAG),
+        node_stack.contains(DEPENDENT_NODE_NAME, DEPENDENT_NODE_TAG, "default"),
         "dependent node should still be in the stack"
     );
 }
@@ -1266,7 +1266,7 @@ async fn node_add_same_node_changing_interface_with_running_instance_and_depende
         "running instance should have been stopped before push_config rejected the overwrite"
     );
     assert!(
-        node_stack.contains(DEPENDENT_NODE_NAME, DEPENDENT_NODE_TAG),
+        node_stack.contains(DEPENDENT_NODE_NAME, DEPENDENT_NODE_TAG, "default"),
         "dependent node should still be in the stack after failed overwrite"
     );
 
@@ -1274,7 +1274,7 @@ async fn node_add_same_node_changing_interface_with_running_instance_and_depende
     // is still exposed and the v2 `new_service` was never spliced in.
     {
         let handle = node_stack
-            .find(DEPENDENCY_NODE_NAME, DEPENDENCY_NODE_TAG)
+            .find(DEPENDENCY_NODE_NAME, DEPENDENCY_NODE_TAG, "default")
             .expect("dependency entity missing");
         let guard = handle.read();
         let exposes = guard
@@ -1481,7 +1481,7 @@ async fn node_add_same_node_with_running_instance_and_dependents_fails_on_stoppe
         "running instance should still be present when shutdown timed out"
     );
     assert!(
-        node_stack.contains(DEPENDENT_NODE_NAME, DEPENDENT_NODE_TAG),
+        node_stack.contains(DEPENDENT_NODE_NAME, DEPENDENT_NODE_TAG, "default"),
         "dependent node should still be in the stack"
     );
 }

--- a/crates/core-node-internal/tests/listen_for_node_add/repo_sources.rs
+++ b/crates/core-node-internal/tests/listen_for_node_add/repo_sources.rs
@@ -1,8 +1,5 @@
 use super::*;
-use common::{
-    TestPackagesCache, send_node_add_and_wait_with_dep_overrides, write_plain_peppy_json5,
-};
-use core_node_api::encoding::DepVariantOverride;
+use common::{TestPackagesCache, write_plain_peppy_json5};
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn repo_node_add_single_no_deps_fs_source() {
@@ -24,6 +21,7 @@ async fn repo_node_add_single_no_deps_fs_source() {
         NodeAddSource::RepoNode {
             name: "standalone",
             tag: "0.1.0",
+            variant: "default",
         },
         GOAL_TIMEOUT,
         RESULT_TIMEOUT,
@@ -37,7 +35,7 @@ async fn repo_node_add_single_no_deps_fs_source() {
         "add should succeed, err={:?}",
         res.error_message
     );
-    assert!(node_stack.contains("standalone", "0.1.0"));
+    assert!(node_stack.contains("standalone", "0.1.0", "default"));
     assert_eq!(node_stack.len(), 2, "root + standalone");
 }
 
@@ -73,6 +71,7 @@ async fn repo_node_add_chain_of_three_fs() {
         NodeAddSource::RepoNode {
             name: "c",
             tag: "0.1.0",
+            variant: "default",
         },
         GOAL_TIMEOUT,
         RESULT_TIMEOUT,
@@ -86,9 +85,9 @@ async fn repo_node_add_chain_of_three_fs() {
         "add should succeed, err={:?}",
         res.error_message
     );
-    assert!(node_stack.contains("a", "0.1.0"));
-    assert!(node_stack.contains("b", "0.1.0"));
-    assert!(node_stack.contains("c", "0.1.0"));
+    assert!(node_stack.contains("a", "0.1.0", "default"));
+    assert!(node_stack.contains("b", "0.1.0", "default"));
+    assert!(node_stack.contains("c", "0.1.0", "default"));
     assert_eq!(node_stack.len(), 4, "root + a + b + c");
     assert_eq!(
         res.node_name.as_deref(),
@@ -129,6 +128,7 @@ async fn repo_node_add_diamond() {
         NodeAddSource::RepoNode {
             name: "d",
             tag: "0.1.0",
+            variant: "default",
         },
         GOAL_TIMEOUT,
         RESULT_TIMEOUT,
@@ -143,7 +143,10 @@ async fn repo_node_add_diamond() {
         res.error_message
     );
     for name in ["a", "b", "c", "d"] {
-        assert!(node_stack.contains(name, "0.1.0"), "missing {name}");
+        assert!(
+            node_stack.contains(name, "0.1.0", "default"),
+            "missing {name}"
+        );
     }
     assert_eq!(
         node_stack.len(),
@@ -195,6 +198,7 @@ async fn repo_node_add_partial_stack_coverage() {
         NodeAddSource::RepoNode {
             name: "a",
             tag: "0.1.0",
+            variant: "default",
         },
         GOAL_TIMEOUT,
         RESULT_TIMEOUT,
@@ -211,9 +215,9 @@ async fn repo_node_add_partial_stack_coverage() {
     // Stack: root + b + c + a = 4. B's stack entry is replaced in-place
     // by the fresh materialization (same key, same count), and c + a are
     // added as new entries.
-    assert!(node_stack.contains("a", "0.1.0"));
-    assert!(node_stack.contains("b", "0.1.0"));
-    assert!(node_stack.contains("c", "0.1.0"));
+    assert!(node_stack.contains("a", "0.1.0", "default"));
+    assert!(node_stack.contains("b", "0.1.0", "default"));
+    assert!(node_stack.contains("c", "0.1.0", "default"));
     assert_eq!(node_stack.len(), 4);
 }
 
@@ -276,6 +280,7 @@ async fn repo_node_add_does_not_materialize_nodes_outside_declared_tree() {
         NodeAddSource::RepoNode {
             name: "a",
             tag: "0.1.0",
+            variant: "default",
         },
         GOAL_TIMEOUT,
         RESULT_TIMEOUT,
@@ -292,11 +297,11 @@ async fn repo_node_add_does_not_materialize_nodes_outside_declared_tree() {
     // Stack = root + c + b + a = 4. c is replaced in-place when re-
     // materialized; b and a are new.
     assert_eq!(node_stack.len(), 4);
-    assert!(node_stack.contains("a", "0.1.0"));
-    assert!(node_stack.contains("b", "0.1.0"));
-    assert!(node_stack.contains("c", "0.1.0"));
+    assert!(node_stack.contains("a", "0.1.0", "default"));
+    assert!(node_stack.contains("b", "0.1.0", "default"));
+    assert!(node_stack.contains("c", "0.1.0", "default"));
     assert!(
-        !node_stack.contains("d", "0.1.0"),
+        !node_stack.contains("d", "0.1.0", "default"),
         "d must never be added — no manifest in the tree declares it"
     );
 }
@@ -371,6 +376,7 @@ async fn repo_node_add_deep_mixed_tree_stack_and_cache_at_multiple_levels() {
         NodeAddSource::RepoNode {
             name: "a",
             tag: "0.1.0",
+            variant: "default",
         },
         GOAL_TIMEOUT,
         RESULT_TIMEOUT,
@@ -390,7 +396,10 @@ async fn repo_node_add_deep_mixed_tree_stack_and_cache_at_multiple_levels() {
         "root + b + e (pre-populated) + d + c + a (newly added)"
     );
     for name in ["a", "b", "c", "d", "e"] {
-        assert!(node_stack.contains(name, "0.1.0"), "missing {name}");
+        assert!(
+            node_stack.contains(name, "0.1.0", "default"),
+            "missing {name}"
+        );
     }
 }
 
@@ -442,15 +451,14 @@ async fn repo_node_add_root_variant_only() {
         .fs_entry("with_variants", "0.1.0", &node_dir, &["default", "alt"])
         .write(&peppy_dirs);
 
-    let res = send_node_add_and_wait_with_dep_overrides(
+    let res = send_node_add_and_wait(
         &started.caller_handle,
         &started.core_node_name,
         NodeAddSource::RepoNode {
             name: "with_variants",
             tag: "0.1.0",
+            variant: "alt",
         },
-        Some("alt"),
-        Vec::new(),
         GOAL_TIMEOUT,
         RESULT_TIMEOUT,
         None,
@@ -463,268 +471,21 @@ async fn repo_node_add_root_variant_only() {
         "add should succeed, err={:?}",
         res.error_message
     );
-    assert!(node_stack.contains("with_variants", "0.1.0"));
+    assert!(node_stack.contains("with_variants", "0.1.0", "alt"));
 }
 
+// TODO: re-express via manifest-declared `NodeDependency.variant` instead of
+// the deleted `DepVariantOverride` plumbing. See repo_sources.rs:466.
+#[ignore = "DepVariantOverride deleted; rewrite via manifest variant field"]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn repo_node_add_dep_variants_only_no_root() {
-    let started = start_core_node_with_mock_messenger().await;
-    let node_stack = started.node_stack.clone();
-    let peppy_dirs = started.peppy_dirs.clone();
+async fn repo_node_add_dep_variants_only_no_root() {}
 
-    // Dep uses the `default` variant idiom with an extra `mock` variant.
-    let tmp = TempDir::new().unwrap();
-    let dep_dir = tmp.path().join("dep_with_variant");
-    let default_dir = dep_dir.join("default");
-    let mock_dir = dep_dir.join("mock");
-    std::fs::create_dir_all(&default_dir).unwrap();
-    std::fs::create_dir_all(&mock_dir).unwrap();
-    let dep_peppy_json5 = r#"{
-            peppy_schema: "node_v1",
-            manifest: {
-                name: "dep_with_variant",
-                tag: "0.1.0",
-                variants: [
-                    { name: "default", source: { local: "./default" } },
-                    { name: "mock", source: { local: "./mock" } }
-                ]
-            },
-            interfaces: {}
-        }"#;
-    write_plain_peppy_json5(&dep_dir, dep_peppy_json5);
-    for d in [&default_dir, &mock_dir] {
-        std::fs::write(
-            d.join(NODE_CONFIG_FILE),
-            r#"{
-                peppy_schema: "node_v1",
-                execution: {
-                    language: "rust",
-                    run_cmd: ["sleep", "10"]
-                }
-            }"#,
-        )
-        .unwrap();
-    }
-
-    let target_dir = tmp.path().join("target");
-    write_plain_peppy_json5(
-        &target_dir,
-        &minimal_node_config("target", "1.0.0", &[("dep_with_variant", "0.1.0")]),
-    );
-
-    TestPackagesCache::new()
-        .fs_entry("dep_with_variant", "0.1.0", &dep_dir, &["mock"])
-        .fs_entry("target", "1.0.0", &target_dir, &[])
-        .write(&peppy_dirs);
-
-    let res = send_node_add_and_wait_with_dep_overrides(
-        &started.caller_handle,
-        &started.core_node_name,
-        NodeAddSource::RepoNode {
-            name: "target",
-            tag: "1.0.0",
-        },
-        None,
-        vec![DepVariantOverride {
-            name: "dep_with_variant".into(),
-            tag: "0.1.0".into(),
-            variant: "mock".into(),
-        }],
-        GOAL_TIMEOUT,
-        RESULT_TIMEOUT,
-        None,
-    )
-    .await
-    .expect("node_add should complete");
-
-    assert!(
-        res.success,
-        "add should succeed, err={:?}",
-        res.error_message
-    );
-    assert!(node_stack.contains("dep_with_variant", "0.1.0"));
-    assert!(node_stack.contains("target", "1.0.0"));
-}
-
+// TODO: re-express via manifest-declared `NodeDependency.variant`. See repo_sources.rs:471.
+#[ignore = "DepVariantOverride deleted; rewrite via manifest variant field"]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn repo_node_add_dep_override_on_unrelated_node_warns() {
-    let started = start_core_node_with_mock_messenger().await;
-    let node_stack = started.node_stack.clone();
-    let peppy_dirs = started.peppy_dirs.clone();
+async fn repo_node_add_dep_override_on_unrelated_node_warns() {}
 
-    let tmp = TempDir::new().unwrap();
-    let target_dir = tmp.path().join("target");
-    write_plain_peppy_json5(&target_dir, &minimal_node_config("target", "1.0.0", &[]));
-
-    TestPackagesCache::new()
-        .fs_entry("target", "1.0.0", &target_dir, &[])
-        .write(&peppy_dirs);
-
-    let (fb_tx, mut fb_rx) = tokio::sync::mpsc::unbounded_channel::<NodeAddFeedback>();
-    let res = send_node_add_and_wait_with_dep_overrides(
-        &started.caller_handle,
-        &started.core_node_name,
-        NodeAddSource::RepoNode {
-            name: "target",
-            tag: "1.0.0",
-        },
-        None,
-        vec![DepVariantOverride {
-            name: "nonexistent".into(),
-            tag: "9.9.9".into(),
-            variant: "whatever".into(),
-        }],
-        GOAL_TIMEOUT,
-        RESULT_TIMEOUT,
-        Some(fb_tx),
-    )
-    .await
-    .expect("node_add should complete");
-
-    assert!(
-        res.success,
-        "add should succeed despite orphan override, err={:?}",
-        res.error_message
-    );
-    assert!(node_stack.contains("target", "1.0.0"));
-
-    let mut feedback = Vec::new();
-    while let Ok(f) = fb_rx.try_recv() {
-        feedback.push(f);
-    }
-    let warned = feedback.iter().any(|f| {
-        f.is_warning() && f.line.contains("nonexistent:9.9.9") && f.line.contains("ignored")
-    });
-    assert!(
-        warned,
-        "expected a warning feedback line about the orphan override; got: {feedback:?}"
-    );
-}
-
-/// Re-running `node add` for the same root with a different dep variant
-/// override must swap the dep's `variant_name` on the stack. This is the
-/// regression test for the bug where the second override was silently
-/// dropped because the dep was already in the stack.
+// TODO: re-express via manifest-declared `NodeDependency.variant`. See repo_sources.rs:476.
+#[ignore = "DepVariantOverride deleted; rewrite via manifest variant field"]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn repo_node_add_re_add_swaps_dep_variant() {
-    let started = start_core_node_with_mock_messenger().await;
-    let node_stack = started.node_stack.clone();
-    let peppy_dirs = started.peppy_dirs.clone();
-
-    // Dep with two selectable variants (plus a required default).
-    let tmp = TempDir::new().unwrap();
-    let dep_dir = tmp.path().join("dep_with_variant");
-    let default_dir = dep_dir.join("default");
-    let mock_a_dir = dep_dir.join("mock-a");
-    let mock_b_dir = dep_dir.join("mock-b");
-    for d in [&default_dir, &mock_a_dir, &mock_b_dir] {
-        std::fs::create_dir_all(d).unwrap();
-        std::fs::write(
-            d.join(NODE_CONFIG_FILE),
-            r#"{
-                peppy_schema: "node_v1",
-                execution: {
-                    language: "rust",
-                    run_cmd: ["sleep", "10"]
-                }
-            }"#,
-        )
-        .unwrap();
-    }
-    write_plain_peppy_json5(
-        &dep_dir,
-        r#"{
-            peppy_schema: "node_v1",
-            manifest: {
-                name: "dep_with_variant",
-                tag: "0.1.0",
-                variants: [
-                    { name: "default", source: { local: "./default" } },
-                    { name: "mock-a",  source: { local: "./mock-a"  } },
-                    { name: "mock-b",  source: { local: "./mock-b"  } }
-                ]
-            },
-            interfaces: {}
-        }"#,
-    );
-
-    let target_dir = tmp.path().join("target");
-    write_plain_peppy_json5(
-        &target_dir,
-        &minimal_node_config("target", "1.0.0", &[("dep_with_variant", "0.1.0")]),
-    );
-
-    TestPackagesCache::new()
-        .fs_entry("dep_with_variant", "0.1.0", &dep_dir, &["mock-a", "mock-b"])
-        .fs_entry("target", "1.0.0", &target_dir, &[])
-        .write(&peppy_dirs);
-
-    // First add pins the dep to `mock-a`.
-    let res_a = send_node_add_and_wait_with_dep_overrides(
-        &started.caller_handle,
-        &started.core_node_name,
-        NodeAddSource::RepoNode {
-            name: "target",
-            tag: "1.0.0",
-        },
-        None,
-        vec![DepVariantOverride {
-            name: "dep_with_variant".into(),
-            tag: "0.1.0".into(),
-            variant: "mock-a".into(),
-        }],
-        GOAL_TIMEOUT,
-        RESULT_TIMEOUT,
-        None,
-    )
-    .await
-    .expect("first node_add should complete");
-    assert!(
-        res_a.success,
-        "first add should succeed, err={:?}",
-        res_a.error_message
-    );
-    assert_eq!(
-        read_variant(&node_stack, "dep_with_variant", "0.1.0"),
-        Some("mock-a".to_owned()),
-        "dep should land on stack with the first requested variant"
-    );
-
-    // Second add requests a different variant for the same dep — the
-    // stack entry must reflect the new variant, not the stale one.
-    let res_b = send_node_add_and_wait_with_dep_overrides(
-        &started.caller_handle,
-        &started.core_node_name,
-        NodeAddSource::RepoNode {
-            name: "target",
-            tag: "1.0.0",
-        },
-        None,
-        vec![DepVariantOverride {
-            name: "dep_with_variant".into(),
-            tag: "0.1.0".into(),
-            variant: "mock-b".into(),
-        }],
-        GOAL_TIMEOUT,
-        RESULT_TIMEOUT,
-        None,
-    )
-    .await
-    .expect("second node_add should complete");
-    assert!(
-        res_b.success,
-        "second add should succeed, err={:?}",
-        res_b.error_message
-    );
-    assert_eq!(
-        read_variant(&node_stack, "dep_with_variant", "0.1.0"),
-        Some("mock-b".to_owned()),
-        "dep variant should be swapped by the second add"
-    );
-    assert!(node_stack.contains("target", "1.0.0"));
-}
-
-fn read_variant(node_stack: &node_stack::NodeStack, name: &str, tag: &str) -> Option<String> {
-    let handle = node_stack.find(name, tag)?;
-    handle.read().variant_name().map(str::to_owned)
-}
+async fn repo_node_add_re_add_swaps_dep_variant() {}

--- a/crates/core-node-internal/tests/listen_for_node_add/repo_sources.rs
+++ b/crates/core-node-internal/tests/listen_for_node_add/repo_sources.rs
@@ -473,19 +473,3 @@ async fn repo_node_add_root_variant_only() {
     );
     assert!(node_stack.contains("with_variants", "0.1.0", "alt"));
 }
-
-// TODO: re-express via manifest-declared `NodeDependency.variant` instead of
-// the deleted `DepVariantOverride` plumbing. See repo_sources.rs:466.
-#[ignore = "DepVariantOverride deleted; rewrite via manifest variant field"]
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn repo_node_add_dep_variants_only_no_root() {}
-
-// TODO: re-express via manifest-declared `NodeDependency.variant`. See repo_sources.rs:471.
-#[ignore = "DepVariantOverride deleted; rewrite via manifest variant field"]
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn repo_node_add_dep_override_on_unrelated_node_warns() {}
-
-// TODO: re-express via manifest-declared `NodeDependency.variant`. See repo_sources.rs:476.
-#[ignore = "DepVariantOverride deleted; rewrite via manifest variant field"]
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn repo_node_add_re_add_swaps_dep_variant() {}

--- a/crates/core-node-internal/tests/listen_for_node_add/variants.rs
+++ b/crates/core-node-internal/tests/listen_for_node_add/variants.rs
@@ -69,10 +69,10 @@ async fn listen_for_node_add_variant_local_source() {
     );
 
     // Variant should be in the stack under the root node's name:tag
-    assert!(node_stack.contains(ROOT_NODE_NAME, ROOT_NODE_TAG));
+    assert!(node_stack.contains(ROOT_NODE_NAME, ROOT_NODE_TAG, "mock"));
 
     let entity = node_stack
-        .find(ROOT_NODE_NAME, ROOT_NODE_TAG)
+        .find(ROOT_NODE_NAME, ROOT_NODE_TAG, "mock")
         .expect("node should exist in stack");
     let entity_guard = entity.read();
     // The config in the stack should have root's interfaces but variant's runtime
@@ -188,10 +188,10 @@ async fn listen_for_node_add_variant_local_source_after_sync() {
     );
 
     // Verify the node is in the stack with the expected merged config
-    assert!(node_stack.contains(ROOT_NODE_NAME, ROOT_NODE_TAG));
+    assert!(node_stack.contains(ROOT_NODE_NAME, ROOT_NODE_TAG, "mock"));
 
     let entity = node_stack
-        .find(ROOT_NODE_NAME, ROOT_NODE_TAG)
+        .find(ROOT_NODE_NAME, ROOT_NODE_TAG, "mock")
         .expect("node should exist in stack");
     let entity_guard = entity.read();
     let config = entity_guard.config();
@@ -336,10 +336,10 @@ async fn listen_for_node_add_variant_only_node_after_sync() {
     );
 
     // Verify the node is in the stack with the expected merged config
-    assert!(node_stack.contains(ROOT_NODE_NAME, ROOT_NODE_TAG));
+    assert!(node_stack.contains(ROOT_NODE_NAME, ROOT_NODE_TAG, "mock"));
 
     let entity = node_stack
-        .find(ROOT_NODE_NAME, ROOT_NODE_TAG)
+        .find(ROOT_NODE_NAME, ROOT_NODE_TAG, "mock")
         .expect("node should exist in stack");
     let entity_guard = entity.read();
     let config = entity_guard.config();
@@ -463,7 +463,7 @@ async fn listen_for_node_add_variant_fingerprint_mismatch_after_sync() {
 
     // Node should not be in the stack
     assert!(
-        !node_stack.contains(ROOT_NODE_NAME, ROOT_NODE_TAG),
+        !node_stack.contains(ROOT_NODE_NAME, ROOT_NODE_TAG, "default"),
         "node should not be added when variant fingerprint mismatches"
     );
 }
@@ -551,10 +551,10 @@ async fn listen_for_node_add_with_fs_archive_variant_uses_archived_root() {
         "archive variant node_add should succeed, got error: {:?}",
         add_result.error_message
     );
-    assert!(node_stack.contains(ROOT_NODE_NAME, ROOT_NODE_TAG));
+    assert!(node_stack.contains(ROOT_NODE_NAME, ROOT_NODE_TAG, "mock"));
 
     let entity = node_stack
-        .find(ROOT_NODE_NAME, ROOT_NODE_TAG)
+        .find(ROOT_NODE_NAME, ROOT_NODE_TAG, "mock")
         .expect("node should exist in stack");
     let entity_guard = entity.read();
     let config = entity_guard.config();
@@ -775,7 +775,7 @@ async fn listen_for_node_add_variant_matching_interfaces_different_order() {
         "variant with matching interfaces (different order) should succeed, got error: {:?}",
         add_result.error_message
     );
-    assert!(node_stack.contains("test_node", "0.1.0"));
+    assert!(node_stack.contains("test_node", "0.1.0", "good"));
 }
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn listen_for_node_add_variant_no_interfaces() {
@@ -838,10 +838,10 @@ async fn listen_for_node_add_variant_no_interfaces() {
         "variant without interfaces should succeed, got error: {:?}",
         add_result.error_message
     );
-    assert!(node_stack.contains("test_node", "0.1.0"));
+    assert!(node_stack.contains("test_node", "0.1.0", "minimal"));
 
     let entity = node_stack
-        .find("test_node", "0.1.0")
+        .find("test_node", "0.1.0", "minimal")
         .expect("node should exist");
     assert!(
         entity.read().config().interfaces.topics.is_some(),
@@ -1016,7 +1016,7 @@ async fn listen_for_node_add_variant_manifest_ignored_warning() {
     // Verify the root manifest was used, not the variant's
     let entity = started_core_node
         .node_stack
-        .find("test_node", "0.1.0")
+        .find("test_node", "0.1.0", "custom")
         .expect("node should be in stack under root's name:tag");
     let entity_guard = entity.read();
     assert_eq!(entity_guard.config().manifest.name.as_str(), "test_node");
@@ -1099,10 +1099,10 @@ async fn listen_for_node_add_default_variant_auto_resolved() {
         add_result.error_message
     );
 
-    assert!(node_stack.contains(ROOT_NODE_NAME, ROOT_NODE_TAG));
+    assert!(node_stack.contains(ROOT_NODE_NAME, ROOT_NODE_TAG, "default"));
 
     let entity = node_stack
-        .find(ROOT_NODE_NAME, ROOT_NODE_TAG)
+        .find(ROOT_NODE_NAME, ROOT_NODE_TAG, "default")
         .expect("node should exist in stack");
     let entity_guard = entity.read();
     let config = entity_guard.config();
@@ -1200,7 +1200,7 @@ async fn listen_for_node_add_default_variant_explicit_other() {
     );
 
     let entity = node_stack
-        .find(ROOT_NODE_NAME, ROOT_NODE_TAG)
+        .find(ROOT_NODE_NAME, ROOT_NODE_TAG, "mujoco")
         .expect("node should exist in stack");
     let entity_guard = entity.read();
     let config = entity_guard.config();
@@ -1387,10 +1387,10 @@ async fn listen_for_node_add_git_variant_verifies_git_hash_at_root() {
         add_result.error_message
     );
 
-    assert!(node_stack.contains(ROOT_NODE_NAME, ROOT_NODE_TAG));
+    assert!(node_stack.contains(ROOT_NODE_NAME, ROOT_NODE_TAG, "git_variant"));
 
     let entity = node_stack
-        .find(ROOT_NODE_NAME, ROOT_NODE_TAG)
+        .find(ROOT_NODE_NAME, ROOT_NODE_TAG, "git_variant")
         .expect("node should exist in stack");
     let entity_guard = entity.read();
     let config = entity_guard.config();

--- a/crates/core-node-internal/tests/listen_for_node_build.rs
+++ b/crates/core-node-internal/tests/listen_for_node_build.rs
@@ -16,7 +16,7 @@ const CONTAINER_RESULT_TIMEOUT: Duration = Duration::from_secs(300);
 
 fn entity_artifact_path(node_stack: &node_stack::NodeStack, name: &str, tag: &str) -> PathBuf {
     node_stack
-        .find(name, tag)
+        .find(name, tag, "default")
         .expect("entity should exist")
         .read()
         .artifact_path()
@@ -414,10 +414,15 @@ async fn listen_for_node_build_writes_log_file() {
     );
 
     let log_dir = started_core_node.peppy_dirs.logs_dir_build();
+    // Log paths are nested per-(name, tag, variant): <logs_dir>/<name>/<tag>/<variant>/<ts>.log.
+    let expected_subdir = log_dir
+        .join(TARGET_NODE_NAME)
+        .join(TARGET_NODE_TAG)
+        .join("default");
     assert!(
-        build_result.log_path.starts_with(&log_dir),
-        "log file should be in logs_dir_build(), expected to start with {:?}, got {:?}",
-        log_dir,
+        build_result.log_path.starts_with(&expected_subdir),
+        "log file should be under {:?}, got {:?}",
+        expected_subdir,
         build_result.log_path
     );
 
@@ -426,11 +431,6 @@ async fn listen_for_node_build_writes_log_file() {
         .file_name()
         .and_then(|n| n.to_str())
         .expect("should have log filename");
-    assert!(
-        log_filename.starts_with(&format!("{TARGET_NODE_NAME}_{TARGET_NODE_TAG}_")),
-        "log filename should start with '<node_name>_<tag>_', got: {}",
-        log_filename
-    );
     assert!(
         log_filename.ends_with(".log"),
         "log filename should end with '.log', got: {}",
@@ -754,7 +754,7 @@ From: {DEFAULT_ALPINE_BASE_IMAGE}
         build_result.error_message
     );
 
-    assert!(node_stack.contains(TARGET_NODE_NAME, TARGET_NODE_TAG));
+    assert!(node_stack.contains(TARGET_NODE_NAME, TARGET_NODE_TAG, "default"));
 
     let root_path = entity_artifact_path(&node_stack, TARGET_NODE_NAME, TARGET_NODE_TAG);
     assert_eq!(build_result.artifact_path.as_path(), root_path.as_path());
@@ -773,12 +773,9 @@ From: {DEFAULT_ALPINE_BASE_IMAGE}
         .file_name()
         .and_then(|n| n.to_str())
         .expect("should have file name");
-    assert_eq!(
-        file_name,
-        format!("{TARGET_NODE_NAME}_{TARGET_NODE_TAG}.sif"),
-        "stored image should be '<node_name>_<tag>.sif', got: {}",
-        file_name
-    );
+    // SIF artifacts are stored at <built_nodes>/<name>/<tag>/<variant>/node.sif —
+    // the per-variant subdir is what disambiguates, so the leaf is a stable name.
+    assert_eq!(file_name, "node.sif", "got: {}", file_name);
 
     assert!(
         !build_result.log_path.as_os_str().is_empty(),
@@ -791,10 +788,15 @@ From: {DEFAULT_ALPINE_BASE_IMAGE}
     );
 
     let log_dir = started_core_node.peppy_dirs.logs_dir_build();
+    // Log paths are nested per-(name, tag, variant): <logs_dir>/<name>/<tag>/<variant>/<ts>.log.
+    let expected_subdir = log_dir
+        .join(TARGET_NODE_NAME)
+        .join(TARGET_NODE_TAG)
+        .join("default");
     assert!(
-        build_result.log_path.starts_with(&log_dir),
-        "log file should be in logs_dir_build(), expected to start with {:?}, got {:?}",
-        log_dir,
+        build_result.log_path.starts_with(&expected_subdir),
+        "log file should be under {:?}, got {:?}",
+        expected_subdir,
         build_result.log_path
     );
 
@@ -803,11 +805,6 @@ From: {DEFAULT_ALPINE_BASE_IMAGE}
         .file_name()
         .and_then(|n| n.to_str())
         .expect("should have log filename");
-    assert!(
-        log_filename.starts_with(&format!("{TARGET_NODE_NAME}_{TARGET_NODE_TAG}_")),
-        "log filename should start with '<node_name>_<tag>_', got: {}",
-        log_filename
-    );
     assert!(
         log_filename.ends_with(".log"),
         "log filename should end with '.log', got: {}",

--- a/crates/core-node-internal/tests/listen_for_node_info.rs
+++ b/crates/core-node-internal/tests/listen_for_node_info.rs
@@ -86,7 +86,7 @@ async fn node_info_reports_stage_instances_and_logs_for_stack_resident_node() {
         .into_resolved()
         .expect("resolve config");
     node_stack
-        .push_config(config, false, node_dir.path())
+        .push_config(config, false, node_dir.path(), "default")
         .expect("push_config should succeed");
 
     let instance_id = Name::new(TARGET_INSTANCE_ID).expect("valid instance id");
@@ -98,7 +98,7 @@ async fn node_info_reports_stage_instances_and_logs_for_stack_resident_node() {
     )
     .await;
 
-    let request = NodeInfoRequest::new(TARGET_NODE_NAME, TARGET_NODE_TAG);
+    let request = NodeInfoRequest::new(TARGET_NODE_NAME, TARGET_NODE_TAG, "default".to_string());
     let info_response = poll_node_info(&started_core_node, &request, Duration::from_secs(5))
         .await
         .expect("node_info request should succeed");
@@ -138,10 +138,15 @@ async fn node_info_reports_stage_instances_and_logs_for_stack_resident_node() {
         .peppy_dirs
         .logs_dir_add()
         .join("recorded.log");
-    node_stack.set_add_log_path(TARGET_NODE_NAME, TARGET_NODE_TAG, recorded_add_log.clone());
+    node_stack.set_add_log_path(
+        TARGET_NODE_NAME,
+        TARGET_NODE_TAG,
+        "default",
+        recorded_add_log.clone(),
+    );
     let info_response = poll_node_info(
         &started_core_node,
-        &NodeInfoRequest::new(TARGET_NODE_NAME, TARGET_NODE_TAG),
+        &NodeInfoRequest::new(TARGET_NODE_NAME, TARGET_NODE_TAG, "default".to_string()),
         Duration::from_secs(5),
     )
     .await
@@ -294,7 +299,7 @@ async fn node_info_has_instance_ids() {
 
     let info_response = poll_node_info(
         &started_core_node,
-        &NodeInfoRequest::new(TARGET_NODE_NAME, TARGET_NODE_TAG),
+        &NodeInfoRequest::new(TARGET_NODE_NAME, TARGET_NODE_TAG, "default".to_string()),
         Duration::from_secs(5),
     )
     .await
@@ -339,7 +344,7 @@ async fn node_info_reports_not_in_stack_and_recovers() {
     // successful response channel. No error log, no transport fault.
     let response = poll_node_info_raw(
         &started_core_node,
-        &NodeInfoRequest::new("ghost_node", "9.9.9"),
+        &NodeInfoRequest::new("ghost_node", "9.9.9", "default".to_string()),
         Duration::from_secs(2),
     )
     .await
@@ -371,12 +376,12 @@ async fn node_info_reports_not_in_stack_and_recovers() {
         .expect("resolve config");
     started_core_node
         .node_stack
-        .push_config(config, false, node_dir.path())
+        .push_config(config, false, node_dir.path(), "default")
         .expect("push_config should succeed");
 
     let info_response = poll_node_info(
         &started_core_node,
-        &NodeInfoRequest::new(TARGET_NODE_NAME, TARGET_NODE_TAG),
+        &NodeInfoRequest::new(TARGET_NODE_NAME, TARGET_NODE_TAG, "default".to_string()),
         Duration::from_secs(5),
     )
     .await

--- a/crates/core-node-internal/tests/listen_for_node_list.rs
+++ b/crates/core-node-internal/tests/listen_for_node_list.rs
@@ -49,7 +49,7 @@ async fn listen_for_node_list_returns_succeeds() {
         "node_add should succeed, got error: {:?}",
         add_response.error_message
     );
-    assert!(node_stack.contains(TARGET_NODE_NAME, TARGET_NODE_TAG));
+    assert!(node_stack.contains(TARGET_NODE_NAME, TARGET_NODE_TAG, "default"));
     assert_eq!(node_stack.len(), 2, "root + added node");
 
     let response = poll_stack_list(
@@ -141,7 +141,7 @@ async fn listen_for_node_list_returns_dot_graph() {
         "node_add should succeed, got error: {:?}",
         add_response.error_message
     );
-    assert!(node_stack.contains(TARGET_NODE_NAME, TARGET_NODE_TAG));
+    assert!(node_stack.contains(TARGET_NODE_NAME, TARGET_NODE_TAG, "default"));
     assert_eq!(node_stack.len(), 2, "root + added node");
 
     let response = poll_stack_list(

--- a/crates/core-node-internal/tests/listen_for_node_remove.rs
+++ b/crates/core-node-internal/tests/listen_for_node_remove.rs
@@ -54,10 +54,10 @@ async fn listen_for_node_remove_success() {
         add_response.error_message
     );
 
-    assert!(node_stack.contains(TARGET_NODE_NAME, TARGET_NODE_TAG));
+    assert!(node_stack.contains(TARGET_NODE_NAME, TARGET_NODE_TAG, "default"));
     assert_eq!(node_stack.len(), 2, "root + added node");
     let entity = node_stack
-        .find(TARGET_NODE_NAME, TARGET_NODE_TAG)
+        .find(TARGET_NODE_NAME, TARGET_NODE_TAG, "default")
         .expect("node should exist in stack");
     assert_eq!(
         entity.read().instances().len(),
@@ -66,7 +66,7 @@ async fn listen_for_node_remove_success() {
     );
 
     let response = poll_node_remove(
-        &NodeRemoveRequest::new(TARGET_NODE_NAME, TARGET_NODE_TAG),
+        &NodeRemoveRequest::new(TARGET_NODE_NAME, TARGET_NODE_TAG, "default".to_string()),
         &started_core_node.caller_handle,
         &started_core_node.core_node_name,
         CALLER_INSTANCE_ID,
@@ -88,7 +88,7 @@ async fn listen_for_node_remove_success() {
     );
 
     assert!(
-        !node_stack.contains(TARGET_NODE_NAME, TARGET_NODE_TAG),
+        !node_stack.contains(TARGET_NODE_NAME, TARGET_NODE_TAG, "default"),
         "node should be removed from node stack"
     );
     assert_eq!(node_stack.len(), 1, "only root should remain");
@@ -104,7 +104,7 @@ async fn listen_for_node_remove_node_name_not_found_fails() {
     let before_len = node_stack.len();
 
     let response = poll_node_remove(
-        &NodeRemoveRequest::new(MISSING_NODE_NAME, MISSING_NODE_TAG),
+        &NodeRemoveRequest::new(MISSING_NODE_NAME, MISSING_NODE_TAG, "default".to_string()),
         &started_core_node.caller_handle,
         &started_core_node.core_node_name,
         CALLER_INSTANCE_ID,
@@ -203,7 +203,8 @@ async fn listen_for_node_remove_stop_running_instances_first() {
     tokio::time::sleep(Duration::from_millis(50)).await;
 
     let response = poll_node_remove(
-        &NodeRemoveRequest::new(TARGET_NODE_NAME, TARGET_NODE_TAG).with_stop_instances(true),
+        &NodeRemoveRequest::new(TARGET_NODE_NAME, TARGET_NODE_TAG, "default".to_string())
+            .with_stop_instances(true),
         &started_core_node.caller_handle,
         &started_core_node.core_node_name,
         CALLER_INSTANCE_ID,
@@ -225,7 +226,7 @@ async fn listen_for_node_remove_stop_running_instances_first() {
         .expect("shutdown channel should not be dropped");
 
     assert!(
-        !node_stack.contains(TARGET_NODE_NAME, TARGET_NODE_TAG),
+        !node_stack.contains(TARGET_NODE_NAME, TARGET_NODE_TAG, "default"),
         "node should be removed from node stack"
     );
     assert_eq!(node_stack.len(), 1, "only root should remain");
@@ -303,7 +304,7 @@ async fn listen_for_node_fails_when_stop_instances_parameter_not_set_and_instanc
     let before_len = node_stack.len();
 
     let response = poll_node_remove(
-        &NodeRemoveRequest::new(TARGET_NODE_NAME, TARGET_NODE_TAG),
+        &NodeRemoveRequest::new(TARGET_NODE_NAME, TARGET_NODE_TAG, "default".to_string()),
         &started_core_node.caller_handle,
         &started_core_node.core_node_name,
         CALLER_INSTANCE_ID,
@@ -339,11 +340,11 @@ async fn listen_for_node_fails_when_stop_instances_parameter_not_set_and_instanc
 
     assert_eq!(node_stack.len(), before_len, "stack should be unchanged");
     assert!(
-        node_stack.contains(TARGET_NODE_NAME, TARGET_NODE_TAG),
+        node_stack.contains(TARGET_NODE_NAME, TARGET_NODE_TAG, "default"),
         "node should remain in node stack"
     );
     let entity = node_stack
-        .find(TARGET_NODE_NAME, TARGET_NODE_TAG)
+        .find(TARGET_NODE_NAME, TARGET_NODE_TAG, "default")
         .expect("node entity should still exist in stack");
     {
         let entity_guard = entity.read();

--- a/crates/core-node-internal/tests/listen_for_node_run.rs
+++ b/crates/core-node-internal/tests/listen_for_node_run.rs
@@ -954,6 +954,7 @@ async fn listen_for_node_run_abandoned_action_does_not_block_next_goal() {
         &first_runtime_config_json5,
         FIRST_NODE_NAME,
         FIRST_NODE_TAG,
+        "default".to_string(),
         60,
     );
     let first_goal_payload = first_goal.encode().expect("failed to encode first goal");

--- a/crates/core-node-internal/tests/listen_for_node_stop.rs
+++ b/crates/core-node-internal/tests/listen_for_node_stop.rs
@@ -68,7 +68,7 @@ async fn listen_for_node_stop_success() {
         "node_add should succeed, got error: {:?}",
         add_response.error_message
     );
-    assert!(node_stack.contains(TARGET_NODE_NAME, TARGET_NODE_TAG));
+    assert!(node_stack.contains(TARGET_NODE_NAME, TARGET_NODE_TAG, "default"));
     build_staged_node(&started_core_node, TARGET_NODE_NAME, TARGET_NODE_TAG).await;
 
     // Drive the real start lifecycle so the entity tracks a live child

--- a/crates/core-node-internal/tests/listen_for_reset.rs
+++ b/crates/core-node-internal/tests/listen_for_reset.rs
@@ -97,8 +97,8 @@ async fn listen_for_node_reset_clears_node_stack() {
         add_response_b.error_message
     );
 
-    assert!(node_stack.contains(TARGET_NODE_A_NAME, TARGET_NODE_A_TAG));
-    assert!(node_stack.contains(TARGET_NODE_B_NAME, TARGET_NODE_B_TAG));
+    assert!(node_stack.contains(TARGET_NODE_A_NAME, TARGET_NODE_A_TAG, "default"));
+    assert!(node_stack.contains(TARGET_NODE_B_NAME, TARGET_NODE_B_TAG, "default"));
     assert_eq!(node_stack.len(), 3, "root + two added nodes");
     build_staged_node(&started_core_node, TARGET_NODE_A_NAME, TARGET_NODE_A_TAG).await;
     build_staged_node(&started_core_node, TARGET_NODE_B_NAME, TARGET_NODE_B_TAG).await;
@@ -112,7 +112,7 @@ async fn listen_for_node_reset_clears_node_stack() {
     )
     .await;
     let entity_a = node_stack
-        .find(TARGET_NODE_A_NAME, TARGET_NODE_A_TAG)
+        .find(TARGET_NODE_A_NAME, TARGET_NODE_A_TAG, "default")
         .expect("node A should exist in stack");
     assert_eq!(
         entity_a.read().instances().len(),
@@ -144,11 +144,11 @@ async fn listen_for_node_reset_clears_node_stack() {
 
     assert_eq!(node_stack.len(), 1, "only root should remain");
     assert!(
-        !node_stack.contains(TARGET_NODE_A_NAME, TARGET_NODE_A_TAG),
+        !node_stack.contains(TARGET_NODE_A_NAME, TARGET_NODE_A_TAG, "default"),
         "node A should be removed from node stack"
     );
     assert!(
-        !node_stack.contains(TARGET_NODE_B_NAME, TARGET_NODE_B_TAG),
+        !node_stack.contains(TARGET_NODE_B_NAME, TARGET_NODE_B_TAG, "default"),
         "node B should be removed from node stack"
     );
 

--- a/crates/node-stack-internal/src/error.rs
+++ b/crates/node-stack-internal/src/error.rs
@@ -26,13 +26,17 @@ pub enum Error {
         interface_name: String,
     },
     #[error(
-        "`{dependant}:{dependant_tag}` depends on `{dependency}:{dependency_tag}`, but it does not exist in the stack"
+        "`{}` depends on `{}`, but it does not exist in the stack",
+        config::node::render_node_id(dependant, dependant_tag, dependant_variant),
+        config::node::render_node_id(dependency, dependency_tag, dependency_variant)
     )]
     MissingDependency {
         dependant: String,
         dependant_tag: String,
+        dependant_variant: String,
         dependency: String,
         dependency_tag: String,
+        dependency_variant: String,
     },
     #[error(
         "`{dependant}:{dependant_tag}` references undeclared local_node_id `{local_node_id}` in consumed interfaces"

--- a/crates/node-stack-internal/src/node_stack.rs
+++ b/crates/node-stack-internal/src/node_stack.rs
@@ -11,7 +11,7 @@ pub use entity::{
 pub use validation::{collect_dependency_specs, validate_dependency_specs};
 
 use crate::error::{Error, Result};
-use config::node::{Name, NodeConfig};
+use config::node::{Name, NodeConfig, NodeKey, render_node_id};
 use core_node_api::{InstanceState, SerializedEdge, SerializedNode, SerializedNodeGraph};
 use names_generator2::get_random;
 use parking_lot::RwLock;
@@ -30,25 +30,11 @@ use std::{collections::HashMap, path::PathBuf, sync::Arc};
 /// reflected in subsequent stack queries without any take-and-replace dance.
 pub type EntityHandle = Arc<RwLock<NodeEntity>>;
 
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
-struct NodeKey {
-    name: String,
-    tag: String,
-}
-
-impl NodeKey {
-    fn new(name: &str, tag: &str) -> Self {
-        Self {
-            name: name.trim().to_owned(),
-            tag: tag.trim().to_owned(),
-        }
-    }
-}
-
 fn key_from_entity(entity: &NodeEntity) -> NodeKey {
     NodeKey::new(
-        entity.config().manifest.name.as_str(),
-        &entity.config().manifest.tag,
+        entity.config().manifest.name.as_str().trim(),
+        entity.config().manifest.tag.trim(),
+        entity.variant(),
     )
 }
 
@@ -58,6 +44,7 @@ fn key_from_entity(entity: &NodeEntity) -> NodeKey {
 pub struct RestoreTarget<'a> {
     pub name: &'a str,
     pub tag: &'a str,
+    pub variant: &'a str,
     pub expected_handle: &'a Arc<RwLock<NodeEntity>>,
     pub expected_generation: u64,
 }
@@ -70,14 +57,18 @@ pub struct EntitySnapshot {
     pub config: NodeConfig,
     pub config_path: PathBuf,
     pub artifact_path: Option<PathBuf>,
-    pub variant_name: Option<String>,
+    pub variant: String,
 }
 
 fn dependency_keys(node: &NodeConfig) -> Vec<NodeKey> {
     collect_dependency_specs(node)
         .into_iter()
-        .map(|spec| NodeKey::new(&spec.node_name, &spec.node_tag))
+        .map(|spec| NodeKey::new(spec.node_name, spec.node_tag, spec.node_variant))
         .collect()
+}
+
+fn trimmed_key(name: &str, tag: &str, variant: &str) -> NodeKey {
+    NodeKey::new(name.trim(), tag.trim(), variant.trim())
 }
 
 struct NodeStackInner {
@@ -137,8 +128,9 @@ impl NodeStackInner {
             &entity.config().interfaces,
             entity.config().manifest.name.as_str(),
             &entity.config().manifest.tag,
-            |name, tag| {
-                let key = NodeKey::new(name, tag);
+            entity.variant(),
+            |name, tag, variant| {
+                let key = trimmed_key(name, tag, variant);
                 self.key_to_index
                     .get(&key)
                     .and_then(|&idx| self.graph.node_weight(idx))
@@ -347,9 +339,13 @@ impl NodeStackInner {
         config: NodeConfig,
         allow_missing_dependencies: bool,
         config_path: P,
-        variant_name: Option<String>,
+        variant: String,
     ) -> Result<Option<EntitySnapshot>> {
-        let key = NodeKey::new(config.manifest.name.as_str(), &config.manifest.tag);
+        let key = trimmed_key(
+            config.manifest.name.as_str(),
+            &config.manifest.tag,
+            &variant,
+        );
         let config_path = config_path.into();
 
         // The root node cannot be modified
@@ -410,7 +406,7 @@ impl NodeStackInner {
 
                 if (interfaces_changed || dependencies_changed) && !allow_missing_dependencies {
                     let candidate =
-                        NodeEntity::new(config.clone(), config_path.clone(), variant_name.clone());
+                        NodeEntity::new(config.clone(), config_path.clone(), variant.clone());
                     self.validate_dependencies(&candidate)?;
                 }
 
@@ -424,13 +420,13 @@ impl NodeStackInner {
                     config: guard.config().clone(),
                     config_path: guard.config_path().to_path_buf(),
                     artifact_path: guard.artifact_path().map(|p| p.to_path_buf()),
-                    variant_name: guard.variant_name().map(str::to_owned),
+                    variant: guard.variant().to_owned(),
                 };
 
                 // Replace the entity in-place under the still-held write
                 // lock. The same `Arc` handle is preserved so any external
                 // readers see the new state.
-                *guard = NodeEntity::new(config, config_path, variant_name);
+                *guard = NodeEntity::new(config, config_path, variant);
 
                 (previous_snapshot, interfaces_changed, dependencies_changed)
             };
@@ -442,7 +438,7 @@ impl NodeStackInner {
             Ok(Some(previous_snapshot))
         } else {
             // Entity doesn't exist, create new one in the Added stage.
-            let entity = NodeEntity::new(config, config_path, variant_name);
+            let entity = NodeEntity::new(config, config_path, variant);
             self.insert_entity(entity, !allow_missing_dependencies)?;
             Ok(None)
         }
@@ -478,12 +474,12 @@ impl NodeStackInner {
                 let guard = handle.read();
                 let name = guard.config().manifest.name.as_str();
                 let tag = &guard.config().manifest.tag;
+                let variant = guard.variant();
                 let stage = guard.stage().name();
                 let instance_count = guard.instances().len();
                 format!(
-                    "label=\"{}:{}\\n[{}] ({} instance{})\"",
-                    name,
-                    tag,
+                    "label=\"{}\\n[{}] ({} instance{})\"",
+                    render_node_id(name, tag, variant),
                     stage,
                     instance_count,
                     if instance_count == 1 { "" } else { "s" }
@@ -531,10 +527,10 @@ impl NodeStackInner {
 #[derive(Clone)]
 pub struct NodeStack {
     shared: Arc<RwLock<NodeStackInner>>,
-    /// Most-recent add log path per `(node_name, node_tag)`. This is a
-    /// daemon-only cache (not persisted) so it lives here rather than on
+    /// Most-recent add log path per `(node_name, node_tag, variant)`. This is
+    /// a daemon-only cache (not persisted) so it lives here rather than on
     /// `NodeEntity`, which is a pure lifecycle/config model.
-    add_log_paths: Arc<parking_lot::Mutex<HashMap<(String, String), PathBuf>>>,
+    add_log_paths: Arc<parking_lot::Mutex<HashMap<(String, String, String), PathBuf>>>,
 }
 
 impl NodeStack {
@@ -570,19 +566,28 @@ impl NodeStack {
         }
     }
 
-    /// Records the add-log path for a `(name, tag)` key. Called by the
-    /// add/launch handlers after creating the log file.
-    pub fn set_add_log_path(&self, name: &str, tag: &str, path: PathBuf) {
-        self.add_log_paths
-            .lock()
-            .insert((name.trim().to_owned(), tag.trim().to_owned()), path);
+    /// Records the add-log path for a `(name, tag, variant)` key. Called by
+    /// the add/launch handlers after creating the log file.
+    pub fn set_add_log_path(&self, name: &str, tag: &str, variant: &str, path: PathBuf) {
+        self.add_log_paths.lock().insert(
+            (
+                name.trim().to_owned(),
+                tag.trim().to_owned(),
+                variant.trim().to_owned(),
+            ),
+            path,
+        );
     }
 
-    /// Returns the most-recent add-log path for `(name, tag)`, if any.
-    pub fn add_log_path(&self, name: &str, tag: &str) -> Option<PathBuf> {
+    /// Returns the most-recent add-log path for `(name, tag, variant)`, if any.
+    pub fn add_log_path(&self, name: &str, tag: &str, variant: &str) -> Option<PathBuf> {
         self.add_log_paths
             .lock()
-            .get(&(name.trim().to_owned(), tag.trim().to_owned()))
+            .get(&(
+                name.trim().to_owned(),
+                tag.trim().to_owned(),
+                variant.trim().to_owned(),
+            ))
             .cloned()
     }
 
@@ -601,18 +606,18 @@ impl NodeStack {
         guard.root()
     }
 
-    pub fn contains(&self, name: &str, tag: &str) -> bool {
+    pub fn contains(&self, name: &str, tag: &str, variant: &str) -> bool {
         let guard = self.shared.read();
-        guard.contains(&NodeKey::new(name, tag))
+        guard.contains(&trimmed_key(name, tag, variant))
     }
 
-    /// Returns a shared handle to the entity with the given name and tag, if
-    /// any. Callers can read or write through the returned `Arc<RwLock<...>>`
-    /// to inspect the entity or to drive lifecycle transitions
+    /// Returns a shared handle to the entity with the given identity, if any.
+    /// Callers can read or write through the returned `Arc<RwLock<...>>` to
+    /// inspect the entity or to drive lifecycle transitions
     /// (`build` / `start_instance` / `stop_instance`).
-    pub fn find(&self, name: &str, tag: &str) -> Option<EntityHandle> {
+    pub fn find(&self, name: &str, tag: &str, variant: &str) -> Option<EntityHandle> {
         let guard = self.shared.read();
-        guard.find(&NodeKey::new(name, tag))
+        guard.find(&trimmed_key(name, tag, variant))
     }
 
     /// Finds a node instance by its instance_id across all entities in the stack.
@@ -645,27 +650,13 @@ impl NodeStack {
         config: NodeConfig,
         allow_missing_dependencies: bool,
         config_path: P,
-    ) -> Result<()> {
-        self.push_config_with_variant(config, allow_missing_dependencies, config_path, None)
-    }
-
-    /// Like [`Self::push_config`] but also records the variant label that
-    /// was selected at `node add` time. The variant is stored as
-    /// first-class state on the resulting [`NodeEntity`] and exposed via
-    /// [`NodeEntity::variant_name`]. Passing `None` is equivalent to
-    /// [`Self::push_config`].
-    pub fn push_config_with_variant<P: Into<PathBuf>>(
-        &self,
-        config: NodeConfig,
-        allow_missing_dependencies: bool,
-        config_path: P,
-        variant_name: Option<String>,
+        variant: impl Into<String>,
     ) -> Result<()> {
         self.push_config_capturing_previous(
             config,
             allow_missing_dependencies,
             config_path,
-            variant_name,
+            variant,
         )
         .map(|_| ())
     }
@@ -682,14 +673,14 @@ impl NodeStack {
         config: NodeConfig,
         allow_missing_dependencies: bool,
         config_path: P,
-        variant_name: Option<String>,
+        variant: impl Into<String>,
     ) -> Result<Option<EntitySnapshot>> {
         let mut guard = self.shared.write();
         guard.push_config_impl(
             config,
             allow_missing_dependencies,
             config_path,
-            variant_name,
+            variant.into(),
         )
     }
 
@@ -698,14 +689,14 @@ impl NodeStack {
         guard.entities_snapshot()
     }
 
-    pub fn dependencies_of(&self, name: &str, tag: &str) -> Vec<EntityHandle> {
+    pub fn dependencies_of(&self, name: &str, tag: &str, variant: &str) -> Vec<EntityHandle> {
         let guard = self.shared.read();
-        guard.dependencies_of(&NodeKey::new(name, tag))
+        guard.dependencies_of(&trimmed_key(name, tag, variant))
     }
 
-    pub fn dependents_of(&self, name: &str, tag: &str) -> Vec<EntityHandle> {
+    pub fn dependents_of(&self, name: &str, tag: &str, variant: &str) -> Vec<EntityHandle> {
         let guard = self.shared.read();
-        guard.dependents_of(&NodeKey::new(name, tag))
+        guard.dependents_of(&trimmed_key(name, tag, variant))
     }
 
     /// Removes a node configuration if it has no instances.
@@ -713,9 +704,9 @@ impl NodeStack {
     /// Returns Ok(true) if the config was found and removed, Ok(false) if not found.
     /// Returns Err(CannotModifyRootNode) if trying to remove the root node.
     /// Returns Err(CannotRemoveNodeWithInstances) if the node still has instances.
-    pub fn remove_config(&self, name: &str, tag: &str) -> Result<bool> {
+    pub fn remove_config(&self, name: &str, tag: &str, variant: &str) -> Result<bool> {
         let mut guard = self.shared.write();
-        let key = NodeKey::new(name, tag);
+        let key = trimmed_key(name, tag, variant);
 
         if guard.is_root(&key) {
             return Err(Error::CannotModifyRootNode);
@@ -742,9 +733,11 @@ impl NodeStack {
             });
         }
         guard.remove_entity(&key);
-        self.add_log_paths
-            .lock()
-            .remove(&(name.trim().to_owned(), tag.trim().to_owned()));
+        self.add_log_paths.lock().remove(&(
+            name.trim().to_owned(),
+            tag.trim().to_owned(),
+            variant.trim().to_owned(),
+        ));
         // Keep `entity_guard` alive until *after* the unlink so an outside
         // thread holding a clone of the handle still cannot mutate the
         // entity between the check and the removal.
@@ -768,11 +761,12 @@ impl NodeStack {
         &self,
         name: &str,
         tag: &str,
+        variant: &str,
         expected_handle: &Arc<RwLock<NodeEntity>>,
         expected_generation: u64,
     ) -> bool {
         let mut guard = self.shared.write();
-        let key = NodeKey::new(name, tag);
+        let key = trimmed_key(name, tag, variant);
 
         if guard.is_root(&key) {
             return false;
@@ -795,9 +789,11 @@ impl NodeStack {
         }
 
         guard.remove_entity(&key);
-        self.add_log_paths
-            .lock()
-            .remove(&(name.trim().to_owned(), tag.trim().to_owned()));
+        self.add_log_paths.lock().remove(&(
+            name.trim().to_owned(),
+            tag.trim().to_owned(),
+            variant.trim().to_owned(),
+        ));
         true
     }
 
@@ -824,7 +820,7 @@ impl NodeStack {
         snapshot: EntitySnapshot,
     ) -> bool {
         let guard = self.shared.write();
-        let key = NodeKey::new(target.name, target.tag);
+        let key = trimmed_key(target.name, target.tag, target.variant);
 
         if guard.is_root(&key) {
             return false;
@@ -858,7 +854,7 @@ impl NodeStack {
             snapshot.config_path,
             snapshot.artifact_path,
             Vec::new(),
-            snapshot.variant_name,
+            snapshot.variant,
         );
         *current.write() = restored;
         true
@@ -908,7 +904,7 @@ impl NodeStack {
             let config_path = source_guard.config_path().to_path_buf();
             let artifact_path = source_guard.artifact_path().map(|p| p.to_path_buf());
             let instances: Vec<TrackedNodeInstance> = source_guard.instances().to_vec();
-            let variant_name = source_guard.variant_name().map(str::to_owned);
+            let variant = source_guard.variant().to_owned();
 
             // Reject transient lifecycle state from the source: snapshot
             // replay only makes sense for entities that are quiescent (no
@@ -951,14 +947,10 @@ impl NodeStack {
             // Materialize the entity directly in the appropriate stage. The
             // `from_snapshot` constructor bypasses the lifecycle because the
             // source artifact already exists on disk.
-            let entity = NodeEntity::from_snapshot(
-                config,
-                config_path,
-                artifact_path,
-                instances,
-                variant_name,
-            );
-            prepared.push((format!("{}:{}", name, tag), entity));
+            let label = render_node_id(&name, &tag, &variant);
+            let entity =
+                NodeEntity::from_snapshot(config, config_path, artifact_path, instances, variant);
+            prepared.push((label, entity));
         }
 
         // Phase 2: only after *every* source entity has validated, clear the

--- a/crates/node-stack-internal/src/node_stack/build_steps.rs
+++ b/crates/node-stack-internal/src/node_stack/build_steps.rs
@@ -25,19 +25,22 @@ pub(super) fn validate_node_tag(node_tag: &str) -> std::io::Result<()> {
 /// Archives the contents of `source_dir` into a `.tar.zst` file in the
 /// peppy built nodes directory.
 ///
-/// The archive path follows the format: `<storage_dir>/<node_name>_<tag>.tar.zst`
+/// The archive path follows the format:
+/// `<storage_dir>/<node_name>/<node_tag>/<variant>/node.tar.zst`.
 ///
 /// Uses zstd compression level 1 (fastest speed).
 pub(super) fn archive_dir_to_storage(
     source_dir: &Path,
     node_name: &str,
     node_tag: &str,
+    variant: &str,
     peppy_dirs: &PeppyDirs,
 ) -> std::io::Result<PathBuf> {
     validate_node_tag(node_tag)?;
-    let storage_dir = peppy_dirs.built_nodes_dir();
-    let archive_name = format!("{}_{}.tar.zst", node_name, node_tag);
-    config::atomic_write::publish_atomic(&storage_dir.join(&archive_name), |tmp_path| {
+    let key = config::node::NodeKey::new(node_name, node_tag, variant);
+    let storage_dir = peppy_dirs.built_nodes_dir().join(key.artifact_subpath());
+    std::fs::create_dir_all(&storage_dir)?;
+    config::atomic_write::publish_atomic(&storage_dir.join("node.tar.zst"), |tmp_path| {
         let file = File::create(tmp_path)?;
         let encoder = ZstdEncoder::new(file, 1)?;
         let mut tar_builder = tar::Builder::new(encoder);
@@ -53,24 +56,27 @@ pub(super) fn archive_dir_to_storage(
 
 /// Moves the built `.sif` container image from the working directory to peppy storage.
 ///
-/// The image is expected at `working_dir/{node_name}_{node_tag}.sif`, which is the
+/// The image is expected at `working_dir/node.sif`, which is the
 /// conventional output path produced by `apptainer build`.
 ///
-/// Returns the final storage path: `<built_nodes_dir>/<node_name>_<tag>.sif`.
+/// Returns the final storage path:
+/// `<built_nodes_dir>/<node_name>/<node_tag>/<variant>/node.sif`.
 pub(super) fn move_sif_to_storage(
     working_dir: &Path,
     node_name: &str,
     node_tag: &str,
+    variant: &str,
     peppy_dirs: &PeppyDirs,
 ) -> std::io::Result<PathBuf> {
     validate_node_tag(node_tag)?;
-    let sif_name = format!("{}_{}.sif", node_name, node_tag);
-    let sif_source = working_dir.join(&sif_name);
-    let storage_dir = peppy_dirs.built_nodes_dir();
+    let sif_source = working_dir.join("node.sif");
+    let key = config::node::NodeKey::new(node_name, node_tag, variant);
+    let storage_dir = peppy_dirs.built_nodes_dir().join(key.artifact_subpath());
+    std::fs::create_dir_all(&storage_dir)?;
 
     // Copy + rename (not rename alone) because the working dir may be on a
     // different filesystem than storage.
-    config::atomic_write::publish_atomic(&storage_dir.join(&sif_name), |tmp_path| {
+    config::atomic_write::publish_atomic(&storage_dir.join("node.sif"), |tmp_path| {
         std::fs::copy(&sif_source, tmp_path)
             .map(|_| ())
             .map_err(|e| {
@@ -89,7 +95,6 @@ pub(super) fn move_sif_to_storage(
 /// Inputs needed to drive an apptainer container build to completion.
 pub(super) struct ContainerBuildInputs<'a> {
     pub working_dir: &'a Path,
-    pub node_name: &'a str,
     pub node_tag: &'a str,
     pub def_file: &'a str,
     pub apptainer_build_extra_args: &'a [String],
@@ -132,8 +137,11 @@ pub(super) async fn build_container_image(
         .map_err(|e| format!("Apptainer initialization task failed: {}", e))?
         .map_err(|e| format!("Failed to initialize Apptainer runtime: {}", e))?;
 
-    let sif_name = format!("{}_{}.sif", inputs.node_name, inputs.node_tag);
-    let output_path = inputs.working_dir.join(&sif_name);
+    // The SIF output is written into the build working directory under a
+    // stable filename and moved into per-variant storage by
+    // [`move_sif_to_storage`]. Different variants build in their own
+    // working dirs, so a fixed filename here cannot collide.
+    let output_path = inputs.working_dir.join("node.sif");
     let def_path = inputs.working_dir.join(inputs.def_file);
 
     let mut cmd_builder = apptainer.build(&output_path, &def_path);
@@ -328,7 +336,6 @@ mod tests {
         ));
         let err = build_container_image(ContainerBuildInputs {
             working_dir,
-            node_name: "sensor",
             node_tag: "../evil",
             def_file: "sensor.def",
             apptainer_build_extra_args: &[],

--- a/crates/node-stack-internal/src/node_stack/entity.rs
+++ b/crates/node-stack-internal/src/node_stack/entity.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 use config::consts::PeppyDirs;
-use config::node::{Name, NodeConfig};
+use config::node::{DEFAULT_VARIANT_NAME, Name, NodeConfig};
 use core_node_api::{
     InstanceState, NodeStage as SerializedNodeStage, SerializedInstance, SerializedNode,
 };
@@ -42,7 +42,7 @@ impl From<&NodeEntity> for SerializedNode {
                     state: i.state(),
                 })
                 .collect(),
-            variant_name: entity.variant_name().map(str::to_owned),
+            variant: entity.variant().to_owned(),
         }
     }
 }
@@ -275,21 +275,21 @@ pub struct NodeEntity {
     /// `take_pending_working_dir` clears the entity-side slot. Never
     /// persisted.
     pending_working_dir: Option<Arc<WorkingDirGuard>>,
-    /// Variant label captured at `node add` time. `None` for nodes added
-    /// without a variant (no default variant, no `--variant` flag) and for
-    /// the synthetic root entity.
-    variant_name: Option<String>,
+    /// Variant label captured at `node add` time. Always populated — the
+    /// synthetic root entity and nodes added without an explicit variant
+    /// default to [`DEFAULT_VARIANT_NAME`] (`"default"`).
+    variant: String,
 }
 
 impl NodeEntity {
     /// Creates a new `NodeEntity` in the [`NodeStage::Added`] stage. The
     /// `config_path` should point at the `peppy.json5` file that supplied
-    /// `config`. `variant_name` is the variant label selected at add time
-    /// (or `None` if no variant applies).
+    /// `config`. `variant` is the variant label selected at add time
+    /// (`"default"` when no variant applies).
     pub fn new<P: Into<PathBuf>>(
         config: NodeConfig,
         config_path: P,
-        variant_name: Option<String>,
+        variant: impl Into<String>,
     ) -> Self {
         Self {
             config,
@@ -298,7 +298,7 @@ impl NodeEntity {
             },
             generation: next_entity_generation(),
             pending_working_dir: None,
-            variant_name,
+            variant: variant.into(),
         }
     }
 
@@ -352,10 +352,11 @@ impl NodeEntity {
         &self.stage
     }
 
-    /// Returns the variant label captured at `node add` time, if any. `None`
-    /// for the synthetic root entity and for nodes added without a variant.
-    pub fn variant_name(&self) -> Option<&str> {
-        self.variant_name.as_deref()
+    /// Returns the variant label captured at `node add` time. Always
+    /// populated — the synthetic root entity and nodes added without an
+    /// explicit variant return [`DEFAULT_VARIANT_NAME`] (`"default"`).
+    pub fn variant(&self) -> &str {
+        &self.variant
     }
 
     /// Returns the `peppy.json5` path that registered this entity. Always
@@ -404,7 +405,15 @@ impl NodeEntity {
     /// calling `NodeStack::remove_config`.
     pub async fn build(handle: &Arc<RwLock<NodeEntity>>, ctx: BuildContext<'_>) -> Result<PathBuf> {
         // ---- Phase 1: Added → Building, snapshot inputs (brief write lock) ----
-        let (node_name, node_tag, config_path, container_opt, build_cmd, build_generation) = {
+        let (
+            node_name,
+            node_tag,
+            node_variant,
+            config_path,
+            container_opt,
+            build_cmd,
+            build_generation,
+        ) = {
             let mut guard = handle.write();
             if let Err(from) = guard.stage.ensure_buildable() {
                 return Err(Error::InvalidStageTransition {
@@ -421,6 +430,7 @@ impl NodeEntity {
             let snapshot = (
                 guard.config.manifest.name.as_str().to_owned(),
                 guard.config.manifest.tag.clone(),
+                guard.variant().to_owned(),
                 config_path.clone(),
                 guard.config.execution.container.clone(),
                 guard.config.execution.build_cmd.clone(),
@@ -453,7 +463,6 @@ impl NodeEntity {
 
                 build_container_image(ContainerBuildInputs {
                     working_dir: ctx.working_dir,
-                    node_name: &node_name,
                     node_tag: &node_tag,
                     def_file: &container.def_file,
                     apptainer_build_extra_args,
@@ -498,12 +507,14 @@ impl NodeEntity {
                 let peppy_dirs = ctx.peppy_dirs.clone();
                 let node_name_pub = node_name.clone();
                 let node_tag_pub = node_tag.clone();
+                let node_variant_pub = node_variant.clone();
                 let join_res = tokio::task::spawn_blocking(move || -> std::io::Result<PathBuf> {
                     if is_container {
                         move_sif_to_storage(
                             &working_dir,
                             &node_name_pub,
                             &node_tag_pub,
+                            &node_variant_pub,
                             &peppy_dirs,
                         )
                     } else {
@@ -511,6 +522,7 @@ impl NodeEntity {
                             &working_dir,
                             &node_name_pub,
                             &node_tag_pub,
+                            &node_variant_pub,
                             &peppy_dirs,
                         )
                     }
@@ -681,12 +693,26 @@ impl NodeEntity {
         // ---- Phase 2/3/4: I/O without any entity lock ----
         let instance_id_str = ctx.instance_id.as_str();
         let is_container = node_config.execution.container.is_some();
+        let entity_variant = handle.read().variant().to_owned();
 
         // ---- Phase 2: prepare instance dir ----
         let instance_dir = if is_container {
-            create_instance_dir(instance_id_str, ctx.peppy_dirs)
+            create_instance_dir(
+                &node_name,
+                &node_tag,
+                &entity_variant,
+                instance_id_str,
+                ctx.peppy_dirs,
+            )
         } else {
-            extract_node_archive(&artifact_path, instance_id_str, ctx.peppy_dirs)
+            extract_node_archive(
+                &artifact_path,
+                &node_name,
+                &node_tag,
+                &entity_variant,
+                instance_id_str,
+                ctx.peppy_dirs,
+            )
         }
         .map_err(|reason| {
             Self::remove_starting_instance(handle, ctx.instance_id);
@@ -978,7 +1004,7 @@ impl NodeEntity {
             },
             generation: next_entity_generation(),
             pending_working_dir: None,
-            variant_name: None,
+            variant: DEFAULT_VARIANT_NAME.to_owned(),
         }
     }
 
@@ -1002,7 +1028,7 @@ impl NodeEntity {
         config_path: PathBuf,
         artifact_path: Option<PathBuf>,
         instances: Vec<TrackedNodeInstance>,
-        variant_name: Option<String>,
+        variant: impl Into<String>,
     ) -> Self {
         let stage = match (artifact_path, instances.is_empty()) {
             (None, true) => NodeStage::Added { config_path },
@@ -1021,7 +1047,7 @@ impl NodeEntity {
             stage,
             generation: next_entity_generation(),
             pending_working_dir: None,
-            variant_name,
+            variant: variant.into(),
         }
     }
 
@@ -1133,4 +1159,5 @@ impl TrackedNodeInstance {
 pub struct DependencySpec {
     pub node_name: String,
     pub node_tag: String,
+    pub node_variant: String,
 }

--- a/crates/node-stack-internal/src/node_stack/entity.rs
+++ b/crates/node-stack-internal/src/node_stack/entity.rs
@@ -641,7 +641,7 @@ impl NodeEntity {
         ctx: StartContext<'_>,
     ) -> Result<(Child, StartedInstanceCtx)> {
         // ---- Phase 1: register the Starting instance under a brief write lock ----
-        let (node_name, node_tag, node_config, artifact_path, start_generation) = {
+        let (node_name, node_tag, entity_variant, node_config, artifact_path, start_generation) = {
             let mut guard = handle.write();
             if let Err(from) = guard.stage.ensure_spawnable() {
                 return Err(Error::InvalidStageTransition {
@@ -652,6 +652,7 @@ impl NodeEntity {
                 });
             }
             let entity_generation = guard.generation;
+            let entity_variant = guard.variant.clone();
             let NodeStage::Ready {
                 artifact_path,
                 instances,
@@ -684,6 +685,7 @@ impl NodeEntity {
             (
                 guard.config.manifest.name.as_str().to_owned(),
                 guard.config.manifest.tag.clone(),
+                entity_variant,
                 guard.config.clone(),
                 snapshot_artifact,
                 entity_generation,
@@ -693,7 +695,6 @@ impl NodeEntity {
         // ---- Phase 2/3/4: I/O without any entity lock ----
         let instance_id_str = ctx.instance_id.as_str();
         let is_container = node_config.execution.container.is_some();
-        let entity_variant = handle.read().variant().to_owned();
 
         // ---- Phase 2: prepare instance dir ----
         let instance_dir = if is_container {

--- a/crates/node-stack-internal/src/node_stack/run_steps.rs
+++ b/crates/node-stack-internal/src/node_stack/run_steps.rs
@@ -50,25 +50,30 @@ pub(super) fn write_runtime_config_temp(
     Ok(runtime_config_path)
 }
 
-/// Creates (or recreates) a clean instance directory under `peppy_dirs.instances_dir()`.
+/// Creates (or recreates) a clean instance directory under
+/// `peppy_dirs.instances_dir()/<name>/<tag>/<variant>/<instance_id>`.
 /// Returns the path to the newly created directory.
 ///
 /// Used directly for container nodes (whose instance dir is empty) and as the
 /// first step of [`extract_node_archive`] for process nodes.
 pub(super) fn create_instance_dir(
+    node_name: &str,
+    node_tag: &str,
+    variant: &str,
     instance_id: &str,
     peppy_dirs: &PeppyDirs,
 ) -> std::result::Result<PathBuf, String> {
-    let instances_dir = peppy_dirs.instances_dir();
-    std::fs::create_dir_all(&instances_dir).map_err(|e| {
+    let key = config::node::NodeKey::new(node_name, node_tag, variant);
+    let parent_dir = peppy_dirs.instances_dir().join(key.artifact_subpath());
+    std::fs::create_dir_all(&parent_dir).map_err(|e| {
         format!(
             "Failed to create instances directory {}: {}",
-            instances_dir.display(),
+            parent_dir.display(),
             e
         )
     })?;
 
-    let instance_dir = instances_dir.join(instance_id);
+    let instance_dir = parent_dir.join(instance_id);
 
     // Clean up any leftover instance directory from a previous failed attempt,
     // since the instance ID is deterministic and may be retried.
@@ -103,10 +108,13 @@ pub(super) fn create_instance_dir(
 /// SIF image is self-contained.
 pub(super) fn extract_node_archive(
     archive_path: &Path,
+    node_name: &str,
+    node_tag: &str,
+    variant: &str,
     instance_id: &str,
     peppy_dirs: &PeppyDirs,
 ) -> std::result::Result<PathBuf, String> {
-    let instance_dir = create_instance_dir(instance_id, peppy_dirs)?;
+    let instance_dir = create_instance_dir(node_name, node_tag, variant, instance_id, peppy_dirs)?;
     if let Err(e) = extract_tar_zst(archive_path, &instance_dir) {
         // Best-effort cleanup of the partially-extracted instance dir so a
         // failed extraction doesn't leave orphaned data on disk.

--- a/crates/node-stack-internal/src/node_stack/validation.rs
+++ b/crates/node-stack-internal/src/node_stack/validation.rs
@@ -38,13 +38,17 @@ pub fn collect_dependency_specs(node: &NodeConfig) -> Vec<DependencySpec> {
         .map(|dep| DependencySpec {
             node_name: dep.name.as_str().to_owned(),
             node_tag: dep.tag.clone(),
+            node_variant: dep.variant.clone(),
         })
         .collect()
 }
 
 /// Validates that all dependencies of a node config exist and expose the required interfaces.
 ///
-/// Uses the provided `resolve` closure to look up a dependency's `NodeConfig` by name and tag.
+/// Uses the provided `resolve` closure to look up a dependency's `NodeConfig` by the full
+/// `(name, tag, variant)` triple. Resolution is exact: a dependent of `foo:bar@v1` binds
+/// to that specific variant or fails validation.
+///
 /// Returns a list of all validation errors found (empty if all dependencies are satisfied).
 ///
 /// Validation is two-phase:
@@ -56,28 +60,35 @@ pub fn validate_dependency_specs(
     interfaces: &Interfaces,
     dependant_name: &str,
     dependant_tag: &str,
-    resolve: impl Fn(&str, &str) -> Option<NodeConfig>,
+    dependant_variant: &str,
+    resolve: impl Fn(&str, &str, &str) -> Option<NodeConfig>,
 ) -> Vec<crate::error::Error> {
     let mut errors = Vec::new();
 
-    // Build local_id → (name, tag, resolved_config) lookup from depends_on.nodes
-    let mut resolved_deps: HashMap<String, (String, String, NodeConfig)> = HashMap::new();
+    // Build local_id → (name, tag, variant, resolved_config) lookup from depends_on.nodes
+    let mut resolved_deps: HashMap<String, (String, String, String, NodeConfig)> = HashMap::new();
 
     // Phase 1: Validate all declared dependency nodes exist
     if let Some(depends_on) = &manifest.depends_on {
         for dep in &depends_on.nodes {
             let dep_name = dep.name.as_str().to_owned();
             let dep_tag = dep.tag.clone();
-            let Some(dependency_config) = resolve(&dep_name, &dep_tag) else {
+            let dep_variant = dep.variant.clone();
+            let Some(dependency_config) = resolve(&dep_name, &dep_tag, &dep_variant) else {
                 errors.push(crate::error::Error::MissingDependency {
                     dependant: dependant_name.to_owned(),
                     dependant_tag: dependant_tag.to_owned(),
+                    dependant_variant: dependant_variant.to_owned(),
                     dependency: dep_name,
                     dependency_tag: dep_tag,
+                    dependency_variant: dep_variant,
                 });
                 continue;
             };
-            resolved_deps.insert(dep.local_id.clone(), (dep_name, dep_tag, dependency_config));
+            resolved_deps.insert(
+                dep.local_id.clone(),
+                (dep_name, dep_tag, dep_variant, dependency_config),
+            );
         }
     }
 
@@ -153,7 +164,7 @@ pub fn validate_dependency_specs(
 fn validate_consumed_items<'a>(
     items: impl Iterator<Item = (&'a str, &'a str)>,
     kind: InterfaceKind,
-    resolved_deps: &HashMap<String, (String, String, NodeConfig)>,
+    resolved_deps: &HashMap<String, (String, String, String, NodeConfig)>,
     declared_local_ids: &HashSet<&str>,
     dependant_name: &str,
     dependant_tag: &str,
@@ -188,12 +199,13 @@ fn validate_consumed_interface(
     local_node_id: &str,
     interface_name: &str,
     kind: InterfaceKind,
-    resolved_deps: &HashMap<String, (String, String, NodeConfig)>,
+    resolved_deps: &HashMap<String, (String, String, String, NodeConfig)>,
     dependant_name: &str,
     dependant_tag: &str,
     errors: &mut Vec<crate::error::Error>,
 ) {
-    let Some((dep_name, dep_tag, dep_config)) = resolved_deps.get(local_node_id) else {
+    let Some((dep_name, dep_tag, _dep_variant, dep_config)) = resolved_deps.get(local_node_id)
+    else {
         // The local_node_id doesn't map to any resolved dependency.
         // This path is only reached when the dependency was declared but failed
         // to resolve (already reported as MissingDependency in Phase 1).

--- a/crates/node-stack-internal/src/virtual_deptree.rs
+++ b/crates/node-stack-internal/src/virtual_deptree.rs
@@ -16,27 +16,27 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-use config::node::NodeConfig;
+pub use config::node::NodeKey;
+use config::node::{DEFAULT_VARIANT_NAME, NodeConfig};
 use petgraph::algo::toposort;
 use petgraph::stable_graph::{NodeIndex, StableDiGraph};
 
 use crate::error::{Error, Result};
-
-/// `(name, tag)` identifier used to address a node in the virtual dep tree.
-pub type NodeKey = (String, String);
 
 /// One node sitting in the virtual dependency tree.
 #[derive(Debug, Clone)]
 pub struct VirtualNodeInfo {
     pub root_dir: PathBuf,
     pub config: NodeConfig,
+    pub variant: String,
 }
 
 impl VirtualNodeInfo {
     pub fn key(&self) -> NodeKey {
-        (
-            self.config.manifest.name.as_str().to_owned(),
+        NodeKey::new(
+            self.config.manifest.name.as_str(),
             self.config.manifest.tag.clone(),
+            &self.variant,
         )
     }
 }
@@ -62,22 +62,35 @@ impl VirtualDeptree {
     ///   `name:tag`.
     /// - [`Error::VirtualDeptreeCycle`] when the resulting graph is not a DAG.
     pub fn build(nodes: Vec<(PathBuf, NodeConfig)>) -> Result<Self> {
+        // Inputs without an explicit variant default to "default". Callers
+        // that need to express variants pass them in via `build_with_variants`.
+        let variants_defaulted: Vec<(PathBuf, NodeConfig, String)> = nodes
+            .into_iter()
+            .map(|(root_dir, config)| (root_dir, config, DEFAULT_VARIANT_NAME.to_owned()))
+            .collect();
+        Self::build_with_variants(variants_defaulted)
+    }
+
+    /// Like [`Self::build`] but accepts an explicit variant string per input
+    /// so callers can register multiple variants of the same `name:tag`.
+    pub fn build_with_variants(nodes: Vec<(PathBuf, NodeConfig, String)>) -> Result<Self> {
         let mut graph: StableDiGraph<NodeKey, ()> = StableDiGraph::new();
         let mut by_key: HashMap<NodeKey, NodeIndex> = HashMap::with_capacity(nodes.len());
         let mut infos: HashMap<NodeIndex, VirtualNodeInfo> = HashMap::with_capacity(nodes.len());
         let mut origin_paths: HashMap<NodeKey, PathBuf> = HashMap::with_capacity(nodes.len());
 
         // First pass: register every input node and detect duplicates.
-        for (root_dir, config) in nodes {
-            let key = (
-                config.manifest.name.as_str().to_owned(),
+        for (root_dir, config, variant) in nodes {
+            let key = NodeKey::new(
+                config.manifest.name.as_str(),
                 config.manifest.tag.clone(),
+                &variant,
             );
 
             if let Some(first) = origin_paths.get(&key) {
                 return Err(Error::DuplicateLocalNode {
-                    name: key.0,
-                    tag: key.1,
+                    name: key.name.clone(),
+                    tag: key.tag.clone(),
                     first: first.clone(),
                     second: root_dir,
                 });
@@ -86,6 +99,7 @@ impl VirtualDeptree {
             let info = VirtualNodeInfo {
                 root_dir: root_dir.clone(),
                 config,
+                variant,
             };
             let idx = graph.add_node(key.clone());
             by_key.insert(key.clone(), idx);
@@ -102,7 +116,7 @@ impl VirtualDeptree {
                 continue;
             };
             for dep in &depends_on.nodes {
-                let dep_key = (dep.name.as_str().to_owned(), dep.tag.clone());
+                let dep_key = NodeKey::new(dep.name.as_str(), dep.tag.clone(), dep.variant.clone());
                 if let Some(dep_idx) = by_key.get(&dep_key) {
                     // Edge: dep -> dependant. Toposort returns a slice in
                     // dependency order (deps first).
@@ -117,9 +131,9 @@ impl VirtualDeptree {
             let key = graph
                 .node_weight(offending)
                 .cloned()
-                .unwrap_or_else(|| ("?".to_owned(), "?".to_owned()));
+                .unwrap_or_else(|| NodeKey::with_default_variant("?", "?"));
             return Err(Error::VirtualDeptreeCycle {
-                nodes: vec![format!("{}:{}", key.0, key.1)],
+                nodes: vec![key.label()],
             });
         }
 
@@ -216,7 +230,7 @@ mod tests {
         assert_eq!(tree.len(), 2);
         let order = tree.topological_order();
         assert_eq!(order.len(), 2);
-        let names: Vec<String> = order.iter().map(|n| key_of(n).0).collect();
+        let names: Vec<String> = order.iter().map(|n| key_of(n).name).collect();
         assert!(names.contains(&"a".to_string()));
         assert!(names.contains(&"b".to_string()));
     }
@@ -240,7 +254,7 @@ mod tests {
         let order: Vec<String> = tree
             .topological_order()
             .iter()
-            .map(|n| key_of(n).0)
+            .map(|n| key_of(n).name)
             .collect();
         assert_eq!(
             order,
@@ -270,7 +284,7 @@ mod tests {
         let order: Vec<String> = tree
             .topological_order()
             .iter()
-            .map(|n| key_of(n).0)
+            .map(|n| key_of(n).name)
             .collect();
         assert_eq!(order.first().unwrap(), "a");
         assert_eq!(order.last().unwrap(), "d");
@@ -304,7 +318,7 @@ mod tests {
         assert_eq!(tree.len(), 1);
         let order = tree.topological_order();
         assert_eq!(order.len(), 1);
-        assert_eq!(key_of(order[0]).0, "a");
+        assert_eq!(key_of(order[0]).name, "a");
     }
 
     #[test]

--- a/crates/node-stack-internal/tests/helpers/fixtures.rs
+++ b/crates/node-stack-internal/tests/helpers/fixtures.rs
@@ -53,7 +53,7 @@ pub async fn start_instance_in_stack(
     instance_id: Option<&Name>,
 ) -> RunningInstanceGuard {
     let handle = stack
-        .find(name, tag)
+        .find(name, tag, "default")
         .expect("test fixture: entity should exist for start_instance_in_stack");
     let instance_id = instance_id.cloned().unwrap_or_else(fixture_instance_name);
     real_lifecycle::spawn_running_instance(handle, harness, instance_id).await
@@ -69,7 +69,7 @@ pub fn stop_instance_in_stack(
     tag: &str,
     instance_id: &Name,
 ) -> bool {
-    let Some(handle) = stack.find(name, tag) else {
+    let Some(handle) = stack.find(name, tag, "default") else {
         return false;
     };
     handle.write().stop_instance(instance_id)

--- a/crates/node-stack-internal/tests/helpers/real_lifecycle.rs
+++ b/crates/node-stack-internal/tests/helpers/real_lifecycle.rs
@@ -123,10 +123,10 @@ pub async fn build_ready(
     let tag = config.manifest.tag.clone();
 
     stack
-        .push_config(config, false, &config_path)
+        .push_config(config, false, &config_path, "default")
         .expect("test fixture: push_config should succeed");
     let handle = stack
-        .find(&name, &tag)
+        .find(&name, &tag, "default")
         .expect("test fixture: just-pushed entity should exist");
 
     NodeEntity::build(

--- a/crates/node-stack-internal/tests/tests_modules/actions_runtime_resolution.rs
+++ b/crates/node-stack-internal/tests/tests_modules/actions_runtime_resolution.rs
@@ -96,7 +96,7 @@ fn action_dependency_resolved_when_dependency_added_first() {
 
     // Add the dependency first
     stack
-        .push_config(dependency, false, PathBuf::from("/tmp"))
+        .push_config(dependency, false, PathBuf::from("/tmp"), "default")
         .expect("dependency node has no dependencies");
     assert_eq!(
         stack.len(),
@@ -106,12 +106,12 @@ fn action_dependency_resolved_when_dependency_added_first() {
 
     // Now add the dependent node
     stack
-        .push_config(dependent, false, PathBuf::from("/tmp"))
+        .push_config(dependent, false, PathBuf::from("/tmp"), "default")
         .expect("dependent node should be added when dependency exists");
     assert_eq!(stack.len(), 3, "stack should include the dependent node");
 
     let deps = stack
-        .dependencies_of("brain", "1.0.0")
+        .dependencies_of("brain", "1.0.0", "default")
         .into_iter()
         .map(|node| {
             let guard = node.read();
@@ -128,7 +128,7 @@ fn action_dependency_resolved_when_dependency_added_first() {
     );
 
     let dependants = stack
-        .dependents_of("controller", "1.0.0")
+        .dependents_of("controller", "1.0.0", "default")
         .into_iter()
         .map(|node| node.read().config().manifest.name.as_str().to_owned())
         .collect::<Vec<_>>();
@@ -174,7 +174,7 @@ fn action_dependency_fails_when_dependency_is_missing() {
     let stack = NodeStack::new(core_node_config(), None, PathBuf::from("/tmp"));
 
     // Adding a node that depends on a non-existent action provider should fail
-    let result = stack.push_config(dependent, false, PathBuf::from("/tmp"));
+    let result = stack.push_config(dependent, false, PathBuf::from("/tmp"), "default");
     let Err(NodeStackError::MissingDependency {
         dependency,
         dependency_tag,
@@ -283,12 +283,17 @@ fn action_dependency_fails_when_action_not_exposed_by_dependency() {
 
     // Add the node with the correct name but wrong action
     stack
-        .push_config(dependency_wrong_action, false, PathBuf::from("/tmp"))
+        .push_config(
+            dependency_wrong_action,
+            false,
+            PathBuf::from("/tmp"),
+            "default",
+        )
         .expect("controller has no dependencies");
     assert_eq!(stack.len(), 2, "stack should have core node + controller");
 
     // Adding brain should fail because controller doesn't expose "move_right_arm"
-    let result = stack.push_config(dependent, false, PathBuf::from("/tmp"));
+    let result = stack.push_config(dependent, false, PathBuf::from("/tmp"), "default");
     let Err(NodeStackError::MissingInterface {
         dependency,
         dependency_tag,
@@ -342,7 +347,7 @@ fn action_dependency_fails_when_local_node_id_is_undeclared() {
 
     let stack = NodeStack::new(core_node_config(), None, PathBuf::from("/tmp"));
 
-    let result = stack.push_config(dependent, false, PathBuf::from("/tmp"));
+    let result = stack.push_config(dependent, false, PathBuf::from("/tmp"), "default");
     let Err(NodeStackError::UndeclaredLocalNodeId { local_node_id, .. }) = result else {
         panic!("expected UndeclaredLocalNodeId error, got {:?}", result);
     };

--- a/crates/node-stack-internal/tests/tests_modules/lifecycle_transitions.rs
+++ b/crates/node-stack-internal/tests/tests_modules/lifecycle_transitions.rs
@@ -44,10 +44,12 @@ fn push_config_creates_entity_in_added_stage() {
     let config_path = PathBuf::from("/tmp/sensor/peppy.json5");
 
     stack
-        .push_config(sensor_config(), false, &config_path)
+        .push_config(sensor_config(), false, &config_path, "default")
         .expect("push_config should succeed");
 
-    let handle = stack.find("sensor", "1.0.0").expect("entity should exist");
+    let handle = stack
+        .find("sensor", "1.0.0", "default")
+        .expect("entity should exist");
     let guard = handle.read();
 
     if let NodeStage::Added { config_path: cp } = guard.stage() {
@@ -234,10 +236,12 @@ async fn push_config_resets_existing_entity_to_added() {
     // Re-push with the same config but a different config_path. The entity
     // should be reset to Added with the new config_path; artifact_path is gone.
     stack
-        .push_config(sensor_config(), false, &config_path_v2)
+        .push_config(sensor_config(), false, &config_path_v2, "default")
         .expect("second push_config should succeed");
 
-    let handle_after = stack.find("sensor", "1.0.0").expect("entity should exist");
+    let handle_after = stack
+        .find("sensor", "1.0.0", "default")
+        .expect("entity should exist");
     let guard = handle_after.read();
     match guard.stage() {
         NodeStage::Added { config_path: cp } => {
@@ -306,22 +310,33 @@ fn push_config_rewires_when_dependency_keys_change_with_unchanged_interfaces() {
     };
 
     stack
-        .push_config(producer_a, false, PathBuf::from("/tmp/producer_a.json5"))
+        .push_config(
+            producer_a,
+            false,
+            PathBuf::from("/tmp/producer_a.json5"),
+            "default",
+        )
         .expect("push producer_a");
     stack
-        .push_config(producer_b, false, PathBuf::from("/tmp/producer_b.json5"))
+        .push_config(
+            producer_b,
+            false,
+            PathBuf::from("/tmp/producer_b.json5"),
+            "default",
+        )
         .expect("push producer_b");
     stack
         .push_config(
             consumer_pointing_at("producer_a"),
             false,
             PathBuf::from("/tmp/consumer_v1.json5"),
+            "default",
         )
         .expect("first consumer push");
 
     // Initially the consumer depends on producer_a.
     let deps_a: Vec<String> = stack
-        .dependencies_of("consumer", "1.0.0")
+        .dependencies_of("consumer", "1.0.0", "default")
         .iter()
         .map(|h| h.read().config().manifest.name.as_str().to_owned())
         .collect();
@@ -334,11 +349,12 @@ fn push_config_rewires_when_dependency_keys_change_with_unchanged_interfaces() {
             consumer_pointing_at("producer_b"),
             false,
             PathBuf::from("/tmp/consumer_v2.json5"),
+            "default",
         )
         .expect("second consumer push");
 
     let deps_b: Vec<String> = stack
-        .dependencies_of("consumer", "1.0.0")
+        .dependencies_of("consumer", "1.0.0", "default")
         .iter()
         .map(|h| h.read().config().manifest.name.as_str().to_owned())
         .collect();
@@ -366,7 +382,7 @@ async fn push_config_rejects_replacement_with_live_instances() {
     .await;
 
     let err = stack
-        .push_config(sensor_config(), false, &config_path_v2)
+        .push_config(sensor_config(), false, &config_path_v2, "default")
         .expect_err("re-push should be rejected when live instances exist");
     match err {
         NodeStackError::CannotOverwriteNodeWithLiveInstances {
@@ -406,10 +422,13 @@ async fn concurrent_builds_are_rejected_immediately() {
             sensor_config_with_build_cmd("sleep 0.5"),
             false,
             &config_path,
+            "default",
         )
         .expect("push_config should succeed");
 
-    let handle = stack.find("sensor", "1.0.0").expect("entity should exist");
+    let handle = stack
+        .find("sensor", "1.0.0", "default")
+        .expect("entity should exist");
 
     // Working directory with some content to archive.
     let working_dir = tempfile::tempdir().expect("tempdir working_dir");
@@ -506,8 +525,13 @@ async fn concurrent_builds_are_rejected_immediately() {
     let guard = handle.read();
     assert!(matches!(guard.stage(), NodeStage::Ready { .. }));
 
-    // The on-disk archive exists exactly once.
-    let archive = peppy_dirs.built_nodes_dir().join("sensor_1.0.0.tar.zst");
+    // The on-disk archive exists exactly once. Storage layout is nested per-variant.
+    let archive = peppy_dirs
+        .built_nodes_dir()
+        .join("sensor")
+        .join("1.0.0")
+        .join("default")
+        .join("node.tar.zst");
     assert!(archive.is_file(), "expected archive at {:?}", archive);
 }
 
@@ -589,10 +613,13 @@ async fn build_runs_add_cmd_for_process_node() {
             sensor_config_with_build_cmd("echo built > marker.txt"),
             false,
             &config_path,
+            "default",
         )
         .expect("push_config should succeed");
 
-    let handle = stack.find("sensor", "1.0.0").expect("entity should exist");
+    let handle = stack
+        .find("sensor", "1.0.0", "default")
+        .expect("entity should exist");
     let h = build_harness();
 
     NodeEntity::build(
@@ -614,7 +641,14 @@ async fn build_runs_add_cmd_for_process_node() {
     drop(guard);
 
     // The archive exists and contains the marker file produced by build_cmd.
-    let archive = h.peppy_dirs.built_nodes_dir().join("sensor_1.0.0.tar.zst");
+    // Storage layout is nested per-variant: <name>/<tag>/<variant>/node.tar.zst.
+    let archive = h
+        .peppy_dirs
+        .built_nodes_dir()
+        .join("sensor")
+        .join("1.0.0")
+        .join("default")
+        .join("node.tar.zst");
     assert!(archive.is_file(), "expected archive at {:?}", archive);
 
     // Decode the archive and look for the marker.
@@ -694,9 +728,16 @@ fn start_harness(instance_id_str: &str) -> (Name, real_lifecycle::LifecycleHarne
 async fn prepare_and_spawn_rejects_when_not_built() {
     let stack = NodeStack::new(core_node_config(), None, PathBuf::from("/tmp"));
     stack
-        .push_config(sensor_config(), false, PathBuf::from("/tmp/sensor"))
+        .push_config(
+            sensor_config(),
+            false,
+            PathBuf::from("/tmp/sensor"),
+            "default",
+        )
         .expect("push_config should succeed");
-    let handle = stack.find("sensor", "1.0.0").expect("entity should exist");
+    let handle = stack
+        .find("sensor", "1.0.0", "default")
+        .expect("entity should exist");
     let (instance_id, h) = start_harness("test-inst-1");
 
     let err = NodeEntity::prepare_and_spawn(
@@ -1136,9 +1177,11 @@ async fn restore_snapshot_if_matches_rolls_back_failed_rebuild() {
         proceed_file_disp
     ));
     stack
-        .push_config(blocking_config, false, &config_path_v2)
+        .push_config(blocking_config, false, &config_path_v2, "default")
         .expect("rebuild push_config should succeed");
-    let handle_after_push = stack.find("sensor", "1.0.0").expect("entity should exist");
+    let handle_after_push = stack
+        .find("sensor", "1.0.0", "default")
+        .expect("entity should exist");
     let captured_generation = handle_after_push.read().generation();
 
     // Kick off the rebuild in a task. It will sit in `Building` until we
@@ -1187,6 +1230,7 @@ async fn restore_snapshot_if_matches_rolls_back_failed_rebuild() {
         RestoreTarget {
             name: "sensor",
             tag: "1.0.0",
+            variant: "default",
             expected_handle: &handle_after_push,
             expected_generation: captured_generation,
         },
@@ -1194,7 +1238,7 @@ async fn restore_snapshot_if_matches_rolls_back_failed_rebuild() {
             config: v1_config,
             config_path: config_path_v1.clone(),
             artifact_path: Some(artifact_v1.clone()),
-            variant_name: None,
+            variant: "default".to_string(),
         },
     );
     assert!(
@@ -1212,7 +1256,9 @@ async fn restore_snapshot_if_matches_rolls_back_failed_rebuild() {
         "build task should fail its Phase 3 commit after the restore drifted the generation, got Ok"
     );
 
-    let handle_final = stack.find("sensor", "1.0.0").expect("entity should exist");
+    let handle_final = stack
+        .find("sensor", "1.0.0", "default")
+        .expect("entity should exist");
     let guard = handle_final.read();
     match guard.stage() {
         NodeStage::Ready {
@@ -1254,9 +1300,11 @@ async fn restore_snapshot_if_matches_no_op_on_generation_drift() {
         proceed_file_disp
     ));
     stack
-        .push_config(blocking_config, false, &config_path_v1)
+        .push_config(blocking_config, false, &config_path_v1, "default")
         .expect("initial push_config should succeed");
-    let handle = stack.find("sensor", "1.0.0").expect("entity should exist");
+    let handle = stack
+        .find("sensor", "1.0.0", "default")
+        .expect("entity should exist");
     let stale_generation = handle.read().generation();
     let stale_config = handle.read().config().clone();
 
@@ -1302,13 +1350,14 @@ async fn restore_snapshot_if_matches_no_op_on_generation_drift() {
     // entity is in Building — the in-flight build task will then fail its
     // Phase 3 check via the generation token.
     stack
-        .push_config(sensor_config(), false, &config_path_v2)
+        .push_config(sensor_config(), false, &config_path_v2, "default")
         .expect("concurrent push_config should succeed");
 
     let restored = stack.restore_snapshot_if_matches(
         RestoreTarget {
             name: "sensor",
             tag: "1.0.0",
+            variant: "default",
             expected_handle: &handle,
             expected_generation: stale_generation,
         },
@@ -1316,7 +1365,7 @@ async fn restore_snapshot_if_matches_no_op_on_generation_drift() {
             config: stale_config,
             config_path: config_path_v1.clone(),
             artifact_path: Some(PathBuf::from("/tmp/sensor-v1.sif")),
-            variant_name: None,
+            variant: "default".to_string(),
         },
     );
     assert!(

--- a/crates/node-stack-internal/tests/tests_modules/runtime_resolution.rs
+++ b/crates/node-stack-internal/tests/tests_modules/runtime_resolution.rs
@@ -43,7 +43,7 @@ async fn add_instance_creates_new_entity() {
 
     assert_eq!(stack.len(), 2, "stack should have core node + one entity");
     assert!(
-        stack.contains("sensor", "1.0.0"),
+        stack.contains("sensor", "1.0.0", "default"),
         "entity should be findable"
     );
 
@@ -51,7 +51,9 @@ async fn add_instance_creates_new_entity() {
     let _guard = fixtures::start_instance_in_stack(&stack, &harness, "sensor", "1.0.0", None).await;
     let instance_id = _guard.instance_id.clone();
 
-    let entity = stack.find("sensor", "1.0.0").expect("entity should exist");
+    let entity = stack
+        .find("sensor", "1.0.0", "default")
+        .expect("entity should exist");
     let entity_guard = entity.read();
     assert_eq!(
         entity_guard.instances().len(),
@@ -153,7 +155,9 @@ async fn add_instance_to_existing_entity() {
     let first_id = _g1.instance_id.clone();
 
     assert_eq!(stack.len(), 2, "stack should have core node + one entity");
-    let entity = stack.find("sensor", "1.0.0").expect("entity should exist");
+    let entity = stack
+        .find("sensor", "1.0.0", "default")
+        .expect("entity should exist");
     assert_eq!(
         entity.read().instances().len(),
         1,
@@ -173,7 +177,9 @@ async fn add_instance_to_existing_entity() {
 
     assert_eq!(stack.len(), 2, "stack should still have root + one entity");
 
-    let entity = stack.find("sensor", "1.0.0").expect("entity should exist");
+    let entity = stack
+        .find("sensor", "1.0.0", "default")
+        .expect("entity should exist");
     let entity_guard = entity.read();
     assert_eq!(
         entity_guard.instances().len(),
@@ -241,7 +247,9 @@ async fn add_instance_with_specific_id() {
         "returned ID should match the provided one"
     );
 
-    let entity = stack.find("sensor", "1.0.0").expect("entity should exist");
+    let entity = stack
+        .find("sensor", "1.0.0", "default")
+        .expect("entity should exist");
     assert_eq!(
         entity.read().instances()[0].instance_id(),
         &custom_id,
@@ -300,7 +308,9 @@ async fn remove_instance_from_entity_with_multiple_instances() {
             .await;
 
     assert_eq!(stack.len(), 2, "stack should have core node + one entity");
-    let entity = stack.find("sensor", "1.0.0").expect("entity should exist");
+    let entity = stack
+        .find("sensor", "1.0.0", "default")
+        .expect("entity should exist");
     assert_eq!(
         entity.read().instances().len(),
         2,
@@ -313,7 +323,9 @@ async fn remove_instance_from_entity_with_multiple_instances() {
 
     // Entity should still exist with one instance
     assert_eq!(stack.len(), 2, "entity should still exist");
-    let entity = stack.find("sensor", "1.0.0").expect("entity should exist");
+    let entity = stack
+        .find("sensor", "1.0.0", "default")
+        .expect("entity should exist");
     let entity_guard = entity.read();
     assert_eq!(
         entity_guard.instances().len(),
@@ -361,7 +373,9 @@ async fn remove_last_instance_keeps_entity_in_graph() {
         fixtures::start_instance_in_stack(&stack, &harness, "sensor", "1.0.0", Some(&instance_id))
             .await;
     assert_eq!(stack.len(), 2, "stack should have root + one entity");
-    let entity = stack.find("sensor", "1.0.0").expect("entity should exist");
+    let entity = stack
+        .find("sensor", "1.0.0", "default")
+        .expect("entity should exist");
     assert_eq!(
         entity.read().instances().len(),
         1,
@@ -375,7 +389,7 @@ async fn remove_last_instance_keeps_entity_in_graph() {
     // Entity stays in the graph with 0 instances; dependency edges are preserved
     assert_eq!(stack.len(), 2, "stack should still have root + entity");
     let entity = stack
-        .find("sensor", "1.0.0")
+        .find("sensor", "1.0.0", "default")
         .expect("entity should still exist");
     assert_eq!(
         entity.read().instances().len(),
@@ -430,7 +444,9 @@ async fn remove_nonexistent_instance_returns_false() {
     assert!(!removed, "should return false for non-existent entity");
 
     // Original instance should still be there
-    let entity = stack.find("sensor", "1.0.0").expect("entity should exist");
+    let entity = stack
+        .find("sensor", "1.0.0", "default")
+        .expect("entity should exist");
     assert_eq!(
         entity.read().instances().len(),
         1,
@@ -500,10 +516,10 @@ fn reset_clears_all_except_core_node() {
 
     let stack = NodeStack::new(core_node_config(), None, PathBuf::from("/tmp"));
     stack
-        .push_config(config1, false, PathBuf::from("/tmp"))
+        .push_config(config1, false, PathBuf::from("/tmp"), "default")
         .expect("config1 has no dependencies");
     stack
-        .push_config(config2, false, PathBuf::from("/tmp"))
+        .push_config(config2, false, PathBuf::from("/tmp"), "default")
         .expect("config2 has no dependencies");
     assert_eq!(stack.len(), 3, "stack should have root + two entities");
 
@@ -511,15 +527,15 @@ fn reset_clears_all_except_core_node() {
 
     assert_eq!(stack.len(), 1, "stack should only have root after reset");
     assert!(
-        stack.contains("core", "1.0.0"),
+        stack.contains("core", "1.0.0", "default"),
         "root should still exist after reset"
     );
     assert!(
-        stack.find("sensor1", "1.0.0").is_none(),
+        stack.find("sensor1", "1.0.0", "default").is_none(),
         "sensor1 should not exist"
     );
     assert!(
-        stack.find("sensor2", "1.0.0").is_none(),
+        stack.find("sensor2", "1.0.0", "default").is_none(),
         "sensor2 should not exist"
     );
 }
@@ -559,7 +575,9 @@ async fn spawning_multiple_instances_on_same_entity() {
         "stack should have the core node + one entity"
     );
 
-    let entity = stack.find("sensor", "1.0.0").expect("entity should exist");
+    let entity = stack
+        .find("sensor", "1.0.0", "default")
+        .expect("entity should exist");
     assert_eq!(
         entity.read().instances().len(),
         0,
@@ -576,7 +594,9 @@ async fn spawning_multiple_instances_on_same_entity() {
     )
     .await;
 
-    let entity = stack.find("sensor", "1.0.0").expect("entity should exist");
+    let entity = stack
+        .find("sensor", "1.0.0", "default")
+        .expect("entity should exist");
     assert_eq!(
         entity.read().instances().len(),
         1,
@@ -598,7 +618,9 @@ async fn spawning_multiple_instances_on_same_entity() {
         "stack should still have the core node + one entity"
     );
 
-    let entity = stack.find("sensor", "1.0.0").expect("entity should exist");
+    let entity = stack
+        .find("sensor", "1.0.0", "default")
+        .expect("entity should exist");
     assert_eq!(
         entity.read().instances().len(),
         2,
@@ -671,7 +693,12 @@ fn adding_same_entity_with_different_interfaces_overwrites_when_no_dependents() 
 
     // Add the first config
     stack
-        .push_config(config_with_topic, false, PathBuf::from("/tmp/sensor_v1"))
+        .push_config(
+            config_with_topic,
+            false,
+            PathBuf::from("/tmp/sensor_v1"),
+            "default",
+        )
         .expect("first config has no dependencies");
     assert_eq!(stack.len(), 2, "stack should have core node + sensor");
 
@@ -681,12 +708,15 @@ fn adding_same_entity_with_different_interfaces_overwrites_when_no_dependents() 
             config_with_topic_and_service,
             false,
             PathBuf::from("/tmp/sensor_v2"),
+            "default",
         )
         .expect("should overwrite existing entity without dependents");
     assert_eq!(stack.len(), 2, "stack should still have core node + sensor");
 
     // Entity should still exist (no instances since push_config doesn't create them)
-    let entity = stack.find("sensor", "1.0.0").expect("entity should exist");
+    let entity = stack
+        .find("sensor", "1.0.0", "default")
+        .expect("entity should exist");
     let entity_guard = entity.read();
     assert_eq!(
         entity_guard.instances().len(),
@@ -766,13 +796,13 @@ fn adding_same_name_with_different_tag_and_different_interfaces_succeeds() {
 
     // Add version 1.0.0
     stack
-        .push_config(config_v1, false, PathBuf::from("/tmp"))
+        .push_config(config_v1, false, PathBuf::from("/tmp"), "default")
         .expect("first config has no dependencies");
     assert_eq!(stack.len(), 2, "stack should have core node + sensor v1");
 
     // Adding version 2.0.0 with different interfaces should succeed (different tag = different entity)
     stack
-        .push_config(config_v2, false, PathBuf::from("/tmp"))
+        .push_config(config_v2, false, PathBuf::from("/tmp"), "default")
         .expect("different tag should create new entity even with different interfaces");
     assert_eq!(
         stack.len(),
@@ -782,10 +812,10 @@ fn adding_same_name_with_different_tag_and_different_interfaces_succeeds() {
 
     // Both entities should exist (with no instances since push_config doesn't create them)
     let entity_v1 = stack
-        .find("sensor", "1.0.0")
+        .find("sensor", "1.0.0", "default")
         .expect("v1 entity should exist");
     let entity_v2 = stack
-        .find("sensor", "2.0.0")
+        .find("sensor", "2.0.0", "default")
         .expect("v2 entity should exist");
 
     assert_eq!(
@@ -829,14 +859,14 @@ fn cannot_modify_root_node() {
     let _root_instance_id = stack.root().read().instances()[0].instance_id().clone();
 
     // Try to remove the root's config — must error with CannotModifyRootNode.
-    let result = stack.remove_config("core", "1.0.0");
+    let result = stack.remove_config("core", "1.0.0", "default");
     assert!(
         result.is_err(),
         "should not be able to remove root node via remove_config"
     );
 
     // Try to push a new config that would overwrite root
-    let result = stack.push_config(core_node_config(), false, PathBuf::from("/tmp"));
+    let result = stack.push_config(core_node_config(), false, PathBuf::from("/tmp"), "default");
     assert!(
         result.is_err(),
         "should not be able to overwrite root node via push_config"
@@ -907,13 +937,13 @@ fn node_stack_wires_dependencies_for_dependants() {
 
     let stack = NodeStack::new(core_node_config(), None, PathBuf::from("/tmp"));
     stack
-        .push_config(dependency, false, PathBuf::from("/tmp"))
+        .push_config(dependency, false, PathBuf::from("/tmp"), "default")
         .expect("dependency has no dependencies");
     stack
-        .push_config(dependent, false, PathBuf::from("/tmp"))
+        .push_config(dependent, false, PathBuf::from("/tmp"), "default")
         .expect("dependent dependency is present");
 
-    let deps = stack.dependencies_of("brain", "1.0.0");
+    let deps = stack.dependencies_of("brain", "1.0.0", "default");
     assert!(
         deps.iter()
             .any(|entity| { entity.read().config().manifest.name.as_str() == "lidar" }),
@@ -970,12 +1000,12 @@ fn dependency_fails_when_node_name_mismatches() {
 
     // Add lidar (which is NOT the expected dependency "uvc_camera")
     stack
-        .push_config(wrong_dependency, false, PathBuf::from("/tmp"))
+        .push_config(wrong_dependency, false, PathBuf::from("/tmp"), "default")
         .expect("lidar has no dependencies");
     assert_eq!(stack.len(), 2, "stack should have core node + lidar");
 
     // Adding brain should fail because it expects "uvc_camera", not "lidar"
-    let result = stack.push_config(dependent, false, PathBuf::from("/tmp"));
+    let result = stack.push_config(dependent, false, PathBuf::from("/tmp"), "default");
     let Err(NodeStackError::MissingDependency {
         dependency,
         dependency_tag,
@@ -1035,12 +1065,17 @@ fn dependency_fails_when_node_tag_mismatches() {
 
     // Add lidar with tag "2.0.0" (NOT the expected tag "1.0.0")
     stack
-        .push_config(wrong_tag_dependency, false, PathBuf::from("/tmp"))
+        .push_config(
+            wrong_tag_dependency,
+            false,
+            PathBuf::from("/tmp"),
+            "default",
+        )
         .expect("lidar has no dependencies");
     assert_eq!(stack.len(), 2, "stack should have core node + lidar");
 
     // Adding brain should fail because it expects lidar with tag "1.0.0", not "2.0.0"
-    let result = stack.push_config(dependent, false, PathBuf::from("/tmp"));
+    let result = stack.push_config(dependent, false, PathBuf::from("/tmp"), "default");
     let Err(NodeStackError::MissingDependency {
         dependency,
         dependency_tag,
@@ -1056,6 +1091,96 @@ fn dependency_fails_when_node_tag_mismatches() {
         2,
         "stack should still only have core node + lidar"
     );
+}
+
+#[test]
+fn dependency_fails_when_node_variant_mismatches() {
+    // Dependent expects lidar:1.0.0@v1, but we only add lidar:1.0.0 (default).
+    let dependent: config::node::NodeConfig = serde_json5::from_str(
+        r#"{
+            peppy_schema: "node_v1",
+            manifest: {
+              name: "brain",
+              tag: "1.0.0",
+              depends_on: {
+                nodes: [
+                  { name: "lidar", tag: "1.0.0", variant: "v1", local_id: "lidar" }
+                ]
+              },
+            },
+            execution: {
+              language: "rust",
+              run_cmd: ["brain"]
+            },
+        }"#,
+    )
+    .expect("valid dependent node config");
+
+    let lidar: config::node::NodeConfig = serde_json5::from_str(
+        r#"{
+            peppy_schema: "node_v1",
+            manifest: {
+              name: "lidar",
+              tag: "1.0.0",
+            },
+            execution: {
+              language: "rust",
+              run_cmd: ["lidar"]
+            },
+        }"#,
+    )
+    .expect("valid dependency node config");
+
+    let stack = NodeStack::new(core_node_config(), None, PathBuf::from("/tmp"));
+
+    // Add lidar under the default variant.
+    stack
+        .push_config(lidar, false, PathBuf::from("/tmp"), "default")
+        .expect("lidar has no dependencies");
+    assert!(
+        stack.contains("lidar", "1.0.0", "default"),
+        "lidar@default should be in the stack"
+    );
+
+    // brain depends on lidar@v1 — strict resolution must reject.
+    let result = stack.push_config(dependent.clone(), false, PathBuf::from("/tmp"), "default");
+    let Err(NodeStackError::MissingDependency {
+        dependency,
+        dependency_tag,
+        dependency_variant,
+        ..
+    }) = result
+    else {
+        panic!("expected MissingDependency error, got {:?}", result);
+    };
+    assert_eq!(dependency, "lidar");
+    assert_eq!(dependency_tag, "1.0.0");
+    assert_eq!(
+        dependency_variant, "v1",
+        "error must name the missing variant"
+    );
+
+    // After we also add lidar@v1, the brain push must succeed.
+    let lidar_v1: config::node::NodeConfig = serde_json5::from_str(
+        r#"{
+            peppy_schema: "node_v1",
+            manifest: {
+              name: "lidar",
+              tag: "1.0.0",
+            },
+            execution: {
+              language: "rust",
+              run_cmd: ["lidar"]
+            },
+        }"#,
+    )
+    .expect("valid lidar v1 config");
+    stack
+        .push_config(lidar_v1, false, PathBuf::from("/tmp"), "v1")
+        .expect("lidar v1 has no dependencies");
+    stack
+        .push_config(dependent, false, PathBuf::from("/tmp"), "default")
+        .expect("brain should resolve once lidar@v1 is in the stack");
 }
 
 #[test]
@@ -1137,13 +1262,23 @@ fn overwriting_existing_node_fails_if_node_has_dependencies() {
     let stack = NodeStack::new(core_node_config(), None, PathBuf::from("/tmp"));
 
     stack
-        .push_config(dependency_v1, false, PathBuf::from("/tmp/lidar_v1"))
+        .push_config(
+            dependency_v1,
+            false,
+            PathBuf::from("/tmp/lidar_v1"),
+            "default",
+        )
         .expect("dependency has no dependencies");
     stack
-        .push_config(dependent, false, PathBuf::from("/tmp/brain"))
+        .push_config(dependent, false, PathBuf::from("/tmp/brain"), "default")
         .expect("dependent dependency is present");
 
-    let result = stack.push_config(dependency_v2, false, PathBuf::from("/tmp/lidar_v2"));
+    let result = stack.push_config(
+        dependency_v2,
+        false,
+        PathBuf::from("/tmp/lidar_v2"),
+        "default",
+    );
     let Err(NodeStackError::CannotOverwriteNodeWithDependents {
         node_name,
         node_tag,
@@ -1163,14 +1298,16 @@ fn overwriting_existing_node_fails_if_node_has_dependencies() {
         "stack should still have core node + lidar + brain"
     );
 
-    let entity = stack.find("lidar", "1.0.0").expect("entity should exist");
+    let entity = stack
+        .find("lidar", "1.0.0", "default")
+        .expect("entity should exist");
     assert_eq!(
         entity.read().config_path(),
         PathBuf::from("/tmp/lidar_v1").as_path(),
         "entity should still point to the original snapshot config path"
     );
 
-    let dependents = stack.dependents_of("lidar", "1.0.0");
+    let dependents = stack.dependents_of("lidar", "1.0.0", "default");
     assert!(
         dependents
             .iter()
@@ -1214,11 +1351,18 @@ fn updating_run_cmd_without_changing_interfaces_applies_new_config() {
     let stack = NodeStack::new(core_node_config(), None, PathBuf::from("/tmp"));
 
     stack
-        .push_config(original_config, false, PathBuf::from("/tmp/sensor"))
+        .push_config(
+            original_config,
+            false,
+            PathBuf::from("/tmp/sensor"),
+            "default",
+        )
         .expect("first config has no dependencies");
     assert_eq!(stack.len(), 2, "stack should have core node + sensor");
 
-    let entity = stack.find("sensor", "1.0.0").expect("entity should exist");
+    let entity = stack
+        .find("sensor", "1.0.0", "default")
+        .expect("entity should exist");
     assert_eq!(
         entity.read().config().execution.run_cmd.as_ref().unwrap(),
         &vec!["./old_binary"],
@@ -1227,11 +1371,18 @@ fn updating_run_cmd_without_changing_interfaces_applies_new_config() {
 
     // Re-push same name:tag:interfaces:root_path with different run_cmd
     stack
-        .push_config(updated_config, false, PathBuf::from("/tmp/sensor"))
+        .push_config(
+            updated_config,
+            false,
+            PathBuf::from("/tmp/sensor"),
+            "default",
+        )
         .expect("should update config without error");
     assert_eq!(stack.len(), 2, "stack should still have core node + sensor");
 
-    let entity = stack.find("sensor", "1.0.0").expect("entity should exist");
+    let entity = stack
+        .find("sensor", "1.0.0", "default")
+        .expect("entity should exist");
     let entity_guard = entity.read();
     assert_eq!(
         entity_guard.config().execution.run_cmd.as_ref().unwrap(),
@@ -1301,18 +1452,25 @@ fn updating_run_cmd_succeeds_even_when_node_has_dependents() {
     let stack = NodeStack::new(core_node_config(), None, PathBuf::from("/tmp"));
 
     stack
-        .push_config(dependency_v1, false, PathBuf::from("/tmp/lidar"))
+        .push_config(dependency_v1, false, PathBuf::from("/tmp/lidar"), "default")
         .expect("dependency has no dependencies");
     stack
-        .push_config(dependent, false, PathBuf::from("/tmp/brain"))
+        .push_config(dependent, false, PathBuf::from("/tmp/brain"), "default")
         .expect("dependent dependency is present");
 
     // Updating run_cmd without changing interfaces should succeed even with dependents
     stack
-        .push_config(dependency_v1_updated, false, PathBuf::from("/tmp/lidar"))
+        .push_config(
+            dependency_v1_updated,
+            false,
+            PathBuf::from("/tmp/lidar"),
+            "default",
+        )
         .expect("non-breaking config update should succeed even with dependents");
 
-    let entity = stack.find("lidar", "1.0.0").expect("entity should exist");
+    let entity = stack
+        .find("lidar", "1.0.0", "default")
+        .expect("entity should exist");
     assert_eq!(
         entity.read().config().execution.run_cmd.as_ref().unwrap(),
         &vec!["./new_lidar"],
@@ -1320,7 +1478,7 @@ fn updating_run_cmd_succeeds_even_when_node_has_dependents() {
     );
 
     // Dependency wiring should still be intact
-    let dependents = stack.dependents_of("lidar", "1.0.0");
+    let dependents = stack.dependents_of("lidar", "1.0.0", "default");
     assert!(
         dependents
             .iter()

--- a/crates/node-stack-internal/tests/tests_modules/services_runtime_resolution.rs
+++ b/crates/node-stack-internal/tests/tests_modules/services_runtime_resolution.rs
@@ -74,7 +74,7 @@ fn service_dependency_resolved_when_dependency_added_first() {
 
     // Add the dependency first
     stack
-        .push_config(dependency, false, PathBuf::from("/tmp"))
+        .push_config(dependency, false, PathBuf::from("/tmp"), "default")
         .expect("dependency node has no dependencies");
     assert_eq!(
         stack.len(),
@@ -84,12 +84,12 @@ fn service_dependency_resolved_when_dependency_added_first() {
 
     // Now add the dependent node
     stack
-        .push_config(dependent, false, PathBuf::from("/tmp"))
+        .push_config(dependent, false, PathBuf::from("/tmp"), "default")
         .expect("dependent node should be added when dependency exists");
     assert_eq!(stack.len(), 3, "stack should include the dependent node");
 
     let deps = stack
-        .dependencies_of("brain", "1.0.0")
+        .dependencies_of("brain", "1.0.0", "default")
         .into_iter()
         .map(|node| {
             let guard = node.read();
@@ -106,7 +106,7 @@ fn service_dependency_resolved_when_dependency_added_first() {
     );
 
     let dependants = stack
-        .dependents_of("lidar", "1.0.0")
+        .dependents_of("lidar", "1.0.0", "default")
         .into_iter()
         .map(|node| node.read().config().manifest.name.as_str().to_owned())
         .collect::<Vec<_>>();
@@ -152,7 +152,7 @@ fn service_dependency_fails_when_dependency_is_missing() {
     let stack = NodeStack::new(core_node_config(), None, PathBuf::from("/tmp"));
 
     // Adding a node that depends on a non-existent service provider should fail
-    let result = stack.push_config(dependent, false, PathBuf::from("/tmp"));
+    let result = stack.push_config(dependent, false, PathBuf::from("/tmp"), "default");
     let Err(NodeStackError::MissingDependency {
         dependency,
         dependency_tag,
@@ -235,12 +235,17 @@ fn service_dependency_fails_when_service_not_exposed_by_dependency() {
 
     // Add the node with the correct name but wrong service
     stack
-        .push_config(dependency_wrong_service, false, PathBuf::from("/tmp"))
+        .push_config(
+            dependency_wrong_service,
+            false,
+            PathBuf::from("/tmp"),
+            "default",
+        )
         .expect("lidar has no dependencies");
     assert_eq!(stack.len(), 2, "stack should have core node + lidar");
 
     // Adding brain should fail because lidar doesn't expose "reset_sensor"
-    let result = stack.push_config(dependent, false, PathBuf::from("/tmp"));
+    let result = stack.push_config(dependent, false, PathBuf::from("/tmp"), "default");
     let Err(NodeStackError::MissingInterface {
         dependency,
         dependency_tag,
@@ -294,7 +299,7 @@ fn service_dependency_fails_when_local_node_id_is_undeclared() {
 
     let stack = NodeStack::new(core_node_config(), None, PathBuf::from("/tmp"));
 
-    let result = stack.push_config(dependent, false, PathBuf::from("/tmp"));
+    let result = stack.push_config(dependent, false, PathBuf::from("/tmp"), "default");
     let Err(NodeStackError::UndeclaredLocalNodeId { local_node_id, .. }) = result else {
         panic!("expected UndeclaredLocalNodeId error, got {:?}", result);
     };

--- a/crates/node-stack-internal/tests/tests_modules/topics_runtime_resolution.rs
+++ b/crates/node-stack-internal/tests/tests_modules/topics_runtime_resolution.rs
@@ -78,7 +78,7 @@ fn topic_dependency_resolved_when_dependency_added_first() {
 
     // Add the lidar dependency first
     stack
-        .push_config(lidar_dependency, false, PathBuf::from("/tmp"))
+        .push_config(lidar_dependency, false, PathBuf::from("/tmp"), "default")
         .expect("dependency node has no dependencies");
     assert_eq!(
         stack.len(),
@@ -88,11 +88,11 @@ fn topic_dependency_resolved_when_dependency_added_first() {
 
     // Now add the dependent node - should succeed because dependency exists
     stack
-        .push_config(brain_dependent, false, PathBuf::from("/tmp"))
+        .push_config(brain_dependent, false, PathBuf::from("/tmp"), "default")
         .expect("dependent node should be added when dependency exists");
     assert_eq!(stack.len(), 3, "stack should include the dependent node");
 
-    let dependencies = stack.dependencies_of("brain", "1.0.0");
+    let dependencies = stack.dependencies_of("brain", "1.0.0", "default");
     let dependency_names: Vec<_> = dependencies
         .iter()
         .map(|node| node.read().config().manifest.name.as_str().to_owned())
@@ -104,7 +104,7 @@ fn topic_dependency_resolved_when_dependency_added_first() {
     );
 
     let dependants = stack
-        .dependents_of("lidar", "1.0.0")
+        .dependents_of("lidar", "1.0.0", "default")
         .into_iter()
         .map(|node| node.read().config().manifest.name.as_str().to_owned())
         .collect::<Vec<_>>();
@@ -150,7 +150,7 @@ fn topic_dependency_fails_when_dependency_is_missing() {
     let stack = NodeStack::new(core_node_config(), None, PathBuf::from("/tmp"));
 
     // Adding a node that depends on a non-existent node should fail
-    let result = stack.push_config(brain_dependent, false, PathBuf::from("/tmp"));
+    let result = stack.push_config(brain_dependent, false, PathBuf::from("/tmp"), "default");
     let Err(NodeStackError::MissingDependency {
         dependency,
         dependency_tag,
@@ -232,12 +232,17 @@ fn topic_dependency_fails_when_topic_not_exposed_by_dependency() {
 
     // Add the node with the correct name but wrong topic
     stack
-        .push_config(dependency_wrong_topic, false, PathBuf::from("/tmp"))
+        .push_config(
+            dependency_wrong_topic,
+            false,
+            PathBuf::from("/tmp"),
+            "default",
+        )
         .expect("lidar has no dependencies");
     assert_eq!(stack.len(), 2, "stack should have core node + lidar");
 
     // Adding brain should fail because lidar doesn't emit "push_lidar_object"
-    let result = stack.push_config(dependent, false, PathBuf::from("/tmp"));
+    let result = stack.push_config(dependent, false, PathBuf::from("/tmp"), "default");
     let Err(NodeStackError::MissingInterface {
         dependency,
         dependency_tag,
@@ -291,7 +296,7 @@ fn topic_dependency_fails_when_local_node_id_is_undeclared() {
 
     let stack = NodeStack::new(core_node_config(), None, PathBuf::from("/tmp"));
 
-    let result = stack.push_config(dependent, false, PathBuf::from("/tmp"));
+    let result = stack.push_config(dependent, false, PathBuf::from("/tmp"), "default");
     let Err(NodeStackError::UndeclaredLocalNodeId { local_node_id, .. }) = result else {
         panic!("expected UndeclaredLocalNodeId error, got {:?}", result);
     };

--- a/crates/peppy/src/commands/node.rs
+++ b/crates/peppy/src/commands/node.rs
@@ -38,29 +38,9 @@ pub struct TimeoutConfig {
     pub max_secs: u64,
 }
 
-/// Parses a node_name:tag argument string into a tuple
-fn parse_node_ref(s: &str) -> Result<(String, String), String> {
-    let pos = s.find(':').ok_or_else(|| {
-        format!(
-            "invalid node reference '{}': expected node_name:tag format",
-            s
-        )
-    })?;
-    let node_name = s[..pos].trim().to_string();
-    let tag = s[pos + 1..].trim().to_string();
-    if node_name.is_empty() {
-        return Err(format!(
-            "invalid node reference '{}': node_name cannot be empty",
-            s
-        ));
-    }
-    if tag.is_empty() {
-        return Err(format!(
-            "invalid node reference '{}': tag cannot be empty",
-            s
-        ));
-    }
-    Ok((node_name, tag))
+/// Parses a `name:tag` (variant=default) or `name:tag@variant` reference.
+fn parse_node_ref(s: &str) -> Result<(String, String, String), String> {
+    config::node::parse_node_ref(s).map_err(|e| e.to_string())
 }
 
 /// Parses a key=value argument string into a tuple
@@ -168,9 +148,9 @@ pub enum NodeCommands {
     },
     /// Build a node previously added to the node stack
     Build {
-        /// Node reference in the format node_name:tag (e.g., my_node:v1)
+        /// Node reference: `name:tag` or `name:tag@variant`.
         #[arg(value_parser = parse_node_ref)]
-        node_ref: (String, String),
+        node_ref: (String, String, String),
         /// Idle timeout in seconds — resets whenever output is received
         #[arg(long, default_value_t = DEFAULT_IDLE_TIMEOUT_SECS)]
         idle_timeout: u64,
@@ -198,15 +178,18 @@ pub enum NodeCommands {
     /// Usage: `peppy node run <node_name>:<tag>` or `peppy node run --node-name <name> --tag <tag>`
     #[command(group(ArgGroup::new("node_source").required(true).args(["node_ref", "node_name"])))]
     Run {
-        /// Node reference in the format node_name:tag (e.g., my_node:v1)
+        /// Node reference: `name:tag` or `name:tag@variant`.
         #[arg(value_parser = parse_node_ref)]
-        node_ref: Option<(String, String)>,
+        node_ref: Option<(String, String, String)>,
         /// Name of the node to spawn
         #[arg(long, requires = "tag")]
         node_name: Option<String>, // Finds the `NodeConfig` in the node stack that matches this name
         /// Tag of the node
         #[arg(long, requires = "node_name")]
         tag: Option<String>,
+        /// Variant identity for the `--node-name` / `--tag` form.
+        #[arg(long, default_value = config::node::DEFAULT_VARIANT_NAME)]
+        variant: String,
         /// Runtime arguments as key=value pairs (e.g., resolution=1280x720 frequency=30)
         /// These are passed to the node via PEPPY_RUNTIME_CONFIG
         #[arg(value_parser = parse_key_value_arg)]
@@ -245,9 +228,9 @@ pub enum NodeCommands {
     },
     /// Remove a node from the node stack
     Remove {
-        /// Node reference in the format node_name:tag (e.g., my_node:v1)
+        /// Node reference: `name:tag` or `name:tag@variant`.
         #[arg(value_parser = parse_node_ref)]
-        node_ref: (String, String),
+        node_ref: (String, String, String),
         /// When set, stop all instances running on this node before removing the node itself. Without this flag, the command prompts if instances are still running
         #[arg(long)]
         stop_instances: bool,
@@ -262,9 +245,9 @@ pub enum NodeCommands {
     /// with an error — inspecting sources on disk is the job of `node add`,
     /// not `node info`.
     Info {
-        /// Node reference in the format node_name:tag (e.g., my_node:v1)
+        /// Node reference: `name:tag` or `name:tag@variant`.
         #[arg(value_parser = parse_node_ref)]
-        node_ref: (String, String),
+        node_ref: (String, String, String),
     },
 }
 
@@ -333,7 +316,7 @@ impl Command for NodeCommand {
                 )
             }
             NodeCommands::Build {
-                node_ref: (node_name, node_tag),
+                node_ref: (node_name, node_tag, node_variant),
                 idle_timeout,
                 max_timeout,
                 force,
@@ -347,6 +330,7 @@ impl Command for NodeCommand {
                     builder::BuildNodeParams {
                         node_name,
                         node_tag,
+                        node_variant,
                         timeouts,
                         force,
                     },
@@ -363,21 +347,40 @@ impl Command for NodeCommand {
                 node_ref,
                 node_name,
                 tag,
+                variant,
                 args,
                 instance_id,
                 idle_timeout,
                 max_timeout,
                 build,
             } => {
-                let (node_name, tag) = node_ref
-                    .or_else(|| node_name.zip(tag))
-                    .expect("either node_ref or node_name+tag must be provided");
-                info!("Running node {}:{}...", node_name, tag);
+                let (node_name, tag, node_variant) = match node_ref {
+                    Some(triple) => triple,
+                    None => {
+                        let (n, t) = node_name
+                            .zip(tag)
+                            .expect("either node_ref or node_name+tag must be provided");
+                        (n, t, variant)
+                    }
+                };
+                info!(
+                    "Running node {}...",
+                    config::node::render_node_id(&node_name, &tag, &node_variant)
+                );
                 let timeouts = TimeoutConfig {
                     idle_secs: idle_timeout,
                     max_secs: max_timeout,
                 };
-                run::run_node(ctx, node_name, tag, args, instance_id, timeouts, build)
+                run::run_node(
+                    ctx,
+                    node_name,
+                    tag,
+                    node_variant,
+                    args,
+                    instance_id,
+                    timeouts,
+                    build,
+                )
             }
             NodeCommands::RuntimeConfig {
                 node_name,
@@ -389,18 +392,24 @@ impl Command for NodeCommand {
                 stop::stop_node(ctx, instance_id)
             }
             NodeCommands::Remove {
-                node_ref: (node_name, tag),
+                node_ref: (node_name, tag, node_variant),
                 stop_instances,
                 force,
             } => {
-                info!("Remove node {}:{}...", node_name, tag);
-                remove::remove_node(ctx, node_name, tag, stop_instances, force)
+                info!(
+                    "Remove node {}...",
+                    config::node::render_node_id(&node_name, &tag, &node_variant)
+                );
+                remove::remove_node(ctx, node_name, tag, node_variant, stop_instances, force)
             }
             NodeCommands::Info {
-                node_ref: (node_name, node_tag),
+                node_ref: (node_name, node_tag, node_variant),
             } => {
-                info!("Getting node info for {}:{}...", node_name, node_tag);
-                info::node_info(ctx, node_name, node_tag)
+                info!(
+                    "Getting node info for {}...",
+                    config::node::render_node_id(&node_name, &node_tag, &node_variant)
+                );
+                info::node_info(ctx, node_name, node_tag, node_variant)
             }
         }
     }

--- a/crates/peppy/src/commands/node/add.rs
+++ b/crates/peppy/src/commands/node/add.rs
@@ -13,7 +13,7 @@ use tracing::info;
 use super::TimeoutConfig;
 use super::env::caller_env_overrides;
 use super::run::run_instance_async;
-use super::source::{parse_node_source, split_variant_args};
+use super::source::{parse_node_source, parse_root_variant_args};
 use crate::commands::{CALLER_INSTANCE_ID, GOAL_TIMEOUT};
 use crate::context::AppContext;
 use crate::error::{Error, Result};
@@ -29,9 +29,9 @@ pub struct RunAfterAddOptions {
 pub struct AddNodeParams {
     pub source: String,
     pub git_ref: Option<String>,
-    /// Raw `--variant` strings passed on the CLI — parsed by
-    /// [`super::source::split_variant_args`] into a root variant plus
-    /// an optional list of per-dependency overrides.
+    /// Raw `--variant` strings passed on the CLI. Only the root-level variant
+    /// is accepted now; manifests declare per-dependency variants directly via
+    /// `depends_on[].variant`.
     pub variant: Vec<String>,
     pub run_options: Option<RunAfterAddOptions>,
     pub timeouts: TimeoutConfig,
@@ -58,35 +58,6 @@ fn validate_git_ref(git_ref: Option<&str>) -> Result<Option<String>> {
     Ok(git_ref.map(str::to_owned))
 }
 
-fn apply_dep_variant_overrides(
-    node_source: NodeSource,
-    dep_overrides: Vec<core_node_api::encoding::DepVariantOverride>,
-) -> Result<NodeSource> {
-    if dep_overrides.is_empty() {
-        return Ok(node_source);
-    }
-
-    let NodeSource::RepoNode { name, tag, .. } = &node_source else {
-        return Err(Error::ExecutionFailed(
-            "`--variant <name>:<tag>@<variant>` dependency overrides are only valid when the source is `<name>:<tag>` (repo lookup)".to_owned(),
-        ));
-    };
-
-    if let Some(root_override) = dep_overrides
-        .iter()
-        .find(|ov| ov.name == *name && ov.tag == *tag)
-    {
-        return Err(Error::ExecutionFailed(format!(
-            "`--variant {}:{}@{}` targets the root repo-node source; use `--variant {}` to select the root variant",
-            root_override.name, root_override.tag, root_override.variant, root_override.variant
-        )));
-    }
-
-    node_source
-        .with_dep_variant_overrides(dep_overrides)
-        .map_err(|e| Error::ExecutionFailed(e.to_string()))
-}
-
 pub fn add_node(ctx: &Arc<AppContext>, params: AddNodeParams) -> Result<()> {
     crate::commands::block_on(add_node_async(ctx, params))
 }
@@ -105,13 +76,11 @@ async fn add_node_async(ctx: &Arc<AppContext>, params: AddNodeParams) -> Result<
     } = params;
     // Validate git_ref and parse the source into a NodeSource
     let git_ref = validate_git_ref(git_ref.as_deref())?;
-    let mut node_source = parse_node_source(&source, git_ref)?;
+    let node_source = parse_node_source(&source, git_ref)?;
 
-    // Split the --variant list into (root_variant, dep_overrides). This also
-    // validates there's at most one root --variant and rejects duplicate
-    // dep entries.
-    let (variant_source, dep_overrides) = split_variant_args(&variant)?;
-    node_source = apply_dep_variant_overrides(node_source, dep_overrides)?;
+    // Parse the (at most one) root-level `--variant` argument. Per-dep
+    // variants are now declared on each manifest's `depends_on[].variant`.
+    let variant_source = parse_root_variant_args(&variant)?;
 
     // `--sync` forces a `peppy node sync` *before* the add so the snapshot
     // taken by the daemon includes freshly regenerated peppygen output.
@@ -145,21 +114,6 @@ async fn add_node_async(ctx: &Arc<AppContext>, params: AddNodeParams) -> Result<
         info!("Adding node (with root variant) from {}...", display_source);
     } else {
         info!("Adding node from {}...", display_source);
-    }
-    if let NodeSource::RepoNode {
-        dep_variant_overrides,
-        ..
-    } = &node_source
-        && !dep_variant_overrides.is_empty()
-    {
-        info!(
-            "Dependency variant overrides: {}",
-            dep_variant_overrides
-                .iter()
-                .map(|o| format!("{}:{}@{}", o.name, o.tag, o.variant))
-                .collect::<Vec<_>>()
-                .join(", ")
-        );
     }
 
     let conn = ctx.connect_to_daemon().await?;
@@ -197,12 +151,15 @@ async fn add_node_async(ctx: &Arc<AppContext>, params: AddNodeParams) -> Result<
                 )
                 .await?
             }
-            NodeSource::RepoNode { name, tag, .. } => {
+            NodeSource::RepoNode {
+                name, tag, variant, ..
+            } => {
                 fetch_active_instances_for_name_tag(
                     conn.messenger,
                     &conn.core_node_name,
                     name.clone(),
                     tag.clone(),
+                    variant.clone(),
                     Duration::from_secs(timeouts.max_secs),
                 )
                 .await?
@@ -210,9 +167,14 @@ async fn add_node_async(ctx: &Arc<AppContext>, params: AddNodeParams) -> Result<
             NodeSource::Git { .. } | NodeSource::Http { .. } => None,
         };
 
-        if let Some((node_name, node_tag, instance_ids)) = active_instances {
-            let confirm =
-                confirm_overwrite(&node_name, &node_tag, &instance_ids, confirm_reader.take())?;
+        if let Some((node_name, node_tag, node_variant, instance_ids)) = active_instances {
+            let confirm = confirm_overwrite(
+                &node_name,
+                &node_tag,
+                &node_variant,
+                &instance_ids,
+                confirm_reader.take(),
+            )?;
             if !confirm {
                 return Err(Error::ExecutionFailed(
                     "Node add aborted by user".to_string(),
@@ -248,10 +210,16 @@ async fn add_node_async(ctx: &Arc<AppContext>, params: AddNodeParams) -> Result<
     >(conn.messenger, &mut action_handle, &timeouts, "node_add")
     .await?;
 
-    if let (Some(name), Some(tag)) = (&add_result.node_name, &add_result.node_tag) {
-        info!("Added node {}:{} to the node stack", name, tag);
-    } else {
-        info!("Added node to the node stack");
+    match (
+        &add_result.node_name,
+        &add_result.node_tag,
+        &add_result.node_variant,
+    ) {
+        (Some(name), Some(tag), Some(variant)) => info!(
+            "Added node {} to the node stack",
+            config::node::render_node_id(name, tag, variant)
+        ),
+        _ => info!("Added node to the node stack"),
     }
 
     if !chain_build && run_options.is_none() {
@@ -268,12 +236,18 @@ async fn add_node_async(ctx: &Arc<AppContext>, params: AddNodeParams) -> Result<
             "Failed to determine node tag after adding. Try running `peppy node list`.".into(),
         )
     })?;
+    let node_variant = add_result.node_variant.as_deref().ok_or_else(|| {
+        Error::ExecutionFailed(
+            "Failed to determine node variant after adding. Try running `peppy node list`.".into(),
+        )
+    })?;
 
     crate::commands::node::builder::build_node_async(
         conn.messenger,
         &conn.core_node_name,
         node_name,
         node_tag,
+        node_variant,
         &timeouts,
         false,
     )
@@ -288,6 +262,7 @@ async fn add_node_async(ctx: &Arc<AppContext>, params: AddNodeParams) -> Result<
         &conn.core_node_name,
         node_name,
         node_tag,
+        node_variant,
         &run_options.args,
         run_options.instance_id,
         &timeouts,
@@ -319,30 +294,39 @@ async fn fetch_active_instances_for_local_source(
     core_node_name: &str,
     source_path: &Path,
     timeout: Duration,
-) -> Result<Option<(String, String, Vec<String>)>> {
+) -> Result<Option<(String, String, String, Vec<String>)>> {
     let config_path = source_path.join(config::consts::NODE_CONFIG_FILE);
     let Ok(parsed) = NodeConfigParser::from_path(&config_path) else {
         return Ok(None);
     };
     let node_name = parsed.manifest_name().to_owned();
     let node_tag = parsed.manifest_tag().to_owned();
-    fetch_active_instances_for_name_tag(messenger, core_node_name, node_name, node_tag, timeout)
-        .await
+    fetch_active_instances_for_name_tag(
+        messenger,
+        core_node_name,
+        node_name,
+        node_tag,
+        config::node::DEFAULT_VARIANT_NAME.to_owned(),
+        timeout,
+    )
+    .await
 }
 
-/// Queries the daemon for the `(name, tag)` entity in the stack and returns
-/// its active (`running`/`starting`) instance ids when present. Used by the
-/// `RepoNode` preflight, which already has `(name, tag)` in hand, and by
-/// the `Fs` wrapper above after it reads them from `peppy.json5`.
+/// Queries the daemon for the `(name, tag, variant)` entity in the stack and
+/// returns its active (`running`/`starting`) instance ids when present. Used
+/// by the `RepoNode` preflight, which already has the full identity in hand,
+/// and by the `Fs` wrapper above after it reads `(name, tag)` from
+/// `peppy.json5`.
 async fn fetch_active_instances_for_name_tag(
     messenger: &MessengerHandle,
     core_node_name: &str,
     node_name: String,
     node_tag: String,
+    node_variant: String,
     timeout: Duration,
-) -> Result<Option<(String, String, Vec<String>)>> {
+) -> Result<Option<(String, String, String, Vec<String>)>> {
     let response = poll_node_info(
-        &NodeInfoRequest::new(node_name.clone(), node_tag.clone()),
+        &NodeInfoRequest::new(node_name.clone(), node_tag.clone(), node_variant.clone()),
         messenger,
         core_node_name,
         CALLER_INSTANCE_ID,
@@ -371,13 +355,14 @@ async fn fetch_active_instances_for_name_tag(
     if active.is_empty() {
         Ok(None)
     } else {
-        Ok(Some((node_name, node_tag, active)))
+        Ok(Some((node_name, node_tag, node_variant, active)))
     }
 }
 
 fn confirm_overwrite(
     node_name: &str,
     tag: &str,
+    variant: &str,
     instance_ids: &[String],
     mut reader: Option<Box<dyn BufRead>>,
 ) -> Result<bool> {
@@ -387,9 +372,10 @@ fn confirm_overwrite(
     let suffix = if count == 1 { "instance" } else { "instances" };
     let ids = format_instance_ids(instance_ids);
     let pronoun = if count == 1 { "it" } else { "them" };
+    let label = config::node::render_node_id(node_name, tag, variant);
 
     let message = format!(
-        "Node `{node_name}:{tag}` already exists with {count} active {suffix} ({ids}). \
+        "Node `{label}` already exists with {count} active {suffix} ({ids}). \
          Adding this node will stop {pronoun} and overwrite the existing node. Continue? [y/n] ",
     );
 
@@ -512,66 +498,5 @@ mod tests {
         let result = validate_git_ref(None).expect("should accept None");
 
         assert!(result.is_none());
-    }
-
-    #[test]
-    fn apply_dep_variant_overrides_rejects_non_repo_source() {
-        let err = apply_dep_variant_overrides(
-            NodeSource::Fs(Path::new("/tmp/example").to_path_buf()),
-            vec![core_node_api::encoding::DepVariantOverride {
-                name: "camera".to_owned(),
-                tag: "1.0".to_owned(),
-                variant: "sim".to_owned(),
-            }],
-        )
-        .expect_err("non-repo source should reject dep overrides");
-
-        assert!(
-            err.to_string()
-                .contains("only valid when the source is `<name>:<tag>`")
-        );
-    }
-
-    #[test]
-    fn apply_dep_variant_overrides_rejects_root_target_override() {
-        let err = apply_dep_variant_overrides(
-            NodeSource::repo_node("camera", "1.0").expect("valid repo-node"),
-            vec![core_node_api::encoding::DepVariantOverride {
-                name: "camera".to_owned(),
-                tag: "1.0".to_owned(),
-                variant: "sim".to_owned(),
-            }],
-        )
-        .expect_err("root-target dep override should be rejected");
-
-        let msg = err.to_string();
-        assert!(msg.contains("targets the root repo-node source"));
-        assert!(msg.contains("use `--variant sim`"));
-    }
-
-    #[test]
-    fn apply_dep_variant_overrides_accepts_non_root_override() {
-        let source = apply_dep_variant_overrides(
-            NodeSource::repo_node("camera", "1.0").expect("valid repo-node"),
-            vec![core_node_api::encoding::DepVariantOverride {
-                name: "dep".to_owned(),
-                tag: "0.2".to_owned(),
-                variant: "sim".to_owned(),
-            }],
-        )
-        .expect("non-root override should be accepted");
-
-        match source {
-            NodeSource::RepoNode {
-                dep_variant_overrides,
-                ..
-            } => {
-                assert_eq!(dep_variant_overrides.len(), 1);
-                assert_eq!(dep_variant_overrides[0].name, "dep");
-                assert_eq!(dep_variant_overrides[0].tag, "0.2");
-                assert_eq!(dep_variant_overrides[0].variant, "sim");
-            }
-            other => panic!("expected repo-node source, got {other:?}"),
-        }
     }
 }

--- a/crates/peppy/src/commands/node/builder.rs
+++ b/crates/peppy/src/commands/node/builder.rs
@@ -15,6 +15,7 @@ use peppylib::core_node::transport::send_node_build;
 pub struct BuildNodeParams {
     pub node_name: String,
     pub node_tag: String,
+    pub node_variant: String,
     pub timeouts: TimeoutConfig,
     pub force: bool,
 }
@@ -33,6 +34,7 @@ async fn build_node_async_with_connect(
         &conn.core_node_name,
         &params.node_name,
         &params.node_tag,
+        &params.node_variant,
         &params.timeouts,
         params.force,
     )
@@ -46,12 +48,14 @@ pub async fn build_node_async(
     core_node_name: &str,
     node_name: &str,
     node_tag: &str,
+    node_variant: &str,
     timeouts: &TimeoutConfig,
     force: bool,
 ) -> Result<()> {
-    info!("Building node {}:{}...", node_name, node_tag);
+    let label = config::node::render_node_id(node_name, node_tag, node_variant);
+    info!("Building node {}...", label);
 
-    let mut goal = NodeBuildGoal::new(node_name, node_tag, timeouts.max_secs)
+    let mut goal = NodeBuildGoal::new(node_name, node_tag, node_variant, timeouts.max_secs)
         .with_env_vars(caller_env_overrides());
     if force {
         goal = goal.with_force(true);
@@ -77,9 +81,8 @@ pub async fn build_node_async(
     .await?;
 
     info!(
-        "Built node {}:{}. Artifact: {}",
-        node_name,
-        node_tag,
+        "Built node {}. Artifact: {}",
+        label,
         build_result.artifact_path.to_string_lossy()
     );
 

--- a/crates/peppy/src/commands/node/info.rs
+++ b/crates/peppy/src/commands/node/info.rs
@@ -11,15 +11,25 @@ use crate::error::{Error, Result};
 use peppylib::core_node::transport::poll_node_info;
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
-pub fn node_info(ctx: &Arc<AppContext>, node_name: String, node_tag: String) -> Result<()> {
-    crate::commands::block_on(node_info_async(ctx, node_name, node_tag))
+pub fn node_info(
+    ctx: &Arc<AppContext>,
+    node_name: String,
+    node_tag: String,
+    node_variant: String,
+) -> Result<()> {
+    crate::commands::block_on(node_info_async(ctx, node_name, node_tag, node_variant))
 }
 
-async fn node_info_async(ctx: &Arc<AppContext>, node_name: String, node_tag: String) -> Result<()> {
+async fn node_info_async(
+    ctx: &Arc<AppContext>,
+    node_name: String,
+    node_tag: String,
+    node_variant: String,
+) -> Result<()> {
     let conn = ctx.connect_to_daemon().await?;
 
     let response = poll_node_info(
-        &NodeInfoRequest::new(node_name.clone(), node_tag.clone()),
+        &NodeInfoRequest::new(node_name.clone(), node_tag.clone(), node_variant.clone()),
         conn.messenger,
         &conn.core_node_name,
         CALLER_INSTANCE_ID,
@@ -35,8 +45,8 @@ async fn node_info_async(ctx: &Arc<AppContext>, node_name: String, node_tag: Str
     let info = match response {
         NodeInfoResponse::NotInStack => {
             return Err(Error::ExecutionFailed(format!(
-                "Node '{}:{}' is not in the node stack",
-                node_name, node_tag
+                "Node '{}' is not in the node stack",
+                config::node::render_node_id(&node_name, &node_tag, &node_variant)
             )));
         }
         NodeInfoResponse::Found(info) => info,
@@ -108,13 +118,11 @@ fn format_node_info(out: &mut String, response: &NodeInfo) {
     let _ = writeln!(out, "Node Stack Status");
     let _ = writeln!(out, "{}", "-".repeat(50));
     let _ = writeln!(out, "Stage:     {}", response.stage);
-    // Always show the selected variant. A node without an explicit
-    // variant is conceptually running the "default" variant — either
-    // literally (auto-resolved from the root manifest's `variants[]`)
-    // or effectively (no variants defined, so the root's own execution
-    // section IS the default).
-    let variant = response.variant_name.as_deref().unwrap_or("default");
-    let _ = writeln!(out, "Variant:   {}", variant);
+    // Always show the selected variant. The wire field is always
+    // populated; a node added without an explicit variant carries the
+    // literal `"default"` string (either auto-resolved from the root
+    // manifest's `variants[]` or used because no variants were defined).
+    let _ = writeln!(out, "Variant:   {}", response.variant);
     if response.instances.is_empty() {
         let _ = writeln!(out, "Instances: None tracked");
     } else {
@@ -137,7 +145,11 @@ fn format_node_info(out: &mut String, response: &NodeInfo) {
         let _ = writeln!(out);
         let _ = writeln!(out, "Logs");
         let _ = writeln!(out, "{}", "-".repeat(50));
-        let _ = writeln!(out, "{}:{}", manifest.name.as_str(), manifest.tag);
+        let _ = writeln!(
+            out,
+            "{}",
+            config::node::render_node_id(manifest.name.as_str(), &manifest.tag, &response.variant)
+        );
         if let Some(add_log_path) = response.add_log_path.as_ref() {
             let _ = writeln!(out, "  Add log: {}", add_log_path.display());
         }
@@ -502,7 +514,7 @@ mod tests {
                 PathBuf::from("/tmp/peppy/logs/run/inst-abc.log"),
                 PathBuf::from("/tmp/peppy/logs/run/inst-def.log"),
             ],
-            variant_name: None,
+            variant: config::node::DEFAULT_VARIANT_NAME.to_owned(),
         }
     }
 
@@ -554,30 +566,34 @@ mod tests {
     }
 
     #[test]
-    fn print_node_info_renders_variant_line_as_default_when_none() {
+    fn print_node_info_renders_variant_line_as_default_when_default() {
         let response = sample_response();
-        assert!(response.variant_name.is_none(), "precondition");
+        assert_eq!(
+            response.variant,
+            config::node::DEFAULT_VARIANT_NAME,
+            "precondition"
+        );
 
         let mut out = String::new();
         format_node_info(&mut out, &response);
 
         assert!(
             out.contains("Variant:   default"),
-            "Variant line should fall back to 'default' when variant_name is None:\n{out}"
+            "Variant line should render 'default' when variant is the implicit default:\n{out}"
         );
     }
 
     #[test]
-    fn print_node_info_renders_variant_line_when_present() {
+    fn print_node_info_renders_variant_line_when_explicit() {
         let mut response = sample_response();
-        response.variant_name = Some("macos".to_string());
+        response.variant = "macos".to_string();
 
         let mut out = String::new();
         format_node_info(&mut out, &response);
 
         assert!(
             out.contains("Variant:   macos"),
-            "Variant line missing when variant_name is Some:\n{out}"
+            "Variant line missing when variant is set:\n{out}"
         );
         // Variant must appear inside the Node Stack Status section, between
         // the Stage line and the Instances line.

--- a/crates/peppy/src/commands/node/remove.rs
+++ b/crates/peppy/src/commands/node/remove.rs
@@ -16,6 +16,7 @@ pub fn remove_node(
     ctx: &Arc<AppContext>,
     node_name: String,
     tag: String,
+    node_variant: String,
     stop_instances: bool,
     force: bool,
 ) -> Result<()> {
@@ -23,6 +24,7 @@ pub fn remove_node(
         ctx,
         node_name,
         tag,
+        node_variant,
         stop_instances,
         force,
     ))
@@ -32,6 +34,7 @@ async fn remove_node_async(
     ctx: &Arc<AppContext>,
     node_name: String,
     tag: String,
+    node_variant: String,
     stop_instances: bool,
     force: bool,
 ) -> Result<()> {
@@ -42,11 +45,17 @@ async fn remove_node_async(
         stop_instances = true;
     }
     if !stop_instances {
-        let instance_ids =
-            fetch_instance_ids(conn.messenger, &conn.core_node_name, &node_name, &tag).await?;
+        let instance_ids = fetch_instance_ids(
+            conn.messenger,
+            &conn.core_node_name,
+            &node_name,
+            &tag,
+            &node_variant,
+        )
+        .await?;
 
         if !instance_ids.is_empty() {
-            let confirm = confirm_removal(&node_name, &tag, &instance_ids)?;
+            let confirm = confirm_removal(&node_name, &tag, &node_variant, &instance_ids)?;
             if !confirm {
                 return Err(Error::ExecutionFailed(
                     "Node removal aborted by user".to_string(),
@@ -56,13 +65,14 @@ async fn remove_node_async(
         }
     }
 
+    let label = config::node::render_node_id(&node_name, &tag, &node_variant);
     info!(
-        "Calling node_remove for '{}:{}' on daemon '{}' (stop_instances={})...",
-        node_name, tag, conn.core_node_name, stop_instances
+        "Calling node_remove for '{}' on daemon '{}' (stop_instances={})...",
+        label, conn.core_node_name, stop_instances
     );
 
     let remove_request =
-        NodeRemoveRequest::new(&node_name, &tag).with_stop_instances(stop_instances);
+        NodeRemoveRequest::new(&node_name, &tag, &node_variant).with_stop_instances(stop_instances);
     let remove_response = poll_node_remove(
         &remove_request,
         conn.messenger,
@@ -82,7 +92,7 @@ async fn remove_node_async(
         ));
     }
 
-    info!("Removed node '{}:{}'", node_name, tag);
+    info!("Removed node '{}'", label);
     Ok(())
 }
 
@@ -91,6 +101,7 @@ async fn fetch_instance_ids(
     core_node_name: &str,
     node_name: &str,
     tag: &str,
+    node_variant: &str,
 ) -> Result<Vec<String>> {
     let response = poll_stack_list(
         &StackListRequest::new(false),
@@ -108,7 +119,7 @@ async fn fetch_instance_ids(
     Ok(graph
         .nodes
         .iter()
-        .find(|node| node.name == node_name && node.tag == tag)
+        .find(|node| node.name == node_name && node.tag == tag && node.variant == node_variant)
         .map(|node| {
             node.running_instance_ids()
                 .into_iter()
@@ -118,16 +129,22 @@ async fn fetch_instance_ids(
         .unwrap_or_default())
 }
 
-fn confirm_removal(node_name: &str, tag: &str, instance_ids: &[String]) -> Result<bool> {
+fn confirm_removal(
+    node_name: &str,
+    tag: &str,
+    node_variant: &str,
+    instance_ids: &[String],
+) -> Result<bool> {
     use crate::commands::confirm::{confirm_prompt, format_instance_ids};
 
     let count = instance_ids.len();
     let suffix = if count == 1 { "instance" } else { "instances" };
     let verb = if count == 1 { "is" } else { "are" };
     let ids = format_instance_ids(instance_ids);
+    let label = config::node::render_node_id(node_name, tag, node_variant);
 
     let message = format!(
-        "Are you sure you want to remove `{node_name}:{tag}`? \
+        "Are you sure you want to remove `{label}`? \
          {count} {suffix} ({ids}) {verb} still running [y/n] ",
     );
 

--- a/crates/peppy/src/commands/node/run.rs
+++ b/crates/peppy/src/commands/node/run.rs
@@ -86,14 +86,19 @@ fn remaining_timeouts(
 ///
 /// Split out as a pure function so the stage-matching logic can be
 /// unit-tested directly.
-fn classify_stage(stage: NodeStage, node_name: &str, tag: &str) -> Result<BuildDecision> {
+fn classify_stage(
+    stage: NodeStage,
+    node_name: &str,
+    tag: &str,
+    variant: &str,
+) -> Result<BuildDecision> {
     match stage {
         NodeStage::Ready => Ok(BuildDecision::Skip),
         NodeStage::Added => Ok(BuildDecision::Build),
         NodeStage::Building => Ok(BuildDecision::Wait),
         NodeStage::Root => Err(Error::ExecutionFailed(format!(
-            "Node '{}:{}' is a root node and cannot be built or run via `node run`",
-            node_name, tag
+            "Node '{}' is a root node and cannot be built or run via `node run`",
+            config::node::render_node_id(node_name, tag, variant)
         ))),
     }
 }
@@ -107,18 +112,24 @@ async fn wait_for_build_to_finish(
     core_node_name: &str,
     node_name: &str,
     tag: &str,
+    node_variant: &str,
     timeouts: &TimeoutConfig,
 ) -> Result<()> {
+    let label = config::node::render_node_id(node_name, tag, node_variant);
     info!(
-        "Node {}:{} is already building, waiting for the in-flight build to finish...",
-        node_name, tag
+        "Node {} is already building, waiting for the in-flight build to finish...",
+        label
     );
 
     let deadline = Instant::now() + Duration::from_secs(timeouts.max_secs);
 
     loop {
         let response = poll_node_info(
-            &NodeInfoRequest::new(node_name.to_string(), tag.to_string()),
+            &NodeInfoRequest::new(
+                node_name.to_string(),
+                tag.to_string(),
+                node_variant.to_string(),
+            ),
             messenger,
             core_node_name,
             CALLER_INSTANCE_ID,
@@ -136,8 +147,8 @@ async fn wait_for_build_to_finish(
         match response {
             NodeInfoResponse::NotInStack => {
                 return Err(Error::ExecutionFailed(format!(
-                    "Node '{}:{}' disappeared from the stack while waiting for build to finish",
-                    node_name, tag
+                    "Node '{}' disappeared from the stack while waiting for build to finish",
+                    label
                 )));
             }
             NodeInfoResponse::Found(info) => match info.stage {
@@ -145,8 +156,8 @@ async fn wait_for_build_to_finish(
                 NodeStage::Building => { /* still in flight — keep polling */ }
                 other => {
                     return Err(Error::ExecutionFailed(format!(
-                        "Node '{}:{}' transitioned to unexpected stage '{}' while waiting for build to finish",
-                        node_name, tag, other
+                        "Node '{}' transitioned to unexpected stage '{}' while waiting for build to finish",
+                        label, other
                     )));
                 }
             },
@@ -154,8 +165,8 @@ async fn wait_for_build_to_finish(
 
         if Instant::now() >= deadline {
             return Err(Error::ExecutionFailed(format!(
-                "Timed out waiting for node '{}:{}' build to finish",
-                node_name, tag
+                "Timed out waiting for node '{}' build to finish",
+                label
             )));
         }
 
@@ -268,6 +279,7 @@ pub async fn run_instance_async(
     core_node_name: &str,
     node_name: &str,
     tag: &str,
+    node_variant: &str,
     args: &[(String, String)],
     instance_id: Option<String>,
     timeouts: &TimeoutConfig,
@@ -278,10 +290,10 @@ pub async fn run_instance_async(
     // Convert CLI arguments to node arguments
     let arguments = args_to_node_arguments(args);
 
+    let label = config::node::render_node_id(node_name, tag, node_variant);
     info!(
-        "Starting node {}:{} with instance_id '{}' and {} argument(s)...",
-        node_name,
-        tag,
+        "Starting node {} with instance_id '{}' and {} argument(s)...",
+        label,
         instance_id,
         arguments.len()
     );
@@ -313,14 +325,15 @@ pub async fn run_instance_async(
         serde_json::to_string(&runtime_config).map_err(|e| Error::Sync(e.to_string()))?;
 
     info!(
-        "Calling node_run for {}:{} (instance_id={})...",
-        node_name, tag, instance_id
+        "Calling node_run for {} (instance_id={})...",
+        label, instance_id
     );
 
     let start_goal = NodeRunGoal::new(
         &runtime_config_json,
         node_name.to_string(),
         tag.to_string(),
+        node_variant.to_string(),
         timeouts.max_secs,
     )
     .with_env_vars(caller_env_overrides());
@@ -355,6 +368,7 @@ pub fn run_node(
     ctx: &Arc<AppContext>,
     node_name: String,
     tag: String,
+    node_variant: String,
     args: Vec<(String, String)>,
     instance_id: Option<String>,
     timeouts: TimeoutConfig,
@@ -364,6 +378,7 @@ pub fn run_node(
         ctx,
         node_name,
         tag,
+        node_variant,
         args,
         instance_id,
         timeouts,
@@ -375,6 +390,7 @@ async fn run_node_async(
     ctx: &Arc<AppContext>,
     node_name: String,
     tag: String,
+    node_variant: String,
     args: Vec<(String, String)>,
     instance_id: Option<String>,
     timeouts: TimeoutConfig,
@@ -389,13 +405,14 @@ async fn run_node_async(
     // uses its own fixed-30s timeout and is exempt (see
     // `NODE_INFO_PREFLIGHT_TIMEOUT` docs above).
     let start = Instant::now();
+    let label = config::node::render_node_id(&node_name, &tag, &node_variant);
 
     if build {
         // Look up the node's current lifecycle stage so we only trigger a
         // build when the node is not yet built. The same `NodeInfoRequest`
         // is used by the `node add` preflight (see add.rs).
         let response = poll_node_info(
-            &NodeInfoRequest::new(node_name.clone(), tag.clone()),
+            &NodeInfoRequest::new(node_name.clone(), tag.clone(), node_variant.clone()),
             conn.messenger,
             &conn.core_node_name,
             CALLER_INSTANCE_ID,
@@ -410,19 +427,16 @@ async fn run_node_async(
         let info = match response {
             NodeInfoResponse::NotInStack => {
                 return Err(Error::ExecutionFailed(format!(
-                    "Node '{}:{}' is not in the node stack",
-                    node_name, tag
+                    "Node '{}' is not in the node stack",
+                    label
                 )));
             }
             NodeInfoResponse::Found(info) => info,
         };
 
-        match classify_stage(info.stage, &node_name, &tag)? {
+        match classify_stage(info.stage, &node_name, &tag, &node_variant)? {
             BuildDecision::Skip => {
-                info!(
-                    "Node {}:{} has already been built, skipping build",
-                    node_name, tag
-                );
+                info!("Node {} has already been built, skipping build", label);
             }
             BuildDecision::Build => {
                 super::builder::build_node_async(
@@ -430,6 +444,7 @@ async fn run_node_async(
                     &conn.core_node_name,
                     &node_name,
                     &tag,
+                    &node_variant,
                     &remaining_timeouts(&timeouts, start, "build")?,
                     false,
                 )
@@ -441,6 +456,7 @@ async fn run_node_async(
                     &conn.core_node_name,
                     &node_name,
                     &tag,
+                    &node_variant,
                     &remaining_timeouts(&timeouts, start, "wait-for-build")?,
                 )
                 .await?;
@@ -453,6 +469,7 @@ async fn run_node_async(
         &conn.core_node_name,
         &node_name,
         &tag,
+        &node_variant,
         &args,
         instance_id,
         &remaining_timeouts(&timeouts, start, "run")?,
@@ -582,7 +599,7 @@ mod tests {
     #[test]
     fn classify_stage_ready_skips() {
         assert_eq!(
-            classify_stage(NodeStage::Ready, "n", "t").expect("Ready should classify"),
+            classify_stage(NodeStage::Ready, "n", "t", "default").expect("Ready should classify"),
             BuildDecision::Skip
         );
     }
@@ -590,7 +607,7 @@ mod tests {
     #[test]
     fn classify_stage_added_builds() {
         assert_eq!(
-            classify_stage(NodeStage::Added, "n", "t").expect("Added should classify"),
+            classify_stage(NodeStage::Added, "n", "t", "default").expect("Added should classify"),
             BuildDecision::Build
         );
     }
@@ -603,14 +620,15 @@ mod tests {
         // waits for the in-flight build instead of trying to start a new
         // one.
         assert_eq!(
-            classify_stage(NodeStage::Building, "n", "t").expect("Building should classify"),
+            classify_stage(NodeStage::Building, "n", "t", "default")
+                .expect("Building should classify"),
             BuildDecision::Wait
         );
     }
 
     #[test]
     fn classify_stage_root_fails_fast() {
-        let err = classify_stage(NodeStage::Root, "my_node", "v1")
+        let err = classify_stage(NodeStage::Root, "my_node", "v1", "default")
             .expect_err("Root should fail to classify");
         let msg = format!("{err}");
         assert!(msg.contains("my_node"), "error should name node: {msg}");

--- a/crates/peppy/src/commands/node/source.rs
+++ b/crates/peppy/src/commands/node/source.rs
@@ -17,9 +17,7 @@ pub fn is_probably_remote_source(source: &str) -> bool {
 /// - Must not contain `/` or `\` (those would make it a path).
 /// - Must not contain `://` (URLs are caught upstream).
 /// - Must not start with `.` or `~` (relative paths).
-/// - Must contain exactly one `:` separating a non-empty name from a
-///   non-empty tag, neither of which may contain further `:`.
-/// - May carry a single trailing `@variant` suffix.
+/// - Must parse as a valid `name:tag[@variant]` reference.
 /// - The arg must not exist on disk (a directory named `foo:bar` wins).
 pub fn looks_like_repo_node_ref(source: &str) -> bool {
     if source.contains('/') || source.contains('\\') {
@@ -31,35 +29,12 @@ pub fn looks_like_repo_node_ref(source: &str) -> bool {
     if source.starts_with('.') || source.starts_with('~') {
         return false;
     }
-    let (left, variant) = match source.split_once('@') {
-        Some((left, variant)) => (left, Some(variant)),
-        None => (source, None),
-    };
-    let Some((name, tag)) = left.split_once(':') else {
+    if config::node::parse_node_ref(source).is_err() {
         return false;
-    };
-    if name.is_empty() || tag.is_empty() {
-        return false;
-    }
-    if name.contains(':') || tag.contains(':') {
-        return false;
-    }
-    // Reject strings with multiple `@` (`a:b@c@v`) or with `@` inside the
-    // name/tag slice — both would not be valid repo-node references.
-    if name.contains('@') || tag.contains('@') {
-        return false;
-    }
-    if let Some(v) = variant {
-        if v.is_empty() || v.contains('@') || v.contains(':') {
-            return false;
-        }
     }
     // Don't treat `some:path` as repo-node if a matching file/dir exists
     // on disk.
-    if Path::new(source).exists() {
-        return false;
-    }
-    true
+    !Path::new(source).exists()
 }
 
 pub fn parse_node_source(source: &str, git_ref: Option<String>) -> Result<NodeSource> {

--- a/crates/peppy/src/commands/node/source.rs
+++ b/crates/peppy/src/commands/node/source.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 
 use config::consts::NODE_CONFIG_FILE;
 use config::node::{NodeConfigParser, find_root_node_dir};
-use core_node_api::encoding::{DepVariantOverride, NodeSource};
+use core_node_api::encoding::NodeSource;
 use gix_url::Url as GitUrl;
 
 use crate::error::{Error, Result};
@@ -11,14 +11,15 @@ pub fn is_probably_remote_source(source: &str) -> bool {
     source.contains("://") || source.starts_with("git@")
 }
 
-/// Heuristic: does this string look like `<name>:<tag>` and NOT like a
-/// filesystem path or URL?
+/// Heuristic: does this string look like `<name>:<tag>` (or
+/// `<name>:<tag>@<variant>`) and NOT like a filesystem path or URL?
 ///
 /// - Must not contain `/` or `\` (those would make it a path).
 /// - Must not contain `://` (URLs are caught upstream).
 /// - Must not start with `.` or `~` (relative paths).
 /// - Must contain exactly one `:` separating a non-empty name from a
-///   non-empty tag, neither of which may contain further `:` or `@`.
+///   non-empty tag, neither of which may contain further `:`.
+/// - May carry a single trailing `@variant` suffix.
 /// - The arg must not exist on disk (a directory named `foo:bar` wins).
 pub fn looks_like_repo_node_ref(source: &str) -> bool {
     if source.contains('/') || source.contains('\\') {
@@ -30,7 +31,11 @@ pub fn looks_like_repo_node_ref(source: &str) -> bool {
     if source.starts_with('.') || source.starts_with('~') {
         return false;
     }
-    let Some((name, tag)) = source.split_once(':') else {
+    let (left, variant) = match source.split_once('@') {
+        Some((left, variant)) => (left, Some(variant)),
+        None => (source, None),
+    };
+    let Some((name, tag)) = left.split_once(':') else {
         return false;
     };
     if name.is_empty() || tag.is_empty() {
@@ -39,8 +44,15 @@ pub fn looks_like_repo_node_ref(source: &str) -> bool {
     if name.contains(':') || tag.contains(':') {
         return false;
     }
+    // Reject strings with multiple `@` (`a:b@c@v`) or with `@` inside the
+    // name/tag slice — both would not be valid repo-node references.
     if name.contains('@') || tag.contains('@') {
         return false;
+    }
+    if let Some(v) = variant {
+        if v.is_empty() || v.contains('@') || v.contains(':') {
+            return false;
+        }
     }
     // Don't treat `some:path` as repo-node if a matching file/dir exists
     // on disk.
@@ -78,10 +90,10 @@ pub fn parse_node_source(source: &str, git_ref: Option<String>) -> Result<NodeSo
                 "`--ref` is only supported for git sources".to_string(),
             ));
         }
-        let (name, tag) = source
-            .split_once(':')
-            .expect("looks_like_repo_node_ref guarantees a ':'");
-        return NodeSource::repo_node(name, tag).map_err(|e| Error::ExecutionFailed(e.to_string()));
+        let (name, tag, variant) = config::node::parse_node_ref(source)
+            .map_err(|e| Error::ExecutionFailed(e.to_string()))?;
+        return NodeSource::repo_node(name, tag, variant)
+            .map_err(|e| Error::ExecutionFailed(e.to_string()));
     }
 
     if git_ref.is_some() {
@@ -177,125 +189,24 @@ pub fn parse_variant_source(variant: &str) -> Result<NodeSource> {
     Ok(NodeSource::Fs(PathBuf::from(variant)))
 }
 
-/// Parsed result of a single `--variant <v>` CLI flag.
-#[derive(Debug, PartialEq, Eq)]
-pub enum VariantArg {
-    /// Root-level variant: a name, a Git URL, or an HTTP URL.
-    Root(NodeSource),
-    /// Dependency-level override: `name:tag@variant_name`.
-    Dep(DepVariantOverride),
+/// Parses the root `--variant` arg into a [`NodeSource`]. Variants for
+/// transitive dependencies are no longer routed through the CLI — manifests
+/// declare them directly via `depends_on[].variant`.
+pub fn parse_root_variant_arg(arg: &str) -> Result<NodeSource> {
+    parse_variant_source(arg)
 }
 
-/// Parses one `--variant` argument into either a root-level variant
-/// selection or a dep-level override.
-///
-/// Accepted shapes:
-/// - `name:tag@variant_name` → [`VariantArg::Dep`].
-/// - Any URL / plain name → [`VariantArg::Root`].
-///
-/// Returns an error for malformed dep-override shapes such as `foo@bar`
-/// (missing `:tag`), `foo:tag@` (empty variant), `:tag@v` (empty name),
-/// and `foo:@v` (empty tag).
-pub fn parse_variant_arg(arg: &str) -> Result<VariantArg> {
-    if let Some((left, variant)) = arg.rsplit_once('@')
-        && looks_like_dep_override_shape(left, variant, arg)
-    {
-        let (name, tag) = left.split_once(':').expect("split_once validated above");
-        if name.is_empty() {
-            return Err(Error::ExecutionFailed(format!(
-                "invalid --variant '{arg}': empty dependency name before ':'"
-            )));
-        }
-        if tag.is_empty() {
-            return Err(Error::ExecutionFailed(format!(
-                "invalid --variant '{arg}': empty dependency tag between ':' and '@'"
-            )));
-        }
-        if variant.is_empty() {
-            return Err(Error::ExecutionFailed(format!(
-                "invalid --variant '{arg}': empty variant name after '@'"
-            )));
-        }
-        return Ok(VariantArg::Dep(DepVariantOverride {
-            name: name.to_owned(),
-            tag: tag.to_owned(),
-            variant: variant.to_owned(),
-        }));
+/// Validates that at most one root-level `--variant` was supplied and
+/// returns the parsed source (or `None` when the list is empty). Dep-level
+/// overrides are no longer accepted; manifests carry the wiring instead.
+pub fn parse_root_variant_args(raw: &[String]) -> Result<Option<NodeSource>> {
+    match raw.len() {
+        0 => Ok(None),
+        1 => Ok(Some(parse_root_variant_arg(&raw[0])?)),
+        _ => Err(Error::ExecutionFailed(
+            "only one root --variant may be given per invocation; declare dependency variants on each manifest's `depends_on[].variant`".to_owned(),
+        )),
     }
-    parse_variant_source(arg).map(VariantArg::Root)
-}
-
-/// Returns `true` when `left@right` (the original arg split on the
-/// **last** `@`) is shaped like a dep-override and not an ordinary
-/// URL with an `@ref` suffix.
-///
-/// - `left` must contain a `:` (the name:tag separator).
-/// - `left` must not look like a git URL (no `.git`, no scheme) —
-///   otherwise the `@` is a ref marker for [`parse_variant_source`].
-fn looks_like_dep_override_shape(left: &str, right: &str, original: &str) -> bool {
-    // Exactly one `:` (the name:tag separator) — `a:b:c` is malformed.
-    if left.matches(':').count() != 1 {
-        return false;
-    }
-    // `rsplit_once('@')` already peeled off the variant; any remaining `@`
-    // in `left` means the original had multiple `@`s (e.g. `a:b@c@v`).
-    if left.contains('@') {
-        return false;
-    }
-    // A URL (http://…) will contain `://` — and that colon must not be
-    // misinterpreted as a name:tag separator.
-    if left.contains("://") || original.contains("://") {
-        return false;
-    }
-    if left.contains(".git") {
-        return false;
-    }
-    if left.starts_with("git@") {
-        return false;
-    }
-    // Name portion should not contain path-separator-like characters.
-    if left.contains('/') || left.contains('\\') {
-        return false;
-    }
-    // Variant name can't contain whitespace or slashes.
-    if right.chars().any(|c| c.is_whitespace() || c == '/') {
-        return false;
-    }
-    true
-}
-
-/// Splits a list of raw `--variant` strings into (root, deps), validating:
-/// - at most one root-form `--variant`;
-/// - no duplicate dep overrides for the same `name:tag`.
-pub fn split_variant_args(raw: &[String]) -> Result<(Option<NodeSource>, Vec<DepVariantOverride>)> {
-    let mut root: Option<NodeSource> = None;
-    let mut deps: Vec<DepVariantOverride> = Vec::new();
-    let mut seen: std::collections::HashSet<(String, String)> = std::collections::HashSet::new();
-
-    for entry in raw {
-        match parse_variant_arg(entry)? {
-            VariantArg::Root(src) => {
-                if root.is_some() {
-                    return Err(Error::ExecutionFailed(
-                        "only one root --variant may be given per invocation; use `name:tag@variant` for dependency overrides".to_owned(),
-                    ));
-                }
-                root = Some(src);
-            }
-            VariantArg::Dep(ov) => {
-                let key = (ov.name.clone(), ov.tag.clone());
-                if !seen.insert(key) {
-                    return Err(Error::ExecutionFailed(format!(
-                        "duplicate --variant override for {}:{}",
-                        ov.name, ov.tag
-                    )));
-                }
-                deps.push(ov);
-            }
-        }
-    }
-
-    Ok((root, deps))
 }
 
 pub fn is_supported_http_archive(url: &url::Url) -> bool {
@@ -459,131 +370,78 @@ mod tests {
     }
 
     #[test]
-    fn looks_like_repo_node_ref_rejects_arg_with_at() {
-        // `foo:bar@variant` is a dep-variant override, not a source.
-        assert!(!looks_like_repo_node_ref("foo:bar@x"));
+    fn looks_like_repo_node_ref_accepts_name_tag_with_variant() {
+        // `foo:bar@variant` is now a valid repo-node reference; the variant
+        // segment is parsed by `config::node::parse_node_ref`.
+        assert!(looks_like_repo_node_ref("foo:bar@x"));
     }
 
     #[test]
     fn parse_node_source_recognizes_name_tag() {
         let src = parse_node_source("some_node:1.2.3", None).unwrap();
-        let NodeSource::RepoNode { name, tag, .. } = &src else {
+        let NodeSource::RepoNode {
+            name, tag, variant, ..
+        } = &src
+        else {
             panic!("expected RepoNode, got {:?}", src);
         };
         assert_eq!(name, "some_node");
         assert_eq!(tag, "1.2.3");
+        assert_eq!(variant, config::node::DEFAULT_VARIANT_NAME);
     }
 
     #[test]
-    fn parse_variant_arg_plain_name_is_root() {
-        let got = parse_variant_arg("mock-python").unwrap();
-        assert_eq!(
-            got,
-            VariantArg::Root(NodeSource::Fs(PathBuf::from("mock-python")))
-        );
+    fn parse_node_source_recognizes_name_tag_variant() {
+        let src = parse_node_source("some_node:1.2.3@v1", None).unwrap();
+        let NodeSource::RepoNode {
+            name, tag, variant, ..
+        } = &src
+        else {
+            panic!("expected RepoNode, got {:?}", src);
+        };
+        assert_eq!(name, "some_node");
+        assert_eq!(tag, "1.2.3");
+        assert_eq!(variant, "v1");
     }
 
     #[test]
-    fn parse_variant_arg_http_url_is_root() {
-        let got = parse_variant_arg("https://example.com/variant.tar.zst").unwrap();
-        assert!(matches!(got, VariantArg::Root(NodeSource::Http { .. })));
+    fn parse_root_variant_arg_plain_name() {
+        let got = parse_root_variant_arg("mock-python").unwrap();
+        assert_eq!(got, NodeSource::Fs(PathBuf::from("mock-python")));
     }
 
     #[test]
-    fn parse_variant_arg_git_url_is_root() {
-        let got = parse_variant_arg("https://github.com/foo/bar.git/x").unwrap();
-        assert!(matches!(got, VariantArg::Root(NodeSource::Git { .. })));
+    fn parse_root_variant_arg_http_url() {
+        let got = parse_root_variant_arg("https://example.com/variant.tar.zst").unwrap();
+        assert!(matches!(got, NodeSource::Http { .. }));
     }
 
     #[test]
-    fn parse_variant_arg_dep_override_parsed() {
-        let got = parse_variant_arg("uvc_camera:0.1.0@mock-python").unwrap();
-        match got {
-            VariantArg::Dep(ov) => {
-                assert_eq!(ov.name, "uvc_camera");
-                assert_eq!(ov.tag, "0.1.0");
-                assert_eq!(ov.variant, "mock-python");
-            }
-            other => panic!("expected dep override, got {:?}", other),
-        }
+    fn parse_root_variant_arg_git_url() {
+        let got = parse_root_variant_arg("https://github.com/foo/bar.git/x").unwrap();
+        assert!(matches!(got, NodeSource::Git { .. }));
     }
 
     #[test]
-    fn parse_variant_arg_rejects_malformed_dep() {
-        // Missing :tag before @
-        assert!(parse_variant_arg("foo@bar").is_ok()); // `foo@bar` => root variant name "foo@bar"
-        // Empty tag between ':' and '@'
-        assert!(parse_variant_arg("foo:@bar").is_err());
-        // Empty variant after '@'
-        assert!(parse_variant_arg("foo:tag@").is_err());
-        // Empty name before ':'
-        assert!(parse_variant_arg(":tag@variant").is_err());
+    fn parse_root_variant_args_accepts_empty() {
+        assert!(parse_root_variant_args(&[]).unwrap().is_none());
     }
 
     #[test]
-    fn parse_variant_arg_rejects_extra_colons_in_dep_shape() {
-        // `a:b:c@v` has two `:` in the left — it is not a well-formed
-        // dep override and must not produce `VariantArg::Dep`. It should
-        // fall through to `parse_variant_source` and be treated as a
-        // (malformed but non-dep) plain-name root variant.
-        let got = parse_variant_arg("a:b:c@v").unwrap();
-        assert!(
-            !matches!(got, VariantArg::Dep(_)),
-            "expected non-Dep parse for 'a:b:c@v', got {:?}",
-            got
-        );
+    fn parse_root_variant_args_accepts_single_root() {
+        let got = parse_root_variant_args(&["mock-python".to_owned()]).unwrap();
+        assert!(got.is_some());
     }
 
     #[test]
-    fn parse_variant_arg_rejects_extra_at_in_dep_shape() {
-        // `a:b@c@v` — after peeling the last `@`, `left = "a:b@c"` still
-        // contains `@`, which means the string has too many `@` markers
-        // for a dep override.
-        let got = parse_variant_arg("a:b@c@v").unwrap();
-        assert!(
-            !matches!(got, VariantArg::Dep(_)),
-            "expected non-Dep parse for 'a:b@c@v', got {:?}",
-            got
-        );
-    }
-
-    #[test]
-    fn split_variant_args_accepts_root_only() {
-        let (root, deps) = split_variant_args(&["mock-python".to_owned()]).unwrap();
-        assert!(root.is_some());
-        assert!(deps.is_empty());
-    }
-
-    #[test]
-    fn split_variant_args_accepts_deps_only() {
-        let (root, deps) =
-            split_variant_args(&["a:1.0@v1".to_owned(), "b:2.0@v2".to_owned()]).unwrap();
-        assert!(root.is_none());
-        assert_eq!(deps.len(), 2);
-    }
-
-    #[test]
-    fn split_variant_args_accepts_root_plus_deps() {
-        let (root, deps) =
-            split_variant_args(&["mock-python".to_owned(), "a:1.0@v1".to_owned()]).unwrap();
-        assert!(root.is_some());
-        assert_eq!(deps.len(), 1);
-    }
-
-    #[test]
-    fn split_variant_args_rejects_two_root_forms() {
-        let err = split_variant_args(&["mock-python".to_owned(), "alt".to_owned()]).unwrap_err();
+    fn parse_root_variant_args_rejects_multiple() {
+        let err =
+            parse_root_variant_args(&["mock-python".to_owned(), "alt".to_owned()]).unwrap_err();
         let msg = err.to_string();
         assert!(
             msg.contains("only one root --variant"),
             "expected multi-root rejection, got: {msg}"
         );
-    }
-
-    #[test]
-    fn split_variant_args_rejects_duplicate_dep_names() {
-        let err = split_variant_args(&["a:1.0@v1".to_owned(), "a:1.0@v2".to_owned()]).unwrap_err();
-        assert!(err.to_string().contains("duplicate"));
     }
 
     #[test]

--- a/crates/peppy/src/commands/stack/list.rs
+++ b/crates/peppy/src/commands/stack/list.rs
@@ -167,7 +167,7 @@ fn write_row(out: &mut String, cells: &[String; 5], widths: &[usize; 5]) {
 }
 
 fn variant_label(node: &SerializedNode) -> &str {
-    node.variant_name.as_deref().unwrap_or("default")
+    &node.variant
 }
 
 /// Compact per-node instance summary. Detailed per-instance info is
@@ -211,7 +211,7 @@ mod tests {
         name: &str,
         tag: &str,
         stage: NodeStage,
-        variant: Option<&str>,
+        variant: &str,
         instances: Vec<(&str, InstanceState)>,
     ) -> SerializedNode {
         SerializedNode {
@@ -227,19 +227,19 @@ mod tests {
                     state,
                 })
                 .collect(),
-            variant_name: variant.map(str::to_owned),
+            variant: variant.to_owned(),
         }
     }
 
     #[test]
     fn table_renders_headers_and_rows() {
         let nodes = vec![
-            node("sensor", "0.1.0", NodeStage::Added, Some("default"), vec![]),
+            node("sensor", "0.1.0", NodeStage::Added, "default", vec![]),
             node(
                 "brain",
                 "0.1.0",
                 NodeStage::Ready,
-                Some("macos"),
+                "macos",
                 vec![("i1", InstanceState::Running)],
             ),
         ];
@@ -266,7 +266,7 @@ mod tests {
 
     #[test]
     fn variant_falls_back_to_default_when_none() {
-        let nodes = vec![node("sensor", "0.1.0", NodeStage::Added, None, vec![])];
+        let nodes = vec![node("sensor", "0.1.0", NodeStage::Added, "default", vec![])];
         let out = format_stack_list(&nodes, &[]);
         assert!(
             out.contains("default"),
@@ -281,7 +281,7 @@ mod tests {
             "brain",
             "0.1.0",
             NodeStage::Ready,
-            Some("default"),
+            "default",
             vec![
                 ("r1", InstanceState::Running),
                 ("s1", InstanceState::Starting),
@@ -309,8 +309,8 @@ mod tests {
 
     #[test]
     fn edges_render_as_arrows() {
-        let from = node("brain", "0.1.0", NodeStage::Ready, None, vec![]);
-        let to = node("sensor", "0.1.0", NodeStage::Ready, None, vec![]);
+        let from = node("brain", "0.1.0", NodeStage::Ready, "default", vec![]);
+        let to = node("sensor", "0.1.0", NodeStage::Ready, "default", vec![]);
         let edges = vec![SerializedEdge {
             from: from.clone(),
             to: to.clone(),

--- a/crates/peppy/tests/node_info.rs
+++ b/crates/peppy/tests/node_info.rs
@@ -144,7 +144,7 @@ fn fetch_info(
     let response = added
         .rt
         .block_on(poll_node_info(
-            &NodeInfoRequest::new(node_name, node_tag),
+            &NodeInfoRequest::new(node_name, node_tag, "default".to_string()),
             messenger_handle,
             &added.core_node_name,
             CALLER_INSTANCE_ID,
@@ -421,7 +421,7 @@ fn node_info_returns_not_in_stack_when_node_not_in_stack() {
 
     let response = rt
         .block_on(poll_node_info(
-            &NodeInfoRequest::new("ghost_node", "9.9.9"),
+            &NodeInfoRequest::new("ghost_node", "9.9.9", "default".to_string()),
             &caller_handle,
             &core_node_name,
             CALLER_INSTANCE_ID,

--- a/crates/peppy/tests/node_remove.rs
+++ b/crates/peppy/tests/node_remove.rs
@@ -113,7 +113,11 @@ fn node_remove_command_succeeds() {
 
     NodeCommand {
         command: NodeCommands::Remove {
-            node_ref: (node_name.to_string(), node_tag.to_string()),
+            node_ref: (
+                node_name.to_string(),
+                node_tag.to_string(),
+                "default".to_string(),
+            ),
             stop_instances: false,
             force: false,
         },
@@ -258,7 +262,11 @@ fn node_remove_command_force_bypasses_prompt_and_stops_instances() {
 
     NodeCommand {
         command: NodeCommands::Remove {
-            node_ref: (node_name.to_string(), node_tag.to_string()),
+            node_ref: (
+                node_name.to_string(),
+                node_tag.to_string(),
+                "default".to_string(),
+            ),
             stop_instances: false,
             force: true,
         },
@@ -403,7 +411,11 @@ fn node_remove_command_with_stop_instances_succeeds_and_stops_instances() {
 
     NodeCommand {
         command: NodeCommands::Remove {
-            node_ref: (node_name.to_string(), node_tag.to_string()),
+            node_ref: (
+                node_name.to_string(),
+                node_tag.to_string(),
+                "default".to_string(),
+            ),
             stop_instances: true,
             force: false,
         },

--- a/crates/peppy/tests/node_run.rs
+++ b/crates/peppy/tests/node_run.rs
@@ -151,6 +151,7 @@ async fn node_run_command_succeeds() {
             idle_timeout: 60,
             max_timeout: 3600,
             build: false,
+            variant: "default".to_string(),
         },
     }
     .execute(&node_ctx)
@@ -378,6 +379,7 @@ async fn node_run_command_with_args_succeeds() {
             idle_timeout: 60,
             max_timeout: 3600,
             build: false,
+            variant: "default".to_string(),
         },
     }
     .execute(&node_ctx)
@@ -576,6 +578,7 @@ async fn node_run_command_with_custom_instance_id_succeeds() {
             idle_timeout: 60,
             max_timeout: 3600,
             build: false,
+            variant: "default".to_string(),
         },
     }
     .execute(&node_ctx)
@@ -704,7 +707,7 @@ async fn node_run_with_build_flag_on_unbuilt_node_builds_then_runs() {
     // Pre-state: the node is in the stack and is in the `Added` stage
     // (not yet built).
     let info_response = poll_node_info(
-        &NodeInfoRequest::new(node_name, "0.1.0"),
+        &NodeInfoRequest::new(node_name, "0.1.0", "default".to_string()),
         messenger_handle,
         &core_node_name,
         CALLER_INSTANCE_ID,
@@ -749,6 +752,7 @@ async fn node_run_with_build_flag_on_unbuilt_node_builds_then_runs() {
             idle_timeout: 60,
             max_timeout: 3600,
             build: true,
+            variant: "default".to_string(),
         },
     }
     .execute(&node_ctx)
@@ -866,7 +870,7 @@ async fn node_run_with_build_flag_on_already_built_node_skips_build() {
 
     // Sanity check: node is in `Ready` stage before we run `-b`.
     let info_response = poll_node_info(
-        &NodeInfoRequest::new(node_name, "0.1.0"),
+        &NodeInfoRequest::new(node_name, "0.1.0", "default".to_string()),
         messenger_handle,
         &core_node_name,
         CALLER_INSTANCE_ID,
@@ -911,6 +915,7 @@ async fn node_run_with_build_flag_on_already_built_node_skips_build() {
             idle_timeout: 60,
             max_timeout: 3600,
             build: true,
+            variant: "default".to_string(),
         },
     }
     .execute(&node_ctx)

--- a/crates/peppy/tests/node_stop.rs
+++ b/crates/peppy/tests/node_stop.rs
@@ -159,6 +159,7 @@ async fn node_stop_command_succeeds() {
             idle_timeout: 60,
             max_timeout: 3600,
             build: false,
+            variant: "default".to_string(),
         },
     }
     .execute(&node_ctx)

--- a/crates/peppy/tests/stack_list.rs
+++ b/crates/peppy/tests/stack_list.rs
@@ -58,6 +58,7 @@ fn make_consumer_depend_on_provider(
             name: ConfigName::new(provider_name).expect("valid provider name"),
             tag: "0.1.0".to_string(),
             local_id: provider_name.to_string(),
+            variant: "default".to_string(),
         }],
     });
 

--- a/crates/peppylib-py/tests/core_node/test_stack.py
+++ b/crates/peppylib-py/tests/core_node/test_stack.py
@@ -22,7 +22,7 @@ def _sample_graph_json() -> str:
         "artifact_path": None,
         "stage": "Ready",
         "instances": [{"instance_id": "i1", "state": "running"}],
-        "variant_name": "default",
+        "variant": "default",
     }
     sensor = {
         "name": "sensor",
@@ -31,7 +31,7 @@ def _sample_graph_json() -> str:
         "artifact_path": None,
         "stage": "Added",
         "instances": [],
-        "variant_name": None,
+        "variant": "default",
     }
     graph = {
         "nodes": [brain, sensor],

--- a/crates/peppylib/tests/core_node/stack.rs
+++ b/crates/peppylib/tests/core_node/stack.rs
@@ -76,7 +76,7 @@ async fn stack_list_parses_graph_and_includes_dot_graph_when_requested() {
             instance_id: "i1".to_string(),
             state: InstanceState::Running,
         }],
-        variant_name: Some("default".to_string()),
+        variant: "default".to_string(),
     };
     let sensor = SerializedNode {
         name: "sensor".to_string(),
@@ -85,7 +85,7 @@ async fn stack_list_parses_graph_and_includes_dot_graph_when_requested() {
         artifact_path: None,
         stage: Some(NodeStage::Added),
         instances: vec![],
-        variant_name: None,
+        variant: "default".to_string(),
     };
     let graph = SerializedNodeGraph {
         nodes: vec![brain.clone(), sensor.clone()],
@@ -127,7 +127,7 @@ async fn stack_list_returns_none_dot_graph_when_not_requested() {
             instance_id: "i1".to_string(),
             state: InstanceState::Running,
         }],
-        variant_name: Some("default".to_string()),
+        variant: "default".to_string(),
     };
     let sensor = SerializedNode {
         name: "sensor".to_string(),
@@ -136,7 +136,7 @@ async fn stack_list_returns_none_dot_graph_when_not_requested() {
         artifact_path: None,
         stage: Some(NodeStage::Added),
         instances: vec![],
-        variant_name: None,
+        variant: "default".to_string(),
     };
     let graph = SerializedNodeGraph {
         nodes: vec![brain.clone(), sensor.clone()],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for node variants, allowing multiple configurations of the same node (identified by name, tag, and optional variant).
  * Extended node reference format from `name:tag` to `name:tag[@variant]` across all commands.
  * Updated build, run, stop, remove, and info operations to work with specific node variants.
  * Node stack listing and dependency resolution now variant-aware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->