### PR TITLE
Add launcher bindings business logic

### DIFF
--- a/crates/config-internal/src/consts.rs
+++ b/crates/config-internal/src/consts.rs
@@ -15,6 +15,13 @@ pub const PEPPY_MESSAGING_PORT_VAR_NAME: &str = "PEPPY_MESSAGING_PORT";
 pub const ALLOWED_CONFIG_CHARS: &str =
     "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-";
 
+/// Reserved literal that occupies the `link_id` slot on the wire when a
+/// producer is launched without an explicit binding. Consumers that opt into
+/// the producer-default path subscribe with this literal as their `link_id`
+/// filter. `pmi::DEFAULT_LINK_ID` re-exports this so the wire layer and the
+/// config layer share one source of truth.
+pub const DEFAULT_LINK_ID_SENTINEL: &str = "_";
+
 /// Minimum Python version required by peppylib and peppygen projects (e.g. "3.11").
 ///
 /// NOTE: When updating, also update the static files in `peppylib-py/`

--- a/crates/config-internal/src/error.rs
+++ b/crates/config-internal/src/error.rs
@@ -40,6 +40,42 @@ where
     })
 }
 
+/// Payload for [`ParsingError::BindingMissingForPinnedDep`]. Boxed in the
+/// variant so the five `String` fields do not inflate `ParsingError` past
+/// the `clippy::result_large_err` threshold.
+#[derive(Debug, Clone, Error)]
+#[error(
+    "instance `{owner_instance_id}` declares a pinned `depends_on.{kind}` \
+     entry for `{expected_name}:{expected_tag}` (link_id `{link_id}`) but the \
+     launcher has no matching binding; this would cause silent message loss"
+)]
+pub struct BindingMissingForPinnedDep {
+    pub owner_instance_id: String,
+    pub link_id: String,
+    pub kind: String,
+    pub expected_name: String,
+    pub expected_tag: String,
+}
+
+/// Payload for [`ParsingError::BindingTargetMismatch`]. Kept as a separate
+/// struct (and boxed in the variant) so the seven `String` fields do not
+/// inflate `ParsingError` past the `clippy::result_large_err` threshold.
+#[derive(Debug, Clone, Error)]
+#[error(
+    "binding `{binding}` on instance `{owner_instance_id}` targets instance \
+     `{target_instance_id}` (deploys `{actual_name}:{actual_tag}`), but the \
+     consumer's `depends_on.nodes` entry expects `{expected_name}:{expected_tag}`"
+)]
+pub struct BindingTargetMismatch {
+    pub owner_instance_id: String,
+    pub binding: String,
+    pub target_instance_id: String,
+    pub expected_name: String,
+    pub expected_tag: String,
+    pub actual_name: String,
+    pub actual_tag: String,
+}
+
 #[derive(Debug, Error, Clone)]
 pub enum ParsingError {
     // -- General yaml syntax
@@ -95,6 +131,34 @@ pub enum ParsingError {
         binding: String,
         instance_id: String,
     },
+    #[error(
+        "binding key `{binding}` on instance `{owner_instance_id}` is the reserved producer-default sentinel and cannot be used as a binding slot"
+    )]
+    BindingSentinelKey {
+        owner_instance_id: String,
+        binding: String,
+    },
+    #[error(
+        "binding `{binding}` on instance `{owner_instance_id}` does not match any `link_id` declared in the consumer's `depends_on` (declared link_ids: [{declared_link_ids}])"
+    )]
+    BindingDeadKey {
+        owner_instance_id: String,
+        binding: String,
+        declared_link_ids: String,
+    },
+    /// Boxed payload for the same reason as
+    /// [`ParsingError::BindingTargetMismatch`]: keeps the variant's
+    /// String-heavy struct from inflating `ParsingError`'s size past the
+    /// `clippy::result_large_err` threshold.
+    #[error(transparent)]
+    BindingMissingForPinnedDep(Box<BindingMissingForPinnedDep>),
+    /// Boxed payload so this variant does not grow `ParsingError` past the
+    /// `clippy::result_large_err` threshold; without the indirection, the
+    /// seven `String` fields would inflate every `Result<_, _>` that
+    /// transitively wraps a `ParsingError` (notably code generated against
+    /// `peppylib::PeppyError`).
+    #[error(transparent)]
+    BindingTargetMismatch(Box<BindingTargetMismatch>),
 
     // -- container config: mount paths
     #[error(
@@ -119,6 +183,10 @@ pub enum StructuredError {
         owner_instance_id: String,
         binding: String,
         instance_id: String,
+    },
+    BindingSentinelKey {
+        owner_instance_id: String,
+        binding: String,
     },
 }
 
@@ -148,6 +216,13 @@ impl From<StructuredError> for ParsingError {
                 owner_instance_id,
                 binding,
                 instance_id,
+            },
+            StructuredError::BindingSentinelKey {
+                owner_instance_id,
+                binding,
+            } => ParsingError::BindingSentinelKey {
+                owner_instance_id,
+                binding,
             },
         }
     }

--- a/crates/config-internal/src/error.rs
+++ b/crates/config-internal/src/error.rs
@@ -76,6 +76,23 @@ pub struct BindingTargetMismatch {
     pub actual_tag: String,
 }
 
+/// Payload for [`ParsingError::MissingInterface`]. Boxed in the variant so
+/// the six `String` fields do not inflate `ParsingError` past the
+/// `clippy::result_large_err` threshold.
+#[derive(Debug, Clone, Error)]
+#[error(
+    "`{dependant}`:{dependant_tag} expects {interface_kind} `{interface_name}` from \
+     `{dependency}`:{dependency_tag}, but it is not exposed"
+)]
+pub struct MissingInterface {
+    pub dependant: String,
+    pub dependant_tag: String,
+    pub dependency: String,
+    pub dependency_tag: String,
+    pub interface_kind: String,
+    pub interface_name: String,
+}
+
 #[derive(Debug, Error, Clone)]
 pub enum ParsingError {
     // -- General yaml syntax
@@ -167,6 +184,31 @@ pub enum ParsingError {
     InvalidMountPath(String, String),
     #[error("Invalid parameter reference `${{parameters:{0}}}` in mount path: {1}")]
     InvalidMountPathParameterRef(String, String),
+
+    // -- node dependency validation
+    #[error(
+        "`{dependant}:{dependant_tag}` depends on `{dependency}:{dependency_tag}`, but it does not exist in the stack"
+    )]
+    MissingDependency {
+        dependant: String,
+        dependant_tag: String,
+        dependency: String,
+        dependency_tag: String,
+    },
+    #[error(
+        "`{dependant}:{dependant_tag}` references undeclared link_id `{link_id}` in consumed interfaces"
+    )]
+    UndeclaredLinkId {
+        dependant: String,
+        dependant_tag: String,
+        link_id: String,
+    },
+    /// Boxed payload for the same reason as
+    /// [`ParsingError::BindingTargetMismatch`]: keeps the variant's
+    /// String-heavy struct from inflating `ParsingError`'s size past the
+    /// `clippy::result_large_err` threshold.
+    #[error(transparent)]
+    MissingInterface(Box<MissingInterface>),
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]

--- a/crates/config-internal/src/launcher.rs
+++ b/crates/config-internal/src/launcher.rs
@@ -1,3 +1,4 @@
+mod bindings;
 mod parse;
 mod types;
 
@@ -5,6 +6,7 @@ mod types;
 // The conventional filename is `peppy_launcher.json5` for standalone projects,
 // but the parser is filename-agnostic — repository discovery accepts any
 // `.json5` file whose body declares the launcher schema.
