### PR TITLE
docs: sync with PR #221

### DIFF
--- a/docs/src/content/docs/guides/node_stack.mdx
+++ b/docs/src/content/docs/guides/node_stack.mdx
@@ -178,7 +178,7 @@ Each health transition (a `running` instance going `unhealthy`, or recovering af
 
 ## Inspecting a node with `peppy node info`
 
-When you need more than the one-line view from `stack list`, `peppy node info` dumps the node's stage, its currently-tracked instances with their individual states, and the paths to its add log and per-instance run logs. It takes a `<node_name>:<node_tag>` reference to a node **that has already been added to the stack**; it doesn't touch the filesystem or any git/http source, so run `peppy node add` first if the node isn't in the stack yet:
+When you need more than the one-line view from `stack list`, `peppy node info` dumps the node's stage, its currently-tracked instances with their individual states and last-known health, and the paths to its add log and per-instance run logs. It takes a `<node_name>:<node_tag>` reference to a node **that has already been added to the stack**; it doesn't touch the filesystem or any git/http source, so run `peppy node add` first if the node isn't in the stack yet:
 
 ```sh
 peppy node info hello_world:v1
@@ -200,8 +200,8 @@ Node Stack Status
 --------------------------------------------------
 Stage:     Ready
 Instances: 2 tracked
-           - suspicious-swanson-5880  [running]
-           - flamboyant-penrose-9622  [running]
+           - suspicious-swanson-5880  [running]  healthy
+           - flamboyant-penrose-9622  [running]  healthy
 
 Logs
 --------------------------------------------------


### PR DESCRIPTION
Automated doc update generated by `scripts/docs/update_docs.py`
in response to code changes in #221.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated `peppy node info` documentation to clarify that it includes health status for each instance alongside lifecycle state. Example output now displays both `[running]` and `healthy` indicators per instance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->