### PR TITLE
Throw warnings on missing `link_id` during `peppy run`

### DIFF
--- a/crates/config-internal/src/error.rs
+++ b/crates/config-internal/src/error.rs
@@ -76,6 +76,22 @@ pub struct BindingTargetMismatch {
     pub actual_tag: String,
 }
 
+/// Payload for [`ParsingError::DuplicateProducerLinkId`]. Boxed in the
+/// variant so the five `String` fields do not inflate `ParsingError` past
+/// the `clippy::result_large_err` threshold.
+#[derive(Debug, Clone, Error)]
+#[error(
+    "two instances of `{node_name}:{node_tag}` would both publish link_id `{link_id}` \
+     (`{instance_a}` and `{instance_b}`); a producer link_id must be unique within a node"
+)]
+pub struct DuplicateProducerLinkId {
+    pub node_name: String,
+    pub node_tag: String,
+    pub link_id: String,
+    pub instance_a: String,
+    pub instance_b: String,
+}
+
 /// Payload for [`ParsingError::MissingInterface`]. Boxed in the variant so
 /// the six `String` fields do not inflate `ParsingError` past the
 /// `clippy::result_large_err` threshold.
@@ -176,6 +192,13 @@ pub enum ParsingError {
     /// `peppylib::PeppyError`).
     #[error(transparent)]
     BindingTargetMismatch(Box<BindingTargetMismatch>),
+    /// Two producer instances of the same `(node_name, node_tag)` would
+    /// end up advertising the same `link_id` (because consumer bindings
+    /// point that `link_id` at distinct producer `instance_id`s). Boxed
+    /// for the same `result_large_err` reason as the other binding
+    /// variants.
+    #[error(transparent)]
+    DuplicateProducerLinkId(Box<DuplicateProducerLinkId>),
 
     // -- container config: mount paths
     #[error(

--- a/crates/config-internal/src/launcher/bindings.rs
+++ b/crates/config-internal/src/launcher/bindings.rs
@@ -9,7 +9,9 @@
 //! configurations into loud parse-time errors.
 
 use crate::consts::DEFAULT_LINK_ID_SENTINEL;
-use crate::error::{BindingMissingForPinnedDep, BindingTargetMismatch, ParsingError};
+use crate::error::{
+    BindingMissingForPinnedDep, BindingTargetMismatch, DuplicateProducerLinkId, ParsingError,
+};
 use crate::node::DependsOn;
 use std::collections::BTreeMap;
 
@@ -26,7 +28,7 @@ pub struct BindingValidationItem<'a> {
     pub depends_on: Option<&'a DependsOn>,
 }
 
-/// Three sub-checks per consumer instance:
+/// Four sub-checks per consumer instance (1–3) or producer group (4):
 ///   1. Each `binding` key matches a `link_id` declared in the
 ///      consumer's `depends_on.{nodes,interfaces}` (dead-binding check).
 ///   2. Each pinned `depends_on` entry (`from_any: false` and a
@@ -34,6 +36,10 @@ pub struct BindingValidationItem<'a> {
 ///      consumer instance (no silent-loss check).
 ///   3. For node-typed pinned deps, the binding's target instance
 ///      deploys a node whose `(name, tag)` matches the dep declaration.
+///   4. No two instances of the same `(node_name, node_tag)` end up
+///      advertising the same producer `link_id`. A producer `link_id`
+///      is a 1:1 contract from the consumer's perspective, so two
+///      sibling instances claiming it would silently multiplex the wire.
 ///
 /// Interface-typed deps bypass check 3 because they do not pre-commit
 /// to a producer node identity; verifying that the bound target
@@ -59,7 +65,88 @@ pub fn validate_bindings(items: &[BindingValidationItem<'_>]) -> Vec<ParsingErro
         }
     }
 
+    check_duplicate_producer_link_ids(items, &instance_to_item, &mut errors);
+
     errors
+}
+
+/// Group all planned instances by `(node_name, node_tag)`, derive each
+/// instance's producer-side link_ids by inverting every consumer's
+/// `bindings` map, and emit a `DuplicateProducerLinkId` for every pair
+/// of sibling instances that end up claiming the same `link_id`.
+///
+/// Why this matters: at runtime `prepare_and_spawn` enforces the same
+/// invariant (see `NodeEntity::prepare_and_spawn` in node-stack), but
+/// the launcher spawns instances sequentially. Without a parse-time
+/// check, a colliding launcher manifest would partially deploy — first
+/// instance wins, second one fails mid-flight — and leave the operator
+/// to clean up. We catch it before any spawn side-effect.
+fn check_duplicate_producer_link_ids(
+    items: &[BindingValidationItem<'_>],
+    instance_to_item: &BTreeMap<&str, &BindingValidationItem<'_>>,
+    errors: &mut Vec<ParsingError>,
+) {
+    // Per (node_name, node_tag) group: producer_instance_id -> link_ids
+    // the consumers have asked that producer to advertise.
+    let mut derived: BTreeMap<(&str, &str), BTreeMap<&str, Vec<&str>>> = BTreeMap::new();
+    // Register every declared instance up front so unbound producers
+    // still appear and trivially pass the duplicate check.
+    for item in items {
+        let group = derived.entry((item.node_name, item.node_tag)).or_default();
+        for inst in item.instances {
+            group.entry(inst.instance_id.as_str()).or_default();
+        }
+    }
+    // Walk every consumer binding and attribute each link_id to its
+    // target producer (scoped to that producer's node group).
+    for item in items {
+        for inst in item.instances {
+            for (link_id, target_id) in &inst.bindings {
+                let Some(target_item) = instance_to_item.get(target_id.as_str()) else {
+                    // Already reported as UnknownInstanceId.
+                    continue;
+                };
+                if let Some(group) =
+                    derived.get_mut(&(target_item.node_name, target_item.node_tag))
+                    && let Some(link_ids) = group.get_mut(target_id.as_str())
+                    && !link_ids.contains(&link_id.as_str())
+                {
+                    link_ids.push(link_id.as_str());
+                }
+            }
+        }
+    }
+    // For each group, invert producer -> link_ids into link_id ->
+    // producers; emit one error per (group, link_id) pair with more
+    // than one producer. Pairs are sorted so error ordering is
+    // deterministic across runs.
+    for ((node_name, node_tag), producers) in &derived {
+        let mut owners: BTreeMap<&str, Vec<&str>> = BTreeMap::new();
+        for (producer_id, link_ids) in producers {
+            for link_id in link_ids {
+                owners.entry(*link_id).or_default().push(*producer_id);
+            }
+        }
+        for (link_id, mut producer_ids) in owners {
+            if producer_ids.len() < 2 {
+                continue;
+            }
+            producer_ids.sort();
+            for (i, a) in producer_ids.iter().enumerate() {
+                for b in &producer_ids[i + 1..] {
+                    errors.push(ParsingError::DuplicateProducerLinkId(Box::new(
+                        DuplicateProducerLinkId {
+                            node_name: (*node_name).to_string(),
+                            node_tag: (*node_tag).to_string(),
+                            link_id: link_id.to_string(),
+                            instance_a: (*a).to_string(),
+                            instance_b: (*b).to_string(),
+                        },
+                    )));
+                }
+            }
+        }
+    }
 }
 
 fn build_instance_lookup<'a>(
@@ -514,6 +601,148 @@ mod tests {
         assert_eq!(owner_instance_id, "cons1");
         assert_eq!(binding, "main");
         assert_eq!(instance_id, "ghost_producer");
+    }
+
+    /// Two consumers each bind `main` to a different instance of the
+    /// same `camera:v1` producer node — both producer instances would
+    /// advertise `main` on the wire, which violates the 1:1 link_id
+    /// contract. Surfaces as a single `DuplicateProducerLinkId` naming
+    /// both colliding producer instances.
+    #[test]
+    fn rejects_two_producer_instances_claiming_same_link_id() {
+        let cons_instances = parse_instances(
+            r#"[
+                { instance_id: "cons_a", bindings: { main: "prod_a" } },
+                { instance_id: "cons_b", bindings: { main: "prod_b" } }
+            ]"#,
+        );
+        let depends_on = parse_depends_on(
+            r#"{
+                nodes: [{ name: "camera", tag: "v1", link_id: "main" }]
+            }"#,
+        );
+        let prod_instances = parse_instances(
+            r#"[
+                { instance_id: "prod_a" },
+                { instance_id: "prod_b" }
+            ]"#,
+        );
+        let items = vec![
+            item("cons", "v1", &cons_instances, Some(&depends_on)),
+            item("camera", "v1", &prod_instances, None),
+        ];
+        let errors = validate_bindings(&items);
+        assert_eq!(errors.len(), 1, "expected one error, got {errors:?}");
+        let ParsingError::DuplicateProducerLinkId(info) = &errors[0] else {
+            panic!("expected DuplicateProducerLinkId, got {:?}", errors[0]);
+        };
+        assert_eq!(info.node_name, "camera");
+        assert_eq!(info.node_tag, "v1");
+        assert_eq!(info.link_id, "main");
+        assert_eq!(info.instance_a, "prod_a");
+        assert_eq!(info.instance_b, "prod_b");
+    }
+
+    /// Producers of *different* nodes may share a `link_id` — the
+    /// uniqueness contract is scoped to `(node_name, node_tag)`.
+    #[test]
+    fn allows_same_link_id_across_different_node_types() {
+        let cons_instances = parse_instances(
+            r#"[{
+                instance_id: "cons1",
+                bindings: { camera_main: "cam_prod", lidar_main: "lidar_prod" }
+            }]"#,
+        );
+        let depends_on = parse_depends_on(
+            r#"{
+                nodes: [
+                    { name: "camera", tag: "v1", link_id: "camera_main" },
+                    { name: "lidar",  tag: "v1", link_id: "lidar_main" }
+                ]
+            }"#,
+        );
+        let cam_instances = parse_instances(r#"[{ instance_id: "cam_prod" }]"#);
+        let lidar_instances = parse_instances(r#"[{ instance_id: "lidar_prod" }]"#);
+        let items = vec![
+            item("cons", "v1", &cons_instances, Some(&depends_on)),
+            item("camera", "v1", &cam_instances, None),
+            item("lidar", "v1", &lidar_instances, None),
+        ];
+        let errors = validate_bindings(&items);
+        assert!(errors.is_empty(), "unexpected errors: {errors:?}");
+    }
+
+    /// Fan-in is fine: multiple consumers binding the same `link_id`
+    /// to a *single* producer instance is the normal pattern.
+    #[test]
+    fn allows_multiple_consumers_binding_same_link_id_to_one_producer() {
+        let cons_instances = parse_instances(
+            r#"[
+                { instance_id: "cons_a", bindings: { main: "prod1" } },
+                { instance_id: "cons_b", bindings: { main: "prod1" } }
+            ]"#,
+        );
+        let depends_on = parse_depends_on(
+            r#"{
+                nodes: [{ name: "camera", tag: "v1", link_id: "main" }]
+            }"#,
+        );
+        let prod_instances = parse_instances(r#"[{ instance_id: "prod1" }]"#);
+        let items = vec![
+            item("cons", "v1", &cons_instances, Some(&depends_on)),
+            item("camera", "v1", &prod_instances, None),
+        ];
+        let errors = validate_bindings(&items);
+        assert!(errors.is_empty(), "unexpected errors: {errors:?}");
+    }
+
+    /// Three sibling producer instances all claiming the same link_id
+    /// surface as 3 pairwise errors (C(3,2)) in alphabetical instance
+    /// order — proves the pairing is deterministic.
+    #[test]
+    fn three_way_collision_emits_pairwise_errors() {
+        let cons_instances = parse_instances(
+            r#"[
+                { instance_id: "cons_a", bindings: { main: "prod_a" } },
+                { instance_id: "cons_b", bindings: { main: "prod_b" } },
+                { instance_id: "cons_c", bindings: { main: "prod_c" } }
+            ]"#,
+        );
+        let depends_on = parse_depends_on(
+            r#"{
+                nodes: [{ name: "camera", tag: "v1", link_id: "main" }]
+            }"#,
+        );
+        let prod_instances = parse_instances(
+            r#"[
+                { instance_id: "prod_a" },
+                { instance_id: "prod_b" },
+                { instance_id: "prod_c" }
+            ]"#,
+        );
+        let items = vec![
+            item("cons", "v1", &cons_instances, Some(&depends_on)),
+            item("camera", "v1", &prod_instances, None),
+        ];
+        let errors = validate_bindings(&items);
+        assert_eq!(errors.len(), 3, "expected 3 pairwise errors: {errors:?}");
+        let pairs: Vec<(String, String)> = errors
+            .iter()
+            .map(|e| match e {
+                ParsingError::DuplicateProducerLinkId(info) => {
+                    (info.instance_a.clone(), info.instance_b.clone())
+                }
+                other => panic!("expected DuplicateProducerLinkId, got {other:?}"),
+            })
+            .collect();
+        assert_eq!(
+            pairs,
+            vec![
+                ("prod_a".to_string(), "prod_b".to_string()),
+                ("prod_a".to_string(), "prod_c".to_string()),
+                ("prod_b".to_string(), "prod_c".to_string()),
+            ]
+        );
     }
 
     /// All three sub-checks are aggregated: a single consumer triggers