+pub use bindings::{BindingValidationItem, validate_bindings};
 pub use parse::PeppyLauncherParser;
 pub use types::{
     Deployment, DeploymentGitSource, DeploymentInstance, DeploymentLocalSource,

--- a/crates/config-internal/src/launcher.rs
+++ b/crates/config-internal/src/launcher.rs
@@ -9,5 +9,5 @@ pub use parse::PeppyLauncherParser;
 pub use types::{
     Deployment, DeploymentGitSource, DeploymentInstance, DeploymentLocalSource,
     DeploymentRepoSource, DeploymentSource, DeploymentUrlSource, FrameworkOverrides, Name,
-    PeppyLauncher,
+    PeppyLauncher, link_ids_by_instance_id,
 };

--- a/crates/config-internal/src/launcher/bindings.rs
+++ b/crates/config-internal/src/launcher/bindings.rs
@@ -4,22 +4,22 @@
 //! `depends_on` declarations and each binding target's deploying node.
 //!
 //! The producer's runtime `link_ids` are derived from the launcher's
-//! bindings at launch time (see [`config::launcher::link_ids_by_instance_id`]
-//! and [`crate::services::stack::launch::start_node_instances`]); the
-//! checks here exist to turn the three classes of silent-failure
+//! bindings at launch time (see [`super::types::link_ids_by_instance_id`]);
+//! the checks here exist to turn the three classes of silent-failure
 //! configurations into loud parse-time errors.
 
-use config::consts::DEFAULT_LINK_ID_SENTINEL;
-use config::launcher::DeploymentInstance;
-use config::node::DependsOn;
-use config::{BindingMissingForPinnedDep, BindingTargetMismatch, ParsingError};
+use crate::consts::DEFAULT_LINK_ID_SENTINEL;
+use crate::error::{BindingMissingForPinnedDep, BindingTargetMismatch, ParsingError};
+use crate::node::DependsOn;
 use std::collections::BTreeMap;
+
+use super::types::DeploymentInstance;
 
 /// Minimal view of one planned deployment needed for binding
 /// validation. Built by the launcher with borrowed references to avoid
-/// cloning the full `PlannedDeployment` graph; consumed by
+/// cloning the full planned-deployment graph; consumed by
 /// [`validate_bindings`].
-pub(super) struct BindingValidationItem<'a> {
+pub struct BindingValidationItem<'a> {
     pub node_name: &'a str,
     pub node_tag: &'a str,
     pub instances: &'a [DeploymentInstance],
@@ -38,7 +38,7 @@ pub(super) struct BindingValidationItem<'a> {
 /// Interface-typed deps bypass check 3 because they do not pre-commit
 /// to a producer node identity; verifying that the bound target
 /// `exposes` the interface contract is left to a future hardening pass.
-pub(super) fn validate_bindings(items: &[BindingValidationItem<'_>]) -> Vec<ParsingError> {
+pub fn validate_bindings(items: &[BindingValidationItem<'_>]) -> Vec<ParsingError> {
     let instance_to_item = build_instance_lookup(items);
 
     let mut errors: Vec<ParsingError> = Vec::new();
@@ -313,7 +313,7 @@ mod tests {
     /// guard against future deserializer loosening.
     #[test]
     fn skips_missing_when_link_id_is_underscore() {
-        use config::node::{Name as NodeName, NodeDependency};
+        use crate::node::{Name as NodeName, NodeDependency};
 
         let instances = parse_instances(r#"[{ instance_id: "cons1" }]"#);
         let depends_on = DependsOn {

--- a/crates/config-internal/src/launcher/types.rs
+++ b/crates/config-internal/src/launcher/types.rs
@@ -1,5 +1,6 @@
 use crate::{
     common::AnyType,
+    consts::DEFAULT_LINK_ID_SENTINEL,
     error::{ParsingError, StructuredError},
     internal::interface::validate_named_items,
     schema::PeppySchema,
@@ -112,21 +113,67 @@ pub struct DeploymentInstance {
     pub bindings: BTreeMap<String, String>,
 }
 
-/// Each key names a binding slot declared by the deployed node and each
-/// value points at an `instance_id` defined elsewhere in the launcher.
-/// Both sides are validated for non-emptiness and intra-collection
-/// duplicates via [`validate_named_items`]; the value's existence as an
-/// `instance_id` is checked later at the [`PeppyLauncher`] level once all
-/// deployments have been parsed.
+/// Each key is a `link_id` literal declared by the deployed node's
+/// `depends_on.{nodes,interfaces}` and each value points at the producer
+/// `instance_id` defined elsewhere in the launcher. Keys and values are
+/// validated for non-emptiness and intra-collection duplicates via
+/// [`validate_named_items`]; the reserved producer-default sentinel
+/// ([`DEFAULT_LINK_ID_SENTINEL`]) is rejected as a key here so the
+/// launcher cannot redundantly "bind" to the default. The value's
+/// existence as an `instance_id` is checked later at the
+/// [`PeppyLauncher`] level once all deployments have been parsed; the
+/// key's existence in the deployed node's `depends_on` and the producer
+/// identity are checked at launch time, when both the launcher and the
+/// node manifests are loaded.
 fn deserialize_bindings<'de, D>(deserializer: D) -> Result<BTreeMap<String, String>, D::Error>
 where
     D: Deserializer<'de>,
 {
     let map = BTreeMap::<String, String>::deserialize(deserializer)?;
     validate_named_items(map.keys().map(String::as_str), "binding").map_err(de::Error::custom)?;
-    validate_named_items(map.values().map(String::as_str), "binding target")
-        .map_err(de::Error::custom)?;
+    // Duplicate binding values are intentionally permitted: a single
+    // producer may serve multiple `link_id` slots on the same consumer
+    // (or across consumers), which the launch-time wiring materializes
+    // as a producer with multiple `link_ids` advertised in parallel.
+    // Only non-emptiness is enforced here.
+    for (key, value) in &map {
+        if value.trim().is_empty() {
+            return Err(de::Error::custom(format!(
+                "binding target for key `{key}` cannot be empty"
+            )));
+        }
+    }
+    if let Some(sentinel_key) = map.keys().find(|k| k.as_str() == DEFAULT_LINK_ID_SENTINEL) {
+        let err = StructuredError::BindingSentinelKey {
+            owner_instance_id: String::new(),
+            binding: sentinel_key.clone(),
+        };
+        return Err(de::Error::custom(err.json5_message()));
+    }
     Ok(map)
+}
+
+/// Walks every consumer instance's `bindings` map and inverts it to
+/// `producer_instance_id -> ordered, deduped Vec<link_id>`.
+///
+/// Ordering rule: deployments in slice order, instances in declared
+/// order, binding keys in `BTreeMap` lexicographic order. The first
+/// `link_id` encountered for a given producer is the primary entry on
+/// the wire (see `peppylib::messaging::topics::emit` for why ordering
+/// matters), so the order must be deterministic across reads.
+pub fn link_ids_by_instance_id(deployments: &[Deployment]) -> BTreeMap<String, Vec<String>> {
+    let mut out: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for deployment in deployments {
+        for instance in &deployment.instances {
+            for (link_id, target_instance_id) in &instance.bindings {
+                let entry = out.entry(target_instance_id.clone()).or_default();
+                if !entry.iter().any(|existing| existing == link_id) {
+                    entry.push(link_id.clone());
+                }
+            }
+        }
+    }
+    out
 }
 
 /// Per-instance framework knobs. Distinct from `arguments`: those are
@@ -455,8 +502,13 @@ mod tests {
         assert!(err.to_string().contains("empty"), "unexpected error: {err}");
     }
 
+    /// Two binding keys may point at the same producer `instance_id`:
+    /// that is the "one producer serves multiple `link_id` slots" case
+    /// the wiring step materializes as a producer with multiple
+    /// concurrent `link_ids` on the wire. Duplicates on the value side
+    /// are therefore intentionally permitted.
     #[test]
-    fn bindings_reject_duplicate_values() {
+    fn bindings_accept_duplicate_values() {
         let json5 = r#"{
             instance_id: "backbone",
             bindings: {
@@ -464,11 +516,15 @@ mod tests {
                 b: "cam_torso"
             }
         }"#;
-        let err = serde_json5::from_str::<DeploymentInstance>(json5)
-            .expect_err("duplicate binding target must be rejected");
-        assert!(
-            err.to_string().contains("duplicate"),
-            "unexpected error: {err}"
+        let instance: DeploymentInstance =
+            serde_json5::from_str(json5).expect("duplicate binding targets should now be accepted");
+        assert_eq!(
+            instance.bindings.get("a").map(String::as_str),
+            Some("cam_torso")
+        );
+        assert_eq!(
+            instance.bindings.get("b").map(String::as_str),
+            Some("cam_torso")
         );
     }
 
@@ -481,5 +537,159 @@ mod tests {
         )
         .expect_err("unknown framework key should be rejected");
         assert!(err.to_string().contains("unknown_knob"));
+    }
+
+    /// The reserved producer-default segment cannot appear as a binding
+    /// key. Using it would be a redundant no-op (the producer already
+    /// publishes under that segment when no binding is declared) and
+    /// likely indicates a misuse.
+    #[test]
+    fn bindings_reject_underscore_key() {
+        let json5 = r#"{
+            instance_id: "backbone",
+            bindings: { "_": "cam_torso" }
+        }"#;
+        let err = serde_json5::from_str::<DeploymentInstance>(json5)
+            .expect_err("`_` binding key must be rejected");
+        let parsing_err = ParsingError::from(err);
+        let ParsingError::BindingSentinelKey { binding, .. } = &parsing_err else {
+            panic!("expected BindingSentinelKey, got {parsing_err:?}");
+        };
+        assert_eq!(binding, "_");
+    }
+
+    fn make_deployments(json5: &str) -> Vec<Deployment> {
+        let launcher: PeppyLauncher =
+            serde_json5::from_str(json5).expect("launcher fixture should parse");
+        launcher.deployments
+    }
+
+    #[test]
+    fn link_ids_by_instance_id_empty_returns_empty() {
+        let deployments = make_deployments(
+            r#"{
+                peppy_schema: "launcher_v1",
+                deployments: [
+                    { source: { local: "./a" }, instances: [{ instance_id: "a1" }] }
+                ]
+            }"#,
+        );
+        assert!(link_ids_by_instance_id(&deployments).is_empty());
+    }
+
+    #[test]
+    fn link_ids_by_instance_id_single_consumer_collects_one_link_id() {
+        let deployments = make_deployments(
+            r#"{
+                peppy_schema: "launcher_v1",
+                deployments: [
+                    { source: { local: "./prod" }, instances: [{ instance_id: "prod1" }] },
+                    {
+                        source: { local: "./cons" },
+                        instances: [{
+                            instance_id: "cons1",
+                            bindings: { camera: "prod1" }
+                        }]
+                    }
+                ]
+            }"#,
+        );
+        let map = link_ids_by_instance_id(&deployments);
+        assert_eq!(map.get("prod1"), Some(&vec!["camera".to_string()]));
+        assert!(!map.contains_key("cons1"));
+    }
+
+    /// Two consumers pinning the same producer under DIFFERENT `link_id`s
+    /// produce a Vec with both entries, in the deterministic walk order
+    /// (deployments → instances → `BTreeMap` keys).
+    #[test]
+    fn link_ids_by_instance_id_two_consumers_distinct_link_ids_preserved_order() {
+        let deployments = make_deployments(
+            r#"{
+                peppy_schema: "launcher_v1",
+                deployments: [
+                    { source: { local: "./prod" }, instances: [{ instance_id: "prod1" }] },
+                    {
+                        source: { local: "./cons_a" },
+                        instances: [{
+                            instance_id: "cons_a1",
+                            bindings: { aaa: "prod1" }
+                        }]
+                    },
+                    {
+                        source: { local: "./cons_b" },
+                        instances: [{
+                            instance_id: "cons_b1",
+                            bindings: { zzz: "prod1" }
+                        }]
+                    }
+                ]
+            }"#,
+        );
+        let map = link_ids_by_instance_id(&deployments);
+        assert_eq!(
+            map.get("prod1"),
+            Some(&vec!["aaa".to_string(), "zzz".to_string()])
+        );
+    }
+
+    /// Two consumers using the SAME `link_id` for the same producer
+    /// collapse to a single entry. This is the load-shared subscriber
+    /// case.
+    #[test]
+    fn link_ids_by_instance_id_two_consumers_same_link_id_dedups() {
+        let deployments = make_deployments(
+            r#"{
+                peppy_schema: "launcher_v1",
+                deployments: [
+                    { source: { local: "./prod" }, instances: [{ instance_id: "prod1" }] },
+                    {
+                        source: { local: "./cons_a" },
+                        instances: [{
+                            instance_id: "cons_a1",
+                            bindings: { main: "prod1" }
+                        }]
+                    },
+                    {
+                        source: { local: "./cons_b" },
+                        instances: [{
+                            instance_id: "cons_b1",
+                            bindings: { main: "prod1" }
+                        }]
+                    }
+                ]
+            }"#,
+        );
+        let map = link_ids_by_instance_id(&deployments);
+        assert_eq!(map.get("prod1"), Some(&vec!["main".to_string()]));
+    }
+
+    /// A producer not pointed at by any consumer is absent from the map
+    /// entirely, so the caller can fall back to the empty-vec / default
+    /// path with a plain `unwrap_or_default()`.
+    #[test]
+    fn link_ids_by_instance_id_omits_unbound_producers() {
+        let deployments = make_deployments(
+            r#"{
+                peppy_schema: "launcher_v1",
+                deployments: [
+                    { source: { local: "./prod_a" }, instances: [{ instance_id: "prod_a1" }] },
+                    { source: { local: "./prod_b" }, instances: [{ instance_id: "prod_b1" }] },
+                    {
+                        source: { local: "./cons" },
+                        instances: [{
+                            instance_id: "cons1",
+                            bindings: { only: "prod_a1" }
+                        }]
+                    }
+                ]
+            }"#,
+        );
+        let map = link_ids_by_instance_id(&deployments);
+        assert_eq!(map.get("prod_a1"), Some(&vec!["only".to_string()]));
+        assert!(
+            !map.contains_key("prod_b1"),
+            "unbound producer should not appear in the lookup"
+        );
     }
 }

--- a/crates/config-internal/src/launcher/types.rs
+++ b/crates/config-internal/src/launcher/types.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use serde::{
     Deserialize, Serialize,
-    de::{self, Deserializer},
+    de::{self, Deserializer, MapAccess, Visitor},
 };
 use std::{
     collections::{BTreeMap, HashSet},
@@ -58,6 +58,13 @@ impl<'de> Deserialize<'de> for PeppyLauncher {
         for deployment in &raw.deployments {
             for instance in &deployment.instances {
                 for (binding, target) in &instance.bindings {
+                    if binding == DEFAULT_LINK_ID_SENTINEL {
+                        let err = StructuredError::BindingSentinelKey {
+                            owner_instance_id: instance.instance_id.to_string(),
+                            binding: binding.clone(),
+                        };
+                        return Err(de::Error::custom(err.json5_message()));
+                    }
                     if !known_ids.contains(target.as_str()) {
                         let err = StructuredError::UnknownInstanceId {
                             owner_instance_id: instance.instance_id.to_string(),
@@ -129,28 +136,49 @@ fn deserialize_bindings<'de, D>(deserializer: D) -> Result<BTreeMap<String, Stri
 where
     D: Deserializer<'de>,
 {
-    let map = BTreeMap::<String, String>::deserialize(deserializer)?;
-    validate_named_items(map.keys().map(String::as_str), "binding").map_err(de::Error::custom)?;
+    // Capture entries as a Vec to preserve duplicate keys: a direct
+    // BTreeMap::deserialize would silently overwrite, hiding the
+    // duplicate from `validate_named_items`. The sentinel-key check
+    // lives in `PeppyLauncher::deserialize` where the owning
+    // `instance_id` is in scope and can be attached to the structured
+    // error.
+    let entries = deserializer.deserialize_map(BindingEntriesVisitor)?;
+    validate_named_items(entries.iter().map(|(k, _)| k.as_str()), "binding")
+        .map_err(de::Error::custom)?;
     // Duplicate binding values are intentionally permitted: a single
     // producer may serve multiple `link_id` slots on the same consumer
     // (or across consumers), which the launch-time wiring materializes
     // as a producer with multiple `link_ids` advertised in parallel.
     // Only non-emptiness is enforced here.
-    for (key, value) in &map {
+    for (key, value) in &entries {
         if value.trim().is_empty() {
             return Err(de::Error::custom(format!(
                 "binding target for key `{key}` cannot be empty"
             )));
         }
     }
-    if let Some(sentinel_key) = map.keys().find(|k| k.as_str() == DEFAULT_LINK_ID_SENTINEL) {
-        let err = StructuredError::BindingSentinelKey {
-            owner_instance_id: String::new(),
-            binding: sentinel_key.clone(),
-        };
-        return Err(de::Error::custom(err.json5_message()));
+    Ok(entries.into_iter().collect())
+}
+
+struct BindingEntriesVisitor;
+
+impl<'de> Visitor<'de> for BindingEntriesVisitor {
+    type Value = Vec<(String, String)>;
+
+    fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("a map of binding link_id -> instance_id strings")
     }
-    Ok(map)
+
+    fn visit_map<A>(self, mut access: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let mut entries = Vec::with_capacity(access.size_hint().unwrap_or(0));
+        while let Some((key, value)) = access.next_entry::<String, String>()? {
+            entries.push((key, value));
+        }
+        Ok(entries)
+    }
 }
 
 /// Walks every consumer instance's `bindings` map and inverts it to
@@ -542,20 +570,52 @@ mod tests {
     /// The reserved producer-default segment cannot appear as a binding
     /// key. Using it would be a redundant no-op (the producer already
     /// publishes under that segment when no binding is declared) and
-    /// likely indicates a misuse.
+    /// likely indicates a misuse. The check runs at the launcher level
+    /// (rather than per-instance) so the structured error can carry the
+    /// owning `instance_id`.
     #[test]
     fn bindings_reject_underscore_key() {
         let json5 = r#"{
-            instance_id: "backbone",
-            bindings: { "_": "cam_torso" }
+            peppy_schema: "launcher_v1",
+            deployments: [
+                {
+                    source: { local: "./backbone" },
+                    instances: [{
+                        instance_id: "backbone",
+                        bindings: { "_": "backbone" }
+                    }]
+                }
+            ]
         }"#;
-        let err = serde_json5::from_str::<DeploymentInstance>(json5)
+        let err = serde_json5::from_str::<PeppyLauncher>(json5)
             .expect_err("`_` binding key must be rejected");
         let parsing_err = ParsingError::from(err);
-        let ParsingError::BindingSentinelKey { binding, .. } = &parsing_err else {
+        let ParsingError::BindingSentinelKey {
+            owner_instance_id,
+            binding,
+        } = &parsing_err
+        else {
             panic!("expected BindingSentinelKey, got {parsing_err:?}");
         };
+        assert_eq!(owner_instance_id, "backbone");
         assert_eq!(binding, "_");
+    }
+
+    /// Duplicate binding keys must be rejected. The raw map deserializer
+    /// must surface them before the BTreeMap collapses duplicates.
+    #[test]
+    fn bindings_reject_duplicate_keys() {
+        let json5 = r#"{
+            instance_id: "backbone",
+            bindings: { "main": "prod_a", "main": "prod_b" }
+        }"#;
+        let err = serde_json5::from_str::<DeploymentInstance>(json5)
+            .expect_err("duplicate binding key must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("duplicate") && msg.contains("main"),
+            "unexpected error: {msg}"
+        );
     }
 
     fn make_deployments(json5: &str) -> Vec<Deployment> {

--- a/crates/config-internal/src/lib.rs
+++ b/crates/config-internal/src/lib.rs
@@ -30,8 +30,8 @@ pub use common::{
 
 // -- error --
 pub use error::{
-    BindingMissingForPinnedDep, BindingTargetMismatch, Error as ConfigError, ParsingError,
-    Result as ConfigResult,
+    BindingMissingForPinnedDep, BindingTargetMismatch, Error as ConfigError, MissingInterface,
+    ParsingError, Result as ConfigResult,
 };
 
 // -- atomic_write --
@@ -82,12 +82,13 @@ pub mod node {
     pub use crate::internal::node::{
         ActionInterfaces, ActionServiceEndpoint, ActionTopicEndpoint, ArrayKind, ArraySchema,
         CallbackNameError, ConformsToItem, ConsumedAction, ConsumedService, ConsumedTopic,
-        ContainerConfig, DependsOn, EmittedTopic, Execution, ExposedAction, ExposedService,
-        ExternalConsumedTopic, InterfaceKind, Interfaces, LinkedConsumedTopic, Manifest,
-        MessageFormat, Name, NodeConfig, NodeConfigCreator, NodeConfigParser, NodeDependency,
-        ObjectKind, ObjectSchema, PeppygenLanguage, PrimitiveSchema, QoSProfile, SchemaType,
-        ServiceInterfaces, Toolchain, TopicInterfaces, TypeToken, extract_parameter_refs,
-        is_blocked_mount_source, load_standalone_node_config,
+        ContainerConfig, DependencySpec, DependsOn, EmittedTopic, Execution, ExposedAction,
+        ExposedService, ExternalConsumedTopic, InterfaceKind, Interfaces, LinkedConsumedTopic,
+        Manifest, MessageFormat, Name, NodeConfig, NodeConfigCreator, NodeConfigParser,
+        NodeDependency, ObjectKind, ObjectSchema, PeppygenLanguage, PrimitiveSchema, QoSProfile,
+        SchemaType, ServiceInterfaces, Toolchain, TopicInterfaces, TypeToken,
+        collect_dependency_specs, extract_parameter_refs, is_blocked_mount_source,
+        load_standalone_node_config, validate_dependency_specs,
     };
 }
 
@@ -101,9 +102,10 @@ pub mod runtime {
 // -- launcher --
 pub mod launcher {
     pub use crate::internal::launcher::{
-        Deployment, DeploymentGitSource, DeploymentInstance, DeploymentLocalSource,
-        DeploymentRepoSource, DeploymentSource, DeploymentUrlSource, FrameworkOverrides, Name,
-        PeppyLauncher, PeppyLauncherParser, link_ids_by_instance_id,
+        BindingValidationItem, Deployment, DeploymentGitSource, DeploymentInstance,
+        DeploymentLocalSource, DeploymentRepoSource, DeploymentSource, DeploymentUrlSource,
+        FrameworkOverrides, Name, PeppyLauncher, PeppyLauncherParser, link_ids_by_instance_id,
+        validate_bindings,
     };
 }
 

--- a/crates/config-internal/src/lib.rs
+++ b/crates/config-internal/src/lib.rs
@@ -29,7 +29,10 @@ pub use common::{
 };
 
 // -- error --
-pub use error::{Error as ConfigError, ParsingError, Result as ConfigResult};
+pub use error::{
+    BindingMissingForPinnedDep, BindingTargetMismatch, Error as ConfigError, ParsingError,
+    Result as ConfigResult,
+};
 
 // -- atomic_write --
 pub mod atomic_write {
@@ -40,9 +43,9 @@ pub mod atomic_write {
 pub mod consts {
     pub use crate::internal::consts::{
         ALLOWED_CONFIG_CHARS, AppEnv, CORE_NODE_TOPIC_NAME, DAEMON_STATE_FILE_ENV,
-        DEFAULT_ALPINE_BASE_IMAGE, DEFAULT_MESSAGING_HOST, DEFAULT_MESSAGING_PORT,
-        DEFAULT_PYTHON_BASE_IMAGE, DEFAULT_RUST_BASE_IMAGE, NODE_CONFIG_FILE,
-        PEPPY_MESSAGING_PORT_VAR_NAME, PEPPY_OUTPUT_DIR, PEPPYGEN_OUTPUT_PATH,
+        DEFAULT_ALPINE_BASE_IMAGE, DEFAULT_LINK_ID_SENTINEL, DEFAULT_MESSAGING_HOST,
+        DEFAULT_MESSAGING_PORT, DEFAULT_PYTHON_BASE_IMAGE, DEFAULT_RUST_BASE_IMAGE,
+        NODE_CONFIG_FILE, PEPPY_MESSAGING_PORT_VAR_NAME, PEPPY_OUTPUT_DIR, PEPPYGEN_OUTPUT_PATH,
         PEPPYLIB_OUTPUT_PATH, PYTHON_MAX_VERSION, PYTHON_MIN_VERSION, PeppyDirs,
         RUNTIME_CONFIG_VAR_NAME, app_env, set_app_env,
     };
@@ -100,7 +103,7 @@ pub mod launcher {
     pub use crate::internal::launcher::{
         Deployment, DeploymentGitSource, DeploymentInstance, DeploymentLocalSource,
         DeploymentRepoSource, DeploymentSource, DeploymentUrlSource, FrameworkOverrides, Name,
-        PeppyLauncher, PeppyLauncherParser,
+        PeppyLauncher, PeppyLauncherParser, link_ids_by_instance_id,
     };
 }
 

--- a/crates/config-internal/src/node.rs
+++ b/crates/config-internal/src/node.rs
@@ -1,6 +1,7 @@
 mod create;
 mod parse;
 mod types;
+mod validation;
 
 // Re-export functions
 pub use create::NodeConfigCreator;
@@ -14,3 +15,4 @@ pub use types::{
     QoSProfile, SchemaType, ServiceInterfaces, Toolchain, TopicInterfaces, TypeToken,
     extract_parameter_refs, is_blocked_mount_source,
 };
+pub use validation::{DependencySpec, collect_dependency_specs, validate_dependency_specs};

--- a/crates/config-internal/src/node/validation.rs
+++ b/crates/config-internal/src/node/validation.rs
@@ -1,30 +1,28 @@
+//! Plan-phase validation for a node's `depends_on` block and its
+//! consumed interfaces. Lives next to the types it validates so any
+//! consumer that parses a [`NodeConfig`] graph (launchers, the daemon's
+//! node stack, code-generation) can run the same checks without
+//! depending on a runtime crate.
+//!
+//! The validator is structural — it does not care which crate orchestrates
+//! the lookup. Callers supply a closure that resolves a `(name, tag)`
+//! pair to a [`NodeConfig`] from whatever store they own (an in-memory
+//! graph, a working stack snapshot, a parsed launcher batch, etc.).
+
 use std::collections::{HashMap, HashSet};
 
-use config::node::{InterfaceKind, Interfaces, Manifest, NodeConfig};
+use crate::error::{MissingInterface, ParsingError};
+use crate::node::{InterfaceKind, Interfaces, Manifest, NodeConfig};
 
-use super::entity::DependencySpec;
-
+/// Minimal `(name, tag)` view of a single `depends_on.nodes` entry,
+/// stripped of the link_id / from_any noise that callers don't need
+/// once dependency resolution has already happened. Used by
+/// [`collect_dependency_specs`] so callers can walk the dep set without
+/// re-deriving it from the manifest.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub(crate) struct InterfaceRequirement {
-    kind: InterfaceKind,
-    name: String,
-}
-
-impl InterfaceRequirement {
-    pub(super) fn new(kind: InterfaceKind, name: &str) -> Self {
-        Self {
-            kind,
-            name: name.trim().to_owned(),
-        }
-    }
-
-    pub(super) fn kind(&self) -> InterfaceKind {
-        self.kind
-    }
-
-    pub(super) fn name(&self) -> &str {
-        &self.name
-    }
+pub struct DependencySpec {
+    pub node_name: String,
+    pub node_tag: String,
 }
 
 pub fn collect_dependency_specs(node: &NodeConfig) -> Vec<DependencySpec> {
@@ -60,7 +58,7 @@ pub fn validate_dependency_specs(
     dependant_name: &str,
     dependant_tag: &str,
     resolve: impl Fn(&str, &str) -> Option<NodeConfig>,
-) -> Vec<crate::error::Error> {
+) -> Vec<ParsingError> {
     let mut errors = Vec::new();
 
     // Build link_id → (name, tag, resolved_config) lookup from depends_on.nodes
@@ -72,7 +70,7 @@ pub fn validate_dependency_specs(
             let dep_name = dep.name.as_str().to_owned();
             let dep_tag = dep.tag.clone();
             let Some(dependency_config) = resolve(&dep_name, &dep_tag) else {
-                errors.push(crate::error::Error::MissingDependency {
+                errors.push(ParsingError::MissingDependency {
                     dependant: dependant_name.to_owned(),
                     dependant_tag: dependant_tag.to_owned(),
                     dependency: dep_name,
@@ -105,7 +103,7 @@ pub fn validate_dependency_specs(
         && let Some(consumes) = &topics.consumes
     {
         let items = consumes.iter().filter_map(|t| match t {
-            config::node::ConsumedTopic::Linked(linked) => {
+            crate::node::ConsumedTopic::Linked(linked) => {
                 Some((linked.link_id.as_str(), linked.name.as_str()))
             }
             _ => None,
@@ -158,6 +156,29 @@ pub fn validate_dependency_specs(
     errors
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct InterfaceRequirement {
+    kind: InterfaceKind,
+    name: String,
+}
+
+impl InterfaceRequirement {
+    fn new(kind: InterfaceKind, name: &str) -> Self {
+        Self {
+            kind,
+            name: name.trim().to_owned(),
+        }
+    }
+
+    fn kind(&self) -> InterfaceKind {
+        self.kind
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+}
+
 /// Validates a set of consumed interfaces, checking that each `link_id` is declared
 /// and that the referenced dependency exposes the required interface.
 fn validate_consumed_items<'a>(
@@ -167,12 +188,12 @@ fn validate_consumed_items<'a>(
     declared_link_ids: &HashSet<&str>,
     dependant_name: &str,
     dependant_tag: &str,
-    errors: &mut Vec<crate::error::Error>,
+    errors: &mut Vec<ParsingError>,
 ) {
     for (link_id, name) in items {
         if !resolved_deps.contains_key(link_id) {
             if !declared_link_ids.contains(link_id) {
-                errors.push(crate::error::Error::UndeclaredLinkId {
+                errors.push(ParsingError::UndeclaredLinkId {
                     dependant: dependant_name.to_owned(),
                     dependant_tag: dependant_tag.to_owned(),
                     link_id: link_id.to_owned(),
@@ -201,7 +222,7 @@ fn validate_consumed_interface(
     resolved_deps: &HashMap<String, (String, String, NodeConfig)>,
     dependant_name: &str,
     dependant_tag: &str,
-    errors: &mut Vec<crate::error::Error>,
+    errors: &mut Vec<ParsingError>,
 ) {
     let Some((dep_name, dep_tag, dep_config)) = resolved_deps.get(link_id) else {
         // The link_id doesn't map to any resolved dependency.
@@ -213,18 +234,18 @@ fn validate_consumed_interface(
 
     let requirement = InterfaceRequirement::new(kind, interface_name);
     if !exposes_interface(dep_config, &requirement) {
-        errors.push(crate::error::Error::MissingInterface {
+        errors.push(ParsingError::MissingInterface(Box::new(MissingInterface {
             dependant: dependant_name.to_owned(),
             dependant_tag: dependant_tag.to_owned(),
             dependency: dep_name.clone(),
             dependency_tag: dep_tag.clone(),
             interface_kind: format!("{:?}", kind),
             interface_name: interface_name.to_owned(),
-        });
+        })));
     }
 }
 
-pub(crate) fn exposes_interface(node: &NodeConfig, requirement: &InterfaceRequirement) -> bool {
+fn exposes_interface(node: &NodeConfig, requirement: &InterfaceRequirement) -> bool {
     match requirement.kind() {
         InterfaceKind::Topic => node
             .interfaces

--- a/crates/core-node-internal/src/services/node/add.rs
+++ b/crates/core-node-internal/src/services/node/add.rs
@@ -19,7 +19,8 @@ use core_node_api::encoding::{
 };
 use futures::FutureExt;
 use node_stack::add_steps::{copy_node_to_temp_dir, verify_git_hash};
-use node_stack::{InstanceState, NodeStack, WorkingDirGuard, validate_dependency_specs};
+use config::node::validate_dependency_specs;
+use node_stack::{InstanceState, NodeStack, WorkingDirGuard};
 use parking_lot::Mutex as StdMutex;
 use peppylib::messaging::{ActionFeedbackPublisher, ServiceRequestContext};
 use peppylib::types::Payload;

--- a/crates/core-node-internal/src/services/node/sync.rs
+++ b/crates/core-node-internal/src/services/node/sync.rs
@@ -2,8 +2,9 @@ use crate::Result;
 use crate::names;
 use crate::services::node::cache as node_cache;
 use crate::services::repo::cache as repo_cache;
+use config::ParsingError;
 use config::consts::PeppyDirs;
-use config::node::NodeConfigParser;
+use config::node::{NodeConfigParser, validate_dependency_specs};
 use core_node_api::encoding::{NodeSyncRequest, NodeSyncResponse, RepoResolvedEntry};
 use generator::{ConsumedActionMessage, DeploymentInterface, InterfaceOrigin, InterfaceVariant};
 use node_stack::NodeStack;
@@ -273,7 +274,7 @@ async fn handle_node_sync_request_inner(
     } else {
         match NodeConfigParser::from_path(&node_config_path) {
             Ok(node_config) => {
-                let dep_errors = node_stack::validate_dependency_specs(
+                let dep_errors = validate_dependency_specs(
                     &node_config.manifest,
                     &node_config.interfaces,
                     node_config.manifest.name.as_str(),
@@ -286,7 +287,7 @@ async fn handle_node_sync_request_inner(
 
                 for err in &dep_errors {
                     match err {
-                        node_stack::NodeStackError::MissingDependency {
+                        ParsingError::MissingDependency {
                             dependency,
                             dependency_tag,
                             ..
@@ -294,22 +295,16 @@ async fn handle_node_sync_request_inner(
                             missing_dependencies
                                 .insert(format!("{}:{}", dependency, dependency_tag));
                         }
-                        node_stack::NodeStackError::MissingInterface {
-                            dependency,
-                            dependency_tag,
-                            interface_kind,
-                            interface_name,
-                            ..
-                        } => {
+                        ParsingError::MissingInterface(info) => {
                             missing_interfaces.push(format!(
                                 "expects {} `{}` from `{}:{}`, but it is not exposed",
-                                interface_kind.to_lowercase(),
-                                interface_name,
-                                dependency,
-                                dependency_tag
+                                info.interface_kind.to_lowercase(),
+                                info.interface_name,
+                                info.dependency,
+                                info.dependency_tag
                             ));
                         }
-                        node_stack::NodeStackError::UndeclaredLinkId { link_id, .. } => {
+                        ParsingError::UndeclaredLinkId { link_id, .. } => {
                             missing_interfaces
                                 .push(format!("references undeclared link_id `{}`", link_id));
                         }

--- a/crates/core-node-internal/src/services/stack.rs
+++ b/crates/core-node-internal/src/services/stack.rs
@@ -1,3 +1,4 @@
+mod bindings;
 mod launch;
 mod list;
 mod reset;

--- a/crates/core-node-internal/src/services/stack.rs
+++ b/crates/core-node-internal/src/services/stack.rs
@@ -1,4 +1,3 @@
-mod bindings;
 mod launch;
 mod list;
 mod reset;

--- a/crates/core-node-internal/src/services/stack/bindings.rs
+++ b/crates/core-node-internal/src/services/stack/bindings.rs
@@ -1,0 +1,503 @@
+//! Plan-phase validation for the launcher's per-instance `bindings`
+//! field. Runs after node configs are loaded so the validator can
+//! cross-reference the launcher's bindings against each consumer's
+//! `depends_on` declarations and each binding target's deploying node.
+//!
+//! The producer's runtime `link_ids` are derived from the launcher's
+//! bindings at launch time (see [`config::launcher::link_ids_by_instance_id`]
+//! and [`crate::services::stack::launch::start_node_instances`]); the
+//! checks here exist to turn the three classes of silent-failure
+//! configurations into loud parse-time errors.
+
+use config::consts::DEFAULT_LINK_ID_SENTINEL;
+use config::launcher::DeploymentInstance;
+use config::node::DependsOn;
+use config::{BindingMissingForPinnedDep, BindingTargetMismatch, ParsingError};
+use std::collections::BTreeMap;
+
+/// Minimal view of one planned deployment needed for binding
+/// validation. Built by the launcher with borrowed references to avoid
+/// cloning the full `PlannedDeployment` graph; consumed by
+/// [`validate_bindings`].
+pub(super) struct BindingValidationItem<'a> {
+    pub node_name: &'a str,
+    pub node_tag: &'a str,
+    pub instances: &'a [DeploymentInstance],
+    pub depends_on: Option<&'a DependsOn>,
+}
+
+/// Three sub-checks per consumer instance:
+///   1. Each `binding` key matches a `link_id` declared in the
+///      consumer's `depends_on.{nodes,interfaces}` (dead-binding check).
+///   2. Each pinned `depends_on` entry (`from_any: false` and a
+///      non-default `link_id`) has a matching binding declared on the
+///      consumer instance (no silent-loss check).
+///   3. For node-typed pinned deps, the binding's target instance
+///      deploys a node whose `(name, tag)` matches the dep declaration.
+///
+/// Interface-typed deps bypass check 3 because they do not pre-commit
+/// to a producer node identity; verifying that the bound target
+/// `exposes` the interface contract is left to a future hardening pass.
+pub(super) fn validate_bindings(items: &[BindingValidationItem<'_>]) -> Vec<ParsingError> {
+    let instance_to_item = build_instance_lookup(items);
+
+    let mut errors: Vec<ParsingError> = Vec::new();
+    for item in items {
+        let (declared_node_deps, declared_interface_deps) = collect_declared_deps(item.depends_on);
+        let declared_csv = format_declared_keys(&declared_node_deps, &declared_interface_deps);
+
+        for instance in item.instances {
+            check_dead_keys_and_target_mismatch(
+                instance,
+                &declared_node_deps,
+                &declared_interface_deps,
+                &declared_csv,
+                &instance_to_item,
+                &mut errors,
+            );
+            check_missing_pinned_bindings(instance, item.depends_on, &mut errors);
+        }
+    }
+
+    errors
+}
+
+fn build_instance_lookup<'a>(
+    items: &'a [BindingValidationItem<'a>],
+) -> BTreeMap<&'a str, &'a BindingValidationItem<'a>> {
+    let mut lookup = BTreeMap::new();
+    for item in items {
+        for instance in item.instances {
+            lookup.insert(instance.instance_id.as_str(), item);
+        }
+    }
+    lookup
+}
+
+/// `link_id` → producer `(name, tag)` lookup, populated from a
+/// consumer's `depends_on.nodes` or `depends_on.interfaces` list.
+type DeclaredDeps<'a> = BTreeMap<&'a str, (&'a str, &'a str)>;
+
+fn collect_declared_deps(depends_on: Option<&DependsOn>) -> (DeclaredDeps<'_>, DeclaredDeps<'_>) {
+    let mut nodes = BTreeMap::new();
+    let mut interfaces = BTreeMap::new();
+    if let Some(deps) = depends_on {
+        for dep in &deps.nodes {
+            nodes.insert(dep.link_id.as_str(), (dep.name.as_str(), dep.tag.as_str()));
+        }
+        for dep in &deps.interfaces {
+            interfaces.insert(dep.link_id.as_str(), (dep.name.as_str(), dep.tag.as_str()));
+        }
+    }
+    (nodes, interfaces)
+}
+
+fn format_declared_keys(nodes: &DeclaredDeps<'_>, interfaces: &DeclaredDeps<'_>) -> String {
+    let mut keys: Vec<&str> = nodes.keys().chain(interfaces.keys()).copied().collect();
+    keys.sort();
+    keys.dedup();
+    keys.join(", ")
+}
+
+fn check_dead_keys_and_target_mismatch(
+    instance: &DeploymentInstance,
+    declared_node_deps: &DeclaredDeps<'_>,
+    declared_interface_deps: &DeclaredDeps<'_>,
+    declared_csv: &str,
+    instance_to_item: &BTreeMap<&str, &BindingValidationItem<'_>>,
+    errors: &mut Vec<ParsingError>,
+) {
+    for (binding_key, target_id) in &instance.bindings {
+        let in_nodes = declared_node_deps.get(binding_key.as_str());
+        let in_interfaces = declared_interface_deps.contains_key(binding_key.as_str());
+        if in_nodes.is_none() && !in_interfaces {
+            errors.push(ParsingError::BindingDeadKey {
+                owner_instance_id: instance.instance_id.to_string(),
+                binding: binding_key.clone(),
+                declared_link_ids: declared_csv.to_string(),
+            });
+            continue;
+        }
+
+        let Some(&(expected_name, expected_tag)) = in_nodes else {
+            continue;
+        };
+        let Some(target_item) = instance_to_item.get(target_id.as_str()) else {
+            continue;
+        };
+        if target_item.node_name != expected_name || target_item.node_tag != expected_tag {
+            errors.push(ParsingError::BindingTargetMismatch(Box::new(
+                BindingTargetMismatch {
+                    owner_instance_id: instance.instance_id.to_string(),
+                    binding: binding_key.clone(),
+                    target_instance_id: target_id.clone(),
+                    expected_name: expected_name.to_string(),
+                    expected_tag: expected_tag.to_string(),
+                    actual_name: target_item.node_name.to_string(),
+                    actual_tag: target_item.node_tag.to_string(),
+                },
+            )));
+        }
+    }
+}
+
+fn check_missing_pinned_bindings(
+    instance: &DeploymentInstance,
+    depends_on: Option<&DependsOn>,
+    errors: &mut Vec<ParsingError>,
+) {
+    let Some(deps) = depends_on else {
+        return;
+    };
+    for dep in &deps.nodes {
+        if requires_binding(dep.from_any, &dep.link_id)
+            && !instance.bindings.contains_key(dep.link_id.as_str())
+        {
+            errors.push(ParsingError::BindingMissingForPinnedDep(Box::new(
+                BindingMissingForPinnedDep {
+                    owner_instance_id: instance.instance_id.to_string(),
+                    link_id: dep.link_id.clone(),
+                    kind: "nodes".to_string(),
+                    expected_name: dep.name.as_str().to_string(),
+                    expected_tag: dep.tag.clone(),
+                },
+            )));
+        }
+    }
+    for dep in &deps.interfaces {
+        if requires_binding(dep.from_any, &dep.link_id)
+            && !instance.bindings.contains_key(dep.link_id.as_str())
+        {
+            errors.push(ParsingError::BindingMissingForPinnedDep(Box::new(
+                BindingMissingForPinnedDep {
+                    owner_instance_id: instance.instance_id.to_string(),
+                    link_id: dep.link_id.clone(),
+                    kind: "interfaces".to_string(),
+                    expected_name: dep.name.as_str().to_string(),
+                    expected_tag: dep.tag.clone(),
+                },
+            )));
+        }
+    }
+}
+
+/// A pinned `depends_on` entry requires a launcher binding only when
+/// it commits to a non-default `link_id`. The reserved sentinel matches
+/// the producer's natural fallback so no binding is needed.
+fn requires_binding(from_any: bool, link_id: &str) -> bool {
+    !from_any && link_id != DEFAULT_LINK_ID_SENTINEL
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_instances(json5: &str) -> Vec<DeploymentInstance> {
+        serde_json5::from_str(json5).expect("instances fixture should parse")
+    }
+
+    fn parse_depends_on(json5: &str) -> DependsOn {
+        serde_json5::from_str(json5).expect("depends_on fixture should parse")
+    }
+
+    /// Convenience: build a `BindingValidationItem` whose lifetimes
+    /// stay tethered to the caller's locals.
+    fn item<'a>(
+        node_name: &'a str,
+        node_tag: &'a str,
+        instances: &'a [DeploymentInstance],
+        depends_on: Option<&'a DependsOn>,
+    ) -> BindingValidationItem<'a> {
+        BindingValidationItem {
+            node_name,
+            node_tag,
+            instances,
+            depends_on,
+        }
+    }
+
+    #[test]
+    fn empty_planned_set_returns_no_errors() {
+        let errors = validate_bindings(&[]);
+        assert!(errors.is_empty());
+    }
+
+    /// A consumer with no `depends_on` and no `bindings` is trivially
+    /// valid.
+    #[test]
+    fn consumer_without_depends_on_and_without_bindings_is_valid() {
+        let instances = parse_instances(r#"[{ instance_id: "cons1" }]"#);
+        let items = vec![item("cons", "v1", &instances, None)];
+        let errors = validate_bindings(&items);
+        assert!(errors.is_empty(), "unexpected errors: {errors:?}");
+    }
+
+    /// (i) A binding whose key isn't declared in `depends_on` surfaces
+    /// as `BindingDeadKey` with the consumer's full declared-link_ids
+    /// list for context. The pinned `main` slot is bound here so that
+    /// the dead-key error is the only one in play.
+    #[test]
+    fn rejects_dead_binding_key() {
+        let instances = parse_instances(
+            r#"[{
+                instance_id: "cons1",
+                bindings: { main: "prod1", stale_slot: "prod1" }
+            }]"#,
+        );
+        let depends_on = parse_depends_on(
+            r#"{
+                nodes: [{ name: "camera", tag: "v1", link_id: "main" }]
+            }"#,
+        );
+        let prod_instances = parse_instances(r#"[{ instance_id: "prod1" }]"#);
+        let items = vec![
+            item("cons", "v1", &instances, Some(&depends_on)),
+            item("camera", "v1", &prod_instances, None),
+        ];
+        let errors = validate_bindings(&items);
+        assert_eq!(errors.len(), 1, "expected one error, got {errors:?}");
+        let ParsingError::BindingDeadKey {
+            owner_instance_id,
+            binding,
+            declared_link_ids,
+        } = &errors[0]
+        else {
+            panic!("expected BindingDeadKey, got {:?}", errors[0]);
+        };
+        assert_eq!(owner_instance_id, "cons1");
+        assert_eq!(binding, "stale_slot");
+        assert_eq!(declared_link_ids, "main");
+    }
+
+    /// (ii) A consumer with a pinned (non-`from_any`, non-`_`)
+    /// `depends_on` entry but no matching binding is the exact
+    /// silent-loss case the issue flags.
+    #[test]
+    fn rejects_missing_binding_for_pinned_node_dep() {
+        let instances = parse_instances(r#"[{ instance_id: "cons1" }]"#);
+        let depends_on = parse_depends_on(
+            r#"{
+                nodes: [{ name: "camera", tag: "v1", link_id: "main" }]
+            }"#,
+        );
+        let items = vec![item("cons", "v1", &instances, Some(&depends_on))];
+        let errors = validate_bindings(&items);
+        assert_eq!(errors.len(), 1);
+        let ParsingError::BindingMissingForPinnedDep(info) = &errors[0] else {
+            panic!("expected BindingMissingForPinnedDep, got {:?}", errors[0]);
+        };
+        assert_eq!(info.owner_instance_id, "cons1");
+        assert_eq!(info.link_id, "main");
+        assert_eq!(info.kind, "nodes");
+        assert_eq!(info.expected_name, "camera");
+        assert_eq!(info.expected_tag, "v1");
+    }
+
+    /// A `depends_on.link_id == "_"` is the explicit "use the producer
+    /// default" opt-in and requires no binding. The deserializer
+    /// currently rejects `_` as a NodeDependency `link_id` so this
+    /// state is unreachable through parsing; the test constructs the
+    /// struct programmatically to exercise the defensive skip and
+    /// guard against future deserializer loosening.
+    #[test]
+    fn skips_missing_when_link_id_is_underscore() {
+        use config::node::{Name as NodeName, NodeDependency};
+
+        let instances = parse_instances(r#"[{ instance_id: "cons1" }]"#);
+        let depends_on = DependsOn {
+            nodes: vec![NodeDependency {
+                name: NodeName::new("camera").expect("name should be valid"),
+                tag: "v1".to_string(),
+                link_id: "_".to_string(),
+                from_any: false,
+            }],
+            interfaces: vec![],
+        };
+        let items = vec![item("cons", "v1", &instances, Some(&depends_on))];
+        let errors = validate_bindings(&items);
+        assert!(errors.is_empty(), "unexpected errors: {errors:?}");
+    }
+
+    /// A `from_any: true` consumer subscribes via wildcard and doesn't
+    /// need a binding.
+    #[test]
+    fn skips_missing_when_from_any() {
+        let instances = parse_instances(r#"[{ instance_id: "cons1" }]"#);
+        let depends_on = parse_depends_on(
+            r#"{
+                nodes: [{ name: "camera", tag: "v1", link_id: "main", from_any: true }]
+            }"#,
+        );
+        let items = vec![item("cons", "v1", &instances, Some(&depends_on))];
+        let errors = validate_bindings(&items);
+        assert!(errors.is_empty(), "unexpected errors: {errors:?}");
+    }
+
+    /// (iii) Binding target points at an instance whose deploying node
+    /// doesn't match the consumer's `depends_on.nodes` entry.
+    #[test]
+    fn rejects_target_node_mismatch() {
+        let cons_instances = parse_instances(
+            r#"[{
+                instance_id: "cons1",
+                bindings: { main: "actually_lidar" }
+            }]"#,
+        );
+        let depends_on = parse_depends_on(
+            r#"{
+                nodes: [{ name: "camera", tag: "v1", link_id: "main" }]
+            }"#,
+        );
+        let prod_instances = parse_instances(r#"[{ instance_id: "actually_lidar" }]"#);
+        let items = vec![
+            item("cons", "v1", &cons_instances, Some(&depends_on)),
+            item("lidar", "v1", &prod_instances, None),
+        ];
+        let errors = validate_bindings(&items);
+        assert_eq!(errors.len(), 1, "expected one error, got {errors:?}");
+        let ParsingError::BindingTargetMismatch(info) = &errors[0] else {
+            panic!("expected BindingTargetMismatch, got {:?}", errors[0]);
+        };
+        assert_eq!(info.owner_instance_id, "cons1");
+        assert_eq!(info.binding, "main");
+        assert_eq!(info.target_instance_id, "actually_lidar");
+        assert_eq!(info.expected_name, "camera");
+        assert_eq!(info.expected_tag, "v1");
+        assert_eq!(info.actual_name, "lidar");
+        assert_eq!(info.actual_tag, "v1");
+    }
+
+    /// A `from_any: true` consumer with a binding is permissive: the
+    /// binding is honored for producer-side wiring (other pinned
+    /// consumers can rely on it) and the wildcard consumer simply
+    /// ignores the link_id pin.
+    #[test]
+    fn allows_binding_on_from_any_dep() {
+        let cons_instances = parse_instances(
+            r#"[{
+                instance_id: "cons1",
+                bindings: { main: "prod1" }
+            }]"#,
+        );
+        let depends_on = parse_depends_on(
+            r#"{
+                nodes: [{ name: "camera", tag: "v1", link_id: "main", from_any: true }]
+            }"#,
+        );
+        let prod_instances = parse_instances(r#"[{ instance_id: "prod1" }]"#);
+        let items = vec![
+            item("cons", "v1", &cons_instances, Some(&depends_on)),
+            item("camera", "v1", &prod_instances, None),
+        ];
+        let errors = validate_bindings(&items);
+        assert!(errors.is_empty(), "unexpected errors: {errors:?}");
+    }
+
+    /// Interface deps are equally bindable: missing binding on a
+    /// pinned interface dep is still a silent-loss bug.
+    #[test]
+    fn rejects_missing_binding_for_pinned_interface_dep() {
+        let instances = parse_instances(r#"[{ instance_id: "cons1" }]"#);
+        let depends_on = parse_depends_on(
+            r#"{
+                nodes: [],
+                interfaces: [{
+                    name: "depth_camera",
+                    tag: "v1",
+                    link_id: "depth"
+                }]
+            }"#,
+        );
+        let items = vec![item("cons", "v1", &instances, Some(&depends_on))];
+        let errors = validate_bindings(&items);
+        assert_eq!(errors.len(), 1);
+        let ParsingError::BindingMissingForPinnedDep(info) = &errors[0] else {
+            panic!("expected BindingMissingForPinnedDep, got {:?}", errors[0]);
+        };
+        assert_eq!(info.kind, "interfaces");
+        assert_eq!(info.link_id, "depth");
+    }
+
+    /// A binding key matching an interface dep does NOT trigger the
+    /// node-identity check (interface deps don't pre-commit to a node
+    /// identity).
+    #[test]
+    fn interface_binding_skips_target_node_check() {
+        let cons_instances = parse_instances(
+            r#"[{
+                instance_id: "cons1",
+                bindings: { depth: "any_producer" }
+            }]"#,
+        );
+        let depends_on = parse_depends_on(
+            r#"{
+                nodes: [],
+                interfaces: [{
+                    name: "depth_camera",
+                    tag: "v1",
+                    link_id: "depth"
+                }]
+            }"#,
+        );
+        let prod_instances = parse_instances(r#"[{ instance_id: "any_producer" }]"#);
+        let items = vec![
+            item("cons", "v1", &cons_instances, Some(&depends_on)),
+            item("whatever", "v1", &prod_instances, None),
+        ];
+        let errors = validate_bindings(&items);
+        assert!(errors.is_empty(), "unexpected errors: {errors:?}");
+    }
+
+    /// A complete, well-formed launcher passes with zero errors.
+    #[test]
+    fn well_formed_launcher_passes() {
+        let cons_instances = parse_instances(
+            r#"[{
+                instance_id: "cons1",
+                bindings: { main: "prod1" }
+            }]"#,
+        );
+        let depends_on = parse_depends_on(
+            r#"{
+                nodes: [{ name: "camera", tag: "v1", link_id: "main" }]
+            }"#,
+        );
+        let prod_instances = parse_instances(r#"[{ instance_id: "prod1" }]"#);
+        let items = vec![
+            item("cons", "v1", &cons_instances, Some(&depends_on)),
+            item("camera", "v1", &prod_instances, None),
+        ];
+        let errors = validate_bindings(&items);
+        assert!(errors.is_empty(), "unexpected errors: {errors:?}");
+    }
+
+    /// All three sub-checks are aggregated: a single consumer triggers
+    /// dead-key + missing-pinned in one pass; the validator does not
+    /// short-circuit on the first error.
+    #[test]
+    fn aggregates_multiple_errors() {
+        let cons_instances = parse_instances(
+            r#"[{
+                instance_id: "cons1",
+                bindings: { unknown_slot: "prod1" }
+            }]"#,
+        );
+        let depends_on = parse_depends_on(
+            r#"{
+                nodes: [{ name: "camera", tag: "v1", link_id: "main" }]
+            }"#,
+        );
+        let prod_instances = parse_instances(r#"[{ instance_id: "prod1" }]"#);
+        let items = vec![
+            item("cons", "v1", &cons_instances, Some(&depends_on)),
+            item("camera", "v1", &prod_instances, None),
+        ];
+        let errors = validate_bindings(&items);
+        assert_eq!(errors.len(), 2, "expected two errors, got {errors:?}");
+        assert!(matches!(errors[0], ParsingError::BindingDeadKey { .. }));
+        assert!(matches!(
+            errors[1],
+            ParsingError::BindingMissingForPinnedDep { .. }
+        ));
+    }
+}

--- a/crates/core-node-internal/src/services/stack/bindings.rs
+++ b/crates/core-node-internal/src/services/stack/bindings.rs
@@ -123,6 +123,18 @@ fn check_dead_keys_and_target_mismatch(
             continue;
         };
         let Some(target_item) = instance_to_item.get(target_id.as_str()) else {
+            // The launcher-level deserializer already rejects bindings
+            // whose target_instance_id is not declared elsewhere in the
+            // launcher. If a target nonetheless fails to resolve at the
+            // plan phase (e.g., the deployment that owned the target
+            // was dropped between parsing and planning), fail loudly
+            // here rather than silently passing the pinned dep through
+            // to runtime.
+            errors.push(ParsingError::UnknownInstanceId {
+                owner_instance_id: instance.instance_id.to_string(),
+                binding: binding_key.clone(),
+                instance_id: target_id.clone(),
+            });
             continue;
         };
         if target_item.node_name != expected_name || target_item.node_tag != expected_tag {
@@ -471,6 +483,39 @@ mod tests {
         assert!(errors.is_empty(), "unexpected errors: {errors:?}");
     }
 
+    /// A binding pointing at an `instance_id` that the planner did not
+    /// produce (defensive case: launcher-level dedup should already
+    /// catch this) surfaces as an `UnknownInstanceId` error instead of
+    /// silently passing the pinned dep through to runtime.
+    #[test]
+    fn rejects_binding_whose_target_is_unknown_to_planner() {
+        let cons_instances = parse_instances(
+            r#"[{
+                instance_id: "cons1",
+                bindings: { main: "ghost_producer" }
+            }]"#,
+        );
+        let depends_on = parse_depends_on(
+            r#"{
+                nodes: [{ name: "camera", tag: "v1", link_id: "main" }]
+            }"#,
+        );
+        let items = vec![item("cons", "v1", &cons_instances, Some(&depends_on))];
+        let errors = validate_bindings(&items);
+        assert_eq!(errors.len(), 1, "expected one error, got {errors:?}");
+        let ParsingError::UnknownInstanceId {
+            owner_instance_id,
+            binding,
+            instance_id,
+        } = &errors[0]
+        else {
+            panic!("expected UnknownInstanceId, got {:?}", errors[0]);
+        };
+        assert_eq!(owner_instance_id, "cons1");
+        assert_eq!(binding, "main");
+        assert_eq!(instance_id, "ghost_producer");
+    }
+
     /// All three sub-checks are aggregated: a single consumer triggers
     /// dead-key + missing-pinned in one pass; the validator does not
     /// short-circuit on the first error.
@@ -497,7 +542,7 @@ mod tests {
         assert!(matches!(errors[0], ParsingError::BindingDeadKey { .. }));
         assert!(matches!(
             errors[1],
-            ParsingError::BindingMissingForPinnedDep { .. }
+            ParsingError::BindingMissingForPinnedDep(_)
         ));
     }
 }

--- a/crates/core-node-internal/src/services/stack/bindings.rs
+++ b/crates/core-node-internal/src/services/stack/bindings.rs
@@ -308,7 +308,7 @@ mod tests {
             nodes: vec![NodeDependency {
                 name: NodeName::new("camera").expect("name should be valid"),
                 tag: "v1".to_string(),
-                link_id: "_".to_string(),
+                link_id: DEFAULT_LINK_ID_SENTINEL.to_string(),
                 from_any: false,
             }],
             interfaces: vec![],

--- a/crates/core-node-internal/src/services/stack/launch.rs
+++ b/crates/core-node-internal/src/services/stack/launch.rs
@@ -1019,6 +1019,25 @@ async fn validate_and_order_dependencies(
         return Err(LaunchResult::failure(&ctx.log_path, msg));
     }
 
+    let binding_items: Vec<super::bindings::BindingValidationItem<'_>> = planned
+        .iter()
+        .map(|p| super::bindings::BindingValidationItem {
+            node_name: &p.node_name,
+            node_tag: &p.node_tag,
+            instances: &p.deployment.instances,
+            depends_on: p.config.manifest.depends_on.as_ref(),
+        })
+        .collect();
+    let binding_errors: Vec<String> = super::bindings::validate_bindings(&binding_items)
+        .into_iter()
+        .map(|e| e.to_string())
+        .collect();
+    if !binding_errors.is_empty() {
+        let msg = binding_errors.join("\n");
+        publish_stderr(ctx, msg.clone(), LaunchFeedbackStep::LauncherStep).await;
+        return Err(LaunchResult::failure(&ctx.log_path, msg));
+    }
+
     // Build the dependency graph for topological ordering.
     let mut deps_for: HashMap<NodeKey, HashSet<NodeKey>> = HashMap::new();
     for item in planned {
@@ -1271,6 +1290,16 @@ async fn start_node_instances(
         .await
         .unwrap_or((DEFAULT_MESSAGING_HOST.to_string(), DEFAULT_MESSAGING_PORT));
 
+    let all_deployments: Vec<Deployment> = planned_by_key
+        .values()
+        .map(|p| p.deployment.clone())
+        .collect();
+    let link_ids_by_instance = config::launcher::link_ids_by_instance_id(&all_deployments);
+    debug!(
+        ?link_ids_by_instance,
+        "resolved producer link_ids from launcher bindings"
+    );
+
     for key in ordered {
         let Some(item) = planned_by_key.get(key) else {
             continue;
@@ -1285,9 +1314,14 @@ async fn start_node_instances(
             )
             .await;
 
+            let link_ids = link_ids_by_instance
+                .get(instance_id)
+                .cloned()
+                .unwrap_or_default();
             let node_instance = config::runtime::NodeInstanceConfig {
                 arguments: instance.arguments.clone(),
                 framework: resolve_framework(&instance.framework, ctx.daemon_use_sim_time),
+                link_ids,
                 ..config::runtime::NodeInstanceConfig::new(instance.instance_id.clone())
             };
             let runtime_config = match RuntimeConfig::new(

--- a/crates/core-node-internal/src/services/stack/launch.rs
+++ b/crates/core-node-internal/src/services/stack/launch.rs
@@ -1002,7 +1002,7 @@ async fn validate_and_order_dependencies(
     let dependency_errors: Vec<String> = planned
         .iter()
         .flat_map(|item| {
-            node_stack::validate_dependency_specs(
+            config::node::validate_dependency_specs(
                 &item.config.manifest,
                 &item.config.interfaces,
                 &item.node_name,
@@ -1019,16 +1019,16 @@ async fn validate_and_order_dependencies(
         return Err(LaunchResult::failure(&ctx.log_path, msg));
     }
 
-    let binding_items: Vec<super::bindings::BindingValidationItem<'_>> = planned
+    let binding_items: Vec<config::launcher::BindingValidationItem<'_>> = planned
         .iter()
-        .map(|p| super::bindings::BindingValidationItem {
+        .map(|p| config::launcher::BindingValidationItem {
             node_name: &p.node_name,
             node_tag: &p.node_tag,
             instances: &p.deployment.instances,
             depends_on: p.config.manifest.depends_on.as_ref(),
         })
         .collect();
-    let binding_errors: Vec<String> = super::bindings::validate_bindings(&binding_items)
+    let binding_errors: Vec<String> = config::launcher::validate_bindings(&binding_items)
         .into_iter()
         .map(|e| e.to_string())
         .collect();
@@ -1043,7 +1043,7 @@ async fn validate_and_order_dependencies(
     for item in planned {
         let dependant_key = NodeKey::new(&item.node_name, &item.node_tag);
         let mut deps = HashSet::new();
-        for spec in node_stack::collect_dependency_specs(&item.config) {
+        for spec in config::node::collect_dependency_specs(&item.config) {
             let dep_key = NodeKey::new(&spec.node_name, &spec.node_tag);
             if dep_key != root_key && planned_keys.contains(&dep_key) {
                 deps.insert(dep_key);

--- a/crates/core-node-internal/tests/launch_assets/fake_robot_brain/peppy.json5
+++ b/crates/core-node-internal/tests/launch_assets/fake_robot_brain/peppy.json5
@@ -12,12 +12,12 @@
         {
           name: "fake_uvc_camera",
           tag: "v1",
-          link_id: "fake_uvc_camera"
+          link_id: "front_camera"
         },
         {
           name: "fake_openarm01_controller",
           tag: "v1",
-          link_id: "fake_openarm01_controller"
+          link_id: "robot_controller"
         },
       ]
     },
@@ -28,7 +28,7 @@
       emits: [],
       consumes: [
         {
-          link_id: "fake_uvc_camera",
+          link_id: "front_camera",
           name: "video_stream",
         }
       ],
@@ -37,7 +37,7 @@
       exposes: [],
       consumes: [
         {
-          link_id: "fake_uvc_camera",
+          link_id: "front_camera",
           name: "video_stream_info",
         }
       ],
@@ -47,11 +47,11 @@
       exposes: [],
       consumes: [
         {
-          link_id: "fake_openarm01_controller",
+          link_id: "robot_controller",
           name: "move_right_arm",
         },
         {
-          link_id: "fake_openarm01_controller",
+          link_id: "robot_controller",
           name: "move_left_arm",
         }
       ],

--- a/crates/core-node-internal/tests/launch_assets/peppy_launcher.json5
+++ b/crates/core-node-internal/tests/launch_assets/peppy_launcher.json5
@@ -10,8 +10,8 @@
           instance_id: "the_brain",
           arguments: {},
           bindings: {
-            fake_uvc_camera: "camera_front",
-            fake_openarm01_controller: "the_nervous_system",
+            front_camera: "camera_front",
+            robot_controller: "the_nervous_system",
           },
         }
       ],

--- a/crates/core-node-internal/tests/launch_assets/peppy_launcher.json5
+++ b/crates/core-node-internal/tests/launch_assets/peppy_launcher.json5
@@ -8,7 +8,11 @@
       instances: [
         {
           instance_id: "the_brain",
-          arguments: {}
+          arguments: {},
+          bindings: {
+            fake_uvc_camera: "camera_front",
+            fake_openarm01_controller: "the_nervous_system",
+          },
         }
       ],
     },

--- a/crates/core-node-internal/tests/listen_for_launch.rs
+++ b/crates/core-node-internal/tests/listen_for_launch.rs
@@ -92,7 +92,10 @@ const LAUNCHER_EXAMPLE1: &str = r#"
       instances: [
         {
           instance_id: "main_robot_brain",
-          arguments: {}
+          arguments: {},
+          bindings: {
+            uvc_camera: "camera_front",
+          },
         }
       ]
     },

--- a/crates/core-node-internal/tests/listen_for_launch.rs
+++ b/crates/core-node-internal/tests/listen_for_launch.rs
@@ -94,7 +94,7 @@ const LAUNCHER_EXAMPLE1: &str = r#"
           instance_id: "main_robot_brain",
           arguments: {},
           bindings: {
-            uvc_camera: "camera_front",
+            front_camera: "camera_front",
           },
         }
       ]
@@ -167,7 +167,7 @@ fn write_node_config_with_options(
 
     let expects_topics = if expects_uvc_camera {
         r#"consumes: [
-                  { link_id: "uvc_camera", name: "camera_stream" }
+                  { link_id: "front_camera", name: "camera_stream" }
                 ],"#
     } else {
         ""
@@ -189,7 +189,7 @@ fn write_node_config_with_options(
     let depends_on = if expects_uvc_camera {
         r#"depends_on: {
                     nodes: [
-                        { name: "uvc_camera", tag: "v1", link_id: "uvc_camera" }
+                        { name: "uvc_camera", tag: "v1", link_id: "front_camera" }
                     ]
                 },"#
     } else {

--- a/crates/node-stack-internal/src/error.rs
+++ b/crates/node-stack-internal/src/error.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use config::ConfigError;
+use config::{ConfigError, ParsingError};
 use thiserror::Error;
 
 pub type Result<T> = core::result::Result<T, Error>;
@@ -14,34 +14,6 @@ pub enum Error {
     // -- nodes errors
     #[error("The node name `{0}` or tag `{1}` could not be found")]
     NoMatchingNode(String, String),
-    #[error(
-        "`{dependant}`:{dependant_tag} expects {interface_kind} `{interface_name}` from `{dependency}`:{dependency_tag}, but it is not exposed"
-    )]
-    MissingInterface {
-        dependant: String,
-        dependant_tag: String,
-        dependency: String,
-        dependency_tag: String,
-        interface_kind: String,
-        interface_name: String,
-    },
-    #[error(
-        "`{dependant}:{dependant_tag}` depends on `{dependency}:{dependency_tag}`, but it does not exist in the stack"
-    )]
-    MissingDependency {
-        dependant: String,
-        dependant_tag: String,
-        dependency: String,
-        dependency_tag: String,
-    },
-    #[error(
-        "`{dependant}:{dependant_tag}` references undeclared link_id `{link_id}` in consumed interfaces"
-    )]
-    UndeclaredLinkId {
-        dependant: String,
-        dependant_tag: String,
-        link_id: String,
-    },
 
     // -- node stack errors
     #[error("Cannot modify the root node (it always has exactly one instance)")]
@@ -90,4 +62,10 @@ pub enum Error {
         first: PathBuf,
         second: PathBuf,
     },
+}
+
+impl From<ParsingError> for Error {
+    fn from(err: ParsingError) -> Self {
+        Self::Config(ConfigError::Parsing(err))
+    }
 }

--- a/crates/node-stack-internal/src/lib.rs
+++ b/crates/node-stack-internal/src/lib.rs
@@ -13,8 +13,7 @@ pub use build_io::{FeedbackLine, FeedbackStream, OutputReaderHooks};
 pub use core_node_api::InstanceState;
 pub use node_stack::add_steps;
 pub use node_stack::{
-    BuildContext, DependencySpec, EntityHandle, EntitySnapshot, NodeEntity, NodeStack, NodeStage,
-    OutputSinks, RestoreTarget, StartContext, StartedInstanceCtx, TrackedNodeInstance,
-    WorkingDirGuard, collect_dependency_specs, validate_dependency_specs,
+    BuildContext, EntityHandle, EntitySnapshot, NodeEntity, NodeStack, NodeStage, OutputSinks,
+    RestoreTarget, StartContext, StartedInstanceCtx, TrackedNodeInstance, WorkingDirGuard,
 };
 pub use virtual_deptree::{NodeKey, VirtualDeptree, VirtualNodeInfo};

--- a/crates/node-stack-internal/src/node_stack.rs
+++ b/crates/node-stack-internal/src/node_stack.rs
@@ -2,16 +2,14 @@ pub mod add_steps;
 mod build_steps;
 mod entity;
 mod run_steps;
-mod validation;
 
 pub use entity::{
-    BuildContext, DependencySpec, NodeEntity, NodeStage, OutputSinks, StartContext,
-    StartedInstanceCtx, TrackedNodeInstance, WorkingDirGuard,
+    BuildContext, NodeEntity, NodeStage, OutputSinks, StartContext, StartedInstanceCtx,
+    TrackedNodeInstance, WorkingDirGuard,
 };
-pub use validation::{collect_dependency_specs, validate_dependency_specs};
 
 use crate::error::{Error, Result};
-use config::node::{Name, NodeConfig};
+use config::node::{Name, NodeConfig, collect_dependency_specs, validate_dependency_specs};
 use core_node_api::{InstanceState, SerializedEdge, SerializedNode, SerializedNodeGraph};
 use names_generator2::get_random;
 use parking_lot::RwLock;
@@ -146,7 +144,7 @@ impl NodeStackInner {
         );
 
         if let Some(err) = errors.into_iter().next() {
-            return Err(err);
+            return Err(err.into());
         }
 
         Ok(())

--- a/crates/node-stack-internal/src/node_stack/entity.rs
+++ b/crates/node-stack-internal/src/node_stack/entity.rs
@@ -1109,8 +1109,3 @@ impl TrackedNodeInstance {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct DependencySpec {
-    pub node_name: String,
-    pub node_tag: String,
-}

--- a/crates/node-stack-internal/tests/tests_modules/actions_runtime_resolution.rs
+++ b/crates/node-stack-internal/tests/tests_modules/actions_runtime_resolution.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use config::{ConfigError, ParsingError};
 use node_stack::{NodeStack, NodeStackError};
 
 use crate::helpers::config_common::core_node_config;
@@ -175,11 +176,11 @@ fn action_dependency_fails_when_dependency_is_missing() {
 
     // Adding a node that depends on a non-existent action provider should fail
     let result = stack.push_config(dependent, false, PathBuf::from("/tmp"));
-    let Err(NodeStackError::MissingDependency {
+    let Err(NodeStackError::Config(ConfigError::Parsing(ParsingError::MissingDependency {
         dependency,
         dependency_tag,
         ..
-    }) = result
+    }))) = result
     else {
         panic!("expected MissingDependency error, got {:?}", result);
     };
@@ -289,20 +290,15 @@ fn action_dependency_fails_when_action_not_exposed_by_dependency() {
 
     // Adding brain should fail because controller doesn't expose "move_right_arm"
     let result = stack.push_config(dependent, false, PathBuf::from("/tmp"));
-    let Err(NodeStackError::MissingInterface {
-        dependency,
-        dependency_tag,
-        interface_kind,
-        interface_name,
-        ..
-    }) = result
+    let Err(NodeStackError::Config(ConfigError::Parsing(ParsingError::MissingInterface(info)))) =
+        result
     else {
         panic!("expected MissingInterface error, got {:?}", result);
     };
-    assert_eq!(dependency, "controller");
-    assert_eq!(dependency_tag, "v1");
-    assert_eq!(interface_kind, "Action");
-    assert_eq!(interface_name, "move_right_arm");
+    assert_eq!(info.dependency, "controller");
+    assert_eq!(info.dependency_tag, "v1");
+    assert_eq!(info.interface_kind, "Action");
+    assert_eq!(info.interface_name, "move_right_arm");
     assert_eq!(
         stack.len(),
         2,
@@ -343,7 +339,11 @@ fn action_dependency_fails_when_link_id_is_undeclared() {
     let stack = NodeStack::new(core_node_config(), None, PathBuf::from("/tmp"));
 
     let result = stack.push_config(dependent, false, PathBuf::from("/tmp"));
-    let Err(NodeStackError::UndeclaredLinkId { link_id, .. }) = result else {
+    let Err(NodeStackError::Config(ConfigError::Parsing(ParsingError::UndeclaredLinkId {
+        link_id,
+        ..
+    }))) = result
+    else {
         panic!("expected UndeclaredLinkId error, got {:?}", result);
     };
     assert_eq!(link_id, "nonexistent");

--- a/crates/node-stack-internal/tests/tests_modules/runtime_resolution.rs
+++ b/crates/node-stack-internal/tests/tests_modules/runtime_resolution.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use config::node::Name;
+use config::{ConfigError, ParsingError};
 use node_stack::{NodeStack, NodeStackError};
 
 use crate::helpers::config_common::core_node_config;
@@ -966,11 +967,11 @@ fn dependency_fails_when_node_name_mismatches() {
 
     // Adding brain should fail because it expects "uvc_camera", not "lidar"
     let result = stack.push_config(dependent, false, PathBuf::from("/tmp"));
-    let Err(NodeStackError::MissingDependency {
+    let Err(NodeStackError::Config(ConfigError::Parsing(ParsingError::MissingDependency {
         dependency,
         dependency_tag,
         ..
-    }) = result
+    }))) = result
     else {
         panic!("expected MissingDependency error, got {:?}", result);
     };
@@ -1031,11 +1032,11 @@ fn dependency_fails_when_node_tag_mismatches() {
 
     // Adding brain should fail because it expects lidar with tag "v1", not "v2"
     let result = stack.push_config(dependent, false, PathBuf::from("/tmp"));
-    let Err(NodeStackError::MissingDependency {
+    let Err(NodeStackError::Config(ConfigError::Parsing(ParsingError::MissingDependency {
         dependency,
         dependency_tag,
         ..
-    }) = result
+    }))) = result
     else {
         panic!("expected MissingDependency error, got {:?}", result);
     };

--- a/crates/node-stack-internal/tests/tests_modules/services_runtime_resolution.rs
+++ b/crates/node-stack-internal/tests/tests_modules/services_runtime_resolution.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use config::{ConfigError, ParsingError};
 use node_stack::{NodeStack, NodeStackError};
 
 use crate::helpers::config_common::core_node_config;
@@ -153,11 +154,11 @@ fn service_dependency_fails_when_dependency_is_missing() {
 
     // Adding a node that depends on a non-existent service provider should fail
     let result = stack.push_config(dependent, false, PathBuf::from("/tmp"));
-    let Err(NodeStackError::MissingDependency {
+    let Err(NodeStackError::Config(ConfigError::Parsing(ParsingError::MissingDependency {
         dependency,
         dependency_tag,
         ..
-    }) = result
+    }))) = result
     else {
         panic!("expected MissingDependency error, got {:?}", result);
     };
@@ -241,20 +242,15 @@ fn service_dependency_fails_when_service_not_exposed_by_dependency() {
 
     // Adding brain should fail because lidar doesn't expose "reset_sensor"
     let result = stack.push_config(dependent, false, PathBuf::from("/tmp"));
-    let Err(NodeStackError::MissingInterface {
-        dependency,
-        dependency_tag,
-        interface_kind,
-        interface_name,
-        ..
-    }) = result
+    let Err(NodeStackError::Config(ConfigError::Parsing(ParsingError::MissingInterface(info)))) =
+        result
     else {
         panic!("expected MissingInterface error, got {:?}", result);
     };
-    assert_eq!(dependency, "lidar");
-    assert_eq!(dependency_tag, "v1");
-    assert_eq!(interface_kind, "Service");
-    assert_eq!(interface_name, "reset_sensor");
+    assert_eq!(info.dependency, "lidar");
+    assert_eq!(info.dependency_tag, "v1");
+    assert_eq!(info.interface_kind, "Service");
+    assert_eq!(info.interface_name, "reset_sensor");
     assert_eq!(
         stack.len(),
         2,
@@ -295,7 +291,11 @@ fn service_dependency_fails_when_link_id_is_undeclared() {
     let stack = NodeStack::new(core_node_config(), None, PathBuf::from("/tmp"));
 
     let result = stack.push_config(dependent, false, PathBuf::from("/tmp"));
-    let Err(NodeStackError::UndeclaredLinkId { link_id, .. }) = result else {
+    let Err(NodeStackError::Config(ConfigError::Parsing(ParsingError::UndeclaredLinkId {
+        link_id,
+        ..
+    }))) = result
+    else {
         panic!("expected UndeclaredLinkId error, got {:?}", result);
     };
     assert_eq!(link_id, "nonexistent");

--- a/crates/node-stack-internal/tests/tests_modules/topics_runtime_resolution.rs
+++ b/crates/node-stack-internal/tests/tests_modules/topics_runtime_resolution.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use config::{ConfigError, ParsingError};
 use node_stack::{NodeStack, NodeStackError};
 
 use crate::helpers::config_common::core_node_config;
@@ -151,11 +152,11 @@ fn topic_dependency_fails_when_dependency_is_missing() {
 
     // Adding a node that depends on a non-existent node should fail
     let result = stack.push_config(brain_dependent, false, PathBuf::from("/tmp"));
-    let Err(NodeStackError::MissingDependency {
+    let Err(NodeStackError::Config(ConfigError::Parsing(ParsingError::MissingDependency {
         dependency,
         dependency_tag,
         ..
-    }) = result
+    }))) = result
     else {
         panic!("expected MissingDependency error, got {:?}", result);
     };
@@ -238,20 +239,15 @@ fn topic_dependency_fails_when_topic_not_exposed_by_dependency() {
 
     // Adding brain should fail because lidar doesn't emit "push_lidar_object"
     let result = stack.push_config(dependent, false, PathBuf::from("/tmp"));
-    let Err(NodeStackError::MissingInterface {
-        dependency,
-        dependency_tag,
-        interface_kind,
-        interface_name,
-        ..
-    }) = result
+    let Err(NodeStackError::Config(ConfigError::Parsing(ParsingError::MissingInterface(info)))) =
+        result
     else {
         panic!("expected MissingInterface error, got {:?}", result);
     };
-    assert_eq!(dependency, "lidar");
-    assert_eq!(dependency_tag, "v1");
-    assert_eq!(interface_kind, "Topic");
-    assert_eq!(interface_name, "push_lidar_object");
+    assert_eq!(info.dependency, "lidar");
+    assert_eq!(info.dependency_tag, "v1");
+    assert_eq!(info.interface_kind, "Topic");
+    assert_eq!(info.interface_name, "push_lidar_object");
     assert_eq!(
         stack.len(),
         2,
@@ -292,7 +288,11 @@ fn topic_dependency_fails_when_link_id_is_undeclared() {
     let stack = NodeStack::new(core_node_config(), None, PathBuf::from("/tmp"));
 
     let result = stack.push_config(dependent, false, PathBuf::from("/tmp"));
-    let Err(NodeStackError::UndeclaredLinkId { link_id, .. }) = result else {
+    let Err(NodeStackError::Config(ConfigError::Parsing(ParsingError::UndeclaredLinkId {
+        link_id,
+        ..
+    }))) = result
+    else {
         panic!("expected UndeclaredLinkId error, got {:?}", result);
     };
     assert_eq!(link_id, "nonexistent");

--- a/crates/peppy/tests/stack_launch.rs
+++ b/crates/peppy/tests/stack_launch.rs
@@ -660,3 +660,280 @@ async fn node_launch_fails_when_max_timeout_is_hit() {
         "error message should mention 'timeout' and 'max' on max launch failure. Got: {err_msg}",
     );
 }
+
+/// Writes a minimal peppy.json5 with an explicit `run_cmd` (so the daemon's
+/// build phase is skipped) and an optional `depends_on` block. Mirrors
+/// `write_node_config` but accepts run_cmd as owned strings and a manifest
+/// extension for `depends_on`.
+fn write_node_config_for_helper(
+    nodes_directory: &Path,
+    node_name: &str,
+    node_tag: &str,
+    git_hash: &str,
+    run_cmd: &[String],
+    depends_on_json5: Option<&str>,
+) -> PathBuf {
+    let node_dir = nodes_directory.join(node_name);
+    fs::create_dir_all(&node_dir).expect("failed to create node directory");
+    let node_config_path = node_dir.join(NODE_CONFIG_FILE);
+    let run_cmd_json5 = run_cmd
+        .iter()
+        .map(|arg| serde_json::to_string(arg).expect("run_cmd arg should serialize"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let manifest_extra = depends_on_json5
+        .map(|deps| format!(",\n            depends_on: {deps}"))
+        .unwrap_or_default();
+    let body = format!(
+        r#"{{
+            peppy_schema: "node_v1",
+            manifest: {{
+                name: "{node_name}",
+                tag: "{node_tag}"{manifest_extra}
+            }},
+            execution: {{
+                language: "rust",
+                run_cmd: [{run_cmd_json5}]
+            }}
+        }}"#
+    );
+    fs::write(&node_config_path, body).expect("failed to write node config");
+    config::fingerprint::create_codegen_fingerprint(
+        &node_config_path,
+        Path::new(PEPPYGEN_OUTPUT_PATH),
+    );
+
+    let peppy_output_dir = node_dir.join(PEPPY_OUTPUT_DIR);
+    fs::create_dir_all(&peppy_output_dir).expect("failed to create peppy output directory");
+    fs::write(peppy_output_dir.join("git.hash"), git_hash).expect("failed to write node git hash");
+    node_dir
+}
+
+/// Regression for the launcher's `bindings` field actually wiring
+/// producer `link_ids` at launch time. The dummy `sh` run_cmd dumps the
+/// `RuntimeConfig` it received from the daemon (via the
+/// `PEPPY_RUNTIME_CONFIG` env var, which points at a JSON5 file) to a
+/// known location; the test then parses that dump and asserts the
+/// producer's `link_ids` vec was populated from the consumer's binding.
+/// Without the fix the vec stays empty (defaulted to `_` later by the
+/// runtime), so this is the boundary that surfaces the silent-loss bug.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn stack_launch_populates_link_ids_from_launcher_bindings() {
+    let serve = ServeCommandEmulation::with_zenoh()
+        .await
+        .expect("failed to create zenoh serve emulation");
+    let core_node_name = serve.core_node_name().to_string();
+    assert!(
+        !core_node_name.is_empty(),
+        "core_node_name should not be empty"
+    );
+
+    let nodes_dir = tempfile::tempdir().expect("failed to create temp nodes directory");
+    let dump_dir = tempfile::tempdir().expect("failed to create temp dump directory");
+    let producer_dump = dump_dir.path().join("producer.json5");
+    let consumer_dump = dump_dir.path().join("consumer.json5");
+
+    let producer_name = "binding_producer";
+    let consumer_name = "binding_consumer";
+    let node_tag = "v1";
+    let producer_instance_id = "binding_prod_inst";
+    let consumer_instance_id = "binding_cons_inst";
+    let link_id = "main";
+    let git_hash = read_daemon_git_hash(serve.daemon_state_path());
+
+    // Each instance's run_cmd snapshots its own `PEPPY_RUNTIME_CONFIG`
+    // file to the test-owned dump location, then sleeps long enough that
+    // the test process has time to read the snapshot before issuing Stop.
+    let producer_run_cmd = vec![
+        "sh".to_string(),
+        "-c".to_string(),
+        format!(
+            "cp \"$PEPPY_RUNTIME_CONFIG\" \"{}\" && exec sleep 30",
+            producer_dump.display()
+        ),
+    ];
+    let producer_path = write_node_config_for_helper(
+        nodes_dir.path(),
+        producer_name,
+        node_tag,
+        &git_hash,
+        &producer_run_cmd,
+        None,
+    );
+
+    let consumer_run_cmd = vec![
+        "sh".to_string(),
+        "-c".to_string(),
+        format!(
+            "cp \"$PEPPY_RUNTIME_CONFIG\" \"{}\" && exec sleep 30",
+            consumer_dump.display()
+        ),
+    ];
+    let consumer_depends_on = format!(
+        r#"{{ nodes: [{{ name: "{producer_name}", tag: "{node_tag}", link_id: "{link_id}" }}] }}"#
+    );
+    let consumer_path = write_node_config_for_helper(
+        nodes_dir.path(),
+        consumer_name,
+        node_tag,
+        &git_hash,
+        &consumer_run_cmd,
+        Some(&consumer_depends_on),
+    );
+
+    let ctx = Arc::new(
+        AppContext::with_messenger(nodes_dir.path(), Arc::clone(&serve.messenger()))
+            .with_daemon_state_file(serve.daemon_state_path()),
+    );
+
+    // The dummy `sh` subprocess does not expose `node_ready`/`node_health`/
+    // `shutdown`, so impersonate them from the test process for each
+    // instance the launcher will spawn. The daemon's `wait_for_ready_signal`
+    // queries via Zenoh with a wildcard `link_id`, so the queryables
+    // declared here (with default link_ids) still match.
+    let node_messenger = MessengerHandle::from_shared(Arc::clone(&serve.messenger()));
+    let _ready_producer = listen_for_node_ready(
+        &node_messenger,
+        &core_node_name,
+        producer_instance_id,
+        test_node_target(producer_name),
+        &[],
+    )
+    .await
+    .expect("producer ready service should start");
+    let _health_producer = listen_for_node_health(
+        &node_messenger,
+        &core_node_name,
+        producer_instance_id,
+        test_node_target(producer_name),
+        &[],
+    )
+    .await
+    .expect("producer health service should start");
+    let (_shutdown_producer, _) = listen_for_shutdown(
+        &node_messenger,
+        &core_node_name,
+        producer_instance_id,
+        test_node_target(producer_name),
+        &[],
+    )
+    .await
+    .expect("producer shutdown service should start");
+    let _ready_consumer = listen_for_node_ready(
+        &node_messenger,
+        &core_node_name,
+        consumer_instance_id,
+        test_node_target(consumer_name),
+        &[],
+    )
+    .await
+    .expect("consumer ready service should start");
+    let _health_consumer = listen_for_node_health(
+        &node_messenger,
+        &core_node_name,
+        consumer_instance_id,
+        test_node_target(consumer_name),
+        &[],
+    )
+    .await
+    .expect("consumer health service should start");
+    let (_shutdown_consumer, _) = listen_for_shutdown(
+        &node_messenger,
+        &core_node_name,
+        consumer_instance_id,
+        test_node_target(consumer_name),
+        &[],
+    )
+    .await
+    .expect("consumer shutdown service should start");
+
+    let launcher_path = nodes_dir.path().join("peppy_launcher.json5");
+    let launcher_json5 = format!(
+        r#"{{
+            peppy_schema: "launcher_v1",
+            deployments: [
+                {{
+                    source: {{ local: "{producer_path}" }},
+                    instances: [{{ instance_id: "{producer_instance_id}" }}]
+                }},
+                {{
+                    source: {{ local: "{consumer_path}" }},
+                    instances: [{{
+                        instance_id: "{consumer_instance_id}",
+                        bindings: {{ {link_id}: "{producer_instance_id}" }}
+                    }}]
+                }}
+            ]
+        }}"#,
+        producer_path = producer_path.display(),
+        consumer_path = consumer_path.display(),
+    );
+    fs::write(&launcher_path, launcher_json5).expect("launcher config should be writable");
+
+    StackCommand {
+        command: StackCommands::Launch {
+            launcher_config_path: launcher_path,
+            node_add_idle_timeout_secs: 60,
+            node_build_idle_timeout_secs: 60,
+            node_run_idle_timeout_secs: 60,
+            max_timeout_secs: Some(120),
+        },
+    }
+    .execute(&ctx)
+    .expect("launch command should succeed");
+
+    // The `sh` wrappers copy the runtime config before sleeping. Poll the
+    // producer dump until it parses (the consumer dump is read once for a
+    // negative-case assertion afterwards).
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let mut producer_config: Option<config::runtime::RuntimeConfig> = None;
+    while Instant::now() < deadline {
+        if let Ok(content) = fs::read_to_string(&producer_dump)
+            && let Ok(cfg) = serde_json5::from_str::<config::runtime::RuntimeConfig>(&content)
+        {
+            producer_config = Some(cfg);
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+
+    // Stop both instances before asserting so a failure doesn't leak
+    // `sleep 30` subprocesses past the test.
+    for instance_id in [consumer_instance_id, producer_instance_id] {
+        let _ = NodeCommand {
+            command: NodeCommands::Stop {
+                instance_id: instance_id.to_string(),
+            },
+        }
+        .execute(&ctx);
+    }
+
+    let producer_config = producer_config.unwrap_or_else(|| {
+        panic!(
+            "producer runtime config dump never appeared / parsed at {}",
+            producer_dump.display()
+        )
+    });
+    assert_eq!(
+        producer_config.node_instance.instance_id.as_str(),
+        producer_instance_id,
+    );
+    assert_eq!(
+        producer_config.node_instance.link_ids,
+        vec![link_id.to_string()],
+        "the launcher's binding `{link_id} -> {producer_instance_id}` should have populated \
+         the producer's link_ids vec with [`{link_id}`]; getting an empty vec here means the \
+         silent-loss bug is back",
+    );
+
+    let consumer_content =
+        fs::read_to_string(&consumer_dump).expect("consumer runtime config dump should exist");
+    let consumer_config: config::runtime::RuntimeConfig =
+        serde_json5::from_str(&consumer_content).expect("consumer dump should parse");
+    assert!(
+        consumer_config.node_instance.link_ids.is_empty(),
+        "the consumer is not a binding target so its link_ids should stay empty (the runtime \
+         defaults to the producer-default sentinel `_`); got {:?}",
+        consumer_config.node_instance.link_ids,
+    );
+}

--- a/crates/peppy/tests/stack_launch.rs
+++ b/crates/peppy/tests/stack_launch.rs
@@ -882,23 +882,34 @@ async fn stack_launch_populates_link_ids_from_launcher_bindings() {
     .execute(&ctx)
     .expect("launch command should succeed");
 
-    // The `sh` wrappers copy the runtime config before sleeping. Poll the
-    // producer dump until it parses (the consumer dump is read once for a
-    // negative-case assertion afterwards).
+    // The `sh` wrappers copy the runtime config before sleeping. Poll
+    // BOTH dumps before stopping anything: stopping the consumer before
+    // its dump has flushed would race with the negative-case assertion
+    // below.
     let deadline = Instant::now() + Duration::from_secs(5);
     let mut producer_config: Option<config::runtime::RuntimeConfig> = None;
+    let mut consumer_config: Option<config::runtime::RuntimeConfig> = None;
     while Instant::now() < deadline {
-        if let Ok(content) = fs::read_to_string(&producer_dump)
+        if producer_config.is_none()
+            && let Ok(content) = fs::read_to_string(&producer_dump)
             && let Ok(cfg) = serde_json5::from_str::<config::runtime::RuntimeConfig>(&content)
         {
             producer_config = Some(cfg);
+        }
+        if consumer_config.is_none()
+            && let Ok(content) = fs::read_to_string(&consumer_dump)
+            && let Ok(cfg) = serde_json5::from_str::<config::runtime::RuntimeConfig>(&content)
+        {
+            consumer_config = Some(cfg);
+        }
+        if producer_config.is_some() && consumer_config.is_some() {
             break;
         }
         std::thread::sleep(Duration::from_millis(50));
     }
 
-    // Stop both instances before asserting so a failure doesn't leak
-    // `sleep 30` subprocesses past the test.
+    // Stop both instances after both dumps are captured so a failure
+    // doesn't leak `sleep 30` subprocesses past the test.
     for instance_id in [consumer_instance_id, producer_instance_id] {
         let _ = NodeCommand {
             command: NodeCommands::Stop {
@@ -926,10 +937,12 @@ async fn stack_launch_populates_link_ids_from_launcher_bindings() {
          silent-loss bug is back",
     );
 
-    let consumer_content =
-        fs::read_to_string(&consumer_dump).expect("consumer runtime config dump should exist");
-    let consumer_config: config::runtime::RuntimeConfig =
-        serde_json5::from_str(&consumer_content).expect("consumer dump should parse");
+    let consumer_config = consumer_config.unwrap_or_else(|| {
+        panic!(
+            "consumer runtime config dump never appeared / parsed at {}",
+            consumer_dump.display()
+        )
+    });
     assert!(
         consumer_config.node_instance.link_ids.is_empty(),
         "the consumer is not a binding target so its link_ids should stay empty (the runtime \

--- a/crates/pmi-internal/src/wire.rs
+++ b/crates/pmi-internal/src/wire.rs
@@ -108,7 +108,7 @@ impl TryFrom<&str> for Segment {
         if s.contains('/') {
             return Err(SegmentError::ContainsSlash(s.to_string()));
         }
-        if matches!(s, "*" | "**" | "_") {
+        if matches!(s, "*" | "**") || s == DEFAULT_LINK_ID {
             return Err(SegmentError::ReservedSentinel(s.to_string()));
         }
         Ok(Self(s.to_string()))

--- a/crates/pmi-internal/src/wire.rs
+++ b/crates/pmi-internal/src/wire.rs
@@ -74,8 +74,9 @@ impl Segment {
 
 /// Wire literal used at the `link_id` slot when a producer is run without
 /// `--link-id`. Kept in sync with [`Segment::default_link_id`] / the CLI
-/// validator in `peppy::commands::node::run`.
-pub const DEFAULT_LINK_ID: &str = "_";
+/// validator in `peppy::commands::node::run`. The single source of truth
+/// lives in `config::consts::DEFAULT_LINK_ID_SENTINEL`; this is a re-export.
+pub const DEFAULT_LINK_ID: &str = config::consts::DEFAULT_LINK_ID_SENTINEL;
 
 impl std::ops::Deref for Segment {
     type Target = str;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Launcher validates instance bindings during plan/launch to catch miswiring and missing pinned bindings.
  * Launcher now computes and supplies resolved link IDs to node instances at startup; reserved sentinel link ID is enforced.

* **Bug Fixes**
  * Corrected link ID propagation so consumers and producers receive consistent wiring.

* **Tests**
  * Added unit and integration tests covering binding validation, sentinel handling, ordering, deduplication, and runtime link-ID propagation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Peppy-bot/peppy/pull/204?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->