### PR TITLE
Fix zenohd stdout/stderr to file to prevent pipe buffer deadlock

### DIFF
--- a/crates/peppy/src/commands/service/builder.rs
+++ b/crates/peppy/src/commands/service/builder.rs
@@ -56,8 +56,12 @@ impl ServeCommandBuilder {
         let listening_port = extract_messaging_port();
         let adapter = match engine.as_str() {
             "zenoh" => {
+                // Reconnecting session: if the router watchdog respawns zenohd,
+                // the daemon's own session re-establishes (and re-declares the
+                // core node's services) instead of going silent.
                 let adapter =
-                    ZenohAdapter::with_router(ZenohNetProtocol::Tcp, "0.0.0.0", listening_port)?;
+                    ZenohAdapter::with_router(ZenohNetProtocol::Tcp, "0.0.0.0", listening_port)?
+                        .with_session_reconnect();
                 MessengerAdapter::Zenoh(adapter)
             }
             "mock" => MessengerAdapter::Mock(MockAdapter::default()),

--- a/crates/peppy/src/commands/service/core_node.rs
+++ b/crates/peppy/src/commands/service/core_node.rs
@@ -9,6 +9,19 @@ use std::time::Duration;
 use tokio::sync::{Mutex, oneshot, watch};
 use tracing::info;
 
+/// Cadence of the per-node health monitor (see
+/// `core_node::services::node::run::spawn_health_monitor`). A running instance
+/// is evicted from the stack after [`HEALTH_MONITOR_MAX_FAILURES`] consecutive
+/// failed polls.
+///
+/// The router watchdog in `messaging_router.rs` is deliberately tuned to detect
+/// and respawn a wedged router *faster* than this eviction window, so a
+/// transient router hang does not tear down the whole stack. The
+/// `watchdog_outpaces_health_monitor_eviction` test enforces that relationship.
+pub(crate) const HEALTH_MONITOR_INTERVAL: Duration = Duration::from_secs(5);
+pub(crate) const HEALTH_MONITOR_TIMEOUT: Duration = Duration::from_secs(3);
+pub(crate) const HEALTH_MONITOR_MAX_FAILURES: u32 = 3;
+
 pub struct CoreNodeRunner {
     core_node: CoreNode,
     messaging_ready: Option<watch::Receiver<bool>>,
@@ -27,9 +40,9 @@ impl CoreNodeRunner {
         let node_arguments = CoreNodeArguments {
             node_startup_timeout,
             node_start_health_timeout,
-            health_monitor_interval: Duration::from_secs(5),
-            health_monitor_timeout: Duration::from_secs(3),
-            health_monitor_max_failures: 3,
+            health_monitor_interval: HEALTH_MONITOR_INTERVAL,
+            health_monitor_timeout: HEALTH_MONITOR_TIMEOUT,
+            health_monitor_max_failures: HEALTH_MONITOR_MAX_FAILURES,
             // 10 Hz: high enough to correlate logs across nodes, low enough to
             // avoid flooding the bus.
             clock_publish_interval: Duration::from_millis(100),

--- a/crates/peppy/src/commands/service/messaging_router.rs
+++ b/crates/peppy/src/commands/service/messaging_router.rs
@@ -66,9 +66,9 @@ impl ServeAsyncCommand for MessagingRouter {
             ready_tx.send(()).ok();
 
             // Router watchdog: probe the router's liveness and respawn zenohd
-            // if it wedges (see the zenohd pipe-deadlock incident). Backends
-            // without a restartable router (the mock) return `None` and just
-            // wait for ctrl-c. Either way, ctrl-c ends the wait.
+            // if it wedges. Backends without a restartable router (the mock)
+            // return `None` and just wait for ctrl-c. Either way, ctrl-c ends
+            // the wait.
             let health_checker = { messenger.lock().await.router_health_checker() };
             match health_checker {
                 Some(checker) => {

--- a/crates/peppy/src/commands/service/messaging_router.rs
+++ b/crates/peppy/src/commands/service/messaging_router.rs
@@ -7,11 +7,19 @@ use tokio::sync::{Mutex, oneshot, watch};
 use tracing::{error, info, warn};
 
 /// How often the watchdog probes the router while it appears healthy.
-const WATCHDOG_PROBE_INTERVAL: Duration = Duration::from_secs(10);
+///
+/// The probe cadence ([`WATCHDOG_PROBE_INTERVAL`] / [`WATCHDOG_PROBE_TIMEOUT`] /
+/// [`WATCHDOG_MAX_FAILURES`]) is tuned so the watchdog detects a wedge, respawns
+/// zenohd, and lets node sessions reconnect *before* the core node's health
+/// monitor evicts those nodes from the stack — otherwise a transient router
+/// hang still tears the stack down even though the watchdog "fixed" the router.
+/// The `watchdog_outpaces_health_monitor_eviction` test enforces this against
+/// the health-monitor cadence in `core_node.rs`.
+const WATCHDOG_PROBE_INTERVAL: Duration = Duration::from_secs(2);
 /// Per-probe timeout. A wedged router exceeds any real localhost round-trip.
-const WATCHDOG_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
+const WATCHDOG_PROBE_TIMEOUT: Duration = Duration::from_secs(2);
 /// Consecutive failed probes before the router is declared wedged.
-const WATCHDOG_MAX_FAILURES: u32 = 3;
+const WATCHDOG_MAX_FAILURES: u32 = 2;
 /// Pause after a restart to let the (reconnecting) sessions re-establish
 /// before re-probing.
 const WATCHDOG_RESTART_GRACE: Duration = Duration::from_secs(3);
@@ -185,9 +193,9 @@ fn warn_messaging_restarting(failures: u32) {
          probes (no response for ~{unresponsive_secs}s). The peppy daemon is\n\
          RESTARTING the messaging router now to recover the bus.\n\
          \n\
-         Impact: in-flight messages were lost and running node instances may\n\
-         have been dropped from the stack. After recovery, check\n\
-         `peppy stack list` and relaunch your stack if needed.\n\
+         Impact: in-flight messages were lost. The daemon and node sessions\n\
+         reconnect automatically; after recovery check `peppy stack list` and\n\
+         relaunch any node that did not rejoin.\n\
          ===================================================================="
     );
 }
@@ -199,8 +207,51 @@ fn warn_messaging_restarted() {
          ====================================================================\n\
          ✅  MESSAGING ROUTER RESTARTED — accepting connections again\n\
          ====================================================================\n\
-         The Zenoh router was respawned and is responsive again. Nodes that\n\
-         did not auto-reconnect must be relaunched (`peppy stack launch`).\n\
+         The Zenoh router was respawned and is responsive again. The daemon and\n\
+         node sessions reconnect automatically; relaunch your stack only if\n\
+         `peppy stack list` shows a node did not rejoin.\n\
          ===================================================================="
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The router watchdog must detect a wedged router, respawn it, and leave
+    /// time for node sessions to reconnect *before* the core node's health
+    /// monitor evicts those nodes from the stack. If this inverts, a transient
+    /// router hang tears the whole stack down even though the watchdog "fixed"
+    /// the router. Both cadences are compile-time constants, so this is a pure
+    /// arithmetic guard against a future tweak silently breaking the ordering.
+    #[test]
+    fn watchdog_outpaces_health_monitor_eviction() {
+        use super::super::core_node::{
+            HEALTH_MONITOR_INTERVAL, HEALTH_MONITOR_MAX_FAILURES, HEALTH_MONITOR_TIMEOUT,
+        };
+
+        // Worst case for the watchdog to declare the router wedged and finish
+        // respawning it.
+        let watchdog_recovery = (WATCHDOG_PROBE_INTERVAL + WATCHDOG_PROBE_TIMEOUT)
+            * WATCHDOG_MAX_FAILURES
+            + WATCHDOG_RESTART_GRACE;
+
+        // Earliest the health monitor can evict an instance: the wedge lands
+        // just before a scheduled poll, so the first failure costs only the
+        // poll timeout and each later failure a full interval + timeout cycle.
+        let health_earliest_evict = HEALTH_MONITOR_TIMEOUT
+            + (HEALTH_MONITOR_INTERVAL + HEALTH_MONITOR_TIMEOUT)
+                * (HEALTH_MONITOR_MAX_FAILURES - 1);
+
+        // Headroom for node sessions to reconnect (zenoh retry backoff ~1-4s)
+        // after the router is back but before the health monitor's final poll.
+        const NODE_RECONNECT_HEADROOM: Duration = Duration::from_secs(4);
+
+        assert!(
+            watchdog_recovery + NODE_RECONNECT_HEADROOM < health_earliest_evict,
+            "watchdog recovery ({watchdog_recovery:?}) + reconnect headroom \
+             ({NODE_RECONNECT_HEADROOM:?}) must beat the health monitor's earliest \
+             eviction ({health_earliest_evict:?})"
+        );
+    }
 }

--- a/crates/peppy/src/commands/service/messaging_router.rs
+++ b/crates/peppy/src/commands/service/messaging_router.rs
@@ -1,9 +1,23 @@
 use super::serve::{ServeAsyncCommand, ServeAsyncHandle};
 use crate::error::Error;
-use pmi::{Messenger, MessengerBackend};
+use pmi::{Messenger, MessengerBackend, RouterHealthChecker};
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::{Mutex, oneshot, watch};
-use tracing::info;
+use tracing::{error, info, warn};
+
+/// How often the watchdog probes the router while it appears healthy.
+const WATCHDOG_PROBE_INTERVAL: Duration = Duration::from_secs(10);
+/// Per-probe timeout. A wedged router exceeds any real localhost round-trip.
+const WATCHDOG_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
+/// Consecutive failed probes before the router is declared wedged.
+const WATCHDOG_MAX_FAILURES: u32 = 3;
+/// Pause after a restart to let the (reconnecting) sessions re-establish
+/// before re-probing.
+const WATCHDOG_RESTART_GRACE: Duration = Duration::from_secs(3);
+/// Extra backoff after a restart attempt so a persistently-failing router does
+/// not spin in a tight restart loop.
+const WATCHDOG_POST_RESTART_BACKOFF: Duration = Duration::from_secs(10);
 
 pub struct MessagingRouter {
     messenger: Arc<Mutex<Messenger>>,
@@ -43,9 +57,30 @@ impl ServeAsyncCommand for MessagingRouter {
             messaging_ready.send(true).ok();
             ready_tx.send(()).ok();
 
-            tokio::signal::ctrl_c().await.map_err(|e| {
-                Error::ExecutionFailed(format!("Failed to listen for ctrl-c: {}", e))
-            })?;
+            // Router watchdog: probe the router's liveness and respawn zenohd
+            // if it wedges (see the zenohd pipe-deadlock incident). Backends
+            // without a restartable router (the mock) return `None` and just
+            // wait for ctrl-c. Either way, ctrl-c ends the wait.
+            let health_checker = { messenger.lock().await.router_health_checker() };
+            match health_checker {
+                Some(checker) => {
+                    tokio::select! {
+                        // The watchdog loops for the daemon's lifetime; in
+                        // practice only ctrl-c resolves this select.
+                        _ = run_router_watchdog(&messenger, &checker) => {}
+                        res = tokio::signal::ctrl_c() => {
+                            res.map_err(|e| {
+                                Error::ExecutionFailed(format!("Failed to listen for ctrl-c: {}", e))
+                            })?;
+                        }
+                    }
+                }
+                None => {
+                    tokio::signal::ctrl_c().await.map_err(|e| {
+                        Error::ExecutionFailed(format!("Failed to listen for ctrl-c: {}", e))
+                    })?;
+                }
+            }
 
             {
                 let mut messenger = messenger.lock().await;
@@ -70,4 +105,102 @@ impl ServeAsyncCommand for MessagingRouter {
 
         ServeAsyncHandle::new(future, Some(ready_rx))
     }
+}
+
+/// Periodically probes the Zenoh router and respawns zenohd if it stops
+/// responding. Loops for the daemon's lifetime. Every restart is announced with
+/// a prominent warning banner, and recovery (or continued failure) is reported.
+async fn run_router_watchdog(messenger: &Arc<Mutex<Messenger>>, checker: &RouterHealthChecker) {
+    let mut consecutive_failures: u32 = 0;
+    loop {
+        tokio::time::sleep(WATCHDOG_PROBE_INTERVAL).await;
+
+        if checker.is_router_responsive(WATCHDOG_PROBE_TIMEOUT).await {
+            consecutive_failures = 0;
+            continue;
+        }
+
+        consecutive_failures += 1;
+        warn!(
+            "Zenoh router liveness probe failed ({}/{})",
+            consecutive_failures, WATCHDOG_MAX_FAILURES
+        );
+        if consecutive_failures < WATCHDOG_MAX_FAILURES {
+            continue;
+        }
+
+        // The router is wedged. Warn loudly *before* touching it, then respawn.
+        warn_messaging_restarting(consecutive_failures);
+
+        let restart = {
+            let mut messenger = messenger.lock().await;
+            // stop_router is best-effort: the old process may already be
+            // unresponsive, but we still need its listening port freed.
+            if let Err(e) = messenger.stop_router().await {
+                warn!("Watchdog: stop_router returned an error (continuing to restart): {e}");
+            }
+            messenger.start_router().await
+        };
+
+        match restart {
+            Ok(()) => {
+                // Give the daemon's reconnecting session (and any nodes) a
+                // moment to re-establish before re-probing.
+                tokio::time::sleep(WATCHDOG_RESTART_GRACE).await;
+                if checker.is_router_responsive(WATCHDOG_PROBE_TIMEOUT).await {
+                    warn_messaging_restarted();
+                } else {
+                    error!(
+                        "Watchdog: Zenoh router still not responding after restart. Will keep \
+                         monitoring; a full `peppy service` restart may be required."
+                    );
+                }
+            }
+            Err(e) => {
+                error!(
+                    "Watchdog: failed to restart the Zenoh router: {e}. Will keep monitoring; a \
+                     full `peppy service` restart may be required."
+                );
+            }
+        }
+
+        // Reset and back off so a persistently-failing router does not spin in a
+        // tight restart loop; the next failure has to accrue from scratch.
+        consecutive_failures = 0;
+        tokio::time::sleep(WATCHDOG_POST_RESTART_BACKOFF).await;
+    }
+}
+
+/// Loud, multi-line banner emitted just before the watchdog respawns the router.
+fn warn_messaging_restarting(failures: u32) {
+    // Rough lower bound on how long the router has been unresponsive.
+    let unresponsive_secs =
+        ((WATCHDOG_PROBE_INTERVAL + WATCHDOG_PROBE_TIMEOUT) * failures).as_secs();
+    error!(
+        "\n\
+         ====================================================================\n\
+         ⚠️  MESSAGING SYSTEM RESTART — the Zenoh router is unresponsive\n\
+         ====================================================================\n\
+         The Zenoh router (zenohd) failed {failures} consecutive liveness\n\
+         probes (no response for ~{unresponsive_secs}s). The peppy daemon is\n\
+         RESTARTING the messaging router now to recover the bus.\n\
+         \n\
+         Impact: in-flight messages were lost and running node instances may\n\
+         have been dropped from the stack. After recovery, check\n\
+         `peppy stack list` and relaunch your stack if needed.\n\
+         ===================================================================="
+    );
+}
+
+/// Banner emitted once the respawned router is confirmed responsive again.
+fn warn_messaging_restarted() {
+    warn!(
+        "\n\
+         ====================================================================\n\
+         ✅  MESSAGING ROUTER RESTARTED — accepting connections again\n\
+         ====================================================================\n\
+         The Zenoh router was respawned and is responsive again. Nodes that\n\
+         did not auto-reconnect must be relaunched (`peppy stack launch`).\n\
+         ===================================================================="
+    );
 }

--- a/crates/peppylib/src/messaging.rs
+++ b/crates/peppylib/src/messaging.rs
@@ -233,6 +233,24 @@ impl MessengerHandle {
         })
     }
 
+    /// Like [`from_host_port`](Self::from_host_port) but opens a *reconnecting*
+    /// session: if the router is restarted under it (e.g. the daemon's router
+    /// watchdog respawning zenohd), the session re-establishes and re-declares
+    /// its subscriptions/queryables instead of going dead.
+    ///
+    /// Used by long-lived node processes. Short-lived / CLI connections keep
+    /// [`from_host_port`](Self::from_host_port) so a dead daemon fails fast
+    /// rather than blocking on connection retries.
+    pub async fn from_host_port_reconnecting(host: &str, port: u16) -> Result<Self> {
+        let adapter =
+            ZenohAdapter::connect_to(ZenohNetProtocol::Tcp, host, port)?.with_session_reconnect();
+        let messenger = Self::new_session(adapter).await?;
+        Ok(Self {
+            messenger: Arc::new(Mutex::new(messenger)),
+            active_from_any_topics: Arc::new(StdMutex::new(HashSet::new())),
+        })
+    }
+
     async fn new_session(adapter: ZenohAdapter) -> Result<Messenger> {
         let mut messenger = Messenger::new(MessengerAdapter::Zenoh(adapter));
         messenger

--- a/crates/peppylib/src/runtime/node_runner.rs
+++ b/crates/peppylib/src/runtime/node_runner.rs
@@ -28,9 +28,14 @@ impl NodeRunner {
         processor: Processor,
         cancellation_token: CancellationToken,
     ) -> Result<Self> {
-        let messenger =
-            MessengerHandle::from_host_port(processor.messaging_host(), processor.messaging_port())
-                .await?;
+        // Nodes are long-lived: use a reconnecting session so a router restart
+        // (e.g. the daemon's watchdog respawning zenohd) is recovered
+        // transparently instead of leaving the node off the bus.
+        let messenger = MessengerHandle::from_host_port_reconnecting(
+            processor.messaging_host(),
+            processor.messaging_port(),
+        )
+        .await?;
 
         Ok(Self {
             messenger,

--- a/crates/peppylib/tests/topics.rs
+++ b/crates/peppylib/tests/topics.rs
@@ -4,7 +4,7 @@ use common::test_node_target;
 use config::node::QoSProfile;
 use peppylib::messaging::{ConsumerFilter, MessengerHandle, TopicMessenger};
 use peppylib::types::Payload;
-use pmi::ZenohAdapter;
+use pmi::{MessengerBackend, ZenohAdapter};
 use std::time::Duration;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -67,4 +67,113 @@ async fn topic_messenger_communication() {
     assert_eq!(message.payload(), &payload);
     assert_eq!(message.instance_id(), instance_id);
     assert_eq!(message.core_node(), core_node);
+}
+
+/// Proves a NODE session keeps receiving after the router process is killed and
+/// respawned on the same port. The subscriber is created via the node-path
+/// `from_host_port_reconnecting`, so this exercises the actual reconnecting
+/// config that `NodeRunner` gives every node — confirming a watchdog
+/// router-respawn doesn't knock running nodes off the bus.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn node_session_recovers_after_router_restart() {
+    let mut instance = ZenohAdapter::start_router_ephemeral("127.0.0.1", None)
+        .await
+        .expect("failed to start zenoh router for test");
+    let (host, port) = (instance.host.clone(), instance.port);
+
+    let core_node = "test_core";
+    let instance_id = "test_instance";
+    let node_name = "test_node";
+    let topic_name = "reconnect_topic";
+
+    // Subscriber uses the NODE path: a reconnecting session.
+    let receiver_handle = MessengerHandle::from_host_port_reconnecting(&host, port)
+        .await
+        .expect("failed to create reconnecting receiver handle");
+    let mut subscription = TopicMessenger::subscribe(
+        &receiver_handle,
+        core_node,
+        instance_id,
+        Some(test_node_target(node_name)),
+        true,
+        topic_name,
+        None,
+        &ConsumerFilter::Any,
+        QoSProfile::Reliable,
+    )
+    .await
+    .expect("subscription should succeed");
+
+    // Baseline: a publisher reaches the subscriber through the router.
+    {
+        let sender_handle = MessengerHandle::from_host_port(&host, port)
+            .await
+            .expect("failed to create sender handle");
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        TopicMessenger::emit(
+            &sender_handle,
+            core_node,
+            instance_id,
+            test_node_target(node_name),
+            topic_name,
+            QoSProfile::Reliable,
+            Payload::from_static(b"before-restart"),
+        )
+        .await
+        .expect("baseline emit should succeed");
+        let msg = tokio::time::timeout(Duration::from_secs(5), subscription.on_next_message())
+            .await
+            .expect("baseline: should receive within timeout")
+            .expect("baseline: message should not be None");
+        assert_eq!(msg.payload(), &Payload::from_static(b"before-restart"));
+    }
+
+    // Kill + respawn zenohd on the same port — exactly what the watchdog does.
+    instance
+        .messenger()
+        .stop_router()
+        .await
+        .expect("stop_router");
+    instance
+        .messenger()
+        .start_router()
+        .await
+        .expect("start_router");
+
+    // The reconnecting node session must re-establish and re-declare its
+    // subscription. Drive a fresh publisher (on the new router) and poll until
+    // delivery, or give up after a generous budget.
+    let sender_handle = MessengerHandle::from_host_port(&host, port)
+        .await
+        .expect("failed to create post-restart sender handle");
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(30);
+    let mut recovered = false;
+    while std::time::Instant::now() < deadline {
+        // Ignore emit errors: the publisher link may still be settling.
+        let _ = TopicMessenger::emit(
+            &sender_handle,
+            core_node,
+            instance_id,
+            test_node_target(node_name),
+            topic_name,
+            QoSProfile::Reliable,
+            Payload::from_static(b"after-restart"),
+        )
+        .await;
+        if tokio::time::timeout(Duration::from_millis(800), subscription.on_next_message())
+            .await
+            .is_ok_and(|m| m.is_some())
+        {
+            recovered = true;
+            break;
+        }
+    }
+
+    assert!(
+        recovered,
+        "node session did not receive after the router was respawned: it failed to reconnect + \
+         re-declare its subscription"
+    );
 }

--- a/crates/peppylib/tests/topics.rs
+++ b/crates/peppylib/tests/topics.rs
@@ -143,10 +143,15 @@ async fn node_session_recovers_after_router_restart() {
     // The reconnecting node session must re-establish and re-declare its
     // subscription. Drive a fresh publisher (on the new router) and poll until
     // delivery, or give up after a generous budget.
-    let sender_handle = MessengerHandle::from_host_port(&host, port)
+    // A non-reconnecting `from_host_port` would race the respawn: the freshly
+    // started router can accept a TCP connection before its protocol handshake
+    // has settled, failing the one-shot session open. A reconnecting publisher
+    // opens immediately and connects in the background instead, so the
+    // emit-until-delivered loop below drives recovery without a hand-rolled
+    // connect-retry loop here.
+    let sender_handle = MessengerHandle::from_host_port_reconnecting(&host, port)
         .await
         .expect("failed to create post-restart sender handle");
-    tokio::time::sleep(Duration::from_millis(500)).await;
 
     let deadline = std::time::Instant::now() + Duration::from_secs(30);
     let mut recovered = false;
@@ -162,9 +167,11 @@ async fn node_session_recovers_after_router_restart() {
             Payload::from_static(b"after-restart"),
         )
         .await;
-        if tokio::time::timeout(Duration::from_millis(800), subscription.on_next_message())
-            .await
-            .is_ok_and(|m| m.is_some())
+        // Only the post-restart payload proves recovery: a stale `before-restart`
+        // delivery redelivered through the reconnecting session must not count.
+        if let Ok(Some(msg)) =
+            tokio::time::timeout(Duration::from_millis(800), subscription.on_next_message()).await
+            && msg.payload() == Payload::from_static(b"after-restart")
         {
             recovered = true;
             break;

--- a/crates/pmi-internal/src/adapters/zenoh.rs
+++ b/crates/pmi-internal/src/adapters/zenoh.rs
@@ -140,6 +140,59 @@ pub struct ZenohClientConfigTemplate {
     pub protocol: zenohd::ZenohNetProtocol,
 }
 
+/// Client config for the daemon's long-lived session. Unlike the fail-fast
+/// default, this retries the connection forever (`timeout_ms: -1`,
+/// `exit_on_failure: false`) so the session re-establishes — and re-declares
+/// its subscriptions/queryables — if the router is restarted under it (e.g. by
+/// the router watchdog respawning zenohd).
+#[derive(Template)]
+#[template(
+    source = r#"{
+    "mode": "client",
+    "connect": {
+        "endpoints": ["{{ protocol }}/{{ host }}:{{ port }}"],
+        "timeout_ms": -1,
+        "exit_on_failure": false,
+        "retry": {
+            "period_init_ms": 1000,
+            "period_max_ms": 4000,
+            "period_increase_factor": 2.0
+        }
+    }
+}"#,
+    ext = "txt"
+)]
+pub struct ZenohReconnectingClientConfigTemplate {
+    pub host: String,
+    pub port: u16,
+    pub protocol: ZenohNetProtocol,
+}
+
+/// Client config for the router watchdog's liveness probe. Scouting is
+/// disabled so the probe only ever tries the configured router endpoint (never
+/// a multicast-discovered peer), making "is *our* router responsive?" a
+/// deterministic question.
+#[derive(Template)]
+#[template(
+    source = r#"{
+    "mode": "client",
+    "connect": {
+        "endpoints": ["{{ protocol }}/{{ host }}:{{ port }}"]
+    },
+    "scouting": {
+        "multicast": {
+            "enabled": false
+        }
+    }
+}"#,
+    ext = "txt"
+)]
+pub struct ZenohProbeClientConfigTemplate {
+    pub host: String,
+    pub port: u16,
+    pub protocol: ZenohNetProtocol,
+}
+
 #[derive(Template)]
 #[template(
     source = r#"{
@@ -169,6 +222,9 @@ pub struct ZenohAdapter {
     zenohd: Option<zenohd::ZenohdFacade>,
     client_config: ZenohClientConfig,
     session: Option<Arc<zenoh::Session>>,
+    /// When true, [`start_session`](MessengerBackend::start_session) opens a
+    /// reconnecting session (see [`ZenohReconnectingClientConfigTemplate`]).
+    reconnect_session: bool,
 }
 
 impl ZenohAdapter {
@@ -183,19 +239,32 @@ impl ZenohAdapter {
             zenohd: Some(facade),
             client_config,
             session: None,
+            reconnect_session: false,
         })
     }
 
     /// Creates a ZenohAdapter that connects to an existing zenohd router.
     /// Use this when you want to connect to a router that's already running.
     pub fn connect_to(protocol: ZenohNetProtocol, host: &str, port: u16) -> Result<Self> {
-        let client_config = Self::create_client_config(protocol, host, port);
+        let client_config = Self::create_client_config(protocol, host, port, false);
 
         Ok(Self {
             zenohd: None,
             client_config,
             session: None,
+            reconnect_session: false,
         })
+    }
+
+    /// Marks this adapter's long-lived session as reconnecting: on
+    /// [`start_session`](MessengerBackend::start_session) it uses a config that
+    /// retries the connection (and re-declares its subscriptions/queryables) if
+    /// the router is restarted under it. Used by the daemon so the router
+    /// watchdog can respawn zenohd without leaving the daemon's own session
+    /// dead. CLI and short-lived adapters leave this off (fail-fast default).
+    pub fn with_session_reconnect(mut self) -> Self {
+        self.reconnect_session = true;
+        self
     }
 
     /// Starts a zenohd router with an ephemeral port, retrying on bind failures.
@@ -269,10 +338,27 @@ impl ZenohAdapter {
         (self.client_config.host.as_str(), self.client_config.port)
     }
 
+    /// Builds a lock-free [`RouterHealthChecker`] bound to this adapter's router
+    /// endpoint, for the router watchdog to probe liveness without holding the
+    /// central messenger lock.
+    pub fn router_health_checker(&self) -> RouterHealthChecker {
+        let probe_str = ZenohProbeClientConfigTemplate {
+            host: self.client_config.host.clone(),
+            port: self.client_config.port,
+            protocol: self.client_config.protocol,
+        }
+        .render()
+        .expect("Failed to render probe client config template");
+        let probe_config = zenoh::config::Config::from_json5(&probe_str)
+            .expect("Failed to create probe client config");
+        RouterHealthChecker { probe_config }
+    }
+
     fn create_client_config(
         protocol: ZenohNetProtocol,
         host: &str,
         port: u16,
+        reconnect: bool,
     ) -> ZenohClientConfig {
         let connect_host = if host == "0.0.0.0" {
             "127.0.0.1".to_string()
@@ -280,32 +366,49 @@ impl ZenohAdapter {
             host.to_string()
         };
 
-        let client_template = ZenohClientConfigTemplate {
-            host: connect_host,
-            port,
-            protocol,
-        };
-
-        let client_config_str = client_template
+        // The long-lived daemon session uses the reconnecting template so it
+        // survives a router restart; everything else (CLI connects, readiness
+        // probes) uses the fail-fast template so a down router errors quickly
+        // instead of blocking on retries.
+        let client_config_str = if reconnect {
+            ZenohReconnectingClientConfigTemplate {
+                host: connect_host.clone(),
+                port,
+                protocol,
+            }
             .render()
-            .expect("Failed to render client config template");
+            .expect("Failed to render reconnecting client config template")
+        } else {
+            ZenohClientConfigTemplate {
+                host: connect_host.clone(),
+                port,
+                protocol,
+            }
+            .render()
+            .expect("Failed to render client config template")
+        };
 
         let client_config = zenoh::config::Config::from_json5(&client_config_str)
             .expect("Failed to create client config");
 
         ZenohClientConfig {
             zenoh_config: client_config,
-            host: client_template.host,
-            port: client_template.port,
-            protocol: client_template.protocol,
+            host: connect_host,
+            port,
+            protocol,
         }
     }
 
     fn derive_client_config_from_zenohd(zenohd: &zenohd::ZenohdFacade) -> ZenohClientConfig {
+        // Fail-fast: this config also backs the ephemeral readiness probe in
+        // `start_router_ephemeral`, which relies on `zenoh::open` erroring
+        // quickly. The daemon's reconnecting session is built separately in
+        // `start_session` when `reconnect_session` is set.
         Self::create_client_config(
             zenohd.zenoh_endpoint.protocol,
             &zenohd.zenoh_endpoint.host,
             zenohd.zenoh_endpoint.port,
+            false,
         )
     }
 
@@ -341,7 +444,23 @@ impl ZenohAdapter {
 
 impl MessengerBackend for ZenohAdapter {
     async fn start_session(&mut self) -> Result<()> {
-        let session = zenoh::open(self.client_config.zenoh_config.clone())
+        // The daemon's long-lived session uses a reconnecting config so it
+        // re-establishes itself (and re-declares its subscriptions/queryables)
+        // if the router is restarted under it — e.g. by the router watchdog.
+        // Short-lived / CLI sessions keep the fail-fast default.
+        let config = if self.reconnect_session {
+            Self::create_client_config(
+                self.client_config.protocol,
+                &self.client_config.host,
+                self.client_config.port,
+                true,
+            )
+            .zenoh_config
+        } else {
+            self.client_config.zenoh_config.clone()
+        };
+
+        let session = zenoh::open(config)
             .await
             .map_err(|e| Error::BackendError(format!("Failed to create Zenoh session: {}", e)))?;
 
@@ -805,5 +924,65 @@ impl ZenohPublisher {
                 topic: e.to_string(),
             })?;
         Ok(())
+    }
+}
+
+/// Lock-free handle for probing whether the Zenoh router is responsive.
+///
+/// Holds a fail-fast probe config (scouting disabled, single connect attempt to
+/// the router endpoint). [`Self::is_router_responsive`] opens a throwaway
+/// session bounded by `timeout` — the same operation a CLI client performs — so
+/// it detects a wedged router that still accepts TCP connections but never
+/// completes the Zenoh session handshake. Obtain one via
+/// [`crate::Messenger::router_health_checker`] and probe without holding the
+/// central messenger lock.
+pub struct RouterHealthChecker {
+    probe_config: zenoh::config::Config,
+}
+
+impl RouterHealthChecker {
+    /// Returns `true` if a fresh session to the router completes within
+    /// `timeout`; `false` otherwise (timed out, connection refused, …).
+    pub async fn is_router_responsive(&self, timeout: std::time::Duration) -> bool {
+        match tokio::time::timeout(timeout, zenoh::open(self.probe_config.clone())).await {
+            Ok(Ok(session)) => {
+                // We only needed the handshake. Close the probe session, but
+                // don't let a slow close stall the watchdog.
+                let _ =
+                    tokio::time::timeout(std::time::Duration::from_secs(1), session.close()).await;
+                true
+            }
+            // Open errored, or our timeout elapsed before the handshake settled.
+            _ => false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reconnecting_and_probe_configs_parse() {
+        // Guards the JSON5 schemas: a malformed connect/scouting block would
+        // otherwise panic at daemon startup inside `create_client_config` /
+        // `router_health_checker` (both `.expect()` on parse).
+        let reconnecting =
+            ZenohAdapter::create_client_config(ZenohNetProtocol::Tcp, "0.0.0.0", 7448, true);
+        // `0.0.0.0` must be rewritten to a connectable loopback host.
+        assert_eq!(reconnecting.host, "127.0.0.1");
+
+        let fail_fast =
+            ZenohAdapter::create_client_config(ZenohNetProtocol::Tcp, "127.0.0.1", 7448, false);
+        assert_eq!(fail_fast.port, 7448);
+
+        let probe_str = ZenohProbeClientConfigTemplate {
+            host: "127.0.0.1".to_string(),
+            port: 7448,
+            protocol: ZenohNetProtocol::Tcp,
+        }
+        .render()
+        .expect("probe template renders");
+        zenoh::config::Config::from_json5(&probe_str).expect("probe config parses");
     }
 }

--- a/crates/pmi-internal/src/lib.rs
+++ b/crates/pmi-internal/src/lib.rs
@@ -24,6 +24,6 @@ pub use wire::{
 pub use adapters::mock::{MockAdapter, MockInstance};
 
 #[cfg(feature = "zenoh")]
-pub use adapters::zenoh::{ZenohAdapter, ZenohdInstance};
+pub use adapters::zenoh::{RouterHealthChecker, ZenohAdapter, ZenohdInstance};
 #[cfg(feature = "zenoh")]
 pub use zenohd::ZenohNetProtocol;

--- a/crates/pmi-internal/src/types.rs
+++ b/crates/pmi-internal/src/types.rs
@@ -13,7 +13,7 @@ use std::net::SocketAddr;
 use zenoh::bytes::ZBytes;
 
 #[cfg(feature = "zenoh")]
-use super::adapters::zenoh::{ZenohAdapter, ZenohPublisher};
+use super::adapters::zenoh::{RouterHealthChecker, ZenohAdapter, ZenohPublisher};
 
 /// QoS settings for publishing messages
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
@@ -718,6 +718,16 @@ impl Messenger {
 
     pub fn messaging_port(&self) -> u16 {
         self.get_host().port()
+    }
+
+    /// Returns a lock-free [`RouterHealthChecker`] for the router watchdog, or
+    /// `None` for backends without a restartable router (e.g. the mock).
+    #[cfg(feature = "zenoh")]
+    pub fn router_health_checker(&self) -> Option<RouterHealthChecker> {
+        match &self.adapter {
+            MessengerAdapter::Zenoh(adapter) => Some(adapter.router_health_checker()),
+            MessengerAdapter::Mock(_) => None,
+        }
     }
 
     /// Pre-bind a per-topic publisher. The returned [`MessengerPublisher`]

--- a/crates/pmi-internal/src/zenohd/facade.rs
+++ b/crates/pmi-internal/src/zenohd/facade.rs
@@ -413,9 +413,11 @@ mod tests {
         use std::io::Write;
         use tempfile::Builder;
 
-        // Missing file: fall back to pointing at the path.
-        let missing = Path::new("/nonexistent/zenohd_0.log");
-        assert!(zenohd_log_excerpt(missing).contains("see zenohd log"));
+        // Missing file: fall back to pointing at the path. Build it inside a
+        // temp dir (without creating the file) so the test is portable.
+        let dir = tempfile::tempdir().expect("Failed to create temp dir");
+        let missing = dir.path().join("zenohd_0.log");
+        assert!(zenohd_log_excerpt(&missing).contains("see zenohd log"));
 
         // Present file: include the tail of its contents.
         let mut log = Builder::new()

--- a/crates/pmi-internal/src/zenohd/facade.rs
+++ b/crates/pmi-internal/src/zenohd/facade.rs
@@ -1,4 +1,5 @@
 use super::super::error::{Error, Result};
+use std::fs::File;
 use std::net::TcpStream;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
@@ -35,24 +36,16 @@ pub struct ZenohEndpoint {
 }
 
 /// Checks whether a child process has exited prematurely.
-/// Returns the process back if still alive, or an error with stderr output if it exited.
-fn check_process_alive(mut child: Child) -> std::result::Result<Child, Error> {
+/// Returns the process back if still alive, or an error carrying the tail of
+/// the router log if it exited. zenohd's stdout/stderr are redirected to
+/// `log_path`, so the diagnostic comes from the file rather than from a pipe.
+fn check_process_alive(mut child: Child, log_path: &Path) -> std::result::Result<Child, Error> {
     match child.try_wait() {
-        Ok(Some(status)) => {
-            let output = child.wait_with_output().map_err(|e| {
-                Error::BackendError(format!("Failed to capture zenohd output: {}", e))
-            })?;
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            Err(Error::BackendError(format!(
-                "zenohd exited unexpectedly with status: {}{}",
-                status,
-                if stderr.trim().is_empty() {
-                    String::new()
-                } else {
-                    format!(" – {}", stderr.trim())
-                }
-            )))
-        }
+        Ok(Some(status)) => Err(Error::BackendError(format!(
+            "zenohd exited unexpectedly with status: {}{}",
+            status,
+            zenohd_log_excerpt(log_path),
+        ))),
         Ok(None) => Ok(child),
         Err(e) => Err(Error::BackendError(format!(
             "Failed to check zenohd status: {}",
@@ -61,11 +54,37 @@ fn check_process_alive(mut child: Child) -> std::result::Result<Child, Error> {
     }
 }
 
+/// Builds a short suffix describing why zenohd exited by reading the tail of
+/// its redirected log file. Used only on the error path; falls back to the log
+/// path when the file is empty or unreadable.
+fn zenohd_log_excerpt(log_path: &Path) -> String {
+    match std::fs::read_to_string(log_path) {
+        Ok(contents) if !contents.trim().is_empty() => {
+            let tail = contents
+                .lines()
+                .rev()
+                .take(20)
+                .collect::<Vec<_>>()
+                .into_iter()
+                .rev()
+                .collect::<Vec<_>>()
+                .join("\n");
+            format!(" – last zenohd log lines:\n{tail}")
+        }
+        _ => format!(" (see zenohd log at {})", log_path.display()),
+    }
+}
+
 /// The Zenoh daemon binary facade. Zenohd is not accessible via the Rust API (or in a very limited fashion).
 /// This facade allows calling the binary in the background.
 pub struct ZenohdFacade {
     zenohd_path: Option<String>,
     pub zenohd_config_path: PathBuf,
+    /// File that receives zenohd's stdout+stderr. These streams must be drained
+    /// for the process's lifetime; an unread pipe deadlocks the router once its
+    /// buffer fills (a zenohd thread blocks in `write` and stops servicing
+    /// sockets). A file sink is bounded by disk and never blocks.
+    zenohd_log_path: PathBuf,
     pub router_process: Option<Child>,
     pub zenoh_endpoint: ZenohEndpoint,
 }
@@ -75,9 +94,17 @@ impl ZenohdFacade {
     pub fn new(zenohd_config_path: impl AsRef<Path>) -> Result<Self> {
         let zenohd_path = ZenohdFacade::get_zenohd_binary();
         let zenoh_endpoint = ZenohdFacade::get_endpoint_from_config(&zenohd_config_path)?;
+        let zenohd_config_path = zenohd_config_path.as_ref().to_path_buf();
+        // Keep the log next to the generated config (same directory), one file
+        // per router port.
+        let zenohd_log_path = zenohd_config_path
+            .parent()
+            .unwrap_or_else(|| Path::new("."))
+            .join(format!("zenohd_{}.log", zenoh_endpoint.port));
         Ok(Self {
             zenohd_path,
-            zenohd_config_path: zenohd_config_path.as_ref().to_path_buf(),
+            zenohd_config_path,
+            zenohd_log_path,
             router_process: None,
             zenoh_endpoint,
         })
@@ -199,12 +226,30 @@ impl ZenohdFacade {
             )));
         }
 
+        // Redirect stdout+stderr to a log file instead of unread pipes: a full
+        // pipe buffer blocks a zenohd thread in `write` and deadlocks the whole
+        // router. Pin the log level too, so a verbose inherited `RUST_LOG`
+        // can't flood the file (override with `PEPPY_ZENOHD_LOG`).
+        let log_file = File::create(&self.zenohd_log_path).map_err(|e| {
+            Error::BackendError(format!(
+                "Failed to create zenohd log file {}: {}",
+                self.zenohd_log_path.display(),
+                e
+            ))
+        })?;
+        let stderr_file = log_file
+            .try_clone()
+            .map_err(|e| Error::BackendError(format!("Failed to set up zenohd log file: {}", e)))?;
+        let zenohd_log_level =
+            env::var("PEPPY_ZENOHD_LOG").unwrap_or_else(|_| "zenoh=warn".to_string());
+
         let mut child = Command::new(zenohd_path)
             .env("ZENOH_CONFIG", self.zenohd_config_path.as_os_str())
+            .env("RUST_LOG", zenohd_log_level)
             .arg("-c")
             .arg(&self.zenohd_config_path)
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
+            .stdout(Stdio::from(log_file))
+            .stderr(Stdio::from(stderr_file))
             .spawn()
             .map_err(|e| Error::BackendError(format!("Failed to start zenohd: {}", e)))?;
 
@@ -220,7 +265,7 @@ impl ZenohdFacade {
             let max_backoff = std::time::Duration::from_millis(500);
 
             loop {
-                child = check_process_alive(child)?;
+                child = check_process_alive(child, &self.zenohd_log_path)?;
 
                 match TcpStream::connect(&connect_addr) {
                     Ok(_) => break,
@@ -238,12 +283,13 @@ impl ZenohdFacade {
                 }
             }
         } else {
-            child = check_process_alive(child)?;
+            child = check_process_alive(child, &self.zenohd_log_path)?;
         }
 
         tracing::info!(
-            "Zenoh router started, with config {}",
-            self.zenohd_config_path.to_str().unwrap()
+            "Zenoh router started (config {}, logs {})",
+            self.zenohd_config_path.display(),
+            self.zenohd_log_path.display()
         );
 
         // Store the child process handle
@@ -316,6 +362,16 @@ mod tests {
         assert_eq!(facade.zenoh_endpoint.host, expected_host);
         assert_eq!(facade.zenoh_endpoint.port, expected_port);
         assert_eq!(facade.zenoh_endpoint.protocol, ZenohNetProtocol::Tcp);
+
+        // The log file sits next to the config, named per router port.
+        assert_eq!(
+            facade.zenohd_log_path,
+            config_file
+                .path()
+                .parent()
+                .unwrap()
+                .join(format!("zenohd_{expected_port}.log"))
+        );
     }
 
     #[test]
@@ -350,5 +406,24 @@ mod tests {
 
         // Process should remain None
         assert!(facade.router_process.is_none());
+    }
+
+    #[test]
+    fn test_zenohd_log_excerpt() {
+        use std::io::Write;
+        use tempfile::Builder;
+
+        // Missing file: fall back to pointing at the path.
+        let missing = Path::new("/nonexistent/zenohd_0.log");
+        assert!(zenohd_log_excerpt(missing).contains("see zenohd log"));
+
+        // Present file: include the tail of its contents.
+        let mut log = Builder::new()
+            .suffix(".log")
+            .tempfile()
+            .expect("Failed to create temp log");
+        writeln!(log, "starting up\nerror: address already in use").expect("write");
+        let excerpt = zenohd_log_excerpt(log.path());
+        assert!(excerpt.contains("address already in use"));
     }
 }

--- a/crates/pmi-internal/tests/zenoh.rs
+++ b/crates/pmi-internal/tests/zenoh.rs
@@ -9,8 +9,9 @@ mod zenoh_tests {
     use bytes::Bytes;
     use pmi::{
         MessengerBackend, Payload, PublisherQoS, SubscriberQoS, TopicWireReceiver, TopicWireSender,
-        ZenohAdapter,
+        ZenohAdapter, ZenohNetProtocol,
     };
+    use std::time::{Duration, Instant};
 
     /// Awaits a single message on `rx` or fails the test on timeout. The
     /// `label` is included in both timeout and channel-closed panics so test
@@ -47,6 +48,139 @@ mod zenoh_tests {
             to_topic,
         )
         .expect("valid wire fields")
+    }
+
+    /// Opens a fresh (non-reconnecting) publisher session against the router at
+    /// `host:port`, retrying briefly in case the router is still settling after
+    /// a respawn. Panics if it can't connect within the retry budget.
+    async fn open_publisher(host: &str, port: u16) -> ZenohAdapter {
+        for _ in 0..40 {
+            if let Ok(mut adapter) = ZenohAdapter::connect_to(ZenohNetProtocol::Tcp, host, port)
+                && adapter.start_session().await.is_ok()
+            {
+                return adapter;
+            }
+            tokio::time::sleep(Duration::from_millis(250)).await;
+        }
+        panic!("could not open a publisher session against {host}:{port}");
+    }
+
+    /// Repeatedly publishes to `topic` and waits briefly for the subscriber to
+    /// receive, until something arrives or `budget` elapses. Returns `true` if a
+    /// message was delivered. Used after a router respawn to give the
+    /// reconnecting subscriber time to re-establish and re-declare.
+    async fn poll_until_delivered(
+        publisher: &mut ZenohAdapter,
+        topic: &str,
+        rx: &mut flume::Receiver<pmi::TopicMessage>,
+        budget: Duration,
+    ) -> bool {
+        let deadline = Instant::now() + budget;
+        let mut attempt = 0u32;
+        while Instant::now() < deadline {
+            attempt += 1;
+            let body = Bytes::from(format!("after-restart-{attempt}"));
+            // Ignore publish errors: the publisher's link may still be
+            // re-establishing in the first moments after the respawn.
+            let _ = publisher
+                .publish_topic(
+                    &sender(topic),
+                    Payload::from_bytes(body),
+                    PublisherQoS::Standard,
+                    true,
+                )
+                .await;
+            if tokio::time::timeout(Duration::from_millis(800), rx.recv_async())
+                .await
+                .is_ok_and(|r| r.is_ok())
+            {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Proves the daemon's in-process recovery path: a reconnecting subscriber
+    /// session keeps working after its router process is killed and respawned on
+    /// the same port — i.e. the session reconnects *and re-declares* its
+    /// subscription. This is the half of the router-watchdog fix that the unit
+    /// tests can't cover.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn reconnecting_subscriber_recovers_after_router_restart() {
+        const TOPIC: &str = "reconnect_topic";
+        let _lock = ZENOH_SERIAL.lock().await;
+
+        // `instance` owns the zenohd process so we can respawn it on the same
+        // port mid-test. We never open a session on it — only use it to drive
+        // the router lifecycle (stop_router / start_router).
+        let mut instance = ZenohAdapter::start_router_ephemeral("127.0.0.1", None)
+            .await
+            .expect("Failed to start zenohd process");
+        let host = instance.host.clone();
+        let port = instance.port;
+
+        // The subscriber session uses the SAME reconnecting config the daemon
+        // uses (`with_session_reconnect`) — this is the behaviour under test.
+        let mut subscriber = ZenohAdapter::connect_to(ZenohNetProtocol::Tcp, &host, port)
+            .expect("subscriber adapter")
+            .with_session_reconnect();
+        subscriber
+            .start_session()
+            .await
+            .expect("subscriber start_session");
+        let mut subscription = subscriber
+            .subscribe_topic(&receiver(TOPIC), SubscriberQoS::Standard)
+            .await
+            .expect("subscribe");
+
+        // Baseline: a fresh publisher reaches the subscriber through the router.
+        {
+            let mut publisher = open_publisher(&host, port).await;
+            wait_for_subscriber_discovery().await;
+            publisher
+                .publish_topic(
+                    &sender(TOPIC),
+                    Payload::from_bytes(Bytes::from_static(b"before-restart")),
+                    PublisherQoS::Standard,
+                    true,
+                )
+                .await
+                .expect("baseline publish");
+            let got = recv_or_timeout(&mut subscription.rx, "baseline").await;
+            assert_eq!(got.payload(), &Bytes::from_static(b"before-restart"));
+        }
+
+        // Respawn zenohd on the same port — exactly what the watchdog does when
+        // it finds the router wedged.
+        instance
+            .messenger()
+            .stop_router()
+            .await
+            .expect("stop_router");
+        instance
+            .messenger()
+            .start_router()
+            .await
+            .expect("start_router");
+
+        // The reconnecting subscriber must re-establish and re-declare its
+        // subscription against the new router. Drive a fresh publisher and poll
+        // until delivery (or give up after a generous budget).
+        let mut publisher = open_publisher(&host, port).await;
+        wait_for_subscriber_discovery().await;
+        let recovered = poll_until_delivered(
+            &mut publisher,
+            TOPIC,
+            &mut subscription.rx,
+            Duration::from_secs(30),
+        )
+        .await;
+
+        assert!(
+            recovered,
+            "reconnecting subscriber did not receive after the router was respawned: the session \
+             did not reconnect + re-declare its subscription"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/crates/pmi-internal/tests/zenoh.rs
+++ b/crates/pmi-internal/tests/zenoh.rs
@@ -90,9 +90,11 @@ mod zenoh_tests {
                     true,
                 )
                 .await;
-            if tokio::time::timeout(Duration::from_millis(800), rx.recv_async())
-                .await
-                .is_ok_and(|r| r.is_ok())
+            // Only a post-restart payload proves recovery: a stale `before-restart`
+            // sample redelivered through the reconnecting session must not count.
+            if let Ok(Ok(msg)) =
+                tokio::time::timeout(Duration::from_millis(800), rx.recv_async()).await
+                && msg.payload().as_bytes().starts_with(b"after-restart-")
             {
                 return true;
             }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-router log files with configurable zenohd log level and graceful log excerpt fallback for diagnostics.
  * Automatic session reconnect for messaging clients so node sessions recover after router restarts.
  * Router watchdog that probes liveness and respawns unresponsive routers; health-monitor timing tuned to avoid premature evictions.

* **Bug Fixes**
  * Improved failure reporting that includes log context on unexpected router exits.

* **Tests**
  * New integration tests cover session recovery after router restart and watchdog/health timing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Peppy-bot/peppyos/pull/218?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->