### PR TITLE
docs: sync with PR #188

### DIFF
--- a/crates/config-internal/src/node/types.rs
+++ b/crates/config-internal/src/node/types.rs
@@ -1451,6 +1451,83 @@ mod tests {
     }
 
     #[test]
+    fn exposed_action_supports_optional_payloads() {
+        let json5 = r#"{
+            name: "move_arm",
+            goal_service: {
+                request_message_format: {
+                    feedback_frequency: "u32",
+                    desired_position: { $type: "array", $items: "f64", $length: 3 },
+                    desired_orientation: { $type: "array", $items: "f64", $length: 4 },
+                },
+                response_message_format: {
+                    accepted: "bool",
+                },
+            },
+            result_service: {
+                response_message_format: {
+                    success: "bool",
+                    message: "string",
+                    final_joint_positions: { $type: "array", $items: "f64" },
+                    final_ee_position: { $type: "array", $items: "f64", $length: 3 },
+                    action_time: "f64",
+                },
+            },
+        }"#;
+
+        let action: ExposedAction =
+            serde_json5::from_str(json5).expect("action with omitted optional payloads must parse");
+
+        assert_eq!(action.name, "move_arm");
+        assert!(
+            action.feedback_topic.is_none(),
+            "feedback_topic is optional"
+        );
+
+        let result = action
+            .result_service
+            .as_ref()
+            .expect("result_service is present");
+        assert!(
+            result.request_message_format.is_none(),
+            "result_service.request_message_format is optional"
+        );
+        assert!(
+            result.response_message_format.is_some(),
+            "result_service.response_message_format was provided"
+        );
+
+        let goal = action
+            .goal_service
+            .as_ref()
+            .expect("goal_service is present");
+        assert!(goal.request_message_format.is_some());
+        assert!(goal.response_message_format.is_some());
+    }
+
+    #[test]
+    fn exposed_action_accepts_empty_message_format_object() {
+        let json5 = r#"{
+            name: "calibrate",
+            goal_service: {
+                request_message_format: {},
+                response_message_format: { accepted: "bool" },
+            },
+        }"#;
+
+        let action: ExposedAction =
+            serde_json5::from_str(json5).expect("empty `{}` message format must parse");
+        let goal = action.goal_service.expect("goal_service is present");
+        let request = goal
+            .request_message_format
+            .expect("request_message_format is Some when `{}` is given explicitly");
+        assert!(
+            request.0.is_empty(),
+            "empty `{{}}` deserializes to an empty MessageFormat"
+        );
+    }
+
+    #[test]
     fn type_tokens_in_message_format() {
         // A snippet similar to the camera stream message_format
         let json5 = r#"{

--- a/crates/core-node-internal/tests/listen_for_node_init.rs
+++ b/crates/core-node-internal/tests/listen_for_node_init.rs
@@ -13,6 +13,8 @@ use std::fs;
 use std::time::Duration;
 use tempfile::tempdir;
 
+const NODE_INIT_TIMEOUT: Duration = Duration::from_secs(30);
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn listen_for_node_init_rust_success() {
     const NODE_NAME: &str = "example_node";
@@ -33,7 +35,7 @@ async fn listen_for_node_init_rust_success() {
         &started_core_node.core_node_name,
         CALLER_INSTANCE_ID,
         &started_core_node.core_node_name,
-        Duration::from_secs(10),
+        NODE_INIT_TIMEOUT,
     )
     .await
     .expect("node_init request should complete");
@@ -132,7 +134,7 @@ async fn listen_for_node_init_rust_container_success() {
         &started_core_node.core_node_name,
         CALLER_INSTANCE_ID,
         &started_core_node.core_node_name,
-        Duration::from_secs(10),
+        NODE_INIT_TIMEOUT,
     )
     .await
     .expect("node_init request should complete");
@@ -245,7 +247,7 @@ async fn listen_for_node_init_python_success() {
         &started_core_node.core_node_name,
         CALLER_INSTANCE_ID,
         &started_core_node.core_node_name,
-        Duration::from_secs(10),
+        NODE_INIT_TIMEOUT,
     )
     .await
     .expect("node_init request should complete");
@@ -347,7 +349,7 @@ async fn listen_for_node_init_python_container_success() {
         &started_core_node.core_node_name,
         CALLER_INSTANCE_ID,
         &started_core_node.core_node_name,
-        Duration::from_secs(10),
+        NODE_INIT_TIMEOUT,
     )
     .await
     .expect("node_init request should complete");
@@ -493,7 +495,7 @@ async fn listen_for_node_init_fails_if_directory_exists() {
         &started_core_node.core_node_name,
         CALLER_INSTANCE_ID,
         &started_core_node.core_node_name,
-        Duration::from_secs(10),
+        NODE_INIT_TIMEOUT,
     )
     .await
     .expect("node_init request should complete");

--- a/docs/src/content/docs/advanced_guides/actions.mdx
+++ b/docs/src/content/docs/advanced_guides/actions.mdx
@@ -100,7 +100,7 @@ Each action defines a `goal_service`, a `feedback_topic`, and a `result_service`
 }
 ```
 
-The `goal_service.request_message_format` is optional — an action can have no goal parameters (e.g. a `calibrate` action that just starts when fired).
+The `goal_service.request_message_format` is optional — an action can have no goal parameters (e.g. a `calibrate` action that just starts when fired). The `feedback_topic.message_format`, in contrast, is required: every feedback message carries a non-empty payload, since empty payloads are reserved as the framework's per-goal end-of-stream signal (see [Receiving feedback](#receiving-feedback)). Code generation will fail if `feedback_topic` is declared without a `message_format`.
 
 ### Handling goals
 

--- a/docs/src/content/docs/advanced_guides/actions.mdx
+++ b/docs/src/content/docs/advanced_guides/actions.mdx
@@ -100,9 +100,9 @@ Each action defines a `goal_service`, a `feedback_topic`, and a `result_service`
 }
 ```
 
-Every payload on `goal_service` and `result_service` is optional: any of `goal_service.request_message_format`, `goal_service.response_message_format`, `result_service.request_message_format`, and `result_service.response_message_format` can be omitted (or set to `{}`) when the corresponding payload is empty. For example, a `calibrate` action can omit `goal_service.request_message_format` because it has no goal parameters, and a `result_service` that only needs to signal completion can omit `request_message_format`. The `feedback_topic` block itself is also optional, so actions that don't stream progress can leave it out entirely.
+Every payload on `goal_service` and `result_service` is optional: any of `goal_service.request_message_format`, `goal_service.response_message_format`, `result_service.request_message_format`, and `result_service.response_message_format` can be omitted (or set to `{}`) when the corresponding payload is empty. For example, a `calibrate` action can omit `goal_service.request_message_format` because it has no goal parameters, and a `result_service` that only needs to signal completion can omit `request_message_format`.
 
-The `feedback_topic.message_format`, in contrast, is required when `feedback_topic` is present: every feedback message carries a non-empty payload, since empty payloads are reserved as the framework's per-goal end-of-stream signal (see [Receiving feedback](#receiving-feedback)). Code generation will fail if `feedback_topic` is declared without a `message_format`.
+The `feedback_topic` block is optional: actions that don't stream progress can omit it entirely. When you do declare `feedback_topic`, however, its `message_format` is required and cannot be empty: every feedback message must carry a non-empty payload, since empty payloads are reserved as the framework's per-goal end-of-stream signal (see [Receiving feedback](#receiving-feedback)). Code generation will fail if `feedback_topic` is declared without a `message_format`.
 
 ### Handling goals
 

--- a/docs/src/content/docs/advanced_guides/actions.mdx
+++ b/docs/src/content/docs/advanced_guides/actions.mdx
@@ -100,7 +100,9 @@ Each action defines a `goal_service`, a `feedback_topic`, and a `result_service`
 }
 ```
 
-The `goal_service.request_message_format` is optional — an action can have no goal parameters (e.g. a `calibrate` action that just starts when fired). The `feedback_topic.message_format`, in contrast, is required: every feedback message carries a non-empty payload, since empty payloads are reserved as the framework's per-goal end-of-stream signal (see [Receiving feedback](#receiving-feedback)). Code generation will fail if `feedback_topic` is declared without a `message_format`.
+Every payload on `goal_service` and `result_service` is optional: any of `goal_service.request_message_format`, `goal_service.response_message_format`, `result_service.request_message_format`, and `result_service.response_message_format` can be omitted (or set to `{}`) when the corresponding payload is empty. For example, a `calibrate` action can omit `goal_service.request_message_format` because it has no goal parameters, and a `result_service` that only needs to signal completion can omit `request_message_format`. The `feedback_topic` block itself is also optional, so actions that don't stream progress can leave it out entirely.
+
+The `feedback_topic.message_format`, in contrast, is required when `feedback_topic` is present: every feedback message carries a non-empty payload, since empty payloads are reserved as the framework's per-goal end-of-stream signal (see [Receiving feedback](#receiving-feedback)). Code generation will fail if `feedback_topic` is declared without a `message_format`.
 
 ### Handling goals
 


### PR DESCRIPTION
Automated doc update generated by `scripts/docs/update_docs.py`
in response to code changes in #188.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that goal/result message-format fields are optional when their payloads are empty and added examples; clarified feedback topics are optional but require a non-empty message format when declared.
* **Tests**
  * Added unit tests covering optional/empty message-format handling and feedback-format validation.
  * Standardized node-init timing across tests via a shared timeout constant.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Peppy-bot/peppy/pull/189)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->