--- a/crates/config-internal/src/lib.rs
+++ b/crates/config-internal/src/lib.rs
@@ -30,8 +30,8 @@ pub use common::{
 
 // -- error --
 pub use error::{
-    BindingMissingForPinnedDep, BindingTargetMismatch, Error as ConfigError, MissingInterface,
-    ParsingError, Result as ConfigResult,
+    BindingMissingForPinnedDep, BindingTargetMismatch, DuplicateProducerLinkId,
+    Error as ConfigError, MissingInterface, ParsingError, Result as ConfigResult,
 };
 
 // -- atomic_write --

--- a/crates/core-node-api/schemas/node.capnp
+++ b/crates/core-node-api/schemas/node.capnp
@@ -274,6 +274,10 @@ struct NodeInstanceInfo {
     instanceId @0 :Text;
     # Per-instance state: "starting" or "running"
     state @1 :Text;
+    # Producer-side link_ids this instance advertises on the wire. Mirrors
+    # `RuntimeConfig.node_instance.link_ids`. An empty list means the
+    # instance only publishes under the default link_id sentinel.
+    linkIds @2 :List(Text);
 }
 
 # Node info lookup result.

--- a/crates/core-node-api/src/encoding/node/info.rs
+++ b/crates/core-node-api/src/encoding/node/info.rs
@@ -55,6 +55,10 @@ impl NodeInfoRequest {
 pub struct NodeInstanceInfo {
     pub instance_id: String,
     pub state: InstanceState,
+    /// Producer-side `link_ids` this instance advertises on the wire,
+    /// mirroring `RuntimeConfig.node_instance.link_ids`. An empty list
+    /// means the instance only publishes under the default link_id sentinel.
+    pub link_ids: Vec<String>,
 }
 
 /// Body of a successful `node_info` lookup — carries all metadata about a
@@ -117,6 +121,13 @@ impl NodeInfoResponse {
                             let mut entry = instances_builder.reborrow().get(i as u32);
                             entry.set_instance_id(&inst.instance_id);
                             entry.set_state(inst.state.as_str());
+                            let link_id_count =
+                                capnp_list_len(inst.link_ids.len(), "NodeInstanceInfo.link_ids")?;
+                            let mut link_ids_builder =
+                                entry.reborrow().init_link_ids(link_id_count);
+                            for (j, link_id) in inst.link_ids.iter().enumerate() {
+                                link_ids_builder.set(j as u32, link_id.as_str());
+                            }
                         }
                     }
                     found.set_add_log_path(
@@ -164,9 +175,15 @@ impl NodeInfoResponse {
                     let state_str = entry.get_state()?.to_str()?;
                     let state = InstanceState::from_str(state_str)
                         .map_err(|e| crate::Error::Decoding(e.to_string()))?;
+                    let link_ids_reader = entry.get_link_ids()?;
+                    let mut link_ids = Vec::with_capacity(link_ids_reader.len() as usize);
+                    for j in 0..link_ids_reader.len() {
+                        link_ids.push(link_ids_reader.get(j)?.to_str()?.to_owned());
+                    }
                     instances.push(NodeInstanceInfo {
                         instance_id: entry.get_instance_id()?.to_str()?.to_owned(),
                         state,
+                        link_ids,
                     });
                 }
                 let add_log_path =
@@ -236,6 +253,49 @@ mod tests {
             NodeInfoResponse::Found(info) => {
                 assert_eq!(info.config.manifest.name.as_str(), "sensor_node");
                 assert_eq!(info.stage, NodeStage::Added);
+            }
+            NodeInfoResponse::NotInStack => panic!("expected Found"),
+        }
+    }
+
+    #[test]
+    fn node_info_response_roundtrips_instance_link_ids() {
+        let info = NodeInfo {
+            config: sample_config_for_roundtrip(),
+            config_integrity: "0".repeat(64),
+            stage: NodeStage::Ready,
+            instances: vec![
+                NodeInstanceInfo {
+                    instance_id: "inst-with-links".to_string(),
+                    state: InstanceState::Running,
+                    link_ids: vec!["front_left".to_string(), "front_right".to_string()],
+                },
+                NodeInstanceInfo {
+                    instance_id: "inst-no-links".to_string(),
+                    state: InstanceState::Starting,
+                    link_ids: vec![],
+                },
+            ],
+            add_log_path: None,
+            run_log_paths: vec![],
+        };
+        let encoded = NodeInfoResponse::Found(Box::new(info))
+            .encode()
+            .expect("encoding should succeed");
+        let decoded = NodeInfoResponse::decode(&encoded).expect("decoding should succeed");
+
+        match decoded {
+            NodeInfoResponse::Found(info) => {
+                assert_eq!(info.instances.len(), 2);
+                assert_eq!(
+                    info.instances[0].link_ids,
+                    vec!["front_left".to_string(), "front_right".to_string()],
+                    "link_ids should round-trip for the first instance"
+                );
+                assert!(
+                    info.instances[1].link_ids.is_empty(),
+                    "empty link_ids should round-trip as empty"
+                );
             }
             NodeInfoResponse::NotInStack => panic!("expected Found"),
         }

--- a/crates/core-node-api/src/graph.rs
+++ b/crates/core-node-api/src/graph.rs
@@ -114,6 +114,12 @@ impl std::error::Error for UnknownNodeStage {}
 pub struct SerializedInstance {
     pub instance_id: String,
     pub state: InstanceState,
+    /// Producer-side `link_ids` this instance advertises on the wire.
+    /// Defaults to an empty list for payloads produced by versions that
+    /// predate the field (and for snapshot-restored or test-fixture
+    /// instances that don't track link_ids).
+    #[serde(default)]
+    pub link_ids: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -175,4 +181,34 @@ pub struct SerializedEdge {
 pub struct SerializedNodeGraph {
     pub nodes: Vec<SerializedNode>,
     pub edges: Vec<SerializedEdge>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serialized_instance_link_ids_roundtrip() {
+        let original = SerializedInstance {
+            instance_id: "i1".to_string(),
+            state: InstanceState::Running,
+            link_ids: vec!["front_left".to_string(), "front_right".to_string()],
+        };
+        let json = serde_json5::to_string::<SerializedInstance>(&original).expect("serialize");
+        let parsed: SerializedInstance = serde_json5::from_str(&json).expect("deserialize");
+        assert_eq!(parsed, original);
+    }
+
+    #[test]
+    fn serialized_instance_legacy_payload_decodes_with_empty_link_ids() {
+        // Payload from a peer that predates the `link_ids` field.
+        let legacy = r#"{ "instance_id": "i1", "state": "running" }"#;
+        let parsed: SerializedInstance = serde_json5::from_str(legacy).expect("legacy decode");
+        assert_eq!(parsed.instance_id, "i1");
+        assert_eq!(parsed.state, InstanceState::Running);
+        assert!(
+            parsed.link_ids.is_empty(),
+            "missing field should default to empty Vec"
+        );
+    }
 }

--- a/crates/core-node-internal/src/services/node/add.rs
+++ b/crates/core-node-internal/src/services/node/add.rs
@@ -13,13 +13,13 @@ use crate::Result;
 use crate::names;
 use chrono::Local;
 use config::consts::{NODE_CONFIG_FILE, PEPPYGEN_OUTPUT_PATH, PeppyDirs};
+use config::node::validate_dependency_specs;
 use config::node::{NodeConfig, NodeConfigParser};
 use core_node_api::encoding::{
     NodeAddFeedback, NodeAddGoal, NodeAddGoalResponse, NodeAddResult, NodeSource,
 };
 use futures::FutureExt;
 use node_stack::add_steps::{copy_node_to_temp_dir, verify_git_hash};
-use config::node::validate_dependency_specs;
 use node_stack::{InstanceState, NodeStack, WorkingDirGuard};
 use parking_lot::Mutex as StdMutex;
 use peppylib::messaging::{ActionFeedbackPublisher, ServiceRequestContext};

--- a/crates/core-node-internal/src/services/node/info.rs
+++ b/crates/core-node-internal/src/services/node/info.rs
@@ -149,6 +149,7 @@ async fn handle_node_info_request_inner(
             instances.push(NodeInstanceInfo {
                 instance_id: id.to_owned(),
                 state: instance.state(),
+                link_ids: instance.link_ids().to_vec(),
             });
             run_log_paths.push(run_log_dir.join(format!("{}.log", id)));
         }

--- a/crates/core-node-internal/src/services/node/run.rs
+++ b/crates/core-node-internal/src/services/node/run.rs
@@ -616,6 +616,7 @@ async fn process_node_run(
             publish_enabled: Arc::clone(&publish_enabled),
             hooks: Arc::new(feedback_sync.clone()),
         },
+        link_ids: &runtime_config.node_instance.link_ids,
     };
     // Reject early if an outer orchestrator already cancelled us — avoids
     // spawning a child process we're only going to tear down on the next line.

--- a/crates/core-node-internal/tests/common.rs
+++ b/crates/core-node-internal/tests/common.rs
@@ -1426,6 +1426,7 @@ async fn spawn_real_running_instance_inner(
             mount_paths_resolved: &[],
             peppy_dirs: &started.peppy_dirs,
             output_sinks,
+            link_ids: &[],
         },
     )
     .await

--- a/crates/node-stack-internal/src/error.rs
+++ b/crates/node-stack-internal/src/error.rs
@@ -28,6 +28,15 @@ pub enum Error {
         node_name: String,
         node_tag: String,
     },
+    #[error(
+        "link_id `{link_id}` is already claimed by instance `{held_by}` of node `{node_name}`:{node_tag}"
+    )]
+    DuplicateLinkId {
+        link_id: String,
+        held_by: String,
+        node_name: String,
+        node_tag: String,
+    },
     #[error("Cannot remove node `{node_name}`:{node_tag} because it still has instances")]
     CannotRemoveNodeWithInstances { node_name: String, node_tag: String },
 

