### PR TITLE
fix: release gate slot before completing goal to eliminate "action already in progress" race

### DIFF
--- a/crates/core-node-internal/src/services/node/add.rs
+++ b/crates/core-node-internal/src/services/node/add.rs
@@ -1030,9 +1030,10 @@ async fn handle_goal_request(
     let log_path_for_cancel = log_path.clone();
     let gate_for_task = gate.clone();
     let task_handle = tokio::spawn(async move {
-        // Frees the gate slot on every exit (completion, panic, or `--force`
-        // abort); a no-op if a later `--force` goal already took over.
-        let _slot = gate_for_task.into_slot_guard(generation);
+        // Frees the gate slot on every exit: explicitly before completion on the
+        // normal path (via `release_then_complete` below), or on unwind for a
+        // panic / `--force` abort. A no-op if a later `--force` goal took over.
+        let slot = gate_for_task.into_slot_guard(generation);
         let (feedback_tx, feedback_rx) = mpsc::unbounded_channel::<FeedbackLine>();
         let consumer_handle =
             super::spawn_feedback_forwarder(feedback_rx, feedback_publisher, |line| {
@@ -1074,7 +1075,7 @@ async fn handle_goal_request(
         // sentinel never races ahead of the last feedback line.
         let _ = consumer_handle.await;
         if let Ok(payload) = result.encode() {
-            let _ = goal_ctx.complete(payload).await;
+            slot.release_then_complete(&goal_ctx, payload).await;
         }
     });
 

--- a/crates/core-node-internal/src/services/node/builder.rs
+++ b/crates/core-node-internal/src/services/node/builder.rs
@@ -297,9 +297,11 @@ impl NodeBuildGoalHandler {
         let gate_for_task = self.gate.clone();
 
         let task_handle = tokio::spawn(async move {
-            // Frees the gate slot on every exit (completion, panic, or `--force`
-            // abort); a no-op if a later `--force` goal already took over.
-            let _slot = gate_for_task.into_slot_guard(generation);
+            // Frees the gate slot on every exit: explicitly before completion on
+            // the normal path (via `release_then_complete` below), or on unwind
+            // for a panic / `--force` abort. A no-op if a later `--force` goal
+            // already took over.
+            let slot = gate_for_task.into_slot_guard(generation);
             let (feedback_tx, feedback_rx) = mpsc::unbounded_channel::<FeedbackLine>();
             let consumer_handle =
                 super::spawn_feedback_forwarder(feedback_rx, feedback_publisher, |line| {
@@ -336,7 +338,7 @@ impl NodeBuildGoalHandler {
 
             let _ = consumer_handle.await;
             if let Ok(payload) = result.encode() {
-                let _ = goal_ctx.complete(payload).await;
+                slot.release_then_complete(&goal_ctx, payload).await;
             }
         });
 

--- a/crates/core-node-internal/src/services/node/gate.rs
+++ b/crates/core-node-internal/src/services/node/gate.rs
@@ -34,6 +34,8 @@
 //! task's release is thus a safe no-op.
 
 use parking_lot::Mutex;
+use peppylib::messaging::GoalContext;
+use peppylib::types::Payload;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::task::JoinHandle;
@@ -182,10 +184,13 @@ impl ConcurrencyGate {
 /// slot so the next goal can be admitted — but only while the gate is still on
 /// the guard's generation.
 ///
-/// Held by the work task for its whole lifetime, it fires on every exit path —
-/// normal completion, an early return, a panic unwinding the task, or a
-/// `--force` `JoinHandle::abort` dropping the future — so the gate is never left
-/// stuck "in progress" (the failure mode every future goal would then hit with
+/// On the normal path the work task releases it explicitly just before
+/// completing the goal, via [`release_then_complete`](Self::release_then_complete):
+/// completion is what lets the client observe the goal as done, so the slot must
+/// already be free by then. As an RAII guard it also fires on every *other* exit
+/// path — an early return, a panic unwinding the task, or a `--force`
+/// `JoinHandle::abort` dropping the future — so the gate is never left stuck
+/// "in progress" (the failure mode every future goal would then hit with
 /// "action already in progress" until the daemon restarts). When a later
 /// `--force` goal has already taken over, bumping the generation, the drop is a
 /// safe no-op and cannot clobber the new owner's slot — the single-goal
@@ -193,10 +198,32 @@ impl ConcurrencyGate {
 ///
 /// The work task completes and drops its `GoalContext` separately; the SDK
 /// retains the result for its grace window so the client's fetch still resolves.
-#[must_use = "the guard must be held for the task's lifetime; dropping it immediately frees the gate"]
+#[must_use = "the guard frees the gate when dropped; release it via release_then_complete or hold it for the task's lifetime"]
 pub(crate) struct GoalSlotGuard {
     gate: ConcurrencyGate,
     generation: u64,
+}
+
+impl GoalSlotGuard {
+    /// Releases this slot, then completes the goal — in that order, which is the
+    /// whole point of bundling them. [`GoalContext::complete`] closes the goal's
+    /// feedback stream and publishes its fetchable result, so a client draining
+    /// feedback learns the goal is done and can fire its next single-goal action
+    /// the instant `complete` returns. Were the slot still held then, that next
+    /// action would be rejected with `"action already in progress"` for the
+    /// window until this task unwound to the guard's end-of-scope drop — a race
+    /// the client can win because `complete` notifies it (in-process) before the
+    /// task winds down. Releasing first closes the window.
+    ///
+    /// The release is generation-checked like any guard drop, so it stays a safe
+    /// no-op when a later `--force` goal has already taken over.
+    pub(crate) async fn release_then_complete(self, goal_ctx: &GoalContext, payload: Payload) {
+        // Explicit drop: without it `self` would live until the end of this
+        // function — i.e. until after `complete` — which is exactly the ordering
+        // this method exists to avoid.
+        drop(self);
+        let _ = goal_ctx.complete(payload).await;
+    }
 }
 
 impl Drop for GoalSlotGuard {

--- a/crates/core-node-internal/src/services/node/run.rs
+++ b/crates/core-node-internal/src/services/node/run.rs
@@ -413,9 +413,10 @@ async fn handle_goal_request(
         .expect("node_run declares a feedback topic");
     let gate_for_task = gate.clone();
     tokio::spawn(async move {
-        // Frees the gate slot on every exit (completion or panic); a no-op if a
-        // later goal already took over.
-        let _slot = gate_for_task.into_slot_guard(generation);
+        // Frees the gate slot on every exit: explicitly before completion on the
+        // normal path (via `release_then_complete` below), or on unwind for a
+        // panic. A no-op if a later goal already took over.
+        let slot = gate_for_task.into_slot_guard(generation);
         let (feedback_tx, mut feedback_rx) = mpsc::unbounded_channel::<FeedbackLine>();
 
         // The node process outlives the action: once `node_run` reports the
@@ -458,7 +459,7 @@ async fn handle_goal_request(
         }
 
         if let Ok(payload) = result.encode() {
-            let _ = goal_ctx.complete(payload).await;
+            slot.release_then_complete(&goal_ctx, payload).await;
         }
     });
 }

--- a/crates/core-node-internal/src/services/repo/refresh.rs
+++ b/crates/core-node-internal/src/services/repo/refresh.rs
@@ -124,9 +124,10 @@ impl GoalHandler for RepoRefreshGoalHandler {
         let gate_for_task = self.gate.clone();
 
         tokio::spawn(async move {
-            // Frees the gate slot on every exit (completion or panic); a no-op
-            // if a later goal already took over.
-            let _slot = gate_for_task.into_slot_guard(generation);
+            // Frees the gate slot on every exit: explicitly before completion on
+            // the normal path (via `release_then_complete` below), or on unwind
+            // for a panic. A no-op if a later goal already took over.
+            let slot = gate_for_task.into_slot_guard(generation);
             let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<RepoRefreshFeedback>();
 
             let drain = tokio::spawn(async move {
@@ -195,7 +196,7 @@ impl GoalHandler for RepoRefreshGoalHandler {
             let _ = drain.await;
 
             if let Ok(payload) = result.encode() {
-                let _ = goal_ctx.complete(payload).await;
+                slot.release_then_complete(&goal_ctx, payload).await;
             }
         });
     }

--- a/crates/core-node-internal/src/services/stack/launch.rs
+++ b/crates/core-node-internal/src/services/stack/launch.rs
@@ -1525,9 +1525,10 @@ async fn handle_goal_request(
     let log_path_clone = log_path.clone();
     let gate_for_task = gate.clone();
     tokio::spawn(async move {
-        // Frees the gate slot on every exit (completion or panic); a no-op if a
-        // later goal already took over.
-        let _slot = gate_for_task.into_slot_guard(generation);
+        // Frees the gate slot on every exit: explicitly before completion on the
+        // normal path (via `release_then_complete` below), or on unwind for a
+        // panic. A no-op if a later goal already took over.
+        let slot = gate_for_task.into_slot_guard(generation);
         let LaunchActionContext {
             messenger,
             bound_core_node,
@@ -1564,7 +1565,7 @@ async fn handle_goal_request(
         // Catch panics so a panic inside the launch sequence still completes the
         // goal with a failure result, rather than leaving the client to wait out
         // the SDK's retention window for a result that never arrives. Releasing
-        // the gate on panic is handled by `_slot` above. Mirrors the panic
+        // the gate on panic is handled by `slot` above. Mirrors the panic
         // handling in `run_node_run` / `run_node_add` / `run_node_build`.
         let result = match AssertUnwindSafe(process_launch(goal, ctx))
             .catch_unwind()
@@ -1581,7 +1582,7 @@ async fn handle_goal_request(
             }
         };
         if let Ok(payload) = result.encode() {
-            let _ = goal_ctx.complete(payload).await;
+            slot.release_then_complete(&goal_ctx, payload).await;
         }
     });
 }

--- a/crates/peppylib/src/messaging/actions.rs
+++ b/crates/peppylib/src/messaging/actions.rs
@@ -1475,9 +1475,7 @@ impl Drop for GoalContext {
         let feedback = self.feedback.clone();
         self.runtime.spawn(async move {
             let transitioned = transition_terminal(&slot, GoalOutcome::Abandoned, grace).await;
-            if transitioned
-                && let Some(publisher) = feedback
-            {
+            if transitioned && let Some(publisher) = feedback {
                 let _ = publisher.publish_end().await;
             }
         });

--- a/docs/src/content/docs/advanced_guides/actions.mdx
+++ b/docs/src/content/docs/advanced_guides/actions.mdx
@@ -586,8 +586,8 @@ Routing for actions uses the same consumer-side model as topics and services. A 
 
 Each slot in `depends_on` is either:
 
-- **Pinned** (the default, when `from_any` is absent or `false`): the slot must be bound. The code generator splices the bound producer's `instance_id` into the generated `fire_goal` as the call's `target_instance_id`, and the goal, cancel, result, and feedback channels all address that one producer. The validator rejects a pinned-unbound slot before the stack starts.
-- **`from_any: true`** (bound or unbound): the generator emits `None` for `target_instance_id` and the call site falls back to wildcard discovery. A probe goes out to every matching producer; the first responder is pinned for the rest of the goal cycle, so the same producer handles the goal, cancel, result, and feedback. The bindings (if any) constrain which producers discovery may consider.
+- **Pinned** (the default, when `from_any` is absent or `false`): the slot must be bound. The generated `fire_goal` resolves the bound producer's `instance_id` from the binding, and the goal, cancel, result, and feedback channels all address that one producer. The validator rejects a pinned-unbound slot before the stack starts.
+- **`from_any: true`**: when the slot is bound, the generated `fire_goal` resolves the binding and addresses the bound producer's `instance_id` directly, exactly like a pinned slot. When the slot is left unbound, the call falls back to wildcard discovery: a probe goes out to every matching producer and the first responder is pinned for the rest of the goal cycle, so the same producer handles the goal, cancel, result, and feedback. Bindings constrain which producers discovery may consider.
 
 In a launcher / stack config:
 

--- a/docs/src/content/docs/advanced_guides/containers.mdx
+++ b/docs/src/content/docs/advanced_guides/containers.mdx
@@ -161,7 +161,7 @@ From: tuatini/peppy-python-uv-base
 
 %labels
     Name my_node
-    Version 0.1.0
+    Version v1
 
 %environment
     export PATH="/opt/my_node/.venv/bin:$PATH"
@@ -187,7 +187,7 @@ From: tuatini/peppy-rust-cargo-base
 
 %labels
     Name my_node
-    Version 0.1.0
+    Version v1
 
 %files
     . /opt/my_node
@@ -478,7 +478,7 @@ You can speed things up by baking those slow steps into a custom Docker image an
 
     %labels
         Name my_node
-        Version 0.1.0
+        Version v1
 
     %environment
         export PATH="/root/.local/bin:/opt/my_node/.venv/bin:$PATH"
@@ -503,7 +503,7 @@ You can speed things up by baking those slow steps into a custom Docker image an
 
     %labels
         Name my_node
-        Version 0.1.0
+        Version v1
 
     %environment
         export PATH="/root/.cargo/bin:$PATH"

--- a/docs/src/content/docs/advanced_guides/repositories.mdx
+++ b/docs/src/content/docs/advanced_guides/repositories.mdx
@@ -5,15 +5,17 @@ sidebar:
   order: 8
 ---
 
-Repositories tell peppy where to look for nodes and launchers. When you run `peppy repo refresh`, peppy walks every configured repository and indexes:
+Repositories tell peppy where to look for nodes, launchers, and interfaces. When you run `peppy repo refresh`, peppy walks every configured repository and indexes:
 
 - **Nodes**, identified by filename: every `peppy.json5` file is treated as a node config.
 - **Launchers**, identified by content: every `.json5` file whose body declares `peppy_schema: "launcher_v1"` is treated as a launcher, regardless of its filename. The launcher is keyed by the file stem (e.g. `openarm01_sim_teleop.json5` becomes the launcher named `openarm01_sim_teleop`).
+- **Interfaces**, identified by content: every `.json5` file whose body declares `peppy_schema: "interface_v1"` is treated as an interface, regardless of its filename. An interface is a reusable contract of topics, services, and actions, keyed by the `name:tag` declared in its manifest; nodes reference interfaces by `name:tag` to declare conformance.
 
-Out of the box, three repositories are configured:
+Out of the box, four repositories are configured:
 
 - **`nodes_hub`** (`https://github.com/Peppy-bot/nodes_hub`, tracked on `main`): a curated collection of ready-to-use nodes.
 - **`launchers_hub`** (`https://github.com/Peppy-bot/launchers_hub`, tracked on `main`): community launch files that compose nodes from the hubs.
+- **`interfaces_hub`** (`https://github.com/Peppy-bot/interfaces_hub`, tracked on `main`): shared interface definitions that nodes reference by `name:tag` to declare conformance.
 - **`openarm01_nodes`** (`https://github.com/Peppy-bot/openarm01_nodes`, tracked on `main`): nodes specific to the OpenArm01 robot.
 
 Add your own local directory with `peppy repo add /path/to/my/nodes` so peppy can discover nodes you create locally.
@@ -28,6 +30,7 @@ Repository configuration lives in `~/.peppy/conf/`, and the indexes built by `pe
 | `conf/excluded_repositories.json5` | Repositories (or subdirectories) to skip |
 | `cache/nodes.json5` | Index of nodes discovered across repositories |
 | `cache/launchers.json5` | Index of launch files discovered across repositories |
+| `cache/interfaces.json5` | Index of interface definitions discovered across repositories |
 
 The two `conf/` files are JSON5 arrays. Each entry has an `id` (auto-assigned if missing), a `type`, and source-specific fields:
 
@@ -44,7 +47,7 @@ The two `conf/` files are JSON5 arrays. Each entry has an `id` (auto-assigned if
 
 | Type | Fields | Description |
 |------|--------|-------------|
-| `fs` | `path` | A local directory. Peppy recursively walks it, indexing every `peppy.json5` (node) and every `.json5` file whose body declares `peppy_schema: "launcher_v1"` (launcher). |
+| `fs` | `path` | A local directory. Peppy recursively walks it, indexing every `peppy.json5` (node) and every `.json5` file whose body declares `peppy_schema: "launcher_v1"` (launcher) or `peppy_schema: "interface_v1"` (interface). |
 | `git` | `url`, `ref` (optional) | A git repository. Peppy shallow-clones it and scans it the same way as an `fs` source. Use `ref` to pin a branch, tag, or commit. |
 | `url` | `url` | An HTTP endpoint (not yet implemented). |
 
@@ -72,14 +75,16 @@ Shows all discovered nodes grouped by the repository that provides them. Each gr
 peppy repo refresh
 ```
 
-Re-scans all configured repositories and rebuilds the node and launcher indexes. `peppy repo update` is accepted as an alias. During refresh, peppy:
+Re-scans all configured repositories and rebuilds the node, launcher, and interface indexes. `peppy repo update` is accepted as an alias. During refresh, peppy:
 
 - Reads `repositories.json5` (creates it with defaults on first run).
 - Skips any repository or path listed in `excluded_repositories.json5`.
 - Walks local directories and shallow-clones git repositories.
-- Records every `peppy.json5` as a node, and every `.json5` file whose body declares `peppy_schema: "launcher_v1"` as a launcher (file stem becomes the launcher name).
-- Reports each discovered node, launcher, and excluded repository in real time.
-- Caches results in `~/.peppy/cache/nodes.json5` and `~/.peppy/cache/launchers.json5`.
+- Records every `peppy.json5` as a node, every `.json5` file whose body declares `peppy_schema: "launcher_v1"` as a launcher (file stem becomes the launcher name), and every `.json5` file whose body declares `peppy_schema: "interface_v1"` as an interface (keyed by the `name:tag` in its manifest).
+- Reports each discovered node, launcher, interface, and excluded repository in real time.
+- Caches results in `~/.peppy/cache/nodes.json5`, `~/.peppy/cache/launchers.json5`, and `~/.peppy/cache/interfaces.json5`.
+
+On completion it prints a summary, for example `Repository refresh complete. 12 node(s), 3 launcher(s), 5 interface(s) found.`
 
 When multiple repositories provide the same `name:tag` pair, the repository with the lower `id` takes priority. The duplicate is still recorded and shown in `repo list` but does not override the primary source.
 

--- a/docs/src/content/docs/advanced_guides/services.mdx
+++ b/docs/src/content/docs/advanced_guides/services.mdx
@@ -235,8 +235,8 @@ Routing for services is the same consumer-side model used by topics. A binding `
 
 Each slot in `depends_on` is either:
 
-- **Pinned** (the default, when `from_any` is absent or `false`): the slot must be bound. The code generator splices the bound producer's `instance_id` into the generated `poll` as the call's `target_instance_id`, so the wire request goes directly to that one producer. The validator rejects a pinned-unbound slot before the stack starts.
-- **`from_any: true`** (bound or unbound): the generator emits `None` for `target_instance_id` and the call site falls back to wildcard discovery. The framework runs a probe to every producer matching the slot's `(name, tag)`, pins the first responder, and delivers the real request only to that producer. The bindings (if any) constrain which producers the wildcard discovery may consider.
+- **Pinned** (the default, when `from_any` is absent or `false`): the slot must be bound. The generated `poll` resolves the bound producer's `instance_id` from the binding and sends the wire request directly to that one producer. The validator rejects a pinned-unbound slot before the stack starts.
+- **`from_any: true`**: when the slot is bound, the generated `poll` resolves the binding and addresses the bound producer's `instance_id` directly, exactly like a pinned slot. When the slot is left unbound, the call falls back to wildcard discovery: the framework runs a probe to every producer matching the slot's `(name, tag)`, pins the first responder, and delivers the real request only to that producer. Bindings constrain which producers the wildcard discovery may consider.
 
 In a launcher / stack config:
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved concurrency gate slot handling across goal handlers so slots are explicitly released on normal completion and panic/abort paths, making goal completion and resource cleanup more reliable.
* **Documentation**
  * Clarified bindings/routing and repository/interface discovery docs; updated container example labels and repository indexing guidance.
* **Style**
  * Minor formatting simplification in goal-context feedback publication logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Peppy-bot/peppyos/pull/217?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->