### PR TITLE
Fix zombie processes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,9 +423,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1031,9 +1031,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1749,9 +1749,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1801,7 +1801,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tokio",
  "tower-service",
  "tracing",
@@ -2222,9 +2222,9 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.18.4+1.9.3"
+version = "0.18.5+1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b26f66f35e1871b22efcf7191564123d2a446ca0538cde63c23adfefa9b15b7"
+checksum = "005d6ae6eac1912906073e069f7db60b1fa98e052a68227824afe3e3a1c59ca2"
 dependencies = [
  "cc",
  "libc",
@@ -2251,18 +2251,18 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "libz-sys"
-version = "1.1.28"
+version = "1.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
+checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
 dependencies = [
  "cc",
  "libc",
@@ -2352,9 +2352,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "micromap"
@@ -2380,9 +2380,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "log",
@@ -2955,6 +2955,7 @@ dependencies = [
  "flume 0.12.0",
  "futures",
  "jsonschema",
+ "libc",
  "pmi",
  "rand 0.10.1",
  "regex",
@@ -3371,7 +3372,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3410,7 +3411,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -4273,9 +4274,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"
@@ -4370,9 +4371,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -4506,9 +4507,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.39.2"
+version = "0.39.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14311e7e9a03114cd4b65eedd54e8fed2945e17f08586ae97ef53bc0669f9581"
+checksum = "21d0d938c10fcda3e897e28aaddf4ab462375d411f4378cd63b1c945f69aba96"
 dependencies = [
  "libc",
  "memchr",
@@ -4690,7 +4691,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -4768,9 +4769,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.11+spec-1.1.0"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap 2.14.0",
  "toml_datetime",
@@ -4962,9 +4963,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ucd-trie"
@@ -5106,9 +5107,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -6432,18 +6433,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2513,6 +2513,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
  "zstd",

--- a/crates/containers-internal/src/apptainer/facade.rs
+++ b/crates/containers-internal/src/apptainer/facade.rs
@@ -472,7 +472,7 @@ impl Apptainer {
     }
 
     pub fn version(&self) -> Result<String> {
-        let mut cmd = self.command(&["--version"], &[])?;
+        let mut cmd = self.command(&["--version"], &[], None)?;
         cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
         let output = cmd.output().map_err(Error::from)?;
         if !output.status.success() {
@@ -484,6 +484,39 @@ impl Apptainer {
             });
         }
         Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    }
+
+    /// SIGKILL the guest-side build process group recorded at `pgid_file` by the
+    /// Lima build wrapper (see [`ApptainerCommand::cancel_pgid_file`]).
+    ///
+    /// On the native backend (Linux) the host process-group SIGKILL already
+    /// reached the whole build tree, so this is a no-op. Under Lima (macOS) the
+    /// guest `apptainer build` and its `%post` children live in a separate
+    /// kernel; this reaches into the VM and kills the whole group. Best-effort:
+    /// a missing or already-dead group is not an error.
+    pub fn kill_inflight_build(&self, pgid_file: &Path) -> Result<()> {
+        match &self.backend {
+            Backend::Native { .. } => Ok(()),
+            Backend::Lima {
+                limactl_path,
+                lima_home,
+                ..
+            } => {
+                let guest_pgid = self.translate_path(pgid_file)?;
+                let script = lima::lima_kill_pgid_script(&guest_pgid);
+                Command::new(limactl_path)
+                    .env("LIMA_HOME", lima_home)
+                    .arg("shell")
+                    .arg(lima::LIMA_INSTANCE)
+                    .arg("--")
+                    .arg("sh")
+                    .arg("-c")
+                    .arg(script)
+                    .status()
+                    .map_err(Error::from)?;
+                Ok(())
+            }
+        }
     }
 
     // -----------------------------------------------------------------------
@@ -518,6 +551,7 @@ impl Apptainer {
             flags: Vec::new(),
             bind_mounts: Vec::new(),
             lima_shell_extra_args: Vec::new(),
+            cancel_pgid_file: None,
         }
     }
 
@@ -535,6 +569,7 @@ impl Apptainer {
             flags: Vec::new(),
             bind_mounts: Vec::new(),
             lima_shell_extra_args: Vec::new(),
+            cancel_pgid_file: None,
         }
     }
 
@@ -551,6 +586,7 @@ impl Apptainer {
             flags: Vec::new(),
             bind_mounts: Vec::new(),
             lima_shell_extra_args: Vec::new(),
+            cancel_pgid_file: None,
         }
     }
 