--- a/crates/node-stack-internal/src/node_stack.rs
+++ b/crates/node-stack-internal/src/node_stack.rs
@@ -556,6 +556,7 @@ impl NodeStack {
             instance_id,
             Some(std::process::id()),
             InstanceState::Running,
+            Vec::new(),
         );
         let root_entity = NodeEntity::root(root_config, root_path, instance);
         Self {

--- a/crates/node-stack-internal/src/node_stack/entity.rs
+++ b/crates/node-stack-internal/src/node_stack/entity.rs
@@ -652,6 +652,27 @@ impl NodeEntity {
                 });
             }
 
+            // Reject collisions against link_ids already claimed by another
+            // live instance of the same node. A producer link_id is a 1:1
+            // binding contract from the consumer's perspective, so two
+            // instances advertising the same link_id would silently
+            // multiplex the wire. Empty ctx.link_ids (the default-launch
+            // path) claims nothing and trivially passes — the `_` sentinel
+            // is materialized downstream by the runtime processor and
+            // permits multiple `from_any` fan-in producers.
+            for new_link_id in ctx.link_ids {
+                if let Some(holder) = instances.iter().find(|inst| {
+                    inst.link_ids().iter().any(|existing| existing == new_link_id)
+                }) {
+                    return Err(Error::DuplicateLinkId {
+                        link_id: new_link_id.clone(),
+                        held_by: holder.instance_id().as_str().to_owned(),
+                        node_name: guard.config.manifest.name.as_str().to_owned(),
+                        node_tag: guard.config.manifest.tag.clone(),
+                    });
+                }
+            }
+
             let snapshot_artifact = artifact_path.clone();
             instances.push(TrackedNodeInstance::new(
                 ctx.instance_id.clone(),

--- a/crates/node-stack-internal/src/node_stack/entity.rs
+++ b/crates/node-stack-internal/src/node_stack/entity.rs
@@ -40,6 +40,7 @@ impl From<&NodeEntity> for SerializedNode {
                 .map(|i| SerializedInstance {
                     instance_id: i.instance_id().as_str().to_string(),
                     state: i.state(),
+                    link_ids: i.link_ids().to_vec(),
                 })
                 .collect(),
         }
@@ -170,6 +171,12 @@ pub struct StartContext<'a> {
     /// `validate_goal_env_vars`, `inject_rust_build_env`, and
     /// `inject_node_runtime_env` in core-node).
     pub env_vars: &'a [(String, String)],
+    /// Producer-side `link_ids` this instance will advertise, mirrored from
+    /// `RuntimeConfig.node_instance.link_ids`. Recorded on the
+    /// `TrackedNodeInstance` so the daemon can expose it via `node_info` /
+    /// `stack_list` for downstream consumers (e.g. the CLI warning for
+    /// unsatisfied stack-consumer link_ids).
+    pub link_ids: &'a [String],
     /// Mount paths with `${parameters:...}` already resolved by core-node
     /// (against runtime arguments and the blocked-source policy). Container
     /// nodes only.
@@ -650,6 +657,7 @@ impl NodeEntity {
                 ctx.instance_id.clone(),
                 None,
                 InstanceState::Starting,
+                ctx.link_ids.to_vec(),
             ));
 
             (
@@ -1052,6 +1060,10 @@ pub struct TrackedNodeInstance {
     /// Persisted so it can be removed when the instance stops or aborts. `None`
     /// for snapshot-restored or test-fixture instances.
     runtime_config_path: Option<PathBuf>,
+    /// Producer-side `link_ids` this instance advertises on the wire, mirroring
+    /// `RuntimeConfig.node_instance.link_ids` at start time. Empty for root
+    /// instances and for snapshot/test fixtures that don't track them.
+    link_ids: Vec<String>,
 }
 
 impl TrackedNodeInstance {
@@ -1060,13 +1072,19 @@ impl TrackedNodeInstance {
     /// child process and have not yet committed it pass `InstanceState::Starting`;
     /// callers that are reconstructing an entity from a snapshot or test
     /// fixture pass `InstanceState::Running`.
-    pub fn new(instance_id: Name, pid: Option<u32>, state: InstanceState) -> Self {
+    pub fn new(
+        instance_id: Name,
+        pid: Option<u32>,
+        state: InstanceState,
+        link_ids: Vec<String>,
+    ) -> Self {
         Self {
             instance_id,
             pid,
             state,
             instance_dir: None,
             runtime_config_path: None,
+            link_ids,
         }
     }
 
@@ -1080,6 +1098,11 @@ impl TrackedNodeInstance {
 
     pub fn state(&self) -> InstanceState {
         self.state
+    }
+
+    /// Returns the producer-side `link_ids` this instance advertises.
+    pub fn link_ids(&self) -> &[String] {
+        &self.link_ids
     }
 
     /// Returns the on-disk instance directory recorded during start, if any.
@@ -1108,4 +1131,3 @@ impl TrackedNodeInstance {
         self.runtime_config_path = Some(runtime_config_path);
     }
 }
-

--- a/crates/node-stack-internal/tests/helpers/real_lifecycle.rs
+++ b/crates/node-stack-internal/tests/helpers/real_lifecycle.rs
@@ -179,6 +179,18 @@ pub async fn spawn_running_instance(
     harness: &LifecycleHarness,
     instance_id: Name,
 ) -> RunningInstanceGuard {
+    spawn_running_instance_with_link_ids(handle, harness, instance_id, &[]).await
+}
+
+/// Same as [`spawn_running_instance`] but advertises the supplied
+/// `link_ids` on the producer side. Used by tests that need to assert
+/// link_id-aware behavior in `prepare_and_spawn`.
+pub async fn spawn_running_instance_with_link_ids(
+    handle: EntityHandle,
+    harness: &LifecycleHarness,
+    instance_id: Name,
+    link_ids: &[String],
+) -> RunningInstanceGuard {
     let (child, started_ctx) = NodeEntity::prepare_and_spawn(
         &handle,
         StartContext {
@@ -188,7 +200,7 @@ pub async fn spawn_running_instance(
             mount_paths_resolved: &[],
             peppy_dirs: &harness.peppy_dirs,
             output_sinks: harness.output_sinks(),
-            link_ids: &[],
+            link_ids,
         },
     )
     .await

--- a/crates/node-stack-internal/tests/helpers/real_lifecycle.rs
+++ b/crates/node-stack-internal/tests/helpers/real_lifecycle.rs
@@ -188,6 +188,7 @@ pub async fn spawn_running_instance(
             mount_paths_resolved: &[],
             peppy_dirs: &harness.peppy_dirs,
             output_sinks: harness.output_sinks(),
+            link_ids: &[],
         },
     )
     .await

--- a/crates/node-stack-internal/tests/tests_modules/lifecycle_transitions.rs
+++ b/crates/node-stack-internal/tests/tests_modules/lifecycle_transitions.rs
@@ -1006,6 +1006,225 @@ async fn prepare_and_spawn_rejects_duplicate_instance_id_when_running_already_pr
     }
 }
 
+#[tokio::test]
+async fn prepare_and_spawn_rejects_duplicate_link_id_across_instances() {
+    // Two instances of the same node may not both advertise the same
+    // producer link_id — that would silently multiplex the wire from the
+    // consumer's perspective. The guard runs under the same write lock
+    // as the duplicate-instance_id check, before any I/O.
+    let stack = NodeStack::new(core_node_config(), None, PathBuf::from("/tmp"));
+    let (id_a, h) = start_harness("cam-a");
+    let id_b = Name::new("cam-b").expect("valid instance id");
+    let handle = push_built_long_running_sensor(&stack, &h).await;
+
+    let _existing = real_lifecycle::spawn_running_instance_with_link_ids(
+        Arc::clone(&handle),
+        &h,
+        id_a.clone(),
+        &["wrist_left_camera".to_string()],
+    )
+    .await;
+
+    let err = NodeEntity::prepare_and_spawn(
+        &handle,
+        node_stack::StartContext {
+            instance_id: &id_b,
+            runtime_config_json5: "{}",
+            env_vars: &[],
+            mount_paths_resolved: &[],
+            peppy_dirs: &h.peppy_dirs,
+            output_sinks: h.output_sinks(),
+            link_ids: &["wrist_left_camera".to_string()],
+        },
+    )
+    .await
+    .expect_err("prepare_and_spawn should reject duplicate link_id");
+
+    match err {
+        NodeStackError::DuplicateLinkId {
+            link_id, held_by, ..
+        } => {
+            assert_eq!(link_id, "wrist_left_camera");
+            assert_eq!(held_by, id_a.as_str());
+        }
+        other => panic!("expected DuplicateLinkId, got {:?}", other),
+    }
+
+    let guard = handle.read();
+    match guard.stage() {
+        NodeStage::Ready { instances, .. } => {
+            assert_eq!(
+                instances.len(),
+                1,
+                "rejected instance must not be partially registered"
+            );
+            assert_eq!(instances[0].instance_id(), &id_a);
+        }
+        other => panic!("expected Ready, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn prepare_and_spawn_rejects_partial_link_id_overlap() {
+    // If only one of the new instance's link_ids collides, the whole
+    // launch is rejected — we don't partially register link_ids.
+    let stack = NodeStack::new(core_node_config(), None, PathBuf::from("/tmp"));
+    let (id_a, h) = start_harness("cam-a");
+    let id_b = Name::new("cam-b").expect("valid instance id");
+    let handle = push_built_long_running_sensor(&stack, &h).await;
+
+    let _existing = real_lifecycle::spawn_running_instance_with_link_ids(
+        Arc::clone(&handle),
+        &h,
+        id_a.clone(),
+        &["wrist_left_camera".to_string()],
+    )
+    .await;
+
+    let err = NodeEntity::prepare_and_spawn(
+        &handle,
+        node_stack::StartContext {
+            instance_id: &id_b,
+            runtime_config_json5: "{}",
+            env_vars: &[],
+            mount_paths_resolved: &[],
+            peppy_dirs: &h.peppy_dirs,
+            output_sinks: h.output_sinks(),
+            link_ids: &[
+                "wrist_left_camera".to_string(),
+                "torso_camera".to_string(),
+            ],
+        },
+    )
+    .await
+    .expect_err("prepare_and_spawn should reject partial overlap");
+
+    match err {
+        NodeStackError::DuplicateLinkId { link_id, .. } => {
+            assert_eq!(link_id, "wrist_left_camera");
+        }
+        other => panic!("expected DuplicateLinkId, got {:?}", other),
+    }
+
+    let guard = handle.read();
+    match guard.stage() {
+        NodeStage::Ready { instances, .. } => {
+            assert_eq!(instances.len(), 1, "no partial registration");
+        }
+        other => panic!("expected Ready, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn prepare_and_spawn_accepts_disjoint_link_ids_on_same_node() {
+    // Sibling instances of the same node may freely claim non-overlapping
+    // link_ids — this is the intended multi-instance pattern.
+    let stack = NodeStack::new(core_node_config(), None, PathBuf::from("/tmp"));
+    let (id_a, h) = start_harness("cam-a");
+    let id_b = Name::new("cam-b").expect("valid instance id");
+    let handle = push_built_long_running_sensor(&stack, &h).await;
+
+    let _a = real_lifecycle::spawn_running_instance_with_link_ids(
+        Arc::clone(&handle),
+        &h,
+        id_a.clone(),
+        &["wrist_left_camera".to_string()],
+    )
+    .await;
+    let _b = real_lifecycle::spawn_running_instance_with_link_ids(
+        Arc::clone(&handle),
+        &h,
+        id_b.clone(),
+        &["wrist_right_camera".to_string()],
+    )
+    .await;
+
+    let guard = handle.read();
+    match guard.stage() {
+        NodeStage::Ready { instances, .. } => {
+            assert_eq!(instances.len(), 2);
+            let ids: Vec<&str> = instances.iter().map(|i| i.instance_id().as_str()).collect();
+            assert!(ids.contains(&"cam-a"));
+            assert!(ids.contains(&"cam-b"));
+        }
+        other => panic!("expected Ready, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn prepare_and_spawn_accepts_multiple_empty_link_ids_on_same_node() {
+    // Default-launch path: empty ctx.link_ids claims nothing, so two
+    // instances with no --link-id can coexist. The `_` sentinel is
+    // materialized downstream by the runtime processor and permits
+    // multi-producer fan-in for `from_any: true` consumers.
+    let stack = NodeStack::new(core_node_config(), None, PathBuf::from("/tmp"));
+    let (id_a, h) = start_harness("cam-a");
+    let id_b = Name::new("cam-b").expect("valid instance id");
+    let handle = push_built_long_running_sensor(&stack, &h).await;
+
+    let _a = real_lifecycle::spawn_running_instance_with_link_ids(
+        Arc::clone(&handle),
+        &h,
+        id_a,
+        &[],
+    )
+    .await;
+    let _b = real_lifecycle::spawn_running_instance_with_link_ids(
+        Arc::clone(&handle),
+        &h,
+        id_b,
+        &[],
+    )
+    .await;
+
+    let guard = handle.read();
+    match guard.stage() {
+        NodeStage::Ready { instances, .. } => assert_eq!(instances.len(), 2),
+        other => panic!("expected Ready, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn prepare_and_spawn_reclaims_link_id_after_instance_stops() {
+    // Once an instance is removed from the Vec via stop_instance, its
+    // link_ids are free for the taking — the duplicate check looks at
+    // currently-tracked instances only.
+    let stack = NodeStack::new(core_node_config(), None, PathBuf::from("/tmp"));
+    let (id_a, h) = start_harness("cam-a");
+    let id_b = Name::new("cam-b").expect("valid instance id");
+    let handle = push_built_long_running_sensor(&stack, &h).await;
+
+    // Spawn instance A holding wrist_left_camera, then explicitly drop the
+    // RAII guard to trigger stop_instance and free the link_id.
+    {
+        let _a = real_lifecycle::spawn_running_instance_with_link_ids(
+            Arc::clone(&handle),
+            &h,
+            id_a,
+            &["wrist_left_camera".to_string()],
+        )
+        .await;
+    }
+
+    let _b = real_lifecycle::spawn_running_instance_with_link_ids(
+        Arc::clone(&handle),
+        &h,
+        id_b.clone(),
+        &["wrist_left_camera".to_string()],
+    )
+    .await;
+
+    let guard = handle.read();
+    match guard.stage() {
+        NodeStage::Ready { instances, .. } => {
+            assert_eq!(instances.len(), 1);
+            assert_eq!(instances[0].instance_id(), &id_b);
+            assert_eq!(instances[0].link_ids(), &["wrist_left_camera".to_string()]);
+        }
+        other => panic!("expected Ready, got {:?}", other),
+    }
+}
+
 // ===========================================================================
 // Backwards / sideways transition rejection (exhaustive)
 // ===========================================================================

--- a/crates/node-stack-internal/tests/tests_modules/lifecycle_transitions.rs
+++ b/crates/node-stack-internal/tests/tests_modules/lifecycle_transitions.rs
@@ -197,6 +197,7 @@ async fn stop_instance_skips_starting_instances() {
             mount_paths_resolved: &[],
             peppy_dirs: &harness.peppy_dirs,
             output_sinks: harness.output_sinks(),
+            link_ids: &[],
         },
     )
     .await
@@ -708,6 +709,7 @@ async fn prepare_and_spawn_rejects_when_not_built() {
             mount_paths_resolved: &[],
             peppy_dirs: &h.peppy_dirs,
             output_sinks: h.output_sinks(),
+            link_ids: &[],
         },
     )
     .await
@@ -741,6 +743,7 @@ async fn prepare_and_spawn_marks_instance_starting_then_commit_marks_running() {
             mount_paths_resolved: &[],
             peppy_dirs: &h.peppy_dirs,
             output_sinks: h.output_sinks(),
+            link_ids: &[],
         },
     )
     .await
@@ -811,6 +814,7 @@ async fn abort_started_removes_starting_instance_and_kills_child() {
             mount_paths_resolved: &[],
             peppy_dirs: &h.peppy_dirs,
             output_sinks: h.output_sinks(),
+            link_ids: &[],
         },
     )
     .await
@@ -889,6 +893,7 @@ async fn prepare_and_spawn_starts_additional_instance_alongside_existing() {
             mount_paths_resolved: &[],
             peppy_dirs: &h.peppy_dirs,
             output_sinks: h.output_sinks(),
+            link_ids: &[],
         },
     )
     .await
@@ -973,6 +978,7 @@ async fn prepare_and_spawn_rejects_duplicate_instance_id_when_running_already_pr
             mount_paths_resolved: &[],
             peppy_dirs: &h.peppy_dirs,
             output_sinks: h.output_sinks(),
+            link_ids: &[],
         },
     )
     .await
@@ -1037,6 +1043,7 @@ mod backwards_transitions_are_rejected {
                 Name::new("inst").unwrap(),
                 Some(1),
                 InstanceState::Running,
+                Vec::new(),
             )],
         }
     }

--- a/crates/peppy/src/commands/node/info.rs
+++ b/crates/peppy/src/commands/node/info.rs
@@ -466,10 +466,12 @@ mod tests {
                 NodeInstanceInfo {
                     instance_id: "inst-abc".to_string(),
                     state: InstanceState::Running,
+                    link_ids: Vec::new(),
                 },
                 NodeInstanceInfo {
                     instance_id: "inst-def".to_string(),
                     state: InstanceState::Starting,
+                    link_ids: Vec::new(),
                 },
             ],
             add_log_path: Some(PathBuf::from("/tmp/peppy/logs/add/sensor_node.log")),

--- a/crates/peppy/src/commands/node/run.rs
+++ b/crates/peppy/src/commands/node/run.rs
@@ -1,19 +1,20 @@
 use config::AnyType;
 use config::launcher::Name;
+use config::node::{DependsOn, NodeDependency};
 use config::runtime::{NodeInstanceConfig, RuntimeConfig};
-use core_node_api::NodeStage;
 use core_node_api::encoding::{
     NodeInfoRequest, NodeInfoResponse, NodeRunFeedback, NodeRunGoal, NodeRunGoalResponse,
-    NodeRunResult,
+    NodeRunResult, StackListRequest,
 };
+use core_node_api::{InstanceState, NodeStage, SerializedNodeGraph};
 use names_generator2::get_random;
 use peppylib::MessengerHandle;
 use rand::rng;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::time::{Instant, sleep};
-use tracing::info;
+use tracing::{debug, info, warn};
 
 use crate::commands::{CALLER_INSTANCE_ID, GOAL_TIMEOUT};
 use crate::context::AppContext;
@@ -22,7 +23,7 @@ use crate::error::{Error, Result};
 use super::TimeoutConfig;
 use super::env::caller_env_overrides;
 
-use peppylib::core_node::transport::{poll_node_info, send_node_run};
+use peppylib::core_node::transport::{poll_node_info, poll_stack_list, send_node_run};
 /// Timeout for the quick `NodeInfoRequest` preflight in the `run -b` flow.
 /// Matches `node info`'s request timeout — this is a metadata lookup,
 /// not a long-running action, so it must fail fast if the daemon is down
@@ -285,6 +286,233 @@ pub fn validate_link_ids(input: &[String]) -> std::result::Result<Vec<String>, S
     Ok(out)
 }
 
+/// One consumer-pin that nobody is publishing yet.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MissingLinkId {
+    pub link_id: String,
+    /// Stack nodes that declared this `link_id` against the target —
+    /// `(consumer_name, consumer_tag)` pairs.
+    pub consumers: Vec<(String, String)>,
+}
+
+/// Pure helper that compares consumer-declared `link_id` pins against
+/// the set of `link_id`s about to exist (this launch's `--link-id`s
+/// plus any already-running instances of the same node). Returns one
+/// `MissingLinkId` per unsatisfied pin, with consumers listed in
+/// first-seen order and link_ids sorted alphabetically.
+///
+/// Inputs are intentionally plain so this function is trivially
+/// testable without a daemon or messenger.
+fn compute_missing_link_ids(
+    consumer_pins: &[(String, String, String)], // (link_id, consumer_name, consumer_tag)
+    available_link_ids: &BTreeSet<String>,
+) -> Vec<MissingLinkId> {
+    // Group pins by link_id (sorted) while preserving first-seen consumer order.
+    let mut grouped: BTreeMap<String, Vec<(String, String)>> = BTreeMap::new();
+    for (link_id, consumer_name, consumer_tag) in consumer_pins {
+        if available_link_ids.contains(link_id) {
+            continue;
+        }
+        let entry = grouped.entry(link_id.clone()).or_default();
+        let pair = (consumer_name.clone(), consumer_tag.clone());
+        if !entry.contains(&pair) {
+            entry.push(pair);
+        }
+    }
+    grouped
+        .into_iter()
+        .map(|(link_id, consumers)| MissingLinkId { link_id, consumers })
+        .collect()
+}
+
+/// Bundle returned by [`gather_missing_consumer_link_ids`] — the pins
+/// the new instance can't cover plus the link_ids already advertised
+/// by Running instances of the same node, both needed to render the
+/// warning body.
+struct ConsumerLinkIdCheck {
+    missing: Vec<MissingLinkId>,
+    existing_link_ids: BTreeSet<String>,
+}
+
+/// Best-effort check that fires before the actual `node_run` goal. If
+/// any stack consumer pins the target node with a `link_id` that no
+/// instance (new or already-running) advertises, returns one
+/// `MissingLinkId` per pin. Returns an empty `missing` vec on success
+/// with no gaps. Returns an error only for unrecoverable transport
+/// failures — the call site logs and swallows it so the run still
+/// proceeds.
+async fn gather_missing_consumer_link_ids(
+    messenger: &MessengerHandle,
+    core_node_name: &str,
+    target_name: &str,
+    target_tag: &str,
+    new_link_ids: &[String],
+) -> Result<ConsumerLinkIdCheck> {
+    let stack_response = poll_stack_list(
+        &StackListRequest::new(false),
+        messenger,
+        core_node_name,
+        CALLER_INSTANCE_ID,
+        core_node_name,
+        NODE_INFO_PREFLIGHT_TIMEOUT,
+    )
+    .await
+    .map_err(|e| Error::ExecutionFailed(format!("failed to list stack: {e}")))?;
+
+    let graph: SerializedNodeGraph = serde_json::from_str(&stack_response.graph_json)
+        .map_err(|e| Error::ExecutionFailed(format!("failed to parse stack graph JSON: {e}")))?;
+
+    // Available link_ids = those advertised by Running instances of the
+    // target node + the ones the operator just supplied for this launch.
+    let mut existing_link_ids: BTreeSet<String> = BTreeSet::new();
+    for node in &graph.nodes {
+        if node.name == target_name && node.tag == target_tag {
+            for inst in &node.instances {
+                if inst.state == InstanceState::Running {
+                    existing_link_ids.extend(inst.link_ids.iter().cloned());
+                }
+            }
+        }
+    }
+    let mut available: BTreeSet<String> = new_link_ids.iter().cloned().collect();
+    available.extend(existing_link_ids.iter().cloned());
+
+    // For every other node in the stack, fetch its full config and scan
+    // its `depends_on.nodes` for pins targeting (target_name, target_tag).
+    // Skip Root entities — those are the daemon's own internals.
+    let mut consumer_pins: Vec<(String, String, String)> = Vec::new();
+    for node in &graph.nodes {
+        if node.name == target_name && node.tag == target_tag {
+            continue;
+        }
+        if matches!(node.stage, Some(NodeStage::Root)) {
+            continue;
+        }
+        let info_response = poll_node_info(
+            &NodeInfoRequest::new(node.name.clone(), node.tag.clone()),
+            messenger,
+            core_node_name,
+            CALLER_INSTANCE_ID,
+            core_node_name,
+            NODE_INFO_PREFLIGHT_TIMEOUT,
+        )
+        .await
+        .map_err(|e| {
+            Error::ExecutionFailed(format!(
+                "failed to fetch info for stack node '{}:{}': {e}",
+                node.name, node.tag
+            ))
+        })?;
+
+        let info = match info_response {
+            NodeInfoResponse::Found(info) => info,
+            NodeInfoResponse::NotInStack => continue,
+        };
+        let Some(depends_on) = info.config.manifest.depends_on.as_ref() else {
+            continue;
+        };
+        collect_target_pins(
+            depends_on,
+            target_name,
+            target_tag,
+            &node.name,
+            &node.tag,
+            &mut consumer_pins,
+        );
+    }
+
+    Ok(ConsumerLinkIdCheck {
+        missing: compute_missing_link_ids(&consumer_pins, &available),
+        existing_link_ids,
+    })
+}
+
+/// Append `(link_id, consumer_name, consumer_tag)` tuples to `pins` for
+/// each entry in `depends_on.nodes` that pins `(target_name,
+/// target_tag)` with a non-wildcard, non-default `link_id`. Interface
+/// deps are intentionally not handled here; see plan §"Out of scope".
+fn collect_target_pins(
+    depends_on: &DependsOn,
+    target_name: &str,
+    target_tag: &str,
+    consumer_name: &str,
+    consumer_tag: &str,
+    pins: &mut Vec<(String, String, String)>,
+) {
+    for dep in &depends_on.nodes {
+        if pin_targets(dep, target_name, target_tag) {
+            pins.push((
+                dep.link_id.clone(),
+                consumer_name.to_owned(),
+                consumer_tag.to_owned(),
+            ));
+        }
+    }
+}
+
+/// Returns `true` when the dep is a concrete pin against `(name, tag)`
+/// — non-wildcard, non-default-sentinel.
+fn pin_targets(dep: &NodeDependency, target_name: &str, target_tag: &str) -> bool {
+    dep.name.as_str() == target_name
+        && dep.tag == target_tag
+        && !dep.from_any
+        && dep.link_id != pmi::DEFAULT_LINK_ID
+}
+
+/// Renders the warning body shown to the operator. Splits out so the
+/// content can be asserted on in unit tests without going through the
+/// tracing layer.
+fn format_missing_link_ids_warning(
+    target_name: &str,
+    target_tag: &str,
+    missing: &[MissingLinkId],
+    new_link_ids: &[String],
+    existing_link_ids: &BTreeSet<String>,
+) -> String {
+    use std::fmt::Write;
+    let mut out = format!(
+        "{}:{} has stack consumers that expect link_ids no instance is publishing:\n",
+        target_name, target_tag
+    );
+    for entry in missing {
+        let consumers = entry
+            .consumers
+            .iter()
+            .map(|(n, t)| format!("{n}:{t}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let _ = writeln!(
+            out,
+            "  - link_id `{}` — required by {}",
+            entry.link_id, consumers
+        );
+    }
+    if !new_link_ids.is_empty() {
+        let _ = writeln!(
+            out,
+            "This instance will publish under: [{}]",
+            new_link_ids.join(", ")
+        );
+    }
+    if !existing_link_ids.is_empty() {
+        let _ = writeln!(
+            out,
+            "Existing running instances publish under: [{}]",
+            existing_link_ids
+                .iter()
+                .cloned()
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+    }
+    out.push_str("Launch additional ");
+    out.push_str(target_name);
+    out.push(':');
+    out.push_str(target_tag);
+    out.push_str(" instances with the missing --link-id values to satisfy these consumers.");
+    out
+}
+
 /// Shared logic for running a node instance.
 /// Used by both `run_node` and `add_node` (when --run is set).
 #[allow(clippy::too_many_arguments)]
@@ -481,6 +709,15 @@ async fn run_node_async(
         }
     }
 
+    emit_missing_consumer_link_ids_warning(
+        conn.messenger,
+        &conn.core_node_name,
+        &node_name,
+        &tag,
+        &link_ids,
+    )
+    .await;
+
     run_instance_async(
         conn.messenger,
         &conn.core_node_name,
@@ -494,6 +731,45 @@ async fn run_node_async(
     .await?;
 
     Ok(())
+}
+
+/// Runs the consumer-pin check and emits a single `warn!` if any pins
+/// are missing. Swallows errors — the warning is informational, not
+/// load-bearing.
+async fn emit_missing_consumer_link_ids_warning(
+    messenger: &MessengerHandle,
+    core_node_name: &str,
+    target_name: &str,
+    target_tag: &str,
+    new_link_ids: &[String],
+) {
+    match gather_missing_consumer_link_ids(
+        messenger,
+        core_node_name,
+        target_name,
+        target_tag,
+        new_link_ids,
+    )
+    .await
+    {
+        Ok(check) if !check.missing.is_empty() => {
+            let body = format_missing_link_ids_warning(
+                target_name,
+                target_tag,
+                &check.missing,
+                new_link_ids,
+                &check.existing_link_ids,
+            );
+            warn!("{}", body);
+        }
+        Ok(_) => {}
+        Err(e) => {
+            debug!(
+                "skipping consumer-link_id warning for {}:{}: {}",
+                target_name, target_tag, e
+            );
+        }
+    }
 }
 
 #[cfg(test)]
@@ -751,5 +1027,210 @@ mod tests {
 
         // Past budget — same error path.
         assert!(remaining_max_secs(30, 45, "run").is_err());
+    }
+
+    fn pin(link_id: &str, consumer_name: &str, consumer_tag: &str) -> (String, String, String) {
+        (
+            link_id.to_owned(),
+            consumer_name.to_owned(),
+            consumer_tag.to_owned(),
+        )
+    }
+
+    fn available(items: &[&str]) -> BTreeSet<String> {
+        items.iter().map(|s| (*s).to_owned()).collect()
+    }
+
+    #[test]
+    fn compute_missing_link_ids_returns_empty_when_no_consumer_pins() {
+        let missing = compute_missing_link_ids(&[], &available(&["main"]));
+        assert!(missing.is_empty());
+    }
+
+    #[test]
+    fn compute_missing_link_ids_returns_empty_when_pin_is_covered_by_new_link_id() {
+        let pins = vec![pin("front_left", "perception", "v3")];
+        let missing = compute_missing_link_ids(&pins, &available(&["front_left"]));
+        assert!(
+            missing.is_empty(),
+            "front_left should be satisfied: {missing:?}"
+        );
+    }
+
+    #[test]
+    fn compute_missing_link_ids_reports_uncovered_pin() {
+        let pins = vec![pin("front_right", "perception", "v3")];
+        let missing = compute_missing_link_ids(&pins, &available(&["main"]));
+        assert_eq!(
+            missing,
+            vec![MissingLinkId {
+                link_id: "front_right".to_owned(),
+                consumers: vec![("perception".to_owned(), "v3".to_owned())],
+            }]
+        );
+    }
+
+    #[test]
+    fn compute_missing_link_ids_groups_consumers_under_same_link_id() {
+        let pins = vec![
+            pin("front_right", "perception", "v3"),
+            pin("front_right", "recorder", "v1"),
+        ];
+        let missing = compute_missing_link_ids(&pins, &available(&[]));
+        assert_eq!(
+            missing.len(),
+            1,
+            "duplicate link_id should group: {missing:?}"
+        );
+        assert_eq!(missing[0].link_id, "front_right");
+        assert_eq!(
+            missing[0].consumers,
+            vec![
+                ("perception".to_owned(), "v3".to_owned()),
+                ("recorder".to_owned(), "v1".to_owned()),
+            ],
+            "consumers should preserve first-seen order"
+        );
+    }
+
+    #[test]
+    fn compute_missing_link_ids_dedupes_identical_consumer_entries() {
+        let pins = vec![
+            pin("front_right", "perception", "v3"),
+            pin("front_right", "perception", "v3"),
+        ];
+        let missing = compute_missing_link_ids(&pins, &available(&[]));
+        assert_eq!(missing.len(), 1);
+        assert_eq!(
+            missing[0].consumers.len(),
+            1,
+            "identical consumer should dedupe"
+        );
+    }
+
+    #[test]
+    fn compute_missing_link_ids_orders_results_alphabetically_by_link_id() {
+        let pins = vec![
+            pin("zebra", "consumer_z", "v1"),
+            pin("apple", "consumer_a", "v1"),
+        ];
+        let missing = compute_missing_link_ids(&pins, &available(&[]));
+        let link_ids: Vec<&str> = missing.iter().map(|m| m.link_id.as_str()).collect();
+        assert_eq!(link_ids, vec!["apple", "zebra"]);
+    }
+
+    #[test]
+    fn pin_targets_accepts_concrete_pin_against_node() {
+        let dep = NodeDependency {
+            name: config::node::Name::new("my_node").unwrap(),
+            tag: "v1".to_string(),
+            link_id: "front_left".to_string(),
+            from_any: false,
+        };
+        assert!(pin_targets(&dep, "my_node", "v1"));
+    }
+
+    #[test]
+    fn pin_targets_rejects_from_any_dep() {
+        let dep = NodeDependency {
+            name: config::node::Name::new("my_node").unwrap(),
+            tag: "v1".to_string(),
+            link_id: "front_left".to_string(),
+            from_any: true,
+        };
+        assert!(!pin_targets(&dep, "my_node", "v1"));
+    }
+
+    #[test]
+    fn pin_targets_rejects_default_sentinel() {
+        let dep = NodeDependency {
+            name: config::node::Name::new("my_node").unwrap(),
+            tag: "v1".to_string(),
+            link_id: pmi::DEFAULT_LINK_ID.to_string(),
+            from_any: false,
+        };
+        assert!(!pin_targets(&dep, "my_node", "v1"));
+    }
+
+    #[test]
+    fn pin_targets_rejects_other_node() {
+        let dep = NodeDependency {
+            name: config::node::Name::new("other_node").unwrap(),
+            tag: "v1".to_string(),
+            link_id: "front_left".to_string(),
+            from_any: false,
+        };
+        assert!(!pin_targets(&dep, "my_node", "v1"));
+    }
+
+    #[test]
+    fn format_missing_link_ids_warning_renders_full_body() {
+        let missing = vec![
+            MissingLinkId {
+                link_id: "front_left".to_owned(),
+                consumers: vec![("perception".to_owned(), "v3".to_owned())],
+            },
+            MissingLinkId {
+                link_id: "front_right".to_owned(),
+                consumers: vec![
+                    ("perception".to_owned(), "v3".to_owned()),
+                    ("recorder".to_owned(), "v1".to_owned()),
+                ],
+            },
+        ];
+        let new_link_ids = vec!["main".to_owned()];
+        let existing: BTreeSet<String> = ["aux".to_owned()].into_iter().collect();
+        let body =
+            format_missing_link_ids_warning("my_node", "v1", &missing, &new_link_ids, &existing);
+        assert!(
+            body.contains("my_node:v1"),
+            "body should name target: {body}"
+        );
+        assert!(
+            body.contains("front_left"),
+            "body should list missing link_id: {body}"
+        );
+        assert!(
+            body.contains("front_right"),
+            "body should list missing link_id: {body}"
+        );
+        assert!(
+            body.contains("perception:v3"),
+            "body should name consumer: {body}"
+        );
+        assert!(
+            body.contains("recorder:v1"),
+            "body should name second consumer: {body}"
+        );
+        assert!(
+            body.contains("This instance will publish under: [main]"),
+            "body should report new link_ids: {body}"
+        );
+        assert!(
+            body.contains("Existing running instances publish under: [aux]"),
+            "body should report existing link_ids: {body}"
+        );
+        assert!(
+            body.contains("--link-id"),
+            "body should hint at the CLI flag: {body}"
+        );
+    }
+
+    #[test]
+    fn format_missing_link_ids_warning_omits_empty_published_lines() {
+        let missing = vec![MissingLinkId {
+            link_id: "front_left".to_owned(),
+            consumers: vec![("perception".to_owned(), "v3".to_owned())],
+        }];
+        let body =
+            format_missing_link_ids_warning("my_node", "v1", &missing, &[], &BTreeSet::new());
+        assert!(
+            !body.contains("This instance will publish under"),
+            "empty new_link_ids should omit the line: {body}"
+        );
+        assert!(
+            !body.contains("Existing running instances publish under"),
+            "empty existing_link_ids should omit the line: {body}"
+        );
     }
 }

--- a/crates/peppy/src/commands/stack/list.rs
+++ b/crates/peppy/src/commands/stack/list.rs
@@ -219,6 +219,7 @@ mod tests {
                 .map(|(id, state)| SerializedInstance {
                     instance_id: id.to_string(),
                     state,
+                    link_ids: Vec::new(),
                 })
                 .collect(),
         }

--- a/crates/peppy/tests/node_run.rs
+++ b/crates/peppy/tests/node_run.rs
@@ -1418,6 +1418,262 @@ async fn node_run_emits_no_warning_when_all_link_ids_are_covered() {
     );
 }
 
+/// Running two instances of the same node that both advertise the
+/// same `--link-id` is rejected by the daemon at goal-acceptance time.
+/// After the first instance is stopped, the second can reclaim the
+/// link_id. Sibling instances with disjoint link_ids both succeed.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn node_run_rejects_duplicate_link_id_across_instances_of_same_node() {
+    let serve = ServeCommandEmulation::with_mock()
+        .await
+        .expect("failed to create serve emulation");
+    let shared_messenger = serve.messenger();
+    let core_node_name = serve.core_node_name().to_string();
+
+    let work_dir = tempfile::tempdir().expect("failed to create work dir");
+    let producer_name = "test_duplinkid_producer";
+    let id_a = "cam_a";
+    let id_b = "cam_b";
+
+    let node_ctx = Arc::new(
+        AppContext::with_messenger(work_dir.path(), Arc::clone(&shared_messenger))
+            .with_daemon_state_file(serve.daemon_state_path()),
+    );
+
+    let log_capture = LogCapture::new();
+    let subscriber = tracing_subscriber::fmt()
+        .with_ansi(false)
+        .without_time()
+        .with_writer(log_capture.clone())
+        .finish();
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    add_built_producer(&node_ctx, work_dir.path(), producer_name).await;
+
+    let node_messenger = MessengerHandle::from_shared(Arc::clone(&shared_messenger));
+    let _services_a =
+        install_node_services(&node_messenger, &core_node_name, producer_name, id_a).await;
+    let (_a_shutdown_handle, _a_shutdown_rx) = peppylib::services::shutdown::listen_for_shutdown(
+        &node_messenger,
+        &core_node_name,
+        id_a,
+        super::common::test_node_target(producer_name),
+        &[],
+    )
+    .await
+    .expect("cam_a shutdown service should start");
+    let _services_b =
+        install_node_services(&node_messenger, &core_node_name, producer_name, id_b).await;
+
+    // First instance claims wrist_left_camera — succeeds.
+    NodeCommand {
+        command: NodeCommands::Run {
+            node_ref: None,
+            node_name: Some(producer_name.to_string()),
+            tag: Some("v1".to_string()),
+            args: Vec::new(),
+            instance_id: Some(id_a.to_string()),
+            link_ids: vec!["wrist_left_camera".to_string()],
+            idle_timeout: 60,
+            max_timeout: 3600,
+            build: false,
+        },
+    }
+    .execute(&node_ctx)
+    .expect("first node run should succeed");
+
+    // Second instance tries to claim the same link_id — the daemon
+    // rejects it via `DuplicateLinkId`, and the CLI surfaces the error.
+    let err = NodeCommand {
+        command: NodeCommands::Run {
+            node_ref: None,
+            node_name: Some(producer_name.to_string()),
+            tag: Some("v1".to_string()),
+            args: Vec::new(),
+            instance_id: Some(id_b.to_string()),
+            link_ids: vec!["wrist_left_camera".to_string()],
+            idle_timeout: 60,
+            max_timeout: 3600,
+            build: false,
+        },
+    }
+    .execute(&node_ctx)
+    .expect_err("second node run should fail on link_id collision");
+
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("wrist_left_camera"),
+        "error should name the colliding link_id. Error:\n{msg}"
+    );
+    assert!(
+        msg.contains(id_a),
+        "error should name the holding instance. Error:\n{msg}"
+    );
+    assert!(
+        msg.contains("already claimed"),
+        "error should use the 'already claimed' phrasing. Error:\n{msg}"
+    );
+
+    // Stop the first instance to free the link_id.
+    NodeCommand {
+        command: NodeCommands::Stop {
+            instance_id: id_a.to_string(),
+        },
+    }
+    .execute(&node_ctx)
+    .expect("stopping cam_a should succeed");
+
+    // Second instance retries and now succeeds.
+    NodeCommand {
+        command: NodeCommands::Run {
+            node_ref: None,
+            node_name: Some(producer_name.to_string()),
+            tag: Some("v1".to_string()),
+            args: Vec::new(),
+            instance_id: Some(id_b.to_string()),
+            link_ids: vec!["wrist_left_camera".to_string()],
+            idle_timeout: 60,
+            max_timeout: 3600,
+            build: false,
+        },
+    }
+    .execute(&node_ctx)
+    .expect("cam_b should succeed after cam_a has stopped");
+
+    // Stack should now show exactly one running cam_b on the producer.
+    let messenger_handle = node_ctx
+        .messenger_handle()
+        .expect("messenger handle should be available");
+    let response = poll_stack_list(
+        &StackListRequest::new(false),
+        messenger_handle,
+        &core_node_name,
+        CALLER_INSTANCE_ID,
+        &core_node_name,
+        Duration::from_secs(5),
+    )
+    .await
+    .expect("stack_list request should complete");
+    let graph: SerializedNodeGraph =
+        serde_json::from_str(&response.graph_json).expect("graph_json should parse");
+    let node = graph
+        .nodes
+        .iter()
+        .find(|n| n.name == producer_name && n.tag == "v1")
+        .expect("producer should still be in the stack");
+    assert_eq!(
+        node.instance_count(),
+        1,
+        "after stop+rerun, exactly one instance should remain. Graph: {:?}",
+        graph
+            .nodes
+            .iter()
+            .map(|n| (n.label(), n.instance_count()))
+            .collect::<Vec<_>>()
+    );
+}
+
+/// Sibling instances of the same producer with *different* `--link-id`
+/// values must both run — this is the intended multi-camera workflow.
+/// The duplicate-link_id guard must not over-reach into this case.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn node_run_allows_distinct_link_ids_on_same_node() {
+    let serve = ServeCommandEmulation::with_mock()
+        .await
+        .expect("failed to create serve emulation");
+    let shared_messenger = serve.messenger();
+    let core_node_name = serve.core_node_name().to_string();
+
+    let work_dir = tempfile::tempdir().expect("failed to create work dir");
+    let producer_name = "test_distinct_linkid_producer";
+    let id_a = "cam_left";
+    let id_b = "cam_right";
+
+    let node_ctx = Arc::new(
+        AppContext::with_messenger(work_dir.path(), Arc::clone(&shared_messenger))
+            .with_daemon_state_file(serve.daemon_state_path()),
+    );
+
+    let log_capture = LogCapture::new();
+    let subscriber = tracing_subscriber::fmt()
+        .with_ansi(false)
+        .without_time()
+        .with_writer(log_capture.clone())
+        .finish();
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    add_built_producer(&node_ctx, work_dir.path(), producer_name).await;
+
+    let node_messenger = MessengerHandle::from_shared(Arc::clone(&shared_messenger));
+    let _services_a =
+        install_node_services(&node_messenger, &core_node_name, producer_name, id_a).await;
+    let _services_b =
+        install_node_services(&node_messenger, &core_node_name, producer_name, id_b).await;
+
+    NodeCommand {
+        command: NodeCommands::Run {
+            node_ref: None,
+            node_name: Some(producer_name.to_string()),
+            tag: Some("v1".to_string()),
+            args: Vec::new(),
+            instance_id: Some(id_a.to_string()),
+            link_ids: vec!["wrist_left_camera".to_string()],
+            idle_timeout: 60,
+            max_timeout: 3600,
+            build: false,
+        },
+    }
+    .execute(&node_ctx)
+    .expect("cam_left should start");
+
+    NodeCommand {
+        command: NodeCommands::Run {
+            node_ref: None,
+            node_name: Some(producer_name.to_string()),
+            tag: Some("v1".to_string()),
+            args: Vec::new(),
+            instance_id: Some(id_b.to_string()),
+            link_ids: vec!["wrist_right_camera".to_string()],
+            idle_timeout: 60,
+            max_timeout: 3600,
+            build: false,
+        },
+    }
+    .execute(&node_ctx)
+    .expect("cam_right should start alongside cam_left");
+
+    let messenger_handle = node_ctx
+        .messenger_handle()
+        .expect("messenger handle should be available");
+    let response = poll_stack_list(
+        &StackListRequest::new(false),
+        messenger_handle,
+        &core_node_name,
+        CALLER_INSTANCE_ID,
+        &core_node_name,
+        Duration::from_secs(5),
+    )
+    .await
+    .expect("stack_list request should complete");
+    let graph: SerializedNodeGraph =
+        serde_json::from_str(&response.graph_json).expect("graph_json should parse");
+    let node = graph
+        .nodes
+        .iter()
+        .find(|n| n.name == producer_name && n.tag == "v1")
+        .expect("producer should be in stack");
+    assert_eq!(
+        node.instance_count(),
+        2,
+        "both sibling instances should be running. Graph: {:?}",
+        graph
+            .nodes
+            .iter()
+            .map(|n| (n.label(), n.instance_count()))
+            .collect::<Vec<_>>()
+    );
+}
+
 /// Test D — when no consumer in the stack pins the target node, no
 /// warning fires.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/peppy/tests/node_run.rs