@@ -623,7 +659,17 @@ impl Apptainer {
     /// On Linux: runs `{apptainer_bin} <args...>` directly.
     /// On macOS: runs `{limactl} shell peppy -- {guest_apptainer_bin} <args...>` to
     /// execute inside the Lima VM using the synced guest-side binary.
-    fn command(&self, args: &[&str], lima_shell_extra_args: &[String]) -> Result<Command> {
+    ///
+    /// `guest_pgid_file` (Lima only) wraps the guest invocation so apptainer runs
+    /// as a process-group leader recording its PGID there; see
+    /// [`lima::lima_guest_build_argv`]. The native backend ignores it (the host
+    /// process group already covers the whole build tree).
+    fn command(
+        &self,
+        args: &[&str],
+        lima_shell_extra_args: &[String],
+        guest_pgid_file: Option<&Path>,
+    ) -> Result<Command> {
         match &self.backend {
             Backend::Native { apptainer_bin } => {
                 let mut cmd = Command::new(apptainer_bin);
@@ -643,8 +689,15 @@ impl Apptainer {
                     cmd.arg(arg);
                 }
                 cmd.arg("--");
-                cmd.arg(apptainer_bin);
-                cmd.args(args);
+                match guest_pgid_file {
+                    Some(pgid_file) => {
+                        cmd.args(lima::lima_guest_build_argv(apptainer_bin, args, pgid_file));
+                    }
+                    None => {
+                        cmd.arg(apptainer_bin);
+                        cmd.args(args);
+                    }
+                }
                 Ok(cmd)
             }
         }
@@ -740,6 +793,10 @@ pub struct ApptainerCommand<'a> {
     flags: Vec<String>,
     bind_mounts: Vec<BindMount>,
     lima_shell_extra_args: Vec<String>,
+    /// When set, run the guest build (Lima only) as a process-group leader that
+    /// records its PGID here, so [`Apptainer::kill_inflight_build`] can SIGKILL
+    /// the whole guest group on cancel. Only meaningful for `build`.
+    cancel_pgid_file: Option<PathBuf>,
 }
 
 impl<'a> ApptainerCommand<'a> {
@@ -811,6 +868,18 @@ impl<'a> ApptainerCommand<'a> {
         self
     }
 
+    /// Make the guest build a process-group leader that records its PGID to
+    /// `pgid_file`, so [`Apptainer::kill_inflight_build`] can SIGKILL the whole
+    /// guest group (apptainer + its `%post` children) on cancellation.
+    ///
+    /// Only effective under the Lima backend (macOS) and only for `build`
+    /// commands. On the native backend (Linux) the host process-group SIGKILL
+    /// already covers the build tree, so this is ignored.
+    pub fn cancel_pgid_file(mut self, pgid_file: &Path) -> Self {
+        self.cancel_pgid_file = Some(pgid_file.to_path_buf());
+        self
+    }
+
     // -----------------------------------------------------------------------
     // Generic flag / args
     // -----------------------------------------------------------------------
@@ -852,12 +921,26 @@ impl<'a> ApptainerCommand<'a> {
     /// Stdout and stderr are inherited (not piped), so build/run progress
     /// output flows directly to the terminal.
     pub fn spawn(self) -> Result<Child> {
+        let mut cmd = self.assemble_command()?;
+        cmd.spawn().map_err(Error::from)
+    }
+
+    /// Assemble the fully-configured [`Command`] (subcommand + flags + binds +
+    /// positional args, wrapped in `limactl shell` under Lima) shared by the
+    /// terminal methods. Resolves the cancel-PGID file to its guest path so the
+    /// Lima build can be run as a process-group leader.
+    fn assemble_command(&self) -> Result<Command> {
         let args = self.build_args()?;
         let str_args: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
-        let mut cmd = self
-            .facade
-            .command(&str_args, &self.lima_shell_extra_args)?;
-        cmd.spawn().map_err(Error::from)
+        let guest_pgid_file = match &self.cancel_pgid_file {
+            Some(pgid_file) => Some(self.facade.translate_path(pgid_file)?),
+            None => None,
+        };
+        self.facade.command(
+            &str_args,
+            &self.lima_shell_extra_args,
+            guest_pgid_file.as_deref(),
+        )
     }
 
     /// Build the fully-configured [`Command`] without spawning it.
@@ -869,20 +952,14 @@ impl<'a> ApptainerCommand<'a> {
     /// The returned command has **no stdio overrides** — stdout, stderr, and
     /// stdin all default to `Inherit`.
     pub fn into_std_command(self) -> Result<Command> {
-        let args = self.build_args()?;
-        let str_args: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
-        self.facade.command(&str_args, &self.lima_shell_extra_args)
+        self.assemble_command()
     }
 
     /// Run the command to completion and return its captured output.
     ///
     /// Stdout and stderr are piped (captured).
     pub fn output(self) -> Result<Output> {
-        let args = self.build_args()?;
-        let str_args: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
-        let mut cmd = self
-            .facade
-            .command(&str_args, &self.lima_shell_extra_args)?;
+        let mut cmd = self.assemble_command()?;
         cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
         cmd.output().map_err(Error::from)
     }

--- a/crates/containers-internal/src/apptainer/facade.rs
+++ b/crates/containers-internal/src/apptainer/facade.rs
@@ -505,15 +505,12 @@ impl Apptainer {
                 ..
             } => {
                 let guest_pgid = lima::guest_pgid_path(build_key);
-                let script = lima::lima_kill_pgid_script(&guest_pgid);
                 Command::new(limactl_path)
                     .env("LIMA_HOME", lima_home)
                     .arg("shell")
                     .arg(lima::LIMA_INSTANCE)
                     .arg("--")
-                    .arg("sh")
-                    .arg("-c")
-                    .arg(script)
+                    .args(lima::lima_kill_pgid_argv(&guest_pgid))
                     .status()
                     .map_err(Error::from)?;
                 Ok(())

--- a/crates/containers-internal/src/apptainer/facade.rs
+++ b/crates/containers-internal/src/apptainer/facade.rs
@@ -932,10 +932,11 @@ impl<'a> ApptainerCommand<'a> {
     fn assemble_command(&self) -> Result<Command> {
         let args = self.build_args()?;
         let str_args: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
-        let guest_pgid_file = match &self.cancel_pgid_file {
-            Some(pgid_file) => Some(self.facade.translate_path(pgid_file)?),
-            None => None,
-        };
+        let guest_pgid_file = self
+            .cancel_pgid_file
+            .as_deref()
+            .map(|pgid_file| self.facade.translate_path(pgid_file))
+            .transpose()?;
         self.facade.command(
             &str_args,
             &self.lima_shell_extra_args,

--- a/crates/containers-internal/src/apptainer/facade.rs
+++ b/crates/containers-internal/src/apptainer/facade.rs
@@ -486,15 +486,17 @@ impl Apptainer {
         Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
     }
 
-    /// SIGKILL the guest-side build process group recorded at `pgid_file` by the
-    /// Lima build wrapper (see [`ApptainerCommand::cancel_pgid_file`]).
+    /// SIGKILL the guest-side build process group recorded for `build_key` by the
+    /// Lima build wrapper (see [`ApptainerCommand::cancel_pgid`]). `build_key`
+    /// must match the one passed to `cancel_pgid` for this build; both resolve to
+    /// the same guest-native pgid path via [`lima::guest_pgid_path`].
     ///
     /// On the native backend (Linux) the host process-group SIGKILL already
     /// reached the whole build tree, so this is a no-op. Under Lima (macOS) the
     /// guest `apptainer build` and its `%post` children live in a separate
     /// kernel; this reaches into the VM and kills the whole group. Best-effort:
     /// a missing or already-dead group is not an error.
-    pub fn kill_inflight_build(&self, pgid_file: &Path) -> Result<()> {
+    pub fn kill_inflight_build(&self, build_key: &str) -> Result<()> {
         match &self.backend {
             Backend::Native { .. } => Ok(()),
             Backend::Lima {
@@ -502,7 +504,7 @@ impl Apptainer {
                 lima_home,
                 ..
             } => {
-                let guest_pgid = self.translate_path(pgid_file)?;
+                let guest_pgid = lima::guest_pgid_path(build_key);
                 let script = lima::lima_kill_pgid_script(&guest_pgid);
                 Command::new(limactl_path)
                     .env("LIMA_HOME", lima_home)
@@ -516,6 +518,38 @@ impl Apptainer {
                     .map_err(Error::from)?;
                 Ok(())
             }
+        }
+    }
+
+    /// Run `args` in the container runtime environment and capture its output.
+    ///
+    /// On Linux (`Backend::Native`) the command runs directly on the host. On
+    /// macOS (`Backend::Lima`) it runs inside the guest VM via
+    /// `limactl shell <instance> -- <args>`. Complements
+    /// [`kill_inflight_build`](Self::kill_inflight_build) for diagnostics and
+    /// lifecycle checks that need to observe runtime-side processes (the same
+    /// kernel the build runs in).
+    pub fn guest_command(&self, args: &[&str]) -> Result<std::process::Output> {
+        let (program, rest) = args.split_first().ok_or_else(|| {
+            Error::ConfigurationError("guest_command requires at least one argument".into())
+        })?;
+        match &self.backend {
+            Backend::Native { .. } => Command::new(program)
+                .args(rest)
+                .output()
+                .map_err(Error::from),
+            Backend::Lima {
+                limactl_path,
+                lima_home,
+                ..
+            } => Command::new(limactl_path)
+                .env("LIMA_HOME", lima_home)
+                .arg("shell")
+                .arg(lima::LIMA_INSTANCE)
+                .arg("--")
+                .args(args)
+                .output()
+                .map_err(Error::from),
         }
     }
 
@@ -551,7 +585,7 @@ impl Apptainer {
             flags: Vec::new(),
             bind_mounts: Vec::new(),
             lima_shell_extra_args: Vec::new(),
-            cancel_pgid_file: None,
+            cancel_pgid_path: None,
         }
     }
 
@@ -569,7 +603,7 @@ impl Apptainer {
             flags: Vec::new(),
             bind_mounts: Vec::new(),
             lima_shell_extra_args: Vec::new(),
-            cancel_pgid_file: None,
+            cancel_pgid_path: None,
         }
     }
 
@@ -586,7 +620,7 @@ impl Apptainer {
             flags: Vec::new(),
             bind_mounts: Vec::new(),
             lima_shell_extra_args: Vec::new(),
-            cancel_pgid_file: None,
+            cancel_pgid_path: None,
         }
     }
 
@@ -794,9 +828,11 @@ pub struct ApptainerCommand<'a> {
     bind_mounts: Vec<BindMount>,
     lima_shell_extra_args: Vec<String>,
     /// When set, run the guest build (Lima only) as a process-group leader that
-    /// records its PGID here, so [`Apptainer::kill_inflight_build`] can SIGKILL
-    /// the whole guest group on cancel. Only meaningful for `build`.
-    cancel_pgid_file: Option<PathBuf>,
+    /// records its PGID to this guest-native path, so
+    /// [`Apptainer::kill_inflight_build`] can SIGKILL the whole guest group on
+    /// cancel. Resolved from a build key via [`lima::guest_pgid_path`]. Only
+    /// meaningful for `build`.
+    cancel_pgid_path: Option<PathBuf>,
 }
 
 impl<'a> ApptainerCommand<'a> {
@@ -868,15 +904,17 @@ impl<'a> ApptainerCommand<'a> {
         self
     }
 
-    /// Make the guest build a process-group leader that records its PGID to
-    /// `pgid_file`, so [`Apptainer::kill_inflight_build`] can SIGKILL the whole
-    /// guest group (apptainer + its `%post` children) on cancellation.
+    /// Make the guest build a process-group leader that records its PGID to a
+    /// guest-native file keyed by `build_key`, so [`Apptainer::kill_inflight_build`]
+    /// (called with the same key) can SIGKILL the whole guest group (apptainer +
+    /// its `%post` children) on cancellation. `build_key` must be unique and
+    /// filesystem-safe (the working-dir basename is a good choice).
     ///
     /// Only effective under the Lima backend (macOS) and only for `build`
     /// commands. On the native backend (Linux) the host process-group SIGKILL
     /// already covers the build tree, so this is ignored.
-    pub fn cancel_pgid_file(mut self, pgid_file: &Path) -> Self {
-        self.cancel_pgid_file = Some(pgid_file.to_path_buf());
+    pub fn cancel_pgid(mut self, build_key: &str) -> Self {
+        self.cancel_pgid_path = Some(lima::guest_pgid_path(build_key));
         self
     }
 
@@ -927,20 +965,18 @@ impl<'a> ApptainerCommand<'a> {
 
     /// Assemble the fully-configured [`Command`] (subcommand + flags + binds +
     /// positional args, wrapped in `limactl shell` under Lima) shared by the
-    /// terminal methods. Resolves the cancel-PGID file to its guest path so the
-    /// Lima build can be run as a process-group leader.
+    /// terminal methods. The cancel-PGID path is already guest-native, so it is
+    /// passed straight through to wrap the Lima build as a process-group leader.
     fn assemble_command(&self) -> Result<Command> {
         let args = self.build_args()?;
         let str_args: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
-        let guest_pgid_file = self
-            .cancel_pgid_file
-            .as_deref()
-            .map(|pgid_file| self.facade.translate_path(pgid_file))
-            .transpose()?;
+        // The pgid path comes from `lima::guest_pgid_path`, i.e. it is already a
+        // guest-side path, so it must NOT go through `translate_path` (which
+        // would reject `/tmp/...` as outside `$HOME`).
         self.facade.command(
             &str_args,
             &self.lima_shell_extra_args,
-            guest_pgid_file.as_deref(),
+            self.cancel_pgid_path.as_deref(),
         )
     }
 

--- a/crates/containers-internal/src/apptainer/lima.rs
+++ b/crates/containers-internal/src/apptainer/lima.rs
@@ -6,10 +6,58 @@ pub(crate) const LIMA_INSTANCE: &str = env!("LIMA_INSTANCE");
 pub(crate) const LIMA_TEMPLATE: &str = env!("LIMA_TEMPLATE");
 pub(crate) const MIN_LIMA_VERSION: (u32, u32, u32) = (2, 1, 0);
 
+/// Single-quote a string for safe embedding in a shell command string.
+pub(crate) fn shell_single_quote(s: &str) -> String {
+    // Replace any single quotes with the '\'' idiom, then wrap in single quotes.
+    format!("'{}'", s.replace('\'', "'\\''"))
+}
+
 /// Single-quote a path for safe embedding in a shell command string.
-fn shell_escape(path: &Path) -> String {
-    // Replace any single quotes in the path with the '\'' idiom, then wrap in single quotes.
-    format!("'{}'", path.display().to_string().replace('\'', "'\\''"))
+pub(crate) fn shell_escape(path: &Path) -> String {
+    shell_single_quote(&path.display().to_string())
+}
+
+/// Builds the guest-side argv (after the `limactl shell ... --` separator) that
+/// runs an `apptainer build` as its own session/process-group leader and records
+/// its PGID to `pgid_file`.
+///
+/// `setsid -w` makes `sh` the session+group leader (so its PGID equals its PID)
+/// and waits for it, forwarding stdout/stderr and the exit status unchanged.
+/// `sh` writes that PID to `pgid_file`, then `exec`s apptainer, which keeps the
+/// PID; apptainer's `%post` children inherit the group. On cancel,
+/// [`lima_kill_pgid_script`] SIGKILLs that whole group from inside the VM.
+pub(crate) fn lima_guest_build_argv(
+    apptainer_bin: &Path,
+    apptainer_args: &[&str],
+    pgid_file: &Path,
+) -> Vec<String> {
+    let mut guest = format!(
+        "echo $$ > {}; exec {}",
+        shell_escape(pgid_file),
+        shell_escape(apptainer_bin)
+    );
+    for arg in apptainer_args {
+        guest.push(' ');
+        guest.push_str(&shell_single_quote(arg));
+    }
+    vec![
+        "setsid".to_string(),
+        "-w".to_string(),
+        "sh".to_string(),
+        "-c".to_string(),
+        guest,
+    ]
+}
+
+/// Guest-side `sh -c` script that SIGKILLs the build process group recorded at
+/// `pgid_file` by [`lima_guest_build_argv`]. The negative PGID targets the whole
+/// group (apptainer + its `%post` children). Best-effort: a missing or
+/// already-dead group is not an error.
+pub(crate) fn lima_kill_pgid_script(pgid_file: &Path) -> String {
+    format!(
+        "kill -KILL -\"$(cat {})\" 2>/dev/null || true",
+        shell_escape(pgid_file)
+    )
 }
 
 /// Build a `limactl shell <instance> --` command pre-configured with LIMA_HOME.

--- a/crates/containers-internal/src/apptainer/lima.rs
+++ b/crates/containers-internal/src/apptainer/lima.rs
@@ -19,68 +19,64 @@ pub(crate) fn guest_pgid_path(build_key: &str) -> PathBuf {
     PathBuf::from(GUEST_PGID_DIR).join(format!("{build_key}.pgid"))
 }
 
-/// Single-quote a string for safe embedding in a shell command string.
-pub(crate) fn shell_single_quote(s: &str) -> String {
-    // Replace any single quotes with the '\'' idiom, then wrap in single quotes.
-    format!("'{}'", s.replace('\'', "'\\''"))
-}
-
-/// Single-quote a path for safe embedding in a shell command string.
-pub(crate) fn shell_escape(path: &Path) -> String {
-    shell_single_quote(&path.display().to_string())
-}
-
 /// Builds the guest-side argv (after the `limactl shell ... --` separator) that
 /// runs an `apptainer build` as its own session/process-group leader and records
 /// its PGID to `pgid_file` (a guest-native path from [`guest_pgid_path`]).
 ///
 /// `setsid -w` makes `sh` the session+group leader (so its PGID equals its PID)
-/// and waits for it, forwarding stdout/stderr and the exit status unchanged.
-/// `sh` records that PID to `pgid_file`, then runs apptainer as a child of the
-/// same group (not via `exec`) so apptainer's `%post` children inherit the group
-/// and `sh` survives to remove the pgid file and forward apptainer's exit status
-/// on the normal path. `mkdir -p` of the guest-native pgid dir makes the write
-/// independent of the virtiofs host mount. On cancel, [`lima_kill_pgid_script`]
-/// SIGKILLs the whole group (`sh` + apptainer + `%post` children) from inside
-/// the VM.
+/// and waits for it, forwarding stdout/stderr and the exit status unchanged. The
+/// `sh -c` script is a fixed constant: the pgid file, apptainer binary, and its
+/// args arrive as the shell's own positional parameters (`$1`, then `$@`), so
+/// they are never re-tokenized and need no shell escaping. The script `mkdir -p`s
+/// the guest-native pgid dir (derived from `$1`) so the write does not race the
+/// virtiofs host mount, records `$$` to `$1`, then runs apptainer as a child of
+/// the same group (not via `exec`) so apptainer's `%post` children inherit the
+/// group and `sh` survives to remove the pgid file and forward apptainer's exit
+/// status on the normal path. On cancel, [`lima_kill_pgid_argv`] SIGKILLs the
+/// whole group (`sh` + apptainer + `%post` children) from inside the VM.
 pub(crate) fn lima_guest_build_argv(
     apptainer_bin: &Path,
     apptainer_args: &[&str],
     pgid_file: &Path,
 ) -> Vec<String> {
-    let pgid_dir = pgid_file.parent().unwrap_or_else(|| Path::new("/tmp"));
-    let mut guest = format!(
-        "mkdir -p {}; echo $$ > {}; {}",
-        shell_escape(pgid_dir),
-        shell_escape(pgid_file),
-        shell_escape(apptainer_bin)
-    );
-    for arg in apptainer_args {
-        guest.push(' ');
-        guest.push_str(&shell_single_quote(arg));
-    }
-    guest.push_str(&format!(
-        "; __rc=$?; rm -f {}; exit $__rc",
-        shell_escape(pgid_file)
-    ));
-    vec![
+    // Fixed script; values follow as positional params. `sh` is the `$0`
+    // placeholder so the next operand is `$1` (the pgid file) and the rest are
+    // apptainer's binary and args. Derive the pgid dir from `$1`, record the
+    // leader PID, then `shift` `$1` off so `"$@"` runs apptainer as a child while
+    // `$pgid` keeps the path for cleanup.
+    let script = "d=$(dirname \"$1\"); mkdir -p \"$d\"; echo $$ > \"$1\"; \
+                  pgid=\"$1\"; shift; \"$@\"; __rc=$?; rm -f \"$pgid\"; exit $__rc";
+    let mut argv = vec![
         "setsid".to_string(),
         "-w".to_string(),
         "sh".to_string(),
         "-c".to_string(),
-        guest,
-    ]
+        script.to_string(),
+        "sh".to_string(),
+        pgid_file.display().to_string(),
+        apptainer_bin.display().to_string(),
+    ];
+    argv.extend(apptainer_args.iter().map(|arg| arg.to_string()));
+    argv
 }
 
-/// Guest-side `sh -c` script that SIGKILLs the build process group recorded at
-/// `pgid_file` by [`lima_guest_build_argv`], then removes the pgid file. The
-/// negative PGID targets the whole group (`sh` + apptainer + its `%post`
-/// children); the `rm -f` cleans up on the cancel path, where the wrapper is
-/// SIGKILLed before it can self-clean. Best-effort: a missing or already-dead
-/// group is not an error.
-pub(crate) fn lima_kill_pgid_script(pgid_file: &Path) -> String {
-    let escaped = shell_escape(pgid_file);
-    format!("kill -KILL -\"$(cat {escaped})\" 2>/dev/null; rm -f {escaped} 2>/dev/null; true")
+/// Guest-side argv (after the `limactl shell ... --` separator) that SIGKILLs the
+/// build process group recorded at `pgid_file` by [`lima_guest_build_argv`], then
+/// removes the pgid file. The `sh -c` script is a fixed constant and the pgid file
+/// arrives as `$1`, so it needs no shell escaping. The negative PGID targets the
+/// whole group (`sh` + apptainer + its `%post` children); the `rm -f` cleans up on
+/// the cancel path, where the wrapper is SIGKILLed before it can self-clean.
+/// Best-effort: a missing or already-dead group is not an error.
+pub(crate) fn lima_kill_pgid_argv(pgid_file: &Path) -> Vec<String> {
+    let script = "kill -KILL -\"$(cat \"$1\")\" 2>/dev/null; \
+                  rm -f \"$1\" 2>/dev/null; true";
+    vec![
+        "sh".to_string(),
+        "-c".to_string(),
+        script.to_string(),
+        "sh".to_string(),
+        pgid_file.display().to_string(),
+    ]
 }
 
 /// Build a `limactl shell <instance> --` command pre-configured with LIMA_HOME.
@@ -430,28 +426,54 @@ pub(crate) fn ensure_guest_apptainer(
         ))
     })?;
 
-    // Copy host installation to guest via tar pipe.
-    // `limactl copy -r` is unreliable with long or special-character paths,
-    // so we tar on the host and untar in the guest through a pipe.
-    let limactl_str = limactl.to_string_lossy();
-    let lima_home_str = lima_home.to_string_lossy();
-    let tar_pipe = Command::new("bash")
-        .arg("-c")
-        .arg(format!(
-            "tar -cf - -C {} . | LIMA_HOME={} {} shell {} -- tar -xf - -C {}",
-            shell_escape(host_dir),
-            shell_escape(Path::new(&*lima_home_str)),
-            shell_escape(Path::new(&*limactl_str)),
-            instance,
-            guest_dir.display(),
-        ))
+    // Copy host installation to guest via tar pipe. `limactl copy -r` is
+    // unreliable with long or special-character paths, so we tar on the host and
+    // untar in the guest. The two `tar` processes are wired together in Rust (no
+    // shell), so paths pass as argv and need no escaping, and a failure on either
+    // side is surfaced (a shell pipe would mask the host-side `tar` exit status).
+    let mut host_tar = Command::new("tar")
+        .args(["-cf", "-", "-C"])
+        .arg(host_dir)
+        .arg(".")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| Error::LimaSyncFailed(format!("failed to start host tar: {e}")))?;
+
+    // Hand the host tar's stdout to the guest tar's stdin. Taking it here also
+    // drops our own copy of the read end so the pipe closes cleanly.
+    let host_stdout = host_tar
+        .stdout
+        .take()
+        .expect("host tar was spawned with a piped stdout");
+
+    let guest_tar = lima_shell_cmd(limactl, lima_home, instance)
+        .args(["tar", "-xf", "-", "-C"])
+        .arg(&guest_dir)
+        .stdin(Stdio::from(host_stdout))
+        .stderr(Stdio::piped())
         .output()
         .map_err(|e| Error::LimaSyncFailed(format!("tar pipe to guest failed: {e}")))?;
 
-    check_output(&tar_pipe, |stderr| {
+    let host_status = host_tar
+        .wait()
+        .map_err(|e| Error::LimaSyncFailed(format!("failed to wait for host tar: {e}")))?;
+    if !host_status.success() {
+        let mut stderr = String::new();
+        if let Some(mut pipe) = host_tar.stderr.take() {
+            use std::io::Read;
+            let _ = pipe.read_to_string(&mut stderr);
+        }
+        return Err(Error::LimaSyncFailed(format!(
+            "host tar returned {host_status}: {}",
+            stderr.trim()
+        )));
+    }
+
+    check_output(&guest_tar, |stderr| {
         Error::LimaSyncFailed(format!(
             "tar pipe to guest returned {}: {stderr}",
-            tar_pipe.status
+            guest_tar.status
         ))
     })?;
 

--- a/crates/containers-internal/src/apptainer/lima.rs
+++ b/crates/containers-internal/src/apptainer/lima.rs
@@ -6,6 +6,19 @@ pub(crate) const LIMA_INSTANCE: &str = env!("LIMA_INSTANCE");
 pub(crate) const LIMA_TEMPLATE: &str = env!("LIMA_TEMPLATE");
 pub(crate) const MIN_LIMA_VERSION: (u32, u32, u32) = (2, 1, 0);
 
+/// Guest-native directory for build PGID files. Lives under `/tmp/peppy` on the
+/// guest's own tmpfs (alongside the synced apptainer install), never the
+/// virtiofs host-home mount, so the wrapper's pgid write cannot lose a
+/// mount-visibility race the way a path under `$HOME` can.
+pub(crate) const GUEST_PGID_DIR: &str = "/tmp/peppy/pgids";
+
+/// Guest-native path of a build's PGID file, keyed by a unique, filesystem-safe
+/// build key (the working-dir basename). The build wrapper and the kill script
+/// both derive the path from this one helper so they can never disagree.
+pub(crate) fn guest_pgid_path(build_key: &str) -> PathBuf {
+    PathBuf::from(GUEST_PGID_DIR).join(format!("{build_key}.pgid"))
+}
+
 /// Single-quote a string for safe embedding in a shell command string.
 pub(crate) fn shell_single_quote(s: &str) -> String {
     // Replace any single quotes with the '\'' idiom, then wrap in single quotes.
@@ -19,20 +32,26 @@ pub(crate) fn shell_escape(path: &Path) -> String {
 
 /// Builds the guest-side argv (after the `limactl shell ... --` separator) that
 /// runs an `apptainer build` as its own session/process-group leader and records
-/// its PGID to `pgid_file`.
+/// its PGID to `pgid_file` (a guest-native path from [`guest_pgid_path`]).
 ///
 /// `setsid -w` makes `sh` the session+group leader (so its PGID equals its PID)
 /// and waits for it, forwarding stdout/stderr and the exit status unchanged.
-/// `sh` writes that PID to `pgid_file`, then `exec`s apptainer, which keeps the
-/// PID; apptainer's `%post` children inherit the group. On cancel,
-/// [`lima_kill_pgid_script`] SIGKILLs that whole group from inside the VM.
+/// `sh` records that PID to `pgid_file`, then runs apptainer as a child of the
+/// same group (not via `exec`) so apptainer's `%post` children inherit the group
+/// and `sh` survives to remove the pgid file and forward apptainer's exit status
+/// on the normal path. `mkdir -p` of the guest-native pgid dir makes the write
+/// independent of the virtiofs host mount. On cancel, [`lima_kill_pgid_script`]
+/// SIGKILLs the whole group (`sh` + apptainer + `%post` children) from inside
+/// the VM.
 pub(crate) fn lima_guest_build_argv(
     apptainer_bin: &Path,
     apptainer_args: &[&str],
     pgid_file: &Path,
 ) -> Vec<String> {
+    let pgid_dir = pgid_file.parent().unwrap_or_else(|| Path::new("/tmp"));
     let mut guest = format!(
-        "echo $$ > {}; exec {}",
+        "mkdir -p {}; echo $$ > {}; {}",
+        shell_escape(pgid_dir),
         shell_escape(pgid_file),
         shell_escape(apptainer_bin)
     );
@@ -40,6 +59,10 @@ pub(crate) fn lima_guest_build_argv(
         guest.push(' ');
         guest.push_str(&shell_single_quote(arg));
     }
+    guest.push_str(&format!(
+        "; __rc=$?; rm -f {}; exit $__rc",
+        shell_escape(pgid_file)
+    ));
     vec![
         "setsid".to_string(),
         "-w".to_string(),
@@ -50,14 +73,14 @@ pub(crate) fn lima_guest_build_argv(
 }
 
 /// Guest-side `sh -c` script that SIGKILLs the build process group recorded at
-/// `pgid_file` by [`lima_guest_build_argv`]. The negative PGID targets the whole
-/// group (apptainer + its `%post` children). Best-effort: a missing or
-/// already-dead group is not an error.
+/// `pgid_file` by [`lima_guest_build_argv`], then removes the pgid file. The
+/// negative PGID targets the whole group (`sh` + apptainer + its `%post`
+/// children); the `rm -f` cleans up on the cancel path, where the wrapper is
+/// SIGKILLed before it can self-clean. Best-effort: a missing or already-dead
+/// group is not an error.
 pub(crate) fn lima_kill_pgid_script(pgid_file: &Path) -> String {
-    format!(
-        "kill -KILL -\"$(cat {})\" 2>/dev/null || true",
-        shell_escape(pgid_file)
-    )
+    let escaped = shell_escape(pgid_file);
+    format!("kill -KILL -\"$(cat {escaped})\" 2>/dev/null; rm -f {escaped} 2>/dev/null; true")
 }
 
 /// Build a `limactl shell <instance> --` command pre-configured with LIMA_HOME.

--- a/crates/containers-internal/src/apptainer/tests.rs
+++ b/crates/containers-internal/src/apptainer/tests.rs
@@ -891,36 +891,59 @@ fn lima_guest_build_argv_wraps_in_setsid_and_records_pgid() {
         Path::new("/tmp/peppy/pgids/buildkey.pgid"),
     );
 
-    // `setsid -w sh -c <script>`: the script is one argv element.
+    // `setsid -w sh -c <fixed script> sh <pgid_file> <apptainer_bin> <args...>`:
+    // the script is a constant and every value is passed as a positional param,
+    // so nothing is interpolated or shell-escaped.
     assert_eq!(argv[0], "setsid");
     assert_eq!(argv[1], "-w");
     assert_eq!(argv[2], "sh");
     assert_eq!(argv[3], "-c");
-    assert_eq!(argv.len(), 5);
-
-    let script = &argv[4];
     assert_eq!(
-        script,
-        "mkdir -p '/tmp/peppy/pgids'; echo $$ > '/tmp/peppy/pgids/buildkey.pgid'; \
-         '/opt/apptainer/bin/apptainer' 'build' '/home/u/out.sif' '/home/u/node.def'; \
-         __rc=$?; rm -f '/tmp/peppy/pgids/buildkey.pgid'; exit $__rc",
+        argv[4],
+        "d=$(dirname \"$1\"); mkdir -p \"$d\"; echo $$ > \"$1\"; \
+         pgid=\"$1\"; shift; \"$@\"; __rc=$?; rm -f \"$pgid\"; exit $__rc",
         "the wrapper makes sh the group leader, records its PGID to the guest-native \
-         pgid file, runs apptainer as a child so its children inherit the group, then \
-         removes the pgid file and forwards apptainer's exit status"
+         pgid file ($1), runs apptainer as a child so its children inherit the group, \
+         then removes the pgid file and forwards apptainer's exit status"
     );
+    assert_eq!(
+        argv[5], "sh",
+        "the `$0` placeholder so the next value is `$1`"
+    );
+    assert_eq!(
+        argv[6], "/tmp/peppy/pgids/buildkey.pgid",
+        "`$1`: the pgid file"
+    );
+    assert_eq!(argv[7], "/opt/apptainer/bin/apptainer");
+    assert_eq!(argv[8], "build");
+    assert_eq!(argv[9], "/home/u/out.sif");
+    assert_eq!(argv[10], "/home/u/node.def");
+    assert_eq!(argv.len(), 11);
 }
 
 #[test]
-fn lima_kill_pgid_script_sigkills_the_whole_group() {
-    let script = super::lima::lima_kill_pgid_script(Path::new("/tmp/peppy/pgids/buildkey.pgid"));
-    // Negative PGID → SIGKILL the whole group (apptainer + its %post children),
-    // then remove the pgid file (the cancel path SIGKILLs the wrapper before it
-    // can self-clean). Best-effort: a missing/already-dead group is not an error.
+fn lima_kill_pgid_argv_sigkills_the_whole_group() {
+    let argv = super::lima::lima_kill_pgid_argv(Path::new("/tmp/peppy/pgids/buildkey.pgid"));
+    // `sh -c <fixed script> sh <pgid_file>`: the pgid file is passed as `$1`, so
+    // nothing is interpolated or shell-escaped. The negative PGID SIGKILLs the
+    // whole group (apptainer + its %post children), then `rm -f` removes the pgid
+    // file (the cancel path SIGKILLs the wrapper before it can self-clean).
+    // Best-effort: a missing/already-dead group is not an error.
+    assert_eq!(argv[0], "sh");
+    assert_eq!(argv[1], "-c");
     assert_eq!(
-        script,
-        "kill -KILL -\"$(cat '/tmp/peppy/pgids/buildkey.pgid')\" 2>/dev/null; \
-         rm -f '/tmp/peppy/pgids/buildkey.pgid' 2>/dev/null; true"
+        argv[2],
+        "kill -KILL -\"$(cat \"$1\")\" 2>/dev/null; rm -f \"$1\" 2>/dev/null; true"
     );
+    assert_eq!(
+        argv[3], "sh",
+        "the `$0` placeholder so the next value is `$1`"
+    );
+    assert_eq!(
+        argv[4], "/tmp/peppy/pgids/buildkey.pgid",
+        "`$1`: the pgid file"
+    );
+    assert_eq!(argv.len(), 5);
 }
 
 /// Builds a Native-backend facade for command-assembly tests without booting a
@@ -986,15 +1009,18 @@ fn lima_build_wraps_in_setsid_with_guest_native_pgid() {
         args.iter().any(|a| a == "setsid"),
         "Lima build must be wrapped in setsid, got: {args:?}"
     );
-    let script = args
-        .last()
-        .expect("the wrapper script is the last argv element");
+    // The pgid path is now its own argv element (a positional param to the
+    // wrapper), not interpolated into the script string.
     assert!(
-        script.contains("/tmp/peppy/pgids/buildkey.pgid"),
-        "wrapper must record the guest-native PGID, got: {script}"
+        args.iter().any(|a| a == "/tmp/peppy/pgids/buildkey.pgid"),
+        "wrapper must pass the guest-native PGID path as an argv element, got: {args:?}"
     );
+    let script = args
+        .iter()
+        .find(|a| a.contains("echo $$"))
+        .expect("the wrapper records the PGID with `echo $$`");
     assert!(
-        script.contains("mkdir -p '/tmp/peppy/pgids'"),
+        script.contains("mkdir -p"),
         "wrapper must create the guest-native PGID dir, got: {script}"
     );
     assert!(

--- a/crates/containers-internal/src/apptainer/tests.rs
+++ b/crates/containers-internal/src/apptainer/tests.rs
@@ -877,3 +877,93 @@ fn gocryptfs_path_matches_apptainer_search_dir() {
         );
     }
 }
+
+// ---------------------------------------------------------------------------
+// Guest-side cancellation (Lima): build wrapped as a process-group leader so
+// `kill_inflight_build` can SIGKILL the whole guest group on --force cancel.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn lima_guest_build_argv_wraps_in_setsid_and_records_pgid() {
+    let argv = super::lima::lima_guest_build_argv(
+        Path::new("/opt/apptainer/bin/apptainer"),
+        &["build", "/home/u/out.sif", "/home/u/node.def"],
+        Path::new("/home/u/build.pgid"),
+    );
+
+    // `setsid -w sh -c <script>`: the script is one argv element.
+    assert_eq!(argv[0], "setsid");
+    assert_eq!(argv[1], "-w");
+    assert_eq!(argv[2], "sh");
+    assert_eq!(argv[3], "-c");
+    assert_eq!(argv.len(), 5);
+
+    let script = &argv[4];
+    assert_eq!(
+        script,
+        "echo $$ > '/home/u/build.pgid'; \
+         exec '/opt/apptainer/bin/apptainer' 'build' '/home/u/out.sif' '/home/u/node.def'",
+        "the wrapper must record the session PGID, then exec apptainer so its \
+         children inherit the group"
+    );
+}
+
+#[test]
+fn lima_kill_pgid_script_sigkills_the_whole_group() {
+    let script = super::lima::lima_kill_pgid_script(Path::new("/home/u/build.pgid"));
+    // Negative PGID → SIGKILL the whole group (apptainer + its %post children);
+    // best-effort so a missing/already-dead group is not an error.
+    assert_eq!(
+        script,
+        "kill -KILL -\"$(cat '/home/u/build.pgid')\" 2>/dev/null || true"
+    );
+}
+
+#[test]
+fn build_command_wrapping_and_kill_match_the_backend() {
+    let facade = Apptainer::new()
+        .expect("Apptainer::new() should succeed — apptainer is bundled at compile time");
+
+    let home = std::env::var("HOME").expect("HOME must be set");
+    let out = PathBuf::from(&home).join("peppy_cancel_test/out.sif");
+    let def = PathBuf::from(&home).join("peppy_cancel_test/node.def");
+    let pgid = PathBuf::from(&home).join("peppy_cancel_test/build.pgid");
+
+    let cmd = facade
+        .build(&out, &def)
+        .cancel_pgid_file(&pgid)
+        .into_std_command()
+        .expect("build command should assemble");
+    let args: Vec<String> = cmd
+        .get_args()
+        .map(|a| a.to_string_lossy().into_owned())
+        .collect();
+
+    match &facade.backend {
+        Backend::Lima { .. } => {
+            // The guest invocation is wrapped so the build is a process-group
+            // leader recording its PGID.
+            assert!(
+                args.iter().any(|a| a == "setsid"),
+                "Lima build must be wrapped in setsid, got: {args:?}"
+            );
+            assert!(
+                args.iter().any(|a| a.contains("build.pgid")),
+                "Lima build wrapper must record the PGID file, got: {args:?}"
+            );
+        }
+        Backend::Native { .. } => {
+            // No VM: the host process group already covers the build tree, so
+            // the command is the plain `apptainer build ...` with no wrapping,
+            // and `kill_inflight_build` is a no-op.
+            assert!(
+                !args.iter().any(|a| a == "setsid"),
+                "native build must not be wrapped, got: {args:?}"
+            );
+            assert_eq!(args[0], "build");
+            facade
+                .kill_inflight_build(&pgid)
+                .expect("native kill_inflight_build must be an Ok no-op");
+        }
+    }
+}

--- a/crates/containers-internal/src/apptainer/tests.rs
+++ b/crates/containers-internal/src/apptainer/tests.rs
@@ -888,7 +888,7 @@ fn lima_guest_build_argv_wraps_in_setsid_and_records_pgid() {
     let argv = super::lima::lima_guest_build_argv(
         Path::new("/opt/apptainer/bin/apptainer"),
         &["build", "/home/u/out.sif", "/home/u/node.def"],
-        Path::new("/home/u/build.pgid"),
+        Path::new("/tmp/peppy/pgids/buildkey.pgid"),
     );
 
     // `setsid -w sh -c <script>`: the script is one argv element.
@@ -901,69 +901,147 @@ fn lima_guest_build_argv_wraps_in_setsid_and_records_pgid() {
     let script = &argv[4];
     assert_eq!(
         script,
-        "echo $$ > '/home/u/build.pgid'; \
-         exec '/opt/apptainer/bin/apptainer' 'build' '/home/u/out.sif' '/home/u/node.def'",
-        "the wrapper must record the session PGID, then exec apptainer so its \
-         children inherit the group"
+        "mkdir -p '/tmp/peppy/pgids'; echo $$ > '/tmp/peppy/pgids/buildkey.pgid'; \
+         '/opt/apptainer/bin/apptainer' 'build' '/home/u/out.sif' '/home/u/node.def'; \
+         __rc=$?; rm -f '/tmp/peppy/pgids/buildkey.pgid'; exit $__rc",
+        "the wrapper makes sh the group leader, records its PGID to the guest-native \
+         pgid file, runs apptainer as a child so its children inherit the group, then \
+         removes the pgid file and forwards apptainer's exit status"
     );
 }
 
 #[test]
 fn lima_kill_pgid_script_sigkills_the_whole_group() {
-    let script = super::lima::lima_kill_pgid_script(Path::new("/home/u/build.pgid"));
-    // Negative PGID → SIGKILL the whole group (apptainer + its %post children);
-    // best-effort so a missing/already-dead group is not an error.
+    let script = super::lima::lima_kill_pgid_script(Path::new("/tmp/peppy/pgids/buildkey.pgid"));
+    // Negative PGID → SIGKILL the whole group (apptainer + its %post children),
+    // then remove the pgid file (the cancel path SIGKILLs the wrapper before it
+    // can self-clean). Best-effort: a missing/already-dead group is not an error.
     assert_eq!(
         script,
-        "kill -KILL -\"$(cat '/home/u/build.pgid')\" 2>/dev/null || true"
+        "kill -KILL -\"$(cat '/tmp/peppy/pgids/buildkey.pgid')\" 2>/dev/null; \
+         rm -f '/tmp/peppy/pgids/buildkey.pgid' 2>/dev/null; true"
     );
 }
 
-#[test]
-fn build_command_wrapping_and_kill_match_the_backend() {
-    let facade = Apptainer::new()
-        .expect("Apptainer::new() should succeed — apptainer is bundled at compile time");
+/// Builds a Native-backend facade for command-assembly tests without booting a
+/// VM. The apptainer path need not exist: these tests only inspect the assembled
+/// argv and the no-op kill path.
+fn native_facade() -> Apptainer {
+    Apptainer {
+        apptainer_dir: PathBuf::from("/opt/apptainer"),
+        backend: Backend::Native {
+            apptainer_bin: PathBuf::from("/opt/apptainer/bin/apptainer"),
+        },
+        extra_mounts: Vec::new(),
+    }
+}
 
+/// Builds a Lima-backend facade for command-assembly tests. The limactl/apptainer
+/// paths need not exist: `into_std_command` only constructs the argv, it does not
+/// spawn anything.
+fn lima_facade() -> Apptainer {
+    Apptainer {
+        apptainer_dir: PathBuf::from("/opt/apptainer"),
+        backend: Backend::Lima {
+            apptainer_bin: PathBuf::from("/tmp/peppy/apptainer/bin/apptainer"),
+            limactl_path: PathBuf::from("/opt/lima/bin/limactl"),
+            lima_home: PathBuf::from("/home/u/.lima"),
+        },
+        extra_mounts: Vec::new(),
+    }
+}
+
+/// The guest-build PGID path is guest-native (`/tmp/peppy/pgids/<key>.pgid`), so
+/// it lives on the guest's tmpfs rather than the virtiofs host mount.
+#[test]
+fn guest_pgid_path_is_guest_native() {
+    assert_eq!(
+        super::lima::guest_pgid_path("foo"),
+        PathBuf::from("/tmp/peppy/pgids/foo.pgid")
+    );
+}
+
+/// Under Lima, a build is wrapped as a process-group leader that records its
+/// PGID to the guest-native path and self-cleans (no `exec`, so `sh` survives to
+/// remove the file). The guest path is passed through untranslated.
+#[test]
+fn lima_build_wraps_in_setsid_with_guest_native_pgid() {
+    let facade = lima_facade();
     let home = std::env::var("HOME").expect("HOME must be set");
-    let out = PathBuf::from(&home).join("peppy_cancel_test/out.sif");
-    let def = PathBuf::from(&home).join("peppy_cancel_test/node.def");
-    let pgid = PathBuf::from(&home).join("peppy_cancel_test/build.pgid");
+    // Output/def live under $HOME so Lima path translation accepts them.
+    let out = PathBuf::from(&home).join("peppy_build_test/out.sif");
+    let def = PathBuf::from(&home).join("peppy_build_test/node.def");
 
     let cmd = facade
         .build(&out, &def)
-        .cancel_pgid_file(&pgid)
+        .cancel_pgid("buildkey")
         .into_std_command()
-        .expect("build command should assemble");
+        .expect("Lima build command should assemble");
     let args: Vec<String> = cmd
         .get_args()
         .map(|a| a.to_string_lossy().into_owned())
         .collect();
 
-    match &facade.backend {
-        Backend::Lima { .. } => {
-            // The guest invocation is wrapped so the build is a process-group
-            // leader recording its PGID.
-            assert!(
-                args.iter().any(|a| a == "setsid"),
-                "Lima build must be wrapped in setsid, got: {args:?}"
-            );
-            assert!(
-                args.iter().any(|a| a.contains("build.pgid")),
-                "Lima build wrapper must record the PGID file, got: {args:?}"
-            );
-        }
-        Backend::Native { .. } => {
-            // No VM: the host process group already covers the build tree, so
-            // the command is the plain `apptainer build ...` with no wrapping,
-            // and `kill_inflight_build` is a no-op.
-            assert!(
-                !args.iter().any(|a| a == "setsid"),
-                "native build must not be wrapped, got: {args:?}"
-            );
-            assert_eq!(args[0], "build");
-            facade
-                .kill_inflight_build(&pgid)
-                .expect("native kill_inflight_build must be an Ok no-op");
-        }
-    }
+    assert!(
+        args.iter().any(|a| a == "setsid"),
+        "Lima build must be wrapped in setsid, got: {args:?}"
+    );
+    let script = args
+        .last()
+        .expect("the wrapper script is the last argv element");
+    assert!(
+        script.contains("/tmp/peppy/pgids/buildkey.pgid"),
+        "wrapper must record the guest-native PGID, got: {script}"
+    );
+    assert!(
+        script.contains("mkdir -p '/tmp/peppy/pgids'"),
+        "wrapper must create the guest-native PGID dir, got: {script}"
+    );
+    assert!(
+        !script.contains("exec "),
+        "wrapper must run apptainer as a child (no exec) so sh can self-clean, got: {script}"
+    );
+}
+
+/// Under Native (Linux) there is no VM: the command is a plain
+/// `apptainer build ...` with no pgid wrapper, `kill_inflight_build` is an Ok
+/// no-op (the host process group already covers the build tree), and
+/// `guest_command` runs directly on the host.
+#[test]
+fn native_build_is_plain_and_kill_is_a_noop() {
+    let facade = native_facade();
+    let out = PathBuf::from("/work/out.sif");
+    let def = PathBuf::from("/work/node.def");
+
+    let cmd = facade
+        .build(&out, &def)
+        .cancel_pgid("buildkey")
+        .into_std_command()
+        .expect("native build command should assemble");
+    let args: Vec<String> = cmd
+        .get_args()
+        .map(|a| a.to_string_lossy().into_owned())
+        .collect();
+
+    assert!(
+        !args.iter().any(|a| a == "setsid"),
+        "native build must not be wrapped, got: {args:?}"
+    );
+    assert_eq!(args[0], "build", "native build runs apptainer directly");
+    assert!(
+        !args.iter().any(|a| a.contains(".pgid")),
+        "native build must not reference a PGID file, got: {args:?}"
+    );
+
+    facade
+        .kill_inflight_build("buildkey")
+        .expect("native kill_inflight_build must be an Ok no-op");
+
+    let output = facade
+        .guest_command(&["echo", "peppy-native"])
+        .expect("guest_command should run on the host under Native");
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "peppy-native"
+    );
 }

--- a/crates/core-node-internal/src/services/node/add.rs
+++ b/crates/core-node-internal/src/services/node/add.rs
@@ -951,7 +951,20 @@ async fn handle_goal_request(
         debug!("Force flag set: aborting any previous node_add task");
     }
     let generation = match gate.try_admit(goal.timeout_secs, goal.force) {
-        super::gate::Admission::Admitted { generation } => generation,
+        super::gate::Admission::Admitted {
+            generation,
+            superseded,
+        } => {
+            // `node_add` keeps the hard-abort semantics: it overwrites the
+            // entity wholesale via `push_config`, so it does not need the old
+            // task's cooperative teardown the way `node_build` does (which
+            // awaits it to reuse the staged working dir). The gate already
+            // signaled the cancel token; abort drops the superseded future.
+            if let Some(old_task) = superseded {
+                old_task.abort();
+            }
+            generation
+        }
         super::gate::Admission::AlreadyRunning { remaining_secs } => {
             reject_goal(
                 pending,

--- a/crates/core-node-internal/src/services/node/builder.rs
+++ b/crates/core-node-internal/src/services/node/builder.rs
@@ -1,5 +1,5 @@
 use super::super::action_loop::{GoalHandler, accept_goal, reject_goal, run_action_loop};
-use super::gate::ConcurrencyGate;
+use super::gate::{COOPERATIVE_TEARDOWN_BUDGET, ConcurrencyGate};
 use super::write_error_to_log;
 use super::{FeedbackLine, FeedbackStream, create_action_log_file};
 use crate::Result;
@@ -20,19 +20,10 @@ use std::fs::File;
 use std::panic::AssertUnwindSafe;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tracing::debug;
-
-/// Upper bound on how long a `--force` admission waits for the build task it
-/// displaced to run its cooperative teardown (SIGKILL + reap the build child,
-/// roll the entity back to `Added`, re-attach the working dir) before the new
-/// build proceeds. Mirrors `RUN_PHASE_CANCEL_CLEANUP_BUDGET` in
-/// `services/stack/launch.rs`. On timeout the entity is still `Building` and the
-/// stage re-read rejects with a transient, retryable message rather than wedging.
-const FORCE_SUPERSEDE_CLEANUP_BUDGET: Duration = Duration::from_secs(30);
 
 pub async fn listen_for_node_build(
     messenger: &MessengerHandle,
@@ -210,11 +201,11 @@ impl NodeBuildGoalHandler {
         // re-reading the entity below. Its cancel token was already signaled in
         // `try_admit`, so awaiting the handle lets it SIGKILL + reap the build
         // child and roll the entity back to `Added` with its working dir
-        // re-attached — leaving it buildable for this goal. Bounded so a wedged
+        // re-attached, leaving it buildable for this goal. Bounded so a wedged
         // old task cannot stall the forced rebuild forever; on timeout the stage
         // re-read rejects transiently rather than wedging permanently.
         if let Some(old_task) = superseded {
-            let _ = tokio::time::timeout(FORCE_SUPERSEDE_CLEANUP_BUDGET, old_task).await;
+            let _ = tokio::time::timeout(COOPERATIVE_TEARDOWN_BUDGET, old_task).await;
         }
 
         debug!(
@@ -458,7 +449,7 @@ async fn run_node_build(run: NodeBuildRun) -> NodeBuildResult {
                 // Superseded by a `--force` build (the build I/O returned a
                 // cancellation error after SIGKILL'ing + reaping the child).
                 // Roll the entity back to `Added` and re-attach the staged
-                // working dir so the forced rebuild can reuse it — the only
+                // working dir so the forced rebuild can reuse it, the only
                 // surviving copy of the source. (Removing it, as the genuine
                 // failure path does, would delete the working dir and make the
                 // rebuild impossible.)

--- a/crates/core-node-internal/src/services/node/builder.rs
+++ b/crates/core-node-internal/src/services/node/builder.rs
@@ -20,10 +20,19 @@ use std::fs::File;
 use std::panic::AssertUnwindSafe;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tracing::debug;
+
+/// Upper bound on how long a `--force` admission waits for the build task it
+/// displaced to run its cooperative teardown (SIGKILL + reap the build child,
+/// roll the entity back to `Added`, re-attach the working dir) before the new
+/// build proceeds. Mirrors `RUN_PHASE_CANCEL_CLEANUP_BUDGET` in
+/// `services/stack/launch.rs`. On timeout the entity is still `Building` and the
+/// stage re-read rejects with a transient, retryable message rather than wedging.
+const FORCE_SUPERSEDE_CLEANUP_BUDGET: Duration = Duration::from_secs(30);
 
 pub async fn listen_for_node_build(
     messenger: &MessengerHandle,
@@ -67,6 +76,11 @@ struct NodeBuildRun {
     feedback_tx: mpsc::UnboundedSender<FeedbackLine>,
     log_file: Arc<StdMutex<File>>,
     log_path: PathBuf,
+    /// Signaled when a `--force` build supersedes this one. Threaded into the
+    /// build I/O so the subprocess is SIGKILL'd + reaped, and consulted after
+    /// the build to roll the entity back to `Added` (re-attaching the working
+    /// dir) rather than removing it.
+    cancel_token: CancellationToken,
 }
 
 /// Drives a build for the entity named `(node_name, node_tag)` that is
@@ -124,6 +138,8 @@ pub(crate) async fn run_node_build_for_entity(
         feedback_tx,
         log_file,
         log_path,
+        // This helper drives a fresh build that nothing supersedes.
+        cancel_token: CancellationToken::new(),
     })
     .await
 }
@@ -170,10 +186,13 @@ impl NodeBuildGoalHandler {
         };
 
         if goal.force {
-            debug!("Force flag set: aborting any previous node_build task");
+            debug!("Force flag set: superseding any previous node_build task");
         }
-        let generation = match self.gate.try_admit(goal.timeout_secs, goal.force) {
-            super::gate::Admission::Admitted { generation } => generation,
+        let (generation, superseded) = match self.gate.try_admit(goal.timeout_secs, goal.force) {
+            super::gate::Admission::Admitted {
+                generation,
+                superseded,
+            } => (generation, superseded),
             super::gate::Admission::AlreadyRunning { remaining_secs } => {
                 reject_goal(
                     pending,
@@ -186,6 +205,17 @@ impl NodeBuildGoalHandler {
                 return;
             }
         };
+
+        // Drive the superseded build's cooperative teardown to completion before
+        // re-reading the entity below. Its cancel token was already signaled in
+        // `try_admit`, so awaiting the handle lets it SIGKILL + reap the build
+        // child and roll the entity back to `Added` with its working dir
+        // re-attached — leaving it buildable for this goal. Bounded so a wedged
+        // old task cannot stall the forced rebuild forever; on timeout the stage
+        // re-read rejects transiently rather than wedging permanently.
+        if let Some(old_task) = superseded {
+            let _ = tokio::time::timeout(FORCE_SUPERSEDE_CLEANUP_BUDGET, old_task).await;
+        }
 
         debug!(
             "Received `node_build` goal from {sender_instance_id}, target={}:{}",
@@ -281,26 +311,18 @@ impl NodeBuildGoalHandler {
             .expect("node_build declares a feedback topic");
         let action_context = self.context.clone();
         let log_path_clone = log_path.clone();
+        // Stored in the gate so a later `--force` goal can signal it, and threaded
+        // into the build so `run_node_build` owns cancellation end-to-end: it
+        // SIGKILLs + reaps the build child and rolls the entity back to `Added`
+        // (re-attaching the working dir) instead of being `abort()`ed mid-flight.
         let cancel_token = CancellationToken::new();
-        let cancel_token_clone = cancel_token.clone();
-
-        // Clones for the cancellation-cleanup branch of `select!`. When a
-        // `--force` build aborts the in-flight task, the entity may already
-        // be in `Building` state. `remove_config_if_matches` rolls it back
-        // so that future builds are not permanently rejected.
-        let node_stack_for_cancel = Arc::clone(&self.context.node_stack);
-        let node_name_for_cancel = goal.node_name.clone();
-        let node_tag_for_cancel = goal.node_tag.clone();
-        let entity_handle_for_cancel = entity_handle.clone();
-        let generation_for_cancel = captured_generation;
-        let log_path_for_cancel = log_path.clone();
+        let cancel_token_for_task = cancel_token.clone();
         let gate_for_task = self.gate.clone();
 
         let task_handle = tokio::spawn(async move {
             // Frees the gate slot on every exit: explicitly before completion on
             // the normal path (via `release_then_complete` below), or on unwind
-            // for a panic / `--force` abort. A no-op if a later `--force` goal
-            // already took over.
+            // for a panic. A no-op if a later `--force` goal already took over.
             let slot = gate_for_task.into_slot_guard(generation);
             let (feedback_tx, feedback_rx) = mpsc::unbounded_channel::<FeedbackLine>();
             let consumer_handle =
@@ -308,33 +330,20 @@ impl NodeBuildGoalHandler {
                     NodeBuildFeedback::from_stream(line.stream, &line.line).encode()
                 });
 
-            let result = tokio::select! {
-                biased;
-                result = run_node_build(NodeBuildRun {
-                    node_name: goal.node_name,
-                    node_tag: goal.node_tag,
-                    env_vars: goal.env_vars,
-                    entity_handle,
-                    working_dir_guard,
-                    captured_generation,
-                    action_context,
-                    feedback_tx,
-                    log_file,
-                    log_path: log_path_clone,
-                }) => result,
-                _ = cancel_token_clone.cancelled() => {
-                    let _ = node_stack_for_cancel.remove_config_if_matches(
-                        &node_name_for_cancel,
-                        &node_tag_for_cancel,
-                        &entity_handle_for_cancel,
-                        generation_for_cancel,
-                    );
-                    NodeBuildResult::failure(
-                        &log_path_for_cancel,
-                        "build cancelled by --force".to_string(),
-                    )
-                }
-            };
+            let result = run_node_build(NodeBuildRun {
+                node_name: goal.node_name,
+                node_tag: goal.node_tag,
+                env_vars: goal.env_vars,
+                entity_handle,
+                working_dir_guard,
+                captured_generation,
+                action_context,
+                feedback_tx,
+                log_file,
+                log_path: log_path_clone,
+                cancel_token: cancel_token_for_task,
+            })
+            .await;
 
             let _ = consumer_handle.await;
             if let Ok(payload) = result.encode() {
@@ -358,6 +367,7 @@ async fn run_node_build(run: NodeBuildRun) -> NodeBuildResult {
         feedback_tx,
         log_file,
         log_path,
+        cancel_token,
     } = run;
 
     let log_file_for_panic = log_file.clone();
@@ -429,6 +439,7 @@ async fn run_node_build(run: NodeBuildRun) -> NodeBuildResult {
                 feedback_tx: &feedback_tx,
                 log_file: Arc::clone(&log_file),
                 env_vars: &env_vars,
+                cancel_token: cancel_token.clone(),
             },
         )
         .await;
@@ -442,6 +453,23 @@ async fn run_node_build(run: NodeBuildRun) -> NodeBuildResult {
                     artifact_path.display()
                 );
                 NodeBuildResult::success(artifact_path, &log_path)
+            }
+            Err(_) if cancel_token.is_cancelled() => {
+                // Superseded by a `--force` build (the build I/O returned a
+                // cancellation error after SIGKILL'ing + reaping the child).
+                // Roll the entity back to `Added` and re-attach the staged
+                // working dir so the forced rebuild can reuse it — the only
+                // surviving copy of the source. (Removing it, as the genuine
+                // failure path does, would delete the working dir and make the
+                // rebuild impossible.)
+                let _ = action_context.node_stack.rollback_to_added_if_matches(
+                    &node_name,
+                    &node_tag,
+                    &entity_handle,
+                    expected_generation,
+                    Arc::clone(&working_dir_guard),
+                );
+                NodeBuildResult::failure(&log_path, "build cancelled by --force".to_string())
             }
             Err(e) => {
                 // `NodeEntity::build` leaves the entity in `Building` on

--- a/crates/core-node-internal/src/services/node/gate.rs
+++ b/crates/core-node-internal/src/services/node/gate.rs
@@ -3,9 +3,13 @@
 //!
 //! Each of those actions allows only one in-flight task at a time and rejects
 //! concurrent goals with `"action already in progress (times out in Xs)"`.
-//! `node_add` and `node_build` additionally support `--force`, which aborts
-//! the in-flight task before admitting the new one. Actions without force
-//! simply never pass `force = true` to [`ConcurrencyGate::try_admit`].
+//! `node_add` and `node_build` additionally support `--force`, which cancels
+//! the in-flight task before admitting the new one. On force, `try_admit`
+//! signals the old task's cancel token and hands its `JoinHandle` back to the
+//! caller (see [`Admission::Admitted::superseded`]); the caller decides whether
+//! to `abort()` it (`node_add`, which overwrites the entity) or `await` its
+//! cooperative teardown (`node_build`, which reuses the staged working dir).
+//! Actions without force simply never pass `force = true`.
 //!
 //! All gate state lives behind a single `parking_lot::Mutex`, so admission
 //! decisions never await. Unlike a poll-based design, the gate does not retain
@@ -24,14 +28,14 @@
 //! only be the goal currently being handled. The one gate access that *is*
 //! concurrent is the in-flight work task freeing its slot when it finishes.
 //!
-//! A `--force` goal can abort that task and admit a replacement while the
-//! aborted task is still winding down — `JoinHandle::abort()` is cooperative and
-//! does not interrupt a synchronous stretch between `.await`s — so a naive
-//! release could clear the *replacement's* slot and break the single-goal
-//! invariant. Each admission therefore carries a monotonic `generation`: the
-//! work task holds a [`GoalSlotGuard`] for its generation, and the guard's drop
-//! frees the slot only while that generation is still current. A superseded
-//! task's release is thus a safe no-op.
+//! A `--force` goal supersedes that task and admits a replacement while the
+//! superseded task is still winding down (whether it is later `abort()`ed or
+//! awaited to cooperative completion) — so a naive release could clear the
+//! *replacement's* slot and break the single-goal invariant. Each admission
+//! therefore carries a monotonic `generation`: the work task holds a
+//! [`GoalSlotGuard`] for its generation, and the guard's drop frees the slot
+//! only while that generation is still current. A superseded task's release is
+//! thus a safe no-op.
 
 use parking_lot::Mutex;
 use peppylib::messaging::GoalContext;
@@ -47,7 +51,16 @@ pub(crate) enum Admission {
     /// `generation` identifies this admission — the work task hands it to its
     /// [`GoalSlotGuard`] so the slot is freed only while this admission is still
     /// the current one (a later `--force` goal bumps the generation).
-    Admitted { generation: u64 },
+    Admitted {
+        generation: u64,
+        /// The task this admission force-displaced, if any. Its cancel token has
+        /// already been signaled inside `try_admit`; the caller awaits this
+        /// handle (bounded) so the old task's cooperative teardown — SIGKILL +
+        /// reap the build child, roll the entity back to `Added`, re-attach the
+        /// working dir — finishes before the new build starts. `None` on a cold
+        /// admission (nothing was running).
+        superseded: Option<JoinHandle<()>>,
+    },
     /// A goal is already in flight and force was not requested.
     AlreadyRunning { remaining_secs: u64 },
 }
@@ -95,13 +108,17 @@ impl ConcurrencyGate {
 
     /// Admits a new goal, starting the gate clock and returning the admission's
     /// generation. When a goal is already in flight and `force` is true, the
-    /// previous task is cancelled and aborted before admission proceeds
-    /// (aborting drops its `GoalContext`, which closes the old goal's feedback
-    /// stream and evicts its registry slot). Otherwise the in-flight goal's
-    /// `remaining_secs` is returned and the gate is left unchanged so the caller
-    /// can encode a rejection.
+    /// previous task's cancel token is signaled and its `JoinHandle` is *handed
+    /// back* in [`Admission::Admitted::superseded`] — it is deliberately NOT
+    /// aborted, because `JoinHandle::abort` drops the task future and skips the
+    /// cooperative teardown (kill+reap the build child, roll the entity back to
+    /// `Added`). The caller awaits the returned handle (bounded) so that
+    /// teardown completes before the new build starts. Otherwise the in-flight
+    /// goal's `remaining_secs` is returned and the gate is left unchanged so the
+    /// caller can encode a rejection.
     pub(crate) fn try_admit(&self, timeout_secs: u64, force: bool) -> Admission {
         let mut state = self.state.lock();
+        let mut superseded = None;
         if let Some(running) = &state.running {
             if !force {
                 let remaining = Duration::from_secs(running.timeout_secs)
@@ -111,14 +128,15 @@ impl ConcurrencyGate {
                     remaining_secs: remaining,
                 };
             }
-            // Force: signal cancellation so the spawned task can run cleanup,
-            // then hard-abort it.
+            // Force: signal cancellation so the spawned task runs its cooperative
+            // teardown, then hand its handle back to the caller to await. Do NOT
+            // abort — that would drop the future and skip the teardown. Bumping
+            // the generation below makes the old task's `GoalSlotGuard` drop a
+            // no-op, so its eventual release cannot clobber this admission.
             if let Some(token) = state.cancel_token.take() {
                 token.cancel();
             }
-            if let Some(handle) = state.running_task.take() {
-                handle.abort();
-            }
+            superseded = state.running_task.take();
         }
         state.running = Some(RunningInfo {
             started_at: Instant::now(),
@@ -129,6 +147,7 @@ impl ConcurrencyGate {
         state.generation = state.generation.wrapping_add(1);
         Admission::Admitted {
             generation: state.generation,
+            superseded,
         }
     }
 
@@ -246,7 +265,7 @@ mod tests {
 
     fn admit(gate: &ConcurrencyGate, force: bool) -> u64 {
         match gate.try_admit(60, force) {
-            Admission::Admitted { generation } => generation,
+            Admission::Admitted { generation, .. } => generation,
             Admission::AlreadyRunning { .. } => panic!("expected admission"),
         }
     }
@@ -320,5 +339,48 @@ mod tests {
         drop(gate.clone().into_slot_guard(generation));
         // Slot is free again, so a fresh goal is admitted rather than rejected.
         assert_eq!(admit(&gate, false), generation + 1);
+    }
+
+    /// A `--force` admission must hand the displaced task's `JoinHandle` back to
+    /// the caller (so it can await cooperative teardown) instead of aborting it.
+    /// The token is signaled, so awaiting the returned handle resolves `Ok(())`
+    /// — proving the task finished cooperatively rather than being `abort()`ed
+    /// (which would make the join return a cancelled `JoinError`).
+    #[tokio::test]
+    async fn force_supersede_returns_old_handle_without_abort() {
+        let gate = ConcurrencyGate::new();
+
+        // Cold admission, then register a real task that runs until its token
+        // fires — mirroring how a build handler installs its task via `set_task`.
+        let gen_a = admit(&gate, false);
+        let token = CancellationToken::new();
+        let token_for_task = token.clone();
+        let task = tokio::spawn(async move {
+            token_for_task.cancelled().await;
+        });
+        gate.set_task(task, token);
+
+        // Force-admit over it.
+        let (gen_b, superseded) = match gate.try_admit(60, true) {
+            Admission::Admitted {
+                generation,
+                superseded,
+            } => (generation, superseded),
+            Admission::AlreadyRunning { .. } => panic!("force admission must succeed"),
+        };
+        assert_eq!(gen_b, gen_a + 1, "force admission bumps the generation");
+        assert!(is_running(&gate));
+
+        let old_task = superseded.expect("the displaced task must be handed back");
+        assert!(
+            !old_task.is_finished(),
+            "the displaced task must not be aborted by `try_admit`"
+        );
+        let join = old_task.await;
+        assert!(
+            join.is_ok(),
+            "the displaced task should finish cooperatively after its token was signaled, \
+             not be aborted (a cancelled join would be `Err`)"
+        );
     }
 }

--- a/crates/core-node-internal/src/services/node/gate.rs
+++ b/crates/core-node-internal/src/services/node/gate.rs
@@ -30,7 +30,7 @@
 //!
 //! A `--force` goal supersedes that task and admits a replacement while the
 //! superseded task is still winding down (whether it is later `abort()`ed or
-//! awaited to cooperative completion) — so a naive release could clear the
+//! awaited to cooperative completion), so a naive release could clear the
 //! *replacement's* slot and break the single-goal invariant. Each admission
 //! therefore carries a monotonic `generation`: the work task holds a
 //! [`GoalSlotGuard`] for its generation, and the guard's drop frees the slot
@@ -45,6 +45,23 @@ use std::time::{Duration, Instant};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
+/// Bounded wait for a gate-cancelled task's cooperative teardown after its
+/// `CancellationToken` has been signaled. Both single-goal callers that signal
+/// a cancel and then await the doomed task rely on this same budget:
+///
+/// - `services/node/builder.rs` on a `--force` `node_build`: after `try_admit`
+///   signals the displaced build's token, it awaits the superseded handle for
+///   up to this long so the old build SIGKILLs + reaps its child and rolls the
+///   entity back to `Added` before the new build starts.
+/// - `services/stack/launch.rs` on a run-phase idle/max timeout: after signaling
+///   the run-phase token it awaits the phase future for up to this long so it
+///   can SIGKILL the child, unregister the `Starting` instance, and clear temp
+///   files before the launch failure is returned.
+///
+/// On expiry both callers fall back to dropping the future and surface a
+/// transient/timeout failure rather than wedging.
+pub(crate) const COOPERATIVE_TEARDOWN_BUDGET: Duration = Duration::from_secs(30);
+
 /// Outcome of [`ConcurrencyGate::try_admit`].
 pub(crate) enum Admission {
     /// The new goal was admitted; the gate clock has been started. The
@@ -55,9 +72,9 @@ pub(crate) enum Admission {
         generation: u64,
         /// The task this admission force-displaced, if any. Its cancel token has
         /// already been signaled inside `try_admit`; the caller awaits this
-        /// handle (bounded) so the old task's cooperative teardown — SIGKILL +
+        /// handle (bounded) so the old task's cooperative teardown (SIGKILL +
         /// reap the build child, roll the entity back to `Added`, re-attach the
-        /// working dir — finishes before the new build starts. `None` on a cold
+        /// working dir) finishes before the new build starts. `None` on a cold
         /// admission (nothing was running).
         superseded: Option<JoinHandle<()>>,
     },
@@ -109,7 +126,7 @@ impl ConcurrencyGate {
     /// Admits a new goal, starting the gate clock and returning the admission's
     /// generation. When a goal is already in flight and `force` is true, the
     /// previous task's cancel token is signaled and its `JoinHandle` is *handed
-    /// back* in [`Admission::Admitted::superseded`] — it is deliberately NOT
+    /// back* in [`Admission::Admitted::superseded`]; it is deliberately NOT
     /// aborted, because `JoinHandle::abort` drops the task future and skips the
     /// cooperative teardown (kill+reap the build child, roll the entity back to
     /// `Added`). The caller awaits the returned handle (bounded) so that
@@ -130,7 +147,7 @@ impl ConcurrencyGate {
             }
             // Force: signal cancellation so the spawned task runs its cooperative
             // teardown, then hand its handle back to the caller to await. Do NOT
-            // abort — that would drop the future and skip the teardown. Bumping
+            // abort; that would drop the future and skip the teardown. Bumping
             // the generation below makes the old task's `GoalSlotGuard` drop a
             // no-op, so its eventual release cannot clobber this admission.
             if let Some(token) = state.cancel_token.take() {
@@ -343,15 +360,15 @@ mod tests {
 
     /// A `--force` admission must hand the displaced task's `JoinHandle` back to
     /// the caller (so it can await cooperative teardown) instead of aborting it.
-    /// The token is signaled, so awaiting the returned handle resolves `Ok(())`
-    /// — proving the task finished cooperatively rather than being `abort()`ed
+    /// The token is signaled, so awaiting the returned handle resolves `Ok(())`,
+    /// proving the task finished cooperatively rather than being `abort()`ed
     /// (which would make the join return a cancelled `JoinError`).
     #[tokio::test]
     async fn force_supersede_returns_old_handle_without_abort() {
         let gate = ConcurrencyGate::new();
 
         // Cold admission, then register a real task that runs until its token
-        // fires — mirroring how a build handler installs its task via `set_task`.
+        // fires, mirroring how a build handler installs its task via `set_task`.
         let gen_a = admit(&gate, false);
         let token = CancellationToken::new();
         let token_for_task = token.clone();

--- a/crates/core-node-internal/src/services/node/run.rs
+++ b/crates/core-node-internal/src/services/node/run.rs
@@ -322,7 +322,8 @@ async fn handle_goal_request(
     };
 
     let generation = match gate.try_admit(goal.timeout_secs, false) {
-        super::gate::Admission::Admitted { generation } => generation,
+        // `node_run` never forces, so nothing is ever superseded here.
+        super::gate::Admission::Admitted { generation, .. } => generation,
         super::gate::Admission::AlreadyRunning { remaining_secs } => {
             reject_goal(
                 pending,

--- a/crates/core-node-internal/src/services/repo/refresh.rs
+++ b/crates/core-node-internal/src/services/repo/refresh.rs
@@ -101,7 +101,8 @@ impl GoalHandler for RepoRefreshGoalHandler {
         }
 
         let generation = match self.gate.try_admit(300, false) {
-            Admission::Admitted { generation } => generation,
+            // `repo_refresh` never forces, so nothing is ever superseded here.
+            Admission::Admitted { generation, .. } => generation,
             Admission::AlreadyRunning { .. } => {
                 reject_goal(
                     pending,

--- a/crates/core-node-internal/src/services/stack/launch.rs
+++ b/crates/core-node-internal/src/services/stack/launch.rs
@@ -1463,7 +1463,8 @@ async fn handle_goal_request(
     // `timeout_secs` is gate-reporting only; 0 indicates "no enforced budget"
     // (when --max-timeout-secs is unset).
     let generation = match gate.try_admit(goal.max_timeout_secs.unwrap_or(0), false) {
-        Admission::Admitted { generation } => generation,
+        // `stack_launch` never forces, so nothing is ever superseded here.
+        Admission::Admitted { generation, .. } => generation,
         Admission::AlreadyRunning { .. } => {
             reject_goal(
                 pending,

--- a/crates/core-node-internal/src/services/stack/launch.rs
+++ b/crates/core-node-internal/src/services/stack/launch.rs
@@ -2,7 +2,7 @@ use crate::Result;
 use crate::names;
 use crate::services::action_loop::{GoalHandler, accept_goal, reject_goal, run_action_loop};
 use crate::services::node::common::panic_message;
-use crate::services::node::gate::{Admission, ConcurrencyGate};
+use crate::services::node::gate::{Admission, COOPERATIVE_TEARDOWN_BUDGET, ConcurrencyGate};
 use crate::services::node::{
     FeedbackLine, FeedbackStream, NodeAddActionContext, NodeBuildActionContext,
     NodeRunActionContext, create_action_log_file, log_label_from_source, resolve_node_config,
@@ -36,11 +36,6 @@ use tokio::task::JoinHandle;
 use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
 use tracing::debug;
-
-/// Upper bound on how long a run-phase future may spend in its cancellation
-/// cleanup (SIGKILL the child + unregister the `Starting` instance + clear
-/// temp files). Keeps a misbehaving cleanup from stalling the launch failure.
-const RUN_PHASE_CANCEL_CLEANUP_BUDGET: Duration = Duration::from_secs(30);
 
 /// Watches for an idle period: returns when no `notify_one()` arrives for `idle_timeout`.
 /// Each call to `notify_one()` on `notify` resets the clock.
@@ -380,7 +375,7 @@ fn spawn_feedback_forwarder(
 ///   dropping it leaves the OS process and its `Starting` stack entry behind. Callers that
 ///   need run-phase cancellation pass `cancel_and_drain = Some(token)`; on timeout the
 ///   runner signals the token and awaits the phase future's cooperative cleanup (bounded by
-///   `RUN_PHASE_CANCEL_CLEANUP_BUDGET`) instead of dropping it.
+///   `COOPERATIVE_TEARDOWN_BUDGET`) instead of dropping it.
 async fn run_phase_with_timeouts<F, T>(
     phase: F,
     activity_notify: Arc<Notify>,
@@ -442,7 +437,7 @@ where
 
 /// Timeout behavior for phases that own resources (e.g. a spawned child
 /// process) not reaped by `Drop`. On timeout, signals `cancel_token` and
-/// awaits the phase future for up to `RUN_PHASE_CANCEL_CLEANUP_BUDGET` so it
+/// awaits the phase future for up to `COOPERATIVE_TEARDOWN_BUDGET` so it
 /// can run its own teardown (SIGKILL the child, unregister the `Starting`
 /// instance, remove temp files) before we return the timeout outcome.
 async fn run_phase_cancel_on_timeout<F, T>(
@@ -480,7 +475,7 @@ where
     // the future as a last resort — still strictly better than today, since
     // the run phase would have been dropped immediately in that branch.
     cancel_token.cancel();
-    let _ = tokio::time::timeout(RUN_PHASE_CANCEL_CLEANUP_BUDGET, phase.as_mut()).await;
+    let _ = tokio::time::timeout(COOPERATIVE_TEARDOWN_BUDGET, phase.as_mut()).await;
 
     timeout_kind
 }

--- a/crates/core-node-internal/tests/common.rs
+++ b/crates/core-node-internal/tests/common.rs
@@ -591,7 +591,7 @@ pub async fn send_node_build_and_wait(
 /// Like [`send_node_build_and_wait`] but sets the `--force` flag, which cancels
 /// any in-flight build for the node and supersedes it.
 #[allow(clippy::too_many_arguments)]
-pub async fn send_node_build_and_wait_with_force(
+pub async fn send_node_build_and_wait_forced(
     messenger: &MessengerHandle,
     core_node_name: &str,
     node_name: &str,
@@ -600,7 +600,6 @@ pub async fn send_node_build_and_wait_with_force(
     result_timeout: Duration,
     env_vars: Vec<(String, String)>,
     feedback_tx: Option<UnboundedSender<NodeBuildFeedback>>,
-    force: bool,
 ) -> Result<NodeBuildResult, String> {
     send_node_build_and_wait_internal(
         messenger,
@@ -611,7 +610,7 @@ pub async fn send_node_build_and_wait_with_force(
         result_timeout,
         env_vars,
         feedback_tx,
-        force,
+        true,
     )
     .await
 }

--- a/crates/core-node-internal/tests/common.rs
+++ b/crates/core-node-internal/tests/common.rs
@@ -53,6 +53,28 @@ impl<T> Drop for AbortOnDrop<T> {
     }
 }
 
+/// Generic polling helper: repeatedly calls `predicate` until it returns
+/// `Some(value)`, then returns that value. If `timeout` elapses first, panics
+/// with `timeout_message`. Polls every 20 ms. `predicate` is synchronous on
+/// purpose: the current callers only touch the filesystem, the node stack, and
+/// child processes, none of which await.
+pub async fn poll_until<T>(
+    timeout: Duration,
+    timeout_message: &str,
+    mut predicate: impl FnMut() -> Option<T>,
+) -> T {
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        if let Some(value) = predicate() {
+            return value;
+        }
+        if std::time::Instant::now() > deadline {
+            panic!("{timeout_message}");
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
 /// Polls `ServiceMessenger::is_reachable` until the named service responds or
 /// `deadline` expires. Replaces fixed sleeps used as broker-propagation
 /// barriers in tests that spawn a `handle_requests` task and then need to

--- a/crates/core-node-internal/tests/common.rs
+++ b/crates/core-node-internal/tests/common.rs
@@ -552,8 +552,63 @@ pub async fn send_node_build_and_wait(
     env_vars: Vec<(String, String)>,
     feedback_tx: Option<UnboundedSender<NodeBuildFeedback>>,
 ) -> Result<NodeBuildResult, String> {
-    let goal =
-        NodeBuildGoal::new(node_name, node_tag, result_timeout.as_secs()).with_env_vars(env_vars);
+    send_node_build_and_wait_internal(
+        messenger,
+        core_node_name,
+        node_name,
+        node_tag,
+        goal_timeout,
+        result_timeout,
+        env_vars,
+        feedback_tx,
+        false,
+    )
+    .await
+}
+
+/// Like [`send_node_build_and_wait`] but sets the `--force` flag, which cancels
+/// any in-flight build for the node and supersedes it.
+#[allow(clippy::too_many_arguments)]
+pub async fn send_node_build_and_wait_with_force(
+    messenger: &MessengerHandle,
+    core_node_name: &str,
+    node_name: &str,
+    node_tag: &str,
+    goal_timeout: Duration,
+    result_timeout: Duration,
+    env_vars: Vec<(String, String)>,
+    feedback_tx: Option<UnboundedSender<NodeBuildFeedback>>,
+    force: bool,
+) -> Result<NodeBuildResult, String> {
+    send_node_build_and_wait_internal(
+        messenger,
+        core_node_name,
+        node_name,
+        node_tag,
+        goal_timeout,
+        result_timeout,
+        env_vars,
+        feedback_tx,
+        force,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn send_node_build_and_wait_internal(
+    messenger: &MessengerHandle,
+    core_node_name: &str,
+    node_name: &str,
+    node_tag: &str,
+    goal_timeout: Duration,
+    result_timeout: Duration,
+    env_vars: Vec<(String, String)>,
+    feedback_tx: Option<UnboundedSender<NodeBuildFeedback>>,
+    force: bool,
+) -> Result<NodeBuildResult, String> {
+    let goal = NodeBuildGoal::new(node_name, node_tag, result_timeout.as_secs())
+        .with_env_vars(env_vars)
+        .with_force(force);
     let goal_payload = goal
         .encode()
         .map_err(|e| format!("Failed to encode build goal: {}", e))?;
@@ -1493,6 +1548,7 @@ pub async fn real_build_and_spawn_instance(
             feedback_tx: &build_feedback_tx,
             log_file: build_log,
             env_vars: &[],
+            cancel_token: tokio_util::sync::CancellationToken::new(),
         },
     )
     .await

--- a/crates/core-node-internal/tests/container_e2e.rs
+++ b/crates/core-node-internal/tests/container_e2e.rs
@@ -5,11 +5,14 @@ mod container_e2e_tests {
 
     use common::{
         CALLER_INSTANCE_ID, NodeRunTestTimeouts, send_node_add_and_wait, send_node_build_and_wait,
-        send_node_run_and_wait, start_core_node_with_real_messenger_and_timeouts,
+        send_node_build_and_wait_forced, send_node_run_and_wait,
+        start_core_node_with_real_messenger_and_timeouts, write_peppy_json5,
     };
+    use config::consts::DEFAULT_ALPINE_BASE_IMAGE;
     use config::node::Name as NodeName;
     use config::node::Toolchain;
     use core_node_api::encoding::NodeInitRequest;
+    use node_stack::{NodeStack, NodeStage};
     use peppylib::core_node::transport::poll_node_init;
     use std::time::Duration;
     use tempfile::tempdir;
@@ -343,6 +346,169 @@ mod container_e2e_tests {
             !log_content.contains("CodegenFingerprintRead"),
             "log file should not contain config fingerprint startup errors, got:\n{}",
             log_content
+        );
+    }
+
+    /// Polls the node stack until `(name, tag)` is `Building`, so the next
+    /// `--force` actually supersedes a running build rather than racing its
+    /// admission.
+    async fn wait_until_building(stack: &NodeStack, name: &str, tag: &str) {
+        let deadline = std::time::Instant::now() + Duration::from_secs(60);
+        loop {
+            if let Some(handle) = stack.find(name, tag)
+                && matches!(handle.read().stage(), NodeStage::Building { .. })
+            {
+                return;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "node {name}:{tag} did not enter Building within 60s"
+            );
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    }
+
+    /// `node build --force` superseding an in-flight container build must SIGKILL
+    /// the displaced build's process group (apptainer + its `%post` children),
+    /// not just the host `limactl`. Regression test for the guest zombie left
+    /// behind when the PGID file write lost a guest-filesystem race and the kill
+    /// became a no-op.
+    ///
+    /// Runs on both backends: `guest_command` queries the kernel the build runs
+    /// in (the Lima guest on macOS, the host on Linux), and the assertion is the
+    /// same. The bug is macOS-only, so this is red on the pre-fix Lima path and a
+    /// green regression guard on Linux (where cancellation already uses the host
+    /// process group).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn container_force_build_kills_displaced_guest_build() {
+        const NODE_NAME: &str = "zombie_e2e_node";
+        const NODE_TAG: &str = "v1";
+        const MARKER: &str = "PEPPY_ZOMBIE_E2E_MARKER";
+        // Each `--force` supersedes the prior in-flight build. The first build is
+        // cold (its PGID write always succeeds), so we need several reuse builds
+        // for the guest-FS race to bite at least once.
+        const BUILDS: usize = 6;
+
+        let started = start_core_node_with_real_messenger_and_timeouts(
+            Duration::from_secs(120),
+            Duration::from_secs(60),
+        )
+        .await;
+
+        // Same runtime the build uses, for inspecting/cleaning its processes.
+        let facade = containers::Apptainer::new().expect("apptainer facade should init");
+
+        // Count live `%post` marker processes in the build kernel. The `[P]...`
+        // class keeps the grep from matching its own argv.
+        let count_markers = || -> usize {
+            let out = facade
+                .guest_command(&[
+                    "sh",
+                    "-c",
+                    "ps -eo args | grep -c '[P]EPPY_ZOMBIE_E2E_MARKER'",
+                ])
+                .expect("guest_command should run");
+            String::from_utf8_lossy(&out.stdout)
+                .trim()
+                .parse()
+                .unwrap_or(0)
+        };
+
+        // A container node whose apptainer build blocks forever in `%post`,
+        // leaving a uniquely-named process (`sh /PEPPY_ZOMBIE_E2E_MARKER`, so the
+        // marker shows up in `ps args`) for each in-flight build.
+        let source_dir = tempfile::tempdir().expect("source dir");
+        write_peppy_json5(
+            source_dir.path(),
+            r#"{
+                peppy_schema: "node_v1",
+                manifest: { name: "zombie_e2e_node", tag: "v1" },
+                execution: { language: "rust", container: { def_file: "apptainer.def" } }
+            }"#,
+        );
+        std::fs::write(
+            source_dir.path().join("apptainer.def"),
+            format!(
+                "Bootstrap: docker\nFrom: {DEFAULT_ALPINE_BASE_IMAGE}\n\n\
+                 %post\n    echo 'while true; do sleep 100000; done' > /{MARKER}\n    sh /{MARKER}\n"
+            ),
+        )
+        .expect("write apptainer.def");
+
+        // Stage the node (node_add does not build the image).
+        let add = send_node_add_and_wait(
+            &started.caller_handle,
+            &started.core_node_name,
+            source_dir.path(),
+            Duration::from_secs(30),
+            Duration::from_secs(300),
+            None,
+        )
+        .await
+        .expect("node_add request should complete");
+        assert!(
+            add.success,
+            "node_add should succeed, got error: {:?}",
+            add.error_message
+        );
+
+        // Fire the builds. Each blocks in `%post` (so it never returns until
+        // superseded) and each `--force` supersedes the prior one, which must
+        // kill the displaced build's whole process group.
+        let mut tasks = Vec::new();
+        for i in 0..BUILDS {
+            let messenger = started.caller_handle.clone();
+            let core_node = started.core_node_name.clone();
+            tasks.push(tokio::spawn(async move {
+                let _ = send_node_build_and_wait_forced(
+                    &messenger,
+                    &core_node,
+                    NODE_NAME,
+                    NODE_TAG,
+                    Duration::from_secs(30),
+                    Duration::from_secs(600),
+                    Vec::new(),
+                    None,
+                )
+                .await;
+            }));
+
+            // Wait until the build is registered Building, then let apptainer
+            // fetch/extract and enter `%post` (its marker process appears).
+            wait_until_building(&started.node_stack, NODE_NAME, NODE_TAG).await;
+            tokio::time::sleep(Duration::from_secs(12)).await;
+            eprintln!(
+                "[zombie-e2e] after build {i}: live markers = {}",
+                count_markers()
+            );
+        }
+
+        // After the supersede chain, at most the final still-active build may have
+        // a live marker. On the pre-fix code, displaced reuse-builds whose PGID
+        // write lost the race were never killed and leak orphaned `%post`
+        // processes.
+        let live = count_markers();
+
+        // Clean up before asserting so a failure never leaks build processes.
+        // Kill each marker's whole (setsid-detached) process group so the
+        // `%post` loop and its `sleep` child go together.
+        let kill_groups = format!(
+            "for p in $(pgrep -f '[P]{m}'); do \
+                 g=$(ps -o pgid= -p \"$p\" 2>/dev/null | tr -d ' '); \
+                 [ -n \"$g\" ] && kill -KILL -\"$g\" 2>/dev/null; \
+             done; true",
+            m = &MARKER[1..]
+        );
+        let _ = facade.guest_command(&["sh", "-c", &kill_groups]);
+        for t in tasks {
+            t.abort();
+        }
+
+        assert!(
+            live <= 1,
+            "after {BUILDS} `--force` rebuilds, {live} `%post` marker processes survived in \
+             the build kernel; every displaced build must be SIGKILLed (expected <= 1, only \
+             the active build)"
         );
     }
 }

--- a/crates/core-node-internal/tests/listen_for_node_build.rs
+++ b/crates/core-node-internal/tests/listen_for_node_build.rs
@@ -2,7 +2,8 @@ mod common;
 
 use common::{
     NodeAddSource, send_node_add_and_wait, send_node_add_and_wait_with_env,
-    send_node_build_and_wait, start_core_node_with_mock_messenger, write_peppy_json5,
+    send_node_build_and_wait, send_node_build_and_wait_with_force,
+    start_core_node_with_mock_messenger, write_peppy_json5,
 };
 use config::consts::DEFAULT_ALPINE_BASE_IMAGE;
 use core_node_api::encoding::NodeBuildFeedback;
@@ -155,6 +156,211 @@ async fn listen_for_node_build_runs_build_cmd() {
         !source_marker.exists(),
         "build_cmd should NOT have created marker file in source dir at {}",
         source_marker.display()
+    );
+}
+
+/// Polls until `pid_file` exists and holds a non-empty PID, returning it.
+async fn wait_for_pid_file(pid_file: &Path) -> String {
+    let deadline = std::time::Instant::now() + Duration::from_secs(30);
+    loop {
+        if let Ok(contents) = std::fs::read_to_string(pid_file) {
+            let pid = contents.trim();
+            if !pid.is_empty() {
+                return pid.to_string();
+            }
+        }
+        if std::time::Instant::now() > deadline {
+            panic!("build_cmd did not record its PID within 30s");
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+/// Polls until the entity for `(name, tag)` is observably in `Building`.
+async fn wait_for_building(node_stack: &node_stack::NodeStack, name: &str, tag: &str) {
+    let deadline = std::time::Instant::now() + Duration::from_secs(30);
+    loop {
+        if let Some(handle) = node_stack.find(name, tag)
+            && matches!(
+                handle.read().stage(),
+                node_stack::NodeStage::Building { .. }
+            )
+        {
+            return;
+        }
+        if std::time::Instant::now() > deadline {
+            panic!("entity did not enter Building within 30s");
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+/// Polls `kill -0 <pid>` (no `libc`/`unsafe`) until the process is gone.
+async fn wait_until_pid_dead(pid: &str) {
+    let deadline = std::time::Instant::now() + Duration::from_secs(30);
+    loop {
+        let alive = std::process::Command::new("kill")
+            .arg("-0")
+            .arg(pid)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        if !alive {
+            return;
+        }
+        if std::time::Instant::now() > deadline {
+            panic!("build subprocess (pid {pid}) was not killed within 30s");
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+/// `node build --force` on a node whose build is stuck mid-flight (the daemon
+/// task kept running after the CLI was Ctrl+C'd) must cancel + SIGKILL the
+/// in-flight build, reuse the staged working dir, and succeed — rather than
+/// rejecting with "is in stage `Building`; cannot build".
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn force_build_cancels_inflight_and_reuses_working_dir_then_succeeds() {
+    const TARGET_NODE_NAME: &str = "force_build_node";
+    const TARGET_NODE_TAG: &str = "v1";
+
+    let started_core_node = start_core_node_with_mock_messenger().await;
+    let node_stack = started_core_node.node_stack.clone();
+
+    // Coordination files live outside the working dir so the test can read/touch
+    // them regardless of where the build runs.
+    let control_dir = tempfile::tempdir().expect("control tempdir");
+    let pid_file = control_dir.path().join("build.pid");
+    let proceed_file = control_dir.path().join("proceed");
+
+    // The build_cmd records its PID, blocks on the proceed sentinel, then writes
+    // the marker (relative path → lands in the working dir → ends up archived).
+    let build_script = format!(
+        "echo $$ > '{}'; while [ ! -f '{}' ]; do sleep 0.05; done; touch '{}'",
+        pid_file.display(),
+        proceed_file.display(),
+        BUILD_CMD_MARKER_FILE
+    );
+
+    let source_dir = tempfile::tempdir().expect("failed to create temp source dir");
+    let peppy_json5 = r#"{
+            peppy_schema: "node_v1",
+            manifest: {
+                name: "{TARGET_NODE_NAME}",
+                tag: "{TARGET_NODE_TAG}",
+            },
+            execution: {
+                language: "rust",
+                build_cmd: ["{BUILD_SCRIPT}"],
+                run_cmd: ["sleep", "10"]
+            }
+        }"#
+    .replace("{TARGET_NODE_NAME}", TARGET_NODE_NAME)
+    .replace("{TARGET_NODE_TAG}", TARGET_NODE_TAG)
+    .replace("{BUILD_SCRIPT}", &build_script);
+    write_peppy_json5(source_dir.path(), &peppy_json5);
+
+    let (node_name, node_tag) =
+        stage_node_for_build(&started_core_node, source_dir.path(), RESULT_TIMEOUT).await;
+
+    // The staged working dir (only surviving copy of the source) the forced
+    // build must reuse.
+    let staged_path = node_stack
+        .find(&node_name, &node_tag)
+        .expect("entity should exist after add")
+        .read()
+        .pending_working_dir()
+        .map(|g| g.path().to_path_buf())
+        .expect("a working dir should be staged after add");
+
+    // Fire the first build; it blocks in `Building` on the proceed sentinel —
+    // simulating a build whose CLI was Ctrl+C'd while the daemon keeps building.
+    let first_build = {
+        let messenger = started_core_node.caller_handle.clone();
+        let core_node_name = started_core_node.core_node_name.clone();
+        let node_name = node_name.clone();
+        let node_tag = node_tag.clone();
+        tokio::spawn(async move {
+            send_node_build_and_wait(
+                &messenger,
+                &core_node_name,
+                &node_name,
+                &node_tag,
+                GOAL_TIMEOUT,
+                RESULT_TIMEOUT,
+                Vec::new(),
+                None,
+            )
+            .await
+        })
+    };
+
+    let first_pid = wait_for_pid_file(&pid_file).await;
+    wait_for_building(&node_stack, &node_name, &node_tag).await;
+
+    // Force-rebuild: must cancel + SIGKILL the in-flight build and take over.
+    let forced_build = {
+        let messenger = started_core_node.caller_handle.clone();
+        let core_node_name = started_core_node.core_node_name.clone();
+        let node_name = node_name.clone();
+        let node_tag = node_tag.clone();
+        tokio::spawn(async move {
+            send_node_build_and_wait_with_force(
+                &messenger,
+                &core_node_name,
+                &node_name,
+                &node_tag,
+                GOAL_TIMEOUT,
+                RESULT_TIMEOUT,
+                Vec::new(),
+                None,
+                true,
+            )
+            .await
+        })
+    };
+
+    // The in-flight build's subprocess must actually be killed by the force.
+    wait_until_pid_dead(&first_pid).await;
+
+    // Let the (reused) forced build run to completion.
+    std::fs::write(&proceed_file, b"").expect("touch proceed file");
+
+    let forced_result = forced_build
+        .await
+        .expect("forced build task should not panic")
+        .expect("forced build request should succeed");
+    assert!(
+        forced_result.success,
+        "forced build must succeed (not be rejected as `Building`), got error: {:?}",
+        forced_result.error_message
+    );
+
+    // The superseded first build reports a cancellation failure, not success.
+    let first_result = first_build
+        .await
+        .expect("first build task should not panic")
+        .expect("first build request should resolve");
+    assert!(
+        !first_result.success,
+        "the superseded first build must not report success"
+    );
+
+    // The entity ends `Ready` and the archive proves the reused build_cmd ran to
+    // completion.
+    let archive_path = entity_artifact_path(&node_stack, TARGET_NODE_NAME, TARGET_NODE_TAG);
+    assert!(
+        archive_contains_entry(&archive_path, BUILD_CMD_MARKER_FILE),
+        "the forced build should have run build_cmd to completion in the reused working dir"
+    );
+
+    // The staged working dir was reused and then consumed by the successful
+    // forced build (it was re-attached on cancel, not deleted).
+    assert!(
+        !staged_path.exists(),
+        "the reused working dir should be cleaned up after a successful build"
     );
 }
 

--- a/crates/core-node-internal/tests/listen_for_node_build.rs
+++ b/crates/core-node-internal/tests/listen_for_node_build.rs
@@ -161,65 +161,58 @@ async fn listen_for_node_build_runs_build_cmd() {
 
 /// Polls until `pid_file` exists and holds a non-empty PID, returning it.
 async fn wait_for_pid_file(pid_file: &Path) -> String {
-    let deadline = std::time::Instant::now() + Duration::from_secs(30);
-    loop {
-        if let Ok(contents) = std::fs::read_to_string(pid_file) {
+    common::poll_until(
+        Duration::from_secs(30),
+        "build_cmd did not record its PID within 30s",
+        || {
+            let contents = std::fs::read_to_string(pid_file).ok()?;
             let pid = contents.trim();
-            if !pid.is_empty() {
-                return pid.to_string();
-            }
-        }
-        if std::time::Instant::now() > deadline {
-            panic!("build_cmd did not record its PID within 30s");
-        }
-        tokio::time::sleep(Duration::from_millis(20)).await;
-    }
+            (!pid.is_empty()).then(|| pid.to_string())
+        },
+    )
+    .await
 }
 
 /// Polls until the entity for `(name, tag)` is observably in `Building`.
 async fn wait_for_building(node_stack: &node_stack::NodeStack, name: &str, tag: &str) {
-    let deadline = std::time::Instant::now() + Duration::from_secs(30);
-    loop {
-        if let Some(handle) = node_stack.find(name, tag)
-            && matches!(
+    common::poll_until(
+        Duration::from_secs(30),
+        "entity did not enter Building within 30s",
+        || {
+            let handle = node_stack.find(name, tag)?;
+            matches!(
                 handle.read().stage(),
                 node_stack::NodeStage::Building { .. }
             )
-        {
-            return;
-        }
-        if std::time::Instant::now() > deadline {
-            panic!("entity did not enter Building within 30s");
-        }
-        tokio::time::sleep(Duration::from_millis(20)).await;
-    }
+            .then_some(())
+        },
+    )
+    .await
 }
 
 /// Polls `kill -0 <pid>` (no `libc`/`unsafe`) until the process is gone.
 async fn wait_until_pid_dead(pid: &str) {
-    let deadline = std::time::Instant::now() + Duration::from_secs(30);
-    loop {
-        let alive = std::process::Command::new("kill")
-            .arg("-0")
-            .arg(pid)
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .status()
-            .map(|s| s.success())
-            .unwrap_or(false);
-        if !alive {
-            return;
-        }
-        if std::time::Instant::now() > deadline {
-            panic!("build subprocess (pid {pid}) was not killed within 30s");
-        }
-        tokio::time::sleep(Duration::from_millis(20)).await;
-    }
+    common::poll_until(
+        Duration::from_secs(30),
+        &format!("build subprocess (pid {pid}) was not killed within 30s"),
+        || {
+            let alive = std::process::Command::new("kill")
+                .arg("-0")
+                .arg(pid)
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .status()
+                .map(|s| s.success())
+                .unwrap_or(false);
+            (!alive).then_some(())
+        },
+    )
+    .await
 }
 
 /// `node build --force` on a node whose build is stuck mid-flight (the daemon
 /// task kept running after the CLI was Ctrl+C'd) must cancel + SIGKILL the
-/// in-flight build, reuse the staged working dir, and succeed — rather than
+/// in-flight build, reuse the staged working dir, and succeed, rather than
 /// rejecting with "is in stage `Building`; cannot build".
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn force_build_cancels_inflight_and_reuses_working_dir_then_succeeds() {
@@ -275,7 +268,7 @@ async fn force_build_cancels_inflight_and_reuses_working_dir_then_succeeds() {
         .map(|g| g.path().to_path_buf())
         .expect("a working dir should be staged after add");
 
-    // Fire the first build; it blocks in `Building` on the proceed sentinel —
+    // Fire the first build; it blocks in `Building` on the proceed sentinel,
     // simulating a build whose CLI was Ctrl+C'd while the daemon keeps building.
     let first_build = {
         let messenger = started_core_node.caller_handle.clone();

--- a/crates/core-node-internal/tests/listen_for_node_build.rs
+++ b/crates/core-node-internal/tests/listen_for_node_build.rs
@@ -2,8 +2,8 @@ mod common;
 
 use common::{
     NodeAddSource, send_node_add_and_wait, send_node_add_and_wait_with_env,
-    send_node_build_and_wait, send_node_build_and_wait_with_force,
-    start_core_node_with_mock_messenger, write_peppy_json5,
+    send_node_build_and_wait, send_node_build_and_wait_forced, start_core_node_with_mock_messenger,
+    write_peppy_json5,
 };
 use config::consts::DEFAULT_ALPINE_BASE_IMAGE;
 use core_node_api::encoding::NodeBuildFeedback;
@@ -300,7 +300,7 @@ async fn force_build_cancels_inflight_and_reuses_working_dir_then_succeeds() {
         let node_name = node_name.clone();
         let node_tag = node_tag.clone();
         tokio::spawn(async move {
-            send_node_build_and_wait_with_force(
+            send_node_build_and_wait_forced(
                 &messenger,
                 &core_node_name,
                 &node_name,
@@ -309,7 +309,6 @@ async fn force_build_cancels_inflight_and_reuses_working_dir_then_succeeds() {
                 RESULT_TIMEOUT,
                 Vec::new(),
                 None,
-                true,
             )
             .await
         })

--- a/crates/node-stack-internal/Cargo.toml
+++ b/crates/node-stack-internal/Cargo.toml
@@ -21,6 +21,7 @@ tokio = { version = "1", features = [
     "time",
     "macros",
 ] }
+tokio-util = "0.7"
 tar = "0.4"
 zstd = "0.13.3"
 chrono = "0.4"

--- a/crates/node-stack-internal/src/build_io.rs
+++ b/crates/node-stack-internal/src/build_io.rs
@@ -31,6 +31,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use tokio::io::AsyncBufReadExt;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
 
 /// Maximum number of stderr lines to retain for error diagnostics.
 /// Used by both the build (apptainer/archive) path and the start (node run) path.
@@ -142,14 +143,18 @@ pub fn spawn_in_process_group(
 /// collected stderr tail lines.
 ///
 /// **Cancellation contract:** the child must have been spawned via
-/// [`spawn_in_process_group`] so that if this future is dropped before the
-/// child exits, the internal `KillGuard` can SIGKILL the entire subprocess
-/// tree.
+/// [`spawn_in_process_group`] so that the entire subprocess tree can be
+/// signaled. When `cancel_token` fires before the child exits, the child's
+/// process group is SIGKILL'd *and reaped* (awaited) before this returns
+/// `Err("build cancelled")`, so no zombie lingers and the working dir is free
+/// for a superseding build. If this future is instead dropped outright, the
+/// `KillGuard` still SIGKILLs the group as a fallback (without reaping).
 pub async fn stream_child_output(
     mut child: Box<dyn ChildWrapper>,
     feedback_tx: &mpsc::UnboundedSender<FeedbackLine>,
     log_file: Arc<StdMutex<File>>,
     collect_stderr_tail: bool,
+    cancel_token: &CancellationToken,
 ) -> std::result::Result<(std::process::ExitStatus, Vec<String>), String> {
     let stderr_tail: Option<Arc<StdMutex<VecDeque<String>>>> = if collect_stderr_tail {
         Some(Arc::new(StdMutex::new(VecDeque::with_capacity(
@@ -210,11 +215,21 @@ pub async fn stream_child_output(
         child: child.as_mut(),
         completed: false,
     };
-    let status = guard
-        .child
-        .wait()
-        .await
-        .map_err(|e| format!("failed to wait for process: {}", e))?;
+    let status = tokio::select! {
+        biased;
+        wait_result = guard.child.wait() => {
+            wait_result.map_err(|e| format!("failed to wait for process: {}", e))?
+        }
+        _ = cancel_token.cancelled() => {
+            // SIGKILL the whole process group, then *await* the child so it is
+            // reaped before we return — the superseding build must not race a
+            // dying subprocess over the same working dir.
+            let _ = guard.child.start_kill();
+            let _ = guard.child.wait().await;
+            guard.completed = true;
+            return Err("build cancelled".to_string());
+        }
+    };
     guard.completed = true;
 
     // Join reader tasks and surface the first error so build diagnostics

--- a/crates/node-stack-internal/src/build_io.rs
+++ b/crates/node-stack-internal/src/build_io.rs
@@ -222,7 +222,7 @@ pub async fn stream_child_output(
         }
         _ = cancel_token.cancelled() => {
             // SIGKILL the whole process group, then *await* the child so it is
-            // reaped before we return — the superseding build must not race a
+            // reaped before we return; the superseding build must not race a
             // dying subprocess over the same working dir.
             let _ = guard.child.start_kill();
             let _ = guard.child.wait().await;

--- a/crates/node-stack-internal/src/node_stack.rs
+++ b/crates/node-stack-internal/src/node_stack.rs
@@ -817,6 +817,59 @@ impl NodeStack {
         true
     }
 
+    /// Rolls the config at `(name, tag)` back from `Building` to `Added` and
+    /// re-attaches `working_dir`, but only if its current entity is `Building`
+    /// AND the underlying `Arc<RwLock<NodeEntity>>` is the same handle the caller
+    /// holds and the entity's `generation` matches.
+    ///
+    /// Used by the `node_build` `--force` cancellation path: rather than
+    /// removing the entity (as the failure path does), the superseded build
+    /// leaves it buildable again so the forced rebuild can reuse the same staged
+    /// working dir (the only surviving copy of the source). The handle +
+    /// generation + `Building` check rules out the race where a concurrent
+    /// `push_config` replaced the entity in-place: if any differs, the entity is
+    /// no longer the one we built and we leave the new state untouched.
+    ///
+    /// Returns `true` if the rollback was applied, `false` otherwise.
+    pub fn rollback_to_added_if_matches(
+        &self,
+        name: &str,
+        tag: &str,
+        expected_handle: &Arc<RwLock<NodeEntity>>,
+        expected_generation: u64,
+        working_dir: Arc<WorkingDirGuard>,
+    ) -> bool {
+        // Hold the stack write lock (not read) so a concurrent `push_config`
+        // cannot swap the graph node between the identity check and the entity
+        // mutation, mirroring `remove_config_if_matches`.
+        let guard = self.shared.write();
+        let key = NodeKey::new(name, tag);
+
+        if guard.is_root(&key) {
+            return false;
+        }
+
+        let Some(&index) = guard.key_to_index.get(&key) else {
+            return false;
+        };
+
+        let Some(current) = guard.graph.node_weight(index).cloned() else {
+            return false;
+        };
+        if !Arc::ptr_eq(&current, expected_handle) {
+            return false;
+        }
+
+        let mut entity = current.write();
+        if entity.generation() != expected_generation
+            || !matches!(entity.stage(), NodeStage::Building { .. })
+        {
+            return false;
+        }
+        entity.rollback_building_to_added(working_dir);
+        true
+    }
+
     /// Slot identity for [`NodeStack::restore_snapshot_if_matches`]: the
     /// name/tag key plus the handle+generation the caller captured before
     /// starting the rebuild. Bundled so callers can express the rollback

--- a/crates/node-stack-internal/src/node_stack.rs
+++ b/crates/node-stack-internal/src/node_stack.rs
@@ -483,6 +483,36 @@ impl NodeStackInner {
         }
     }
 
+    /// Resolves the graph slot for `key` and confirms it still holds the exact
+    /// `Arc<RwLock<NodeEntity>>` the caller captured. Returns the slot's
+    /// `NodeIndex` and a clone of the handle when the slot exists, is not the
+    /// root, and is pointer-identical to `expected_handle`; returns `None`
+    /// otherwise.
+    ///
+    /// This is the shared identity prologue for the `*_if_matches` cleanup
+    /// methods on `NodeStack`. It deliberately stops at the pointer check: each
+    /// caller applies its own generation + `Building` stage check under the
+    /// specific lock it needs for its mutation, so those checks stay in the
+    /// callers rather than being folded in here.
+    fn resolve_matching_slot(
+        &self,
+        key: &NodeKey,
+        expected_handle: &Arc<RwLock<NodeEntity>>,
+    ) -> Option<(NodeIndex, EntityHandle)> {
+        if self.is_root(key) {
+            return None;
+        }
+
+        let &index = self.key_to_index.get(key)?;
+        let current = self.graph.node_weight(index)?.clone();
+
+        if !Arc::ptr_eq(&current, expected_handle) {
+            return None;
+        }
+
+        Some((index, current))
+    }
+
     /// Clears all nodes except the root node from the stack.
     fn clear(&mut self) {
         let root_handle = self.root();
@@ -790,23 +820,16 @@ impl NodeStack {
         let mut guard = self.shared.write();
         let key = NodeKey::new(name, tag);
 
-        if guard.is_root(&key) {
-            return false;
-        }
-
-        let Some(&index) = guard.key_to_index.get(&key) else {
+        let Some((_index, current)) = guard.resolve_matching_slot(&key, expected_handle) else {
             return false;
         };
 
-        let matches = guard.graph.node_weight(index).is_some_and(|current| {
-            Arc::ptr_eq(current, expected_handle) && {
-                let entity = current.read();
-                entity.generation() == expected_generation
-                    && matches!(entity.stage(), NodeStage::Building { .. })
-            }
-        });
-
-        if !matches {
+        let generation_and_stage_match = {
+            let entity = current.read();
+            entity.generation() == expected_generation
+                && matches!(entity.stage(), NodeStage::Building { .. })
+        };
+        if !generation_and_stage_match {
             return false;
         }
 
@@ -845,20 +868,9 @@ impl NodeStack {
         let guard = self.shared.write();
         let key = NodeKey::new(name, tag);
 
-        if guard.is_root(&key) {
-            return false;
-        }
-
-        let Some(&index) = guard.key_to_index.get(&key) else {
+        let Some((_index, current)) = guard.resolve_matching_slot(&key, expected_handle) else {
             return false;
         };
-
-        let Some(current) = guard.graph.node_weight(index).cloned() else {
-            return false;
-        };
-        if !Arc::ptr_eq(&current, expected_handle) {
-            return false;
-        }
 
         let mut entity = current.write();
         if entity.generation() != expected_generation
@@ -895,20 +907,10 @@ impl NodeStack {
         let mut guard = self.shared.write();
         let key = NodeKey::new(target.name, target.tag);
 
-        if guard.is_root(&key) {
-            return false;
-        }
-
-        let Some(&index) = guard.key_to_index.get(&key) else {
+        let Some((index, current)) = guard.resolve_matching_slot(&key, target.expected_handle)
+        else {
             return false;
         };
-
-        let Some(current) = guard.graph.node_weight(index).cloned() else {
-            return false;
-        };
-        if !Arc::ptr_eq(&current, target.expected_handle) {
-            return false;
-        }
         {
             let entity = current.read();
             if entity.generation() != target.expected_generation

--- a/crates/node-stack-internal/src/node_stack/build_steps.rs
+++ b/crates/node-stack-internal/src/node_stack/build_steps.rs
@@ -145,17 +145,20 @@ pub(super) async fn build_container_image(
     // On macOS the build runs inside a Lima VM, so SIGKILL'ing the host
     // `limactl shell` does not reach the guest `apptainer build` or its
     // `%post` children. The facade therefore runs the guest build as a
-    // process-group leader and records its PGID here, which
-    // `kill_inflight_build` uses on cancel to SIGKILL the whole guest group.
-    // Kept as a sibling of `working_dir` (still under `$HOME`, so guest-visible
-    // at the same path) but *outside* it, so the def file's `%files .` does not
-    // bake it into the image. A no-op file on the native backend.
-    let pgid_file = pgid_file_path(inputs.working_dir);
-    let _pgid_cleanup = PgidFileCleanup(&pgid_file);
+    // process-group leader and records its PGID to a guest-native file keyed by
+    // this build key, which `kill_inflight_build` (called with the same key)
+    // uses on cancel to SIGKILL the whole guest group. The working-dir basename
+    // is a unique, filesystem-safe key. A no-op on the native backend.
+    let build_key = inputs
+        .working_dir
+        .file_name()
+        .and_then(|n| n.to_str())
+        .map(str::to_owned);
 
-    let mut cmd_builder = apptainer
-        .build(&output_path, &def_path)
-        .cancel_pgid_file(&pgid_file);
+    let mut cmd_builder = apptainer.build(&output_path, &def_path);
+    if let Some(key) = &build_key {
+        cmd_builder = cmd_builder.cancel_pgid(key);
+    }
     for arg in inputs.apptainer_build_extra_args {
         cmd_builder = cmd_builder.raw_flag(arg);
     }
@@ -189,10 +192,11 @@ pub(super) async fn build_container_image(
     // into the VM and kill the guest process group too (no-op on Linux). Reuses
     // the already-initialized facade. Runs on a blocking thread because the
     // guest kill shells out to `limactl`.
-    if inputs.cancel_token.is_cancelled() {
-        let pgid_file_for_kill = pgid_file.clone();
+    if inputs.cancel_token.is_cancelled()
+        && let Some(key) = build_key
+    {
         let _ = tokio::task::spawn_blocking(move || {
-            let _ = apptainer.kill_inflight_build(&pgid_file_for_kill);
+            let _ = apptainer.kill_inflight_build(&key);
         })
         .await;
     }
@@ -209,26 +213,6 @@ pub(super) async fn build_container_image(
     }
 
     Ok(())
-}
-
-/// Path of the guest build's PGID file: a sibling of `working_dir` (same parent,
-/// under `$HOME`) with a `.pgid` suffix, so it is guest-visible but not captured
-/// by the def file's `%files .`.
-fn pgid_file_path(working_dir: &Path) -> PathBuf {
-    let mut os = working_dir.as_os_str().to_owned();
-    os.push(".pgid");
-    PathBuf::from(os)
-}
-
-/// Removes the guest-build PGID file on drop. The file is written by the guest
-/// build wrapper (Lima) and never created on the native backend, so removal is
-/// best-effort and silent.
-struct PgidFileCleanup<'a>(&'a Path);
-
-impl Drop for PgidFileCleanup<'_> {
-    fn drop(&mut self) {
-        let _ = std::fs::remove_file(self.0);
-    }
 }
 
 /// Expands `${VAR}` references in a string using the provided environment

--- a/crates/node-stack-internal/src/node_stack/build_steps.rs
+++ b/crates/node-stack-internal/src/node_stack/build_steps.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 
 use config::consts::PeppyDirs;
 use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
 use tracing::debug;
 use zstd::stream::write::Encoder as ZstdEncoder;
 
@@ -96,6 +97,11 @@ pub(super) struct ContainerBuildInputs<'a> {
     pub lima_shell_extra_args: &'a [String],
     pub feedback_tx: &'a mpsc::UnboundedSender<FeedbackLine>,
     pub log_file: Arc<StdMutex<File>>,
+    /// Fired when a `--force` build supersedes this one. On Linux the
+    /// host process-group SIGKILL is enough; on macOS the guest-side apptainer
+    /// (and its `%post` children) live in a separate kernel and are killed via
+    /// [`containers::Apptainer::kill_inflight_build`].
+    pub cancel_token: &'a CancellationToken,
 }
 
 /// Builds a container image using the Apptainer facade.
@@ -136,7 +142,20 @@ pub(super) async fn build_container_image(
     let output_path = inputs.working_dir.join(&sif_name);
     let def_path = inputs.working_dir.join(inputs.def_file);
 
-    let mut cmd_builder = apptainer.build(&output_path, &def_path);
+    // On macOS the build runs inside a Lima VM, so SIGKILL'ing the host
+    // `limactl shell` does not reach the guest `apptainer build` or its
+    // `%post` children. The facade therefore runs the guest build as a
+    // process-group leader and records its PGID here, which
+    // `kill_inflight_build` uses on cancel to SIGKILL the whole guest group.
+    // Kept as a sibling of `working_dir` (still under `$HOME`, so guest-visible
+    // at the same path) but *outside* it, so the def file's `%files .` does not
+    // bake it into the image. A no-op file on the native backend.
+    let pgid_file = pgid_file_path(inputs.working_dir);
+    let _pgid_cleanup = PgidFileCleanup(&pgid_file);
+
+    let mut cmd_builder = apptainer
+        .build(&output_path, &def_path)
+        .cancel_pgid_file(&pgid_file);
     for arg in inputs.apptainer_build_extra_args {
         cmd_builder = cmd_builder.raw_flag(arg);
     }
@@ -157,8 +176,28 @@ pub(super) async fn build_container_image(
     let child = spawn_in_process_group(cmd)
         .map_err(|e| format!("Failed to spawn apptainer build: {}", e))?;
 
-    let (status, stderr_tail) =
-        stream_child_output(child, inputs.feedback_tx, inputs.log_file, true).await?;
+    let stream_result = stream_child_output(
+        child,
+        inputs.feedback_tx,
+        inputs.log_file,
+        true,
+        inputs.cancel_token,
+    )
+    .await;
+
+    // A `--force` supersede SIGKILL'd + reaped the host child above; now reach
+    // into the VM and kill the guest process group too (no-op on Linux). Reuses
+    // the already-initialized facade. Runs on a blocking thread because the
+    // guest kill shells out to `limactl`.
+    if inputs.cancel_token.is_cancelled() {
+        let pgid_file_for_kill = pgid_file.clone();
+        let _ = tokio::task::spawn_blocking(move || {
+            let _ = apptainer.kill_inflight_build(&pgid_file_for_kill);
+        })
+        .await;
+    }
+
+    let (status, stderr_tail) = stream_result?;
 
     if !status.success() {
         let mut msg = format!("apptainer build failed with status {}", status);
@@ -170,6 +209,26 @@ pub(super) async fn build_container_image(
     }
 
     Ok(())
+}
+
+/// Path of the guest build's PGID file: a sibling of `working_dir` (same parent,
+/// under `$HOME`) with a `.pgid` suffix, so it is guest-visible but not captured
+/// by the def file's `%files .`.
+fn pgid_file_path(working_dir: &Path) -> PathBuf {
+    let mut os = working_dir.as_os_str().to_owned();
+    os.push(".pgid");
+    PathBuf::from(os)
+}
+
+/// Removes the guest-build PGID file on drop. The file is written by the guest
+/// build wrapper (Lima) and never created on the native backend, so removal is
+/// best-effort and silent.
+struct PgidFileCleanup<'a>(&'a Path);
+
+impl Drop for PgidFileCleanup<'_> {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(self.0);
+    }
 }
 
 /// Expands `${VAR}` references in a string using the provided environment
@@ -217,6 +276,7 @@ pub(super) async fn run_build_cmd(
     env_vars: &[(String, String)],
     feedback_tx: &mpsc::UnboundedSender<FeedbackLine>,
     log_file: Arc<StdMutex<File>>,
+    cancel_token: &CancellationToken,
 ) -> std::result::Result<(), String> {
     let Some(cmd) = build_cmd else {
         return Ok(());
@@ -285,7 +345,8 @@ pub(super) async fn run_build_cmd(
     let child = spawn_in_process_group(command)
         .map_err(|e| format!("failed to execute build_cmd `{}`: {}", full_cmd_display, e))?;
 
-    let (status, _) = stream_child_output(child, feedback_tx, log_file, false).await?;
+    let (status, _) =
+        stream_child_output(child, feedback_tx, log_file, false, cancel_token).await?;
 
     if !status.success() {
         return Err(format!(
@@ -326,6 +387,7 @@ mod tests {
         let log_file = Arc::new(StdMutex::new(
             tempfile::tempfile().expect("tempfile should succeed"),
         ));
+        let cancel_token = CancellationToken::new();
         let err = build_container_image(ContainerBuildInputs {
             working_dir,
             node_name: "sensor",
@@ -335,6 +397,7 @@ mod tests {
             lima_shell_extra_args: &[],
             feedback_tx: &feedback_tx,
             log_file,
+            cancel_token: &cancel_token,
         })
         .await
         .expect_err("unsafe tag must be rejected");

--- a/crates/node-stack-internal/src/node_stack/entity.rs
+++ b/crates/node-stack-internal/src/node_stack/entity.rs
@@ -13,6 +13,7 @@ use core_node_api::{
 use tokio::process::Child;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
 
 use crate::build_io::{FeedbackLine, FeedbackStream, OutputReaderHooks, spawn_output_reader_async};
 use crate::error::{Error, Result};
@@ -153,6 +154,10 @@ pub struct BuildContext<'a> {
     /// `inject_rust_build_env`, and `inject_node_runtime_env`. Container
     /// nodes ignore this field — apptainer build does not consume it.
     pub env_vars: &'a [(String, String)],
+    /// Fired when a `--force` build supersedes this one. The build I/O layer
+    /// SIGKILLs and reaps the build subprocess so the superseding build can
+    /// reuse the working dir without racing a dying process.
+    pub cancel_token: CancellationToken,
 }
 
 /// Inputs required to drive [`NodeEntity::prepare_and_spawn`] to completion.
@@ -340,6 +345,31 @@ impl NodeEntity {
         self.generation
     }
 
+    /// Rolls a `Building` entity back to `Added`, preserving `config_path`, and
+    /// re-attaches the staged working-directory guard so a follow-up build can
+    /// reuse it. Used by the `node_build` `--force` cancellation path: the
+    /// superseded build leaves the entity buildable again rather than removing
+    /// it (the staged working dir is the only surviving copy of the source).
+    ///
+    /// The caller ([`super::NodeStack::rollback_to_added_if_matches`]) holds the
+    /// stack + entity write locks and has already verified the entity is
+    /// `Building` with a matching generation. Deliberately does NOT bump the
+    /// generation: this is the same entity, re-presented as buildable, and the
+    /// superseding build captures the current generation via its own lookup.
+    pub fn rollback_building_to_added(&mut self, working_dir: Arc<WorkingDirGuard>) {
+        let NodeStage::Building { config_path } = &self.stage else {
+            debug_assert!(
+                false,
+                "rollback_building_to_added called on a non-Building entity"
+            );
+            return;
+        };
+        self.stage = NodeStage::Added {
+            config_path: config_path.clone(),
+        };
+        self.pending_working_dir = Some(working_dir);
+    }
+
     pub fn config(&self) -> &NodeConfig {
         &self.config
     }
@@ -450,6 +480,7 @@ impl NodeEntity {
                     lima_shell_extra_args,
                     feedback_tx: ctx.feedback_tx,
                     log_file: Arc::clone(&ctx.log_file),
+                    cancel_token: &ctx.cancel_token,
                 })
                 .await
                 .map_err(|reason| Error::BuildFailed {
@@ -465,6 +496,7 @@ impl NodeEntity {
                     ctx.env_vars,
                     ctx.feedback_tx,
                     Arc::clone(&ctx.log_file),
+                    &ctx.cancel_token,
                 )
                 .await
                 .map_err(|reason| Error::BuildFailed {

--- a/crates/node-stack-internal/tests/helpers/real_lifecycle.rs
+++ b/crates/node-stack-internal/tests/helpers/real_lifecycle.rs
@@ -137,6 +137,7 @@ pub async fn build_ready(
             feedback_tx: &harness.feedback_tx,
             log_file: Arc::clone(&harness.log_file),
             env_vars: &[],
+            cancel_token: tokio_util::sync::CancellationToken::new(),
         },
     )
     .await

--- a/crates/node-stack-internal/tests/helpers/real_lifecycle.rs
+++ b/crates/node-stack-internal/tests/helpers/real_lifecycle.rs
@@ -8,7 +8,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use config::consts::PeppyDirs;
 use config::node::{Name, NodeConfig};
 use node_stack::{
-    BuildContext, EntityHandle, NodeEntity, NodeStack, OutputSinks, StartContext,
+    BuildContext, EntityHandle, NodeEntity, NodeStack, NodeStage, OutputSinks, StartContext,
     build_io::{FeedbackLine, OutputReaderHooks},
 };
 use tokio::sync::mpsc;
@@ -204,5 +204,22 @@ pub async fn spawn_running_instance(
         handle,
         instance_id,
         pid,
+    }
+}
+
+/// Polls `handle` until its entity is observably in `Building`, panicking if
+/// that does not happen within 10s. Used by lifecycle tests that drive a real
+/// `NodeEntity::build` into `Building` (via a blocking build_cmd) before
+/// exercising the rollback / restore paths.
+pub async fn wait_for_building(handle: &EntityHandle) {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    loop {
+        if matches!(handle.read().stage(), NodeStage::Building { .. }) {
+            break;
+        }
+        if std::time::Instant::now() > deadline {
+            panic!("entity did not enter Building within 10s");
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
     }
 }

--- a/crates/node-stack-internal/tests/tests_modules/lifecycle_transitions.rs
+++ b/crates/node-stack-internal/tests/tests_modules/lifecycle_transitions.rs
@@ -1185,19 +1185,7 @@ async fn restore_snapshot_if_matches_rolls_back_failed_rebuild() {
     });
 
     // Wait until the entity is observably in `Building`.
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
-    loop {
-        {
-            let guard = handle_after_push.read();
-            if matches!(guard.stage(), NodeStage::Building { .. }) {
-                break;
-            }
-        }
-        if std::time::Instant::now() > deadline {
-            panic!("entity did not enter Building within 10s");
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-    }
+    real_lifecycle::wait_for_building(&handle_after_push).await;
 
     // Build "fails" — the caller rolls back by restoring the v1 snapshot it
     // captured before calling push_config.
@@ -1261,7 +1249,7 @@ async fn rollback_to_added_if_matches_rolls_building_back_and_reattaches_working
     let harness = real_lifecycle::lifecycle_harness();
     let config_path = harness.peppy_root.path().join("sensor_v1.json5");
 
-    // Push a node with a blocking build_cmd and drive it into `Building` — the
+    // Push a node with a blocking build_cmd and drive it into `Building`, the
     // legitimate way to observe the stage with no backdoor.
     let control_dir = tempfile::tempdir().expect("control tempdir");
     let proceed_file = control_dir.path().join("proceed");
@@ -1297,16 +1285,7 @@ async fn rollback_to_added_if_matches_rolls_building_back_and_reattaches_working
         .await
     });
 
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
-    loop {
-        if matches!(handle.read().stage(), NodeStage::Building { .. }) {
-            break;
-        }
-        if std::time::Instant::now() > deadline {
-            panic!("entity did not enter Building within 10s");
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-    }
+    real_lifecycle::wait_for_building(&handle).await;
 
     // The working dir to re-attach on a successful rollback, plus a scratch dir
     // for the throwaway guards the mismatch cases never store.
@@ -1436,19 +1415,7 @@ async fn restore_snapshot_if_matches_no_op_on_generation_drift() {
     });
 
     // Wait until we observe `Building` on the entity.
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
-    loop {
-        {
-            let guard = handle.read();
-            if matches!(guard.stage(), NodeStage::Building { .. }) {
-                break;
-            }
-        }
-        if std::time::Instant::now() > deadline {
-            panic!("entity did not enter Building within 10s");
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-    }
+    real_lifecycle::wait_for_building(&handle).await;
 
     // A concurrent push replaces the entity under the same handle, bumping
     // its generation. push_config accepts the replacement even while the

--- a/crates/node-stack-internal/tests/tests_modules/lifecycle_transitions.rs
+++ b/crates/node-stack-internal/tests/tests_modules/lifecycle_transitions.rs
@@ -1,15 +1,16 @@
 //! Tests focused on the `NodeStage` lifecycle transitions managed by
 //! `NodeEntity`.
 
-use parking_lot::Mutex as StdMutex;
+use parking_lot::{Mutex as StdMutex, RwLock};
 use std::path::PathBuf;
 use std::sync::Arc;
 
 use config::node::Name;
 use node_stack::{
     BuildContext, EntitySnapshot, InstanceState, NodeEntity, NodeStack, NodeStackError, NodeStage,
-    RestoreTarget,
+    RestoreTarget, WorkingDirGuard,
 };
+use tokio_util::sync::CancellationToken;
 
 use crate::helpers::config_common::core_node_config;
 use crate::helpers::real_lifecycle;
@@ -450,6 +451,7 @@ async fn concurrent_builds_are_rejected_immediately() {
                         feedback_tx: &feedback_tx,
                         log_file,
                         env_vars: &[],
+                        cancel_token: CancellationToken::new(),
                     },
                 )
                 .await
@@ -604,6 +606,7 @@ async fn build_runs_add_cmd_for_process_node() {
             feedback_tx: &h.feedback_tx,
             log_file: Arc::clone(&h.log_file),
             env_vars: &[],
+            cancel_token: CancellationToken::new(),
         },
     )
     .await
@@ -1175,6 +1178,7 @@ async fn restore_snapshot_if_matches_rolls_back_failed_rebuild() {
                 feedback_tx: &feedback_tx_clone,
                 log_file: log_file_clone,
                 env_vars: &[],
+                cancel_token: CancellationToken::new(),
             },
         )
         .await
@@ -1246,6 +1250,141 @@ async fn restore_snapshot_if_matches_rolls_back_failed_rebuild() {
     );
 }
 
+/// `rollback_to_added_if_matches` is the node-stack API the `node_build`
+/// `--force` cancellation path calls: it rolls a `Building` entity back to
+/// `Added` and re-attaches the staged working dir so the forced rebuild can
+/// reuse it, but only when the handle + generation + `Building` slot identity
+/// still matches.
+#[tokio::test]
+async fn rollback_to_added_if_matches_rolls_building_back_and_reattaches_working_dir() {
+    let stack = NodeStack::new(core_node_config(), None, PathBuf::from("/tmp"));
+    let harness = real_lifecycle::lifecycle_harness();
+    let config_path = harness.peppy_root.path().join("sensor_v1.json5");
+
+    // Push a node with a blocking build_cmd and drive it into `Building` — the
+    // legitimate way to observe the stage with no backdoor.
+    let control_dir = tempfile::tempdir().expect("control tempdir");
+    let proceed_file = control_dir.path().join("proceed");
+    let blocking_config = sensor_config_with_build_cmd(&format!(
+        "while [ ! -f '{}' ]; do sleep 0.02; done; exit 0",
+        proceed_file.display()
+    ));
+    stack
+        .push_config(blocking_config, false, &config_path)
+        .expect("push_config should succeed");
+    let handle = stack.find("sensor", "v1").expect("entity should exist");
+    let captured_generation = handle.read().generation();
+    let original_config_path = handle.read().config_path().to_path_buf();
+
+    let working_dir = tempfile::tempdir().expect("working_dir tempdir");
+    let working_path = working_dir.path().to_path_buf();
+    let peppy_dirs_clone = harness.peppy_dirs.clone();
+    let feedback_tx_clone = harness.feedback_tx.clone();
+    let log_file_clone = Arc::clone(&harness.log_file);
+    let build_handle_clone = Arc::clone(&handle);
+    let build_task = tokio::spawn(async move {
+        NodeEntity::build(
+            &build_handle_clone,
+            BuildContext {
+                working_dir: &working_path,
+                peppy_dirs: &peppy_dirs_clone,
+                feedback_tx: &feedback_tx_clone,
+                log_file: log_file_clone,
+                env_vars: &[],
+                cancel_token: CancellationToken::new(),
+            },
+        )
+        .await
+    });
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    loop {
+        if matches!(handle.read().stage(), NodeStage::Building { .. }) {
+            break;
+        }
+        if std::time::Instant::now() > deadline {
+            panic!("entity did not enter Building within 10s");
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+
+    // The working dir to re-attach on a successful rollback, plus a scratch dir
+    // for the throwaway guards the mismatch cases never store.
+    let restaged = tempfile::tempdir().expect("restaged dir");
+    let restaged_path = restaged.path().to_path_buf();
+    let scratch = tempfile::tempdir().expect("scratch dir");
+    let scratch_guard = || Arc::new(WorkingDirGuard::new(scratch.path().to_path_buf()));
+
+    // Mismatch cases mutate nothing and return false.
+    assert!(
+        !stack.rollback_to_added_if_matches(
+            "sensor",
+            "v1",
+            &handle,
+            captured_generation + 1,
+            scratch_guard(),
+        ),
+        "a generation mismatch must not roll back"
+    );
+    let unrelated_handle = Arc::new(RwLock::new(NodeEntity::new(sensor_config(), &config_path)));
+    assert!(
+        !stack.rollback_to_added_if_matches(
+            "sensor",
+            "v1",
+            &unrelated_handle,
+            captured_generation,
+            scratch_guard(),
+        ),
+        "a different handle must not roll back"
+    );
+    assert!(
+        matches!(handle.read().stage(), NodeStage::Building { .. }),
+        "the entity must still be Building after the mismatch cases"
+    );
+
+    // Success: rolls back to `Added`, preserving config_path and re-attaching
+    // the staged working dir.
+    assert!(
+        stack.rollback_to_added_if_matches(
+            "sensor",
+            "v1",
+            &handle,
+            captured_generation,
+            Arc::new(WorkingDirGuard::new(restaged_path.clone())),
+        ),
+        "a matching handle + generation + Building slot must roll back"
+    );
+    {
+        let guard = handle.read();
+        match guard.stage() {
+            NodeStage::Added { config_path } => assert_eq!(config_path, &original_config_path),
+            other => panic!("expected Added after rollback, got {:?}", other),
+        }
+        assert_eq!(
+            guard.pending_working_dir().map(|g| g.path().to_path_buf()),
+            Some(restaged_path.clone()),
+            "the staged working dir must be re-attached so the rebuild can reuse it"
+        );
+    }
+
+    // Rolling back again is a no-op: the entity is no longer `Building`.
+    assert!(
+        !stack.rollback_to_added_if_matches(
+            "sensor",
+            "v1",
+            &handle,
+            captured_generation,
+            scratch_guard(),
+        ),
+        "a non-Building entity must not roll back"
+    );
+
+    // Unblock and drain the build task so it does not leak. Its Phase 3 commit
+    // observes the entity is no longer `Building` and returns an error.
+    std::fs::write(&proceed_file, b"").expect("touch proceed file");
+    let _ = build_task.await.expect("build task should not panic");
+}
+
 /// `restore_snapshot_if_matches` must not clobber a concurrent replacement:
 /// if the handle+generation drift (because another `push_config` landed
 /// between the caller's capture and the build failure), the rollback should
@@ -1290,6 +1429,7 @@ async fn restore_snapshot_if_matches_no_op_on_generation_drift() {
                 feedback_tx: &feedback_tx_clone,
                 log_file: log_file_clone,
                 env_vars: &[],
+                cancel_token: CancellationToken::new(),
             },
         )
         .await

--- a/crates/peppy/src/commands/stack/list.rs
+++ b/crates/peppy/src/commands/stack/list.rs
@@ -17,17 +17,21 @@ use peppylib::core_node::transport::poll_stack_list;
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 
 pub fn list_nodes(ctx: &Arc<AppContext>, dot_graph_path: Option<PathBuf>) -> Result<()> {
-    let output = crate::commands::block_on(list_nodes_collecting(ctx, dot_graph_path))?;
+    let colorize = crate::terminal::colors_enabled();
+    let output = crate::commands::block_on(list_nodes_collecting(ctx, dot_graph_path, colorize))?;
     print!("{}", output);
     Ok(())
 }
 
 /// Like [`list_nodes`] but returns the rendered output as a `String` instead
-/// of printing it. Used by integration tests so they can assert against the
-/// exact bytes the CLI would print without having to capture stdout.
+/// of printing it. `colorize` is passed in rather than read from the ambient
+/// terminal so the result is deterministic: the CLI passes
+/// [`crate::terminal::colors_enabled`], while integration tests pass `false`
+/// for stable, color-free assertions.
 pub async fn list_nodes_collecting(
     ctx: &Arc<AppContext>,
     dot_graph_path: Option<PathBuf>,
+    colorize: bool,
 ) -> Result<String> {
     let conn = ctx.connect_to_daemon().await?;
 
@@ -64,7 +68,7 @@ pub async fn list_nodes_collecting(
         a_key.cmp(&b_key)
     });
 
-    let mut out = format_stack_list(&nodes, &edges, crate::terminal::colors_enabled());
+    let mut out = format_stack_list(&nodes, &edges, colorize);
 
     if let (Some(path), Some(dot_graph)) = (dot_graph_path, response.dot_graph) {
         std::fs::write(&path, dot_graph).map_err(|e| {

--- a/crates/peppy/tests/stack_list.rs
+++ b/crates/peppy/tests/stack_list.rs
@@ -78,6 +78,35 @@ fn make_consumer_depend_on_provider(
     );
 }
 
+/// A node's row parsed from the rendered stack inventory table.
+struct InventoryRow {
+    stage: String,
+    instances: String,
+}
+
+/// Parse a node's row from the rendered stack inventory table.
+///
+/// Inventory rows are drawn with box borders ('│'), which sets them apart from
+/// the plain-text dependency edges and lets us read each padded cell by column
+/// order: NODE, STAGE, INSTANCES, PATH. Reading the cells directly keeps the
+/// assertions independent of comfy-table's column widths and padding, which
+/// shift with the detected terminal width.
+fn node_inventory_row(output: &str, label: &str) -> InventoryRow {
+    let row = output
+        .lines()
+        .find(|line| line.contains('│') && line.contains(label))
+        .unwrap_or_else(|| panic!("inventory row for {label} should be present:\n{output}"));
+
+    // split('│') yields an empty leading cell before the first border, then the
+    // padded NODE, STAGE, INSTANCES, PATH cells, then an empty trailing cell.
+    let cells: Vec<&str> = row.split('│').map(str::trim).collect();
+
+    InventoryRow {
+        stage: cells.get(2).unwrap_or(&"").to_string(),
+        instances: cells.get(3).unwrap_or(&"").to_string(),
+    }
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn node_list_command_succeeds() {
     // Mock messaging is sufficient for listing and dependency graph tests (no spawned node process).
@@ -193,7 +222,9 @@ async fn node_list_command_succeeds() {
 
     // Run the list command via the testable collecting variant so we can
     // assert on the exact text the CLI would print without capturing stdout.
-    let output = peppy::commands::stack::list_nodes_collecting(&node_ctx, None)
+    // `false`: render without ANSI color so the assertions match plain table
+    // text regardless of whether the test runs attached to a terminal.
+    let output = peppy::commands::stack::list_nodes_collecting(&node_ctx, None, false)
         .await
         .expect("node list command should succeed");
 
@@ -214,26 +245,20 @@ async fn node_list_command_succeeds() {
         "table headers missing:\n{output}"
     );
 
-    let provider_line = output
-        .lines()
-        .find(|line| line.contains(&provider_label))
-        .expect("output should contain the provider node");
-    assert!(
-        provider_line.contains("Ready"),
+    let provider_row = node_inventory_row(&output, &provider_label);
+    assert_eq!(
+        provider_row.stage, "Ready",
         "provider row should be in Ready stage:\n{output}"
     );
     // No instances were started, so the INSTANCES column must render as "0".
-    assert!(
-        provider_line.contains(" 0 "),
+    assert_eq!(
+        provider_row.instances, "0",
         "provider row should report zero instances:\n{output}"
     );
 
-    let consumer_line = output
-        .lines()
-        .find(|line| line.contains(&consumer_label))
-        .expect("output should contain the consumer node");
-    assert!(
-        consumer_line.contains("Ready"),
+    let consumer_row = node_inventory_row(&output, &consumer_label);
+    assert_eq!(
+        consumer_row.stage, "Ready",
         "consumer row should be in Ready stage:\n{output}"
     );
 
@@ -358,10 +383,13 @@ async fn node_list_command_with_dot_representation_succeeds() {
 
     let dot_graph_path = node_dir.path().join("node_stack.dot");
 
-    let output =
-        peppy::commands::stack::list_nodes_collecting(&node_ctx, Some(dot_graph_path.clone()))
-            .await
-            .expect("node list command should succeed");
+    let output = peppy::commands::stack::list_nodes_collecting(
+        &node_ctx,
+        Some(dot_graph_path.clone()),
+        false,
+    )
+    .await
+    .expect("node list command should succeed");
 
     assert!(
         dot_graph_path.exists(),

--- a/crates/peppylib/Cargo.toml
+++ b/crates/peppylib/Cargo.toml
@@ -36,6 +36,7 @@ build-helpers = { path = "../build-helpers-internal" }
 capnpc = "0.25"
 
 [dev-dependencies]
+libc = "0.2"
 tempfile = "3.10"
 askama = "0.16"
 tokio = { version = "1", features = ["full"] }

--- a/crates/peppylib/src/messaging/tests.rs
+++ b/crates/peppylib/src/messaging/tests.rs
@@ -3,8 +3,8 @@ use config::node::QoSProfile;
 use pmi::{MessengerBackend, ZenohAdapter, ZenohdInstance};
 use rand::seq::SliceRandom;
 use std::collections::HashMap;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Once};
 use std::time::Duration;
 use tokio::sync::oneshot;
 
@@ -46,12 +46,46 @@ impl ActionClientCase {
     }
 }
 
+/// Raises the process soft `nofile` limit once per test binary. Each test below
+/// spawns an ephemeral zenoh router, and running them in parallel can exhaust
+/// file descriptors under the macOS default soft limit of 256, surfacing as
+/// flaky `Too many open files` (EMFILE) errors. Bumping the soft limit toward
+/// the hard limit removes that ceiling without reducing test parallelism. Best
+/// effort: a failed syscall leaves the original limit in place and the real
+/// EMFILE error still surfaces.
+fn ensure_test_fd_limit() {
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        // 8192 is comfortably above the peak concurrent router count and well
+        // under the macOS per-process cap (kern.maxfilesperproc).
+        const DESIRED_SOFT: libc::rlim_t = 8192;
+        // SAFETY: get/setrlimit operate on a stack-allocated rlimit and report
+        // failure through their return code, which we honor.
+        unsafe {
+            let mut limit = libc::rlimit {
+                rlim_cur: 0,
+                rlim_max: 0,
+            };
+            if libc::getrlimit(libc::RLIMIT_NOFILE, &mut limit) != 0 {
+                return;
+            }
+            let target = DESIRED_SOFT.min(limit.rlim_max);
+            if limit.rlim_cur >= target {
+                return;
+            }
+            limit.rlim_cur = target;
+            let _ = libc::setrlimit(libc::RLIMIT_NOFILE, &limit);
+        }
+    });
+}
+
 struct TestRouterContext {
     instance: ZenohdInstance,
 }
 
 impl TestRouterContext {
     async fn start() -> Self {
+        ensure_test_fd_limit();
         let instance = ZenohAdapter::start_router_ephemeral("127.0.0.1", None)
             .await
             .expect("failed to start zenoh router for tests");

--- a/crates/peppylib/src/runtime.rs
+++ b/crates/peppylib/src/runtime.rs
@@ -133,7 +133,7 @@ where
 #[cfg(test)]
 pub(crate) mod test_utils {
     use std::env;
-    use std::sync::Mutex;
+    use std::sync::{Mutex, PoisonError};
 
     /// Global mutex that serializes all env-var mutations across test threads
     /// within this crate, preventing races between processor (daemon-mode) and
@@ -150,7 +150,11 @@ pub(crate) mod test_utils {
 
     impl EnvVarGuard {
         pub(crate) fn set(key: &'static str, value: &str) -> Self {
-            let _lock = ENV_VAR_MUTEX.lock().expect("env mutex should lock");
+            // Recover from a poisoned mutex: the guarded section only mutates a
+            // single env var, so a panic while held leaves no broken invariant.
+            // Without this, one failing test cascades PoisonError into every
+            // later env-dependent test and hides the real failure.
+            let _lock = ENV_VAR_MUTEX.lock().unwrap_or_else(PoisonError::into_inner);
             let previous = env::var(key).ok();
             // SAFETY: environment mutation is guarded by a global mutex to avoid races.
             unsafe { env::set_var(key, value) };
@@ -162,7 +166,11 @@ pub(crate) mod test_utils {
         }
 
         pub(crate) fn remove(key: &'static str) -> Self {
-            let _lock = ENV_VAR_MUTEX.lock().expect("env mutex should lock");
+            // Recover from a poisoned mutex: the guarded section only mutates a
+            // single env var, so a panic while held leaves no broken invariant.
+            // Without this, one failing test cascades PoisonError into every
+            // later env-dependent test and hides the real failure.
+            let _lock = ENV_VAR_MUTEX.lock().unwrap_or_else(PoisonError::into_inner);
             let previous = env::var(key).ok();
             // SAFETY: environment mutation is guarded by a global mutex to avoid races.
             unsafe { env::remove_var(key) };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cooperative build cancellation with forced-rebuilds terminating superseded in-flight builds; macOS (Lima) supports guest-side kill and running guest commands.
  * Listing now supports explicit colorization control.

* **Bug Fixes**
  * Superseded builds are rolled back/killed without leaking staged working directories or leaving stray processes.

* **Tests**
  * New unit and integration tests covering cancellation, guest-side kill behavior, forced rebuilds, and working-dir reuse.

* **Chores**
  * Added shared cancellation plumbing across build paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->