+++ b/crates/peppy/tests/node_run.rs
@@ -995,3 +995,486 @@ async fn node_run_with_build_flag_on_already_built_node_skips_build() {
         "graph should show 1 instance after `run -b`"
     );
 }
+
+/// Hand-crafts a peppy.json5 declaring `depends_on.nodes` against
+/// `(producer_name, "v1")` with one entry per supplied `link_id`. The
+/// consumer carries no interfaces and a no-op `run_cmd`, so the
+/// daemon's dependency-spec validator is happy with the dep being
+/// declared but never actually consumed. Returns the path to the
+/// consumer directory ready to feed into `NodeCommands::Add`.
+fn write_consumer_with_depends_on(
+    work_dir: &std::path::Path,
+    consumer_name: &str,
+    producer_name: &str,
+    link_ids: &[&str],
+) -> std::path::PathBuf {
+    let consumer_dir = work_dir.join(consumer_name);
+    std::fs::create_dir_all(&consumer_dir).expect("create consumer dir");
+    let entries = link_ids
+        .iter()
+        .map(|lid| {
+            format!(r#"            {{ name: "{producer_name}", tag: "v1", link_id: "{lid}" }}"#)
+        })
+        .collect::<Vec<_>>()
+        .join(",\n");
+    let body = format!(
+        r#"{{
+    peppy_schema: "node_v1",
+    manifest: {{
+        name: "{consumer_name}",
+        tag: "v1",
+        depends_on: {{
+            nodes: [
+{entries}
+            ]
+        }}
+    }},
+    execution: {{
+        language: "rust",
+        run_cmd: ["sleep", "30"]
+    }}
+}}
+"#
+    );
+    std::fs::write(consumer_dir.join("peppy.json5"), body).expect("write consumer peppy.json5");
+    consumer_dir
+}
+
+/// Adds a scaffolded producer node to the stack and builds it.
+/// Mirrors the boilerplate that `node_run_command_succeeds` runs
+/// through; tests below treat it as the "set up a runnable target"
+/// step.
+async fn add_built_producer(
+    node_ctx: &Arc<AppContext>,
+    work_dir: &std::path::Path,
+    producer_name: &str,
+) {
+    NodeCommand {
+        command: NodeCommands::Init {
+            node_name: NodeName::new(producer_name).expect("valid node name"),
+            to_dir: None,
+            toolchain: Toolchain::Cargo,
+            with_container: false,
+        },
+    }
+    .execute(node_ctx)
+    .expect("producer node init should succeed");
+    let producer_path = work_dir.join(producer_name);
+    let producer_json5 = producer_path.join("peppy.json5");
+    peppy::test_support::override_run_cmd(&producer_json5);
+    NodeCommand {
+        command: NodeCommands::Add {
+            source: Some(producer_path.display().to_string()),
+            git_ref: None,
+            sync: false,
+            build: true,
+            run: false,
+            args: Vec::new(),
+            instance_id: None,
+            idle_timeout: 60,
+            max_timeout: 3600,
+            force: false,
+        },
+    }
+    .execute(node_ctx)
+    .expect("producer node add should succeed");
+}
+
+async fn add_consumer_with_pins(
+    node_ctx: &Arc<AppContext>,
+    work_dir: &std::path::Path,
+    consumer_name: &str,
+    producer_name: &str,
+    link_ids: &[&str],
+) {
+    let consumer_dir =
+        write_consumer_with_depends_on(work_dir, consumer_name, producer_name, link_ids);
+    NodeCommand {
+        command: NodeCommands::Add {
+            source: Some(consumer_dir.display().to_string()),
+            git_ref: None,
+            sync: false,
+            build: false,
+            run: false,
+            args: Vec::new(),
+            instance_id: None,
+            idle_timeout: 60,
+            max_timeout: 3600,
+            force: false,
+        },
+    }
+    .execute(node_ctx)
+    .expect("consumer node add should succeed");
+}
+
+/// Installs in-process node_ready and node_health services for the
+/// given producer + instance_id so the daemon's start handshake can
+/// complete. Returns the join handles so callers can hold them past
+/// the `node run` call. The two services must outlive the run.
+async fn install_node_services(
+    node_messenger: &MessengerHandle,
+    core_node_name: &str,
+    producer_name: &str,
+    instance_id: &str,
+) -> (
+    impl std::any::Any + Send + Sync,
+    impl std::any::Any + Send + Sync,
+) {
+    let ready = listen_for_node_ready(
+        node_messenger,
+        core_node_name,
+        instance_id,
+        test_node_target(producer_name),
+        &[],
+    )
+    .await
+    .expect("node ready service should start");
+    let health = listen_for_node_health(
+        node_messenger,
+        core_node_name,
+        instance_id,
+        test_node_target(producer_name),
+        &[],
+    )
+    .await
+    .expect("node health service should start");
+    (ready, health)
+}
+
+/// Test A — running a producer with `--link-id main` when a stack
+/// consumer pins it with `front_left` and `front_right` emits a
+/// warning listing both link_ids and the consumer that asked.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn node_run_warns_when_stack_consumers_have_unsatisfied_link_ids() {
+    let serve = ServeCommandEmulation::with_mock()
+        .await
+        .expect("failed to create serve emulation");
+    let shared_messenger = serve.messenger();
+    let core_node_name = serve.core_node_name().to_string();
+
+    let work_dir = tempfile::tempdir().expect("failed to create work dir");
+    let producer_name = "test_warn_producer";
+    let consumer_name = "test_warn_consumer";
+    let instance_id = "main_instance";
+
+    let node_ctx = Arc::new(
+        AppContext::with_messenger(work_dir.path(), Arc::clone(&shared_messenger))
+            .with_daemon_state_file(serve.daemon_state_path()),
+    );
+
+    let log_capture = LogCapture::new();
+    let subscriber = tracing_subscriber::fmt()
+        .with_ansi(false)
+        .without_time()
+        .with_writer(log_capture.clone())
+        .finish();
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    add_built_producer(&node_ctx, work_dir.path(), producer_name).await;
+    add_consumer_with_pins(
+        &node_ctx,
+        work_dir.path(),
+        consumer_name,
+        producer_name,
+        &["front_left", "front_right"],
+    )
+    .await;
+
+    let node_messenger = MessengerHandle::from_shared(Arc::clone(&shared_messenger));
+    let _services =
+        install_node_services(&node_messenger, &core_node_name, producer_name, instance_id).await;
+
+    NodeCommand {
+        command: NodeCommands::Run {
+            node_ref: None,
+            node_name: Some(producer_name.to_string()),
+            tag: Some("v1".to_string()),
+            args: Vec::new(),
+            instance_id: Some(instance_id.to_string()),
+            link_ids: vec!["main".to_string()],
+            idle_timeout: 60,
+            max_timeout: 3600,
+            build: false,
+        },
+    }
+    .execute(&node_ctx)
+    .expect("node run should succeed despite the warning");
+
+    let logs = log_capture.logs();
+    assert!(
+        logs.contains("stack consumers that expect link_ids no instance is publishing"),
+        "warning preamble should be present. Logs:\n{logs}"
+    );
+    assert!(
+        logs.contains("front_left"),
+        "warning should name missing link_id 'front_left'. Logs:\n{logs}"
+    );
+    assert!(
+        logs.contains("front_right"),
+        "warning should name missing link_id 'front_right'. Logs:\n{logs}"
+    );
+    assert!(
+        logs.contains(&format!("{consumer_name}:v1")),
+        "warning should name the consumer ({consumer_name}:v1). Logs:\n{logs}"
+    );
+    assert!(
+        logs.contains("This instance will publish under: [main]"),
+        "warning should report the new instance's link_ids. Logs:\n{logs}"
+    );
+    assert!(
+        logs.contains("Started node instance"),
+        "run should still complete successfully. Logs:\n{logs}"
+    );
+}
+
+/// Test B — a second launch sees the first instance's `link_ids` as
+/// already-running and only warns about pins that are still
+/// uncovered.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn node_run_warning_accounts_for_existing_running_instances() {
+    let serve = ServeCommandEmulation::with_mock()
+        .await
+        .expect("failed to create serve emulation");
+    let shared_messenger = serve.messenger();
+    let core_node_name = serve.core_node_name().to_string();
+
+    let work_dir = tempfile::tempdir().expect("failed to create work dir");
+    let producer_name = "test_warn_shrink_producer";
+    let consumer_name = "test_warn_shrink_consumer";
+    let first_instance = "inst_left";
+    let second_instance = "inst_main";
+
+    let node_ctx = Arc::new(
+        AppContext::with_messenger(work_dir.path(), Arc::clone(&shared_messenger))
+            .with_daemon_state_file(serve.daemon_state_path()),
+    );
+
+    let log_capture = LogCapture::new();
+    let subscriber = tracing_subscriber::fmt()
+        .with_ansi(false)
+        .without_time()
+        .with_writer(log_capture.clone())
+        .finish();
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    add_built_producer(&node_ctx, work_dir.path(), producer_name).await;
+    add_consumer_with_pins(
+        &node_ctx,
+        work_dir.path(),
+        consumer_name,
+        producer_name,
+        &["front_left", "front_right"],
+    )
+    .await;
+
+    // First instance — supplies front_left only.
+    let node_messenger = MessengerHandle::from_shared(Arc::clone(&shared_messenger));
+    let _services_first = install_node_services(
+        &node_messenger,
+        &core_node_name,
+        producer_name,
+        first_instance,
+    )
+    .await;
+    let marker_before_first = log_capture.logs().len();
+    NodeCommand {
+        command: NodeCommands::Run {
+            node_ref: None,
+            node_name: Some(producer_name.to_string()),
+            tag: Some("v1".to_string()),
+            args: Vec::new(),
+            instance_id: Some(first_instance.to_string()),
+            link_ids: vec!["front_left".to_string()],
+            idle_timeout: 60,
+            max_timeout: 3600,
+            build: false,
+        },
+    }
+    .execute(&node_ctx)
+    .expect("first node run should succeed");
+
+    let first_logs = log_capture.logs()[marker_before_first..].to_string();
+    assert!(
+        first_logs.contains("front_right"),
+        "first run should warn about front_right. New logs:\n{first_logs}"
+    );
+    assert!(
+        !first_logs.contains("link_id `front_left`"),
+        "first run should NOT list front_left as missing — this instance covers it. New logs:\n{first_logs}"
+    );
+
+    // Second instance — supplies an unrelated link_id `main`, so
+    // front_right is still uncovered. front_left should now be
+    // accounted for by the *existing* running instance.
+    let _services_second = install_node_services(
+        &node_messenger,
+        &core_node_name,
+        producer_name,
+        second_instance,
+    )
+    .await;
+    let marker_before_second = log_capture.logs().len();
+    NodeCommand {
+        command: NodeCommands::Run {
+            node_ref: None,
+            node_name: Some(producer_name.to_string()),
+            tag: Some("v1".to_string()),
+            args: Vec::new(),
+            instance_id: Some(second_instance.to_string()),
+            link_ids: vec!["main".to_string()],
+            idle_timeout: 60,
+            max_timeout: 3600,
+            build: false,
+        },
+    }
+    .execute(&node_ctx)
+    .expect("second node run should succeed");
+
+    let second_logs = log_capture.logs()[marker_before_second..].to_string();
+    assert!(
+        second_logs.contains("front_right"),
+        "second run should still warn about front_right. New logs:\n{second_logs}"
+    );
+    assert!(
+        !second_logs.contains("link_id `front_left`"),
+        "second run should NOT list front_left as missing — the first instance covers it. New logs:\n{second_logs}"
+    );
+    assert!(
+        second_logs.contains("Existing running instances publish under:"),
+        "second run should advertise the existing instance's link_ids. New logs:\n{second_logs}"
+    );
+    assert!(
+        second_logs.contains("front_left"),
+        "second run should report front_left under the 'existing' line. New logs:\n{second_logs}"
+    );
+}
+
+/// Test C — when the new instance fully covers every consumer-pin,
+/// no warning is emitted.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn node_run_emits_no_warning_when_all_link_ids_are_covered() {
+    let serve = ServeCommandEmulation::with_mock()
+        .await
+        .expect("failed to create serve emulation");
+    let shared_messenger = serve.messenger();
+    let core_node_name = serve.core_node_name().to_string();
+
+    let work_dir = tempfile::tempdir().expect("failed to create work dir");
+    let producer_name = "test_warn_covered_producer";
+    let consumer_name = "test_warn_covered_consumer";
+    let instance_id = "covered_instance";
+
+    let node_ctx = Arc::new(
+        AppContext::with_messenger(work_dir.path(), Arc::clone(&shared_messenger))
+            .with_daemon_state_file(serve.daemon_state_path()),
+    );
+
+    let log_capture = LogCapture::new();
+    let subscriber = tracing_subscriber::fmt()
+        .with_ansi(false)
+        .without_time()
+        .with_writer(log_capture.clone())
+        .finish();
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    add_built_producer(&node_ctx, work_dir.path(), producer_name).await;
+    add_consumer_with_pins(
+        &node_ctx,
+        work_dir.path(),
+        consumer_name,
+        producer_name,
+        &["front_left", "front_right"],
+    )
+    .await;
+
+    let node_messenger = MessengerHandle::from_shared(Arc::clone(&shared_messenger));
+    let _services =
+        install_node_services(&node_messenger, &core_node_name, producer_name, instance_id).await;
+
+    NodeCommand {
+        command: NodeCommands::Run {
+            node_ref: None,
+            node_name: Some(producer_name.to_string()),
+            tag: Some("v1".to_string()),
+            args: Vec::new(),
+            instance_id: Some(instance_id.to_string()),
+            link_ids: vec!["front_left".to_string(), "front_right".to_string()],
+            idle_timeout: 60,
+            max_timeout: 3600,
+            build: false,
+        },
+    }
+    .execute(&node_ctx)
+    .expect("node run should succeed");
+
+    let logs = log_capture.logs();
+    assert!(
+        !logs.contains("stack consumers that expect link_ids no instance is publishing"),
+        "no warning should fire when every consumer pin is covered. Logs:\n{logs}"
+    );
+    assert!(
+        logs.contains("Started node instance"),
+        "run should complete successfully. Logs:\n{logs}"
+    );
+}
+
+/// Test D — when no consumer in the stack pins the target node, no
+/// warning fires.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn node_run_emits_no_warning_when_stack_has_no_consumer_pin() {
+    let serve = ServeCommandEmulation::with_mock()
+        .await
+        .expect("failed to create serve emulation");
+    let shared_messenger = serve.messenger();
+    let core_node_name = serve.core_node_name().to_string();
+
+    let work_dir = tempfile::tempdir().expect("failed to create work dir");
+    let producer_name = "test_warn_no_consumer_producer";
+    let instance_id = "no_consumer_instance";
+
+    let node_ctx = Arc::new(
+        AppContext::with_messenger(work_dir.path(), Arc::clone(&shared_messenger))
+            .with_daemon_state_file(serve.daemon_state_path()),
+    );
+
+    let log_capture = LogCapture::new();
+    let subscriber = tracing_subscriber::fmt()
+        .with_ansi(false)
+        .without_time()
+        .with_writer(log_capture.clone())
+        .finish();
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    add_built_producer(&node_ctx, work_dir.path(), producer_name).await;
+    // Intentionally no consumer in the stack.
+
+    let node_messenger = MessengerHandle::from_shared(Arc::clone(&shared_messenger));
+    let _services =
+        install_node_services(&node_messenger, &core_node_name, producer_name, instance_id).await;
+
+    NodeCommand {
+        command: NodeCommands::Run {
+            node_ref: None,
+            node_name: Some(producer_name.to_string()),
+            tag: Some("v1".to_string()),
+            args: Vec::new(),
+            instance_id: Some(instance_id.to_string()),
+            link_ids: vec!["any".to_string()],
+            idle_timeout: 60,
+            max_timeout: 3600,
+            build: false,
+        },
+    }
+    .execute(&node_ctx)
+    .expect("node run should succeed");
+
+    let logs = log_capture.logs();
+    assert!(
+        !logs.contains("stack consumers that expect link_ids no instance is publishing"),
+        "no warning should fire when no consumer pins us. Logs:\n{logs}"
+    );
+    assert!(
+        logs.contains("Started node instance"),
+        "run should complete successfully. Logs:\n{logs}"
+    );
+}

--- a/crates/peppy/tests/stack_launch.rs
+++ b/crates/peppy/tests/stack_launch.rs
@@ -950,3 +950,157 @@ async fn stack_launch_populates_link_ids_from_launcher_bindings() {
         consumer_config.node_instance.link_ids,
     );
 }
+
+/// A launcher whose bindings would cause two producer instances of the
+/// same node to advertise the same `link_id` must fail at the parse
+/// stage — *before* any node is added, built, or spawned. The error
+/// must name both colliding producer instances so the operator can fix
+/// the manifest without guessing.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn stack_launch_rejects_launcher_with_duplicate_producer_link_id() {
+    let serve = ServeCommandEmulation::with_mock()
+        .await
+        .expect("failed to create serve emulation");
+    let shared_messenger = serve.messenger();
+    let core_node_name = serve.core_node_name().to_string();
+
+    let nodes_dir = tempfile::tempdir().expect("failed to create temp nodes directory");
+    let producer_name = "duplinkid_camera";
+    let consumer_name = "duplinkid_backbone";
+    let node_tag = "v1";
+    let git_hash = read_daemon_git_hash(serve.daemon_state_path());
+
+    let producer_path = write_node_config(
+        nodes_dir.path(),
+        producer_name,
+        node_tag,
+        &git_hash,
+        &["sh", "-c", "sleep 30"],
+    );
+    let consumer_path = nodes_dir.path().join(consumer_name);
+    fs::create_dir_all(&consumer_path).expect("create consumer dir");
+    fs::write(
+        consumer_path.join(NODE_CONFIG_FILE),
+        format!(
+            r#"{{
+                peppy_schema: "node_v1",
+                manifest: {{
+                    name: "{consumer_name}",
+                    tag: "{node_tag}",
+                    depends_on: {{
+                        nodes: [
+                            {{ name: "{producer_name}", tag: "{node_tag}", link_id: "wrist_left_camera" }}
+                        ]
+                    }}
+                }},
+                execution: {{
+                    language: "rust",
+                    run_cmd: ["sh", "-c", "sleep 30"]
+                }}
+            }}"#
+        ),
+    )
+    .expect("write consumer peppy.json5");
+    config::fingerprint::create_codegen_fingerprint(
+        &consumer_path.join(NODE_CONFIG_FILE),
+        Path::new(PEPPYGEN_OUTPUT_PATH),
+    );
+    let consumer_output_dir = consumer_path.join(PEPPY_OUTPUT_DIR);
+    fs::create_dir_all(&consumer_output_dir).expect("create consumer output dir");
+    fs::write(consumer_output_dir.join("git.hash"), &git_hash).expect("write consumer git.hash");
+
+    let ctx = Arc::new(
+        AppContext::with_messenger(nodes_dir.path(), Arc::clone(&shared_messenger))
+            .with_daemon_state_file(serve.daemon_state_path()),
+    );
+
+    let log_capture = LogCapture::new();
+    let subscriber = tracing_subscriber::fmt()
+        .with_ansi(false)
+        .without_time()
+        .with_writer(log_capture.clone())
+        .finish();
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    // Two camera instances + two backbone instances each binding the
+    // SAME link_id `wrist_left_camera` to a DIFFERENT camera. That's
+    // two cameras both claiming the same producer link_id.
+    let launcher_path = nodes_dir.path().join("peppy_launcher.json5");
+    let launcher_json5 = format!(
+        r#"{{
+            peppy_schema: "launcher_v1",
+            deployments: [
+                {{
+                    source: {{ local: "{producer}" }},
+                    instances: [
+                        {{ instance_id: "cam_a" }},
+                        {{ instance_id: "cam_b" }}
+                    ]
+                }},
+                {{
+                    source: {{ local: "{consumer}" }},
+                    instances: [
+                        {{ instance_id: "back_a", bindings: {{ wrist_left_camera: "cam_a" }} }},
+                        {{ instance_id: "back_b", bindings: {{ wrist_left_camera: "cam_b" }} }}
+                    ]
+                }}
+            ]
+        }}"#,
+        producer = producer_path.display(),
+        consumer = consumer_path.display(),
+    );
+    fs::write(&launcher_path, launcher_json5).expect("launcher config should be writable");
+
+    let result = StackCommand {
+        command: StackCommands::Launch {
+            launcher_config_path: launcher_path,
+            node_add_idle_timeout_secs: 60,
+            node_build_idle_timeout_secs: 60,
+            node_run_idle_timeout_secs: 60,
+            max_timeout_secs: Some(3600),
+        },
+    }
+    .execute(&ctx);
+
+    let err_msg = result
+        .expect_err("launch must fail on duplicate producer link_id")
+        .to_string();
+    assert!(
+        err_msg.contains("wrist_left_camera"),
+        "error should name the colliding link_id. Got:\n{err_msg}"
+    );
+    assert!(
+        err_msg.contains("cam_a") && err_msg.contains("cam_b"),
+        "error should name both colliding producer instances. Got:\n{err_msg}"
+    );
+    assert!(
+        err_msg.contains(producer_name),
+        "error should name the producer node. Got:\n{err_msg}"
+    );
+
+    // No spawn side-effect: neither camera nor backbone should appear
+    // in the stack.
+    let messenger_handle = ctx
+        .messenger_handle()
+        .expect("messenger handle should be available");
+    let response = poll_stack_list(
+        &StackListRequest::new(false),
+        messenger_handle,
+        &core_node_name,
+        CALLER_INSTANCE_ID,
+        &core_node_name,
+        Duration::from_secs(5),
+    )
+    .await
+    .expect("stack_list request should complete");
+    let graph: SerializedNodeGraph =
+        serde_json::from_str(&response.graph_json).expect("graph_json should parse");
+    assert!(
+        !graph
+            .nodes
+            .iter()
+            .any(|n| n.name == producer_name || n.name == consumer_name),
+        "rejected launcher must not have added or spawned anything. Graph: {:?}",
+        graph.nodes.iter().map(|n| n.label()).collect::<Vec<_>>()
+    );
+}

--- a/crates/peppylib/tests/core_node/stack.rs
+++ b/crates/peppylib/tests/core_node/stack.rs
@@ -78,6 +78,7 @@ async fn stack_list_parses_graph_and_includes_dot_graph_when_requested() {
         instances: vec![SerializedInstance {
             instance_id: "i1".to_string(),
             state: InstanceState::Running,
+            link_ids: Vec::new(),
         }],
     };
     let sensor = SerializedNode {
@@ -127,6 +128,7 @@ async fn stack_list_returns_none_dot_graph_when_not_requested() {
         instances: vec![SerializedInstance {
             instance_id: "i1".to_string(),
             state: InstanceState::Running,
+            link_ids: Vec::new(),
         }],
     };
     let sensor = SerializedNode {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Track and expose producer-advertised link IDs per node instance.
  * `node run` now warns when consumer-pinned link IDs are not published by the target instance.

* **Bug Fixes**
  * Launch validation now rejects stack launches that would create conflicting producer link IDs, with clear error details.

* **Tests**
  * Added unit and integration tests covering link-ID serialization, uniqueness rules, and dependency pinning scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Peppy-bot/peppy/pull/205?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->