### PR TITLE
Add from_any bidirectional guide with robot arm snippets

### DIFF
--- a/crates/config-internal/tests/example_configurations.rs
+++ b/crates/config-internal/tests/example_configurations.rs
@@ -5,8 +5,11 @@
 //! drifted from the example files — either the code or the examples need updating.
 
 use config::consts::NODE_CONFIG_FILE;
+use config::interface::PeppyInterfaceParser;
 use config::launcher::PeppyLauncherParser;
 use config::node::NodeConfigParser;
+use config::schema::PeppySchema;
+use serde::Deserialize;
 use std::path::{Path, PathBuf};
 
 /// Walk `root` recursively and collect every file named `peppy.json5`.
@@ -22,6 +25,49 @@ fn find_node_configs(root: &Path) -> Vec<PathBuf> {
         })
         .map(|e| e.into_path())
         .collect()
+}
+
+/// The schema tag a config declares, read without parsing the whole document.
+/// Snippet `peppy.json5` files mix node and interface schemas, so the test must
+/// peek the tag and dispatch each file to the parser that matches it.
+#[derive(Deserialize)]
+struct SchemaPeek {
+    peppy_schema: PeppySchema,
+}
+
+/// Parse `path` with the typed parser matching its declared `peppy_schema` and
+/// assert it succeeds. This keeps interface snippets covered by the same
+/// schema-sync guarantee as node snippets instead of skipping them.
+fn assert_parses_with_matching_schema(path: &Path) {
+    let content = std::fs::read_to_string(path)
+        .unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()));
+    let peek: SchemaPeek = serde_json5::from_str(&content)
+        .unwrap_or_else(|e| panic!("missing peppy_schema in {}: {e}", path.display()));
+
+    match peek.peppy_schema {
+        PeppySchema::NodeV1 => {
+            let result = NodeConfigParser::from_path(path);
+            assert!(
+                result.is_ok(),
+                "failed to parse node {}: {:?}",
+                path.display(),
+                result.unwrap_err()
+            );
+        }
+        PeppySchema::InterfaceV1 => {
+            let result = PeppyInterfaceParser::from_path(path);
+            assert!(
+                result.is_ok(),
+                "failed to parse interface {}: {:?}",
+                path.display(),
+                result.unwrap_err()
+            );
+        }
+        PeppySchema::LauncherV1 => panic!(
+            "unexpected launcher_v1 among node/interface snippets: {}",
+            path.display()
+        ),
+    }
 }
 
 #[test]
@@ -77,13 +123,7 @@ fn test_docs_snippet_configs_parse() {
     );
 
     for path in &configs {
-        let result = NodeConfigParser::from_path(path);
-        assert!(
-            result.is_ok(),
-            "failed to parse {}: {:?}",
-            path.display(),
-            result.unwrap_err()
-        );
+        assert_parses_with_matching_schema(path);
     }
 }
 

--- a/crates/peppy/tests/stack_launch.rs
+++ b/crates/peppy/tests/stack_launch.rs
@@ -1064,11 +1064,36 @@ async fn stack_launch_rejects_stack_wide_duplicate_instance_id() {
     );
 }
 
-/// Writes a minimal `peppy_schema: "interface_v1"` document at `path`.
-/// Used by the conformance-binding integration tests to materialize the
-/// interface contract on disk alongside the producer/consumer node
-/// configs that reference it.
+/// Writes a minimal `peppy_schema: "interface_v1"` document at `path` with
+/// a single `video_stream` topic. Used by the conformance-binding
+/// integration tests to materialize the interface contract on disk
+/// alongside the producer/consumer node configs that reference it.
 fn write_interface_v1_doc(path: &Path, name: &str, tag: &str) {
+    write_interface_v1_doc_with_topic(
+        path,
+        name,
+        tag,
+        "video_stream",
+        r#"{
+                            width: "u32",
+                            height: "u32",
+                            encoding: "string"
+                        }"#,
+    );
+}
+
+/// Like [`write_interface_v1_doc`] but parameterized on the single topic
+/// name and its `message_format` body. The bidirectional `from_any` test
+/// uses this to materialize two distinct per-direction contracts
+/// (`joint_states` and `joint_commands`) rather than the default
+/// `video_stream` shape.
+fn write_interface_v1_doc_with_topic(
+    path: &Path,
+    name: &str,
+    tag: &str,
+    topic_name: &str,
+    message_format_json5: &str,
+) {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).expect("failed to create interface parent dir");
     }
@@ -1079,13 +1104,9 @@ fn write_interface_v1_doc(path: &Path, name: &str, tag: &str) {
             interfaces: {{
                 topics: [
                     {{
-                        name: "video_stream",
+                        name: "{topic_name}",
                         qos_profile: "sensor_data",
-                        message_format: {{
-                            width: "u32",
-                            height: "u32",
-                            encoding: "string"
-                        }}
+                        message_format: {message_format_json5}
                     }}
                 ]
             }}
@@ -1565,5 +1586,308 @@ async fn stack_launch_rejects_binding_with_wrong_tag_in_conforms_to() {
     assert!(
         err_msg.contains(&format!("{interface_name}:{consumer_wants_tag}")),
         "error should name the requested interface `{interface_name}:{consumer_wants_tag}`. Got:\n{err_msg}"
+    );
+}
+
+/// Bidirectional `from_any` is the optional, wildcard form of interface
+/// communication: two nodes each emit one interface (`conforms_to`) and
+/// consume the other through a `from_any: true` interface dep, launched
+/// with NO `--bind` on either side. Because neither slot pins a producer,
+/// the launcher must materialize each consumed slot as
+/// `SlotBinding::FromAnyUnbound` without raising
+/// `BindingInterfaceNotConformed`, and the stack must come up regardless
+/// of deployment order: no node depends on the other being present. This
+/// is the end-to-end counterpart to the unit-level binding validator tests
+/// and the wire-level flow test in `peppylib/tests/topics.rs`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn stack_launch_bidirectional_from_any_needs_no_binds() {
+    let serve = ServeCommandEmulation::with_zenoh()
+        .await
+        .expect("failed to create zenoh serve emulation");
+    let core_node_name = serve.core_node_name().to_string();
+
+    let nodes_dir = tempfile::tempdir().expect("failed to create temp nodes directory");
+    let dump_dir = tempfile::tempdir().expect("failed to create temp dump directory");
+    let interface_repo_dir = tempfile::tempdir().expect("failed to create temp interface repo");
+    let controller_dump = dump_dir.path().join("arm_controller.json5");
+    let arm_dump = dump_dir.path().join("robot_arm.json5");
+
+    let state_interface = "joint_state_source";
+    let command_interface = "joint_command_source";
+    let interface_tag = "v1";
+    let controller_name = "arm_controller";
+    let arm_name = "robot_arm";
+    let node_tag = "v1";
+    let controller_instance_id = "ctrl_1";
+    let arm_instance_id = "arm_1";
+    // The consumed-interface slot link_id on each side (the direction it reads).
+    let controller_link_id = "arm"; // arm_controller consumes joint_states from the arm
+    let arm_link_id = "controller"; // robot_arm consumes joint_commands from the controller
+    let git_hash = read_daemon_git_hash(serve.daemon_state_path());
+
+    // Two interface contracts, one per direction, both registered in the
+    // same fs repo so the consumer node-add can resolve each `(name, tag)`
+    // from cache even though nothing is bound.
+    write_interface_v1_doc_with_topic(
+        &interface_repo_dir
+            .path()
+            .join("joint_state_source/peppy.json5"),
+        state_interface,
+        interface_tag,
+        "joint_states",
+        r#"{
+                            positions: { $type: "array", $items: "f64", $length: 3 },
+                            velocities: { $type: "array", $items: "f64", $length: 3 },
+                            timestamp: "time"
+                        }"#,
+    );
+    write_interface_v1_doc_with_topic(
+        &interface_repo_dir
+            .path()
+            .join("joint_command_source/peppy.json5"),
+        command_interface,
+        interface_tag,
+        "joint_commands",
+        r#"{
+                            target_positions: { $type: "array", $items: "f64", $length: 3 },
+                            max_velocity: "f64"
+                        }"#,
+    );
+    let conf_dir = serve.temp_dir().join("conf");
+    fs::create_dir_all(&conf_dir).expect("create conf dir");
+    let repos_content = serde_json::to_string_pretty(&serde_json::json!([
+        { "id": 1, "type": "fs", "path": interface_repo_dir.path().to_string_lossy() }
+    ]))
+    .expect("serialize repos");
+    fs::write(conf_dir.join("repositories.json5"), repos_content).expect("write repos");
+
+    // arm_controller: emits joint_commands (conforms_to joint_command_source),
+    // consumes joint_states from any conforming producer (from_any, unbound).
+    let controller_run_cmd = vec![
+        "sh".to_string(),
+        "-c".to_string(),
+        format!(
+            "cp \"$PEPPY_RUNTIME_CONFIG\" \"{}\" && exec sleep 30",
+            controller_dump.display()
+        ),
+    ];
+    let controller_depends_on = format!(
+        r#"{{
+            nodes: [],
+            interfaces: [{{
+                name: "{state_interface}",
+                tag: "{interface_tag}",
+                link_id: "{controller_link_id}",
+                from_any: true
+            }}]
+        }}"#
+    );
+    let controller_interfaces = format!(
+        r#"{{
+            conforms_to: [{{ name: "{command_interface}", tag: "{interface_tag}" }}]
+        }}"#
+    );
+    let controller_path = write_node_config_for_helper(
+        nodes_dir.path(),
+        controller_name,
+        node_tag,
+        &git_hash,
+        &controller_run_cmd,
+        Some(&controller_depends_on),
+        Some(&controller_interfaces),
+    );
+
+    // robot_arm: emits joint_states (conforms_to joint_state_source),
+    // consumes joint_commands from any conforming producer (from_any, unbound).
+    let arm_run_cmd = vec![
+        "sh".to_string(),
+        "-c".to_string(),
+        format!(
+            "cp \"$PEPPY_RUNTIME_CONFIG\" \"{}\" && exec sleep 30",
+            arm_dump.display()
+        ),
+    ];
+    let arm_depends_on = format!(
+        r#"{{
+            nodes: [],
+            interfaces: [{{
+                name: "{command_interface}",
+                tag: "{interface_tag}",
+                link_id: "{arm_link_id}",
+                from_any: true
+            }}]
+        }}"#
+    );
+    let arm_interfaces = format!(
+        r#"{{
+            conforms_to: [{{ name: "{state_interface}", tag: "{interface_tag}" }}]
+        }}"#
+    );
+    let arm_path = write_node_config_for_helper(
+        nodes_dir.path(),
+        arm_name,
+        node_tag,
+        &git_hash,
+        &arm_run_cmd,
+        Some(&arm_depends_on),
+        Some(&arm_interfaces),
+    );
+
+    let ctx = Arc::new(
+        AppContext::with_messenger(nodes_dir.path(), Arc::clone(&serve.messenger()))
+            .with_daemon_state_file(serve.daemon_state_path()),
+    );
+
+    RepoCommand {
+        command: RepoCommands::Refresh,
+    }
+    .execute(&ctx)
+    .expect("repo refresh should populate interface cache");
+
+    // The dummy `sh` subprocesses don't expose ready/health/shutdown, so
+    // impersonate them from the test process for both instances (the
+    // daemon's launch waits for each instance to report ready).
+    let node_messenger = MessengerHandle::from_shared(Arc::clone(&serve.messenger()));
+    let _ready_controller = listen_for_node_ready(
+        &node_messenger,
+        &core_node_name,
+        controller_instance_id,
+        test_node_target(controller_name),
+    )
+    .await
+    .expect("controller ready service should start");
+    let _health_controller = listen_for_node_health(
+        &node_messenger,
+        &core_node_name,
+        controller_instance_id,
+        test_node_target(controller_name),
+    )
+    .await
+    .expect("controller health service should start");
+    let (_shutdown_controller, _) = listen_for_shutdown(
+        &node_messenger,
+        &core_node_name,
+        controller_instance_id,
+        test_node_target(controller_name),
+    )
+    .await
+    .expect("controller shutdown service should start");
+    let _ready_arm = listen_for_node_ready(
+        &node_messenger,
+        &core_node_name,
+        arm_instance_id,
+        test_node_target(arm_name),
+    )
+    .await
+    .expect("arm ready service should start");
+    let _health_arm = listen_for_node_health(
+        &node_messenger,
+        &core_node_name,
+        arm_instance_id,
+        test_node_target(arm_name),
+    )
+    .await
+    .expect("arm health service should start");
+    let (_shutdown_arm, _) = listen_for_shutdown(
+        &node_messenger,
+        &core_node_name,
+        arm_instance_id,
+        test_node_target(arm_name),
+    )
+    .await
+    .expect("arm shutdown service should start");
+
+    // Launch BOTH deployments with NO `bindings` on either instance.
+    let launcher_path = nodes_dir.path().join("peppy_launcher.json5");
+    let launcher_json5 = format!(
+        r#"{{
+            peppy_schema: "launcher_v1",
+            deployments: [
+                {{
+                    source: {{ local: "{controller_path}" }},
+                    instances: [{{ instance_id: "{controller_instance_id}" }}]
+                }},
+                {{
+                    source: {{ local: "{arm_path}" }},
+                    instances: [{{ instance_id: "{arm_instance_id}" }}]
+                }}
+            ]
+        }}"#,
+        controller_path = controller_path.display(),
+        arm_path = arm_path.display(),
+    );
+    fs::write(&launcher_path, launcher_json5).expect("launcher config should be writable");
+
+    StackCommand {
+        command: StackCommands::Launch {
+            launcher_config_path: launcher_path,
+            node_add_idle_timeout_secs: 60,
+            node_build_idle_timeout_secs: 60,
+            node_run_idle_timeout_secs: 60,
+            max_timeout_secs: Some(120),
+        },
+    }
+    .execute(&ctx)
+    .expect("launch should succeed with no binds on either bidirectional node");
+
+    // Both `sh` wrappers snapshot their runtime config before sleeping.
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let mut controller_config: Option<config::runtime::RuntimeConfig> = None;
+    let mut arm_config: Option<config::runtime::RuntimeConfig> = None;
+    while Instant::now() < deadline {
+        if controller_config.is_none()
+            && let Ok(content) = fs::read_to_string(&controller_dump)
+            && let Ok(cfg) = serde_json5::from_str::<config::runtime::RuntimeConfig>(&content)
+        {
+            controller_config = Some(cfg);
+        }
+        if arm_config.is_none()
+            && let Ok(content) = fs::read_to_string(&arm_dump)
+            && let Ok(cfg) = serde_json5::from_str::<config::runtime::RuntimeConfig>(&content)
+        {
+            arm_config = Some(cfg);
+        }
+        if controller_config.is_some() && arm_config.is_some() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    for instance_id in [controller_instance_id, arm_instance_id] {
+        let _ = NodeCommand {
+            command: NodeCommands::Stop {
+                instance_id: instance_id.to_string(),
+            },
+        }
+        .execute(&ctx);
+    }
+
+    let controller_config = controller_config.unwrap_or_else(|| {
+        panic!(
+            "arm_controller runtime config dump never appeared / parsed at {}",
+            controller_dump.display()
+        )
+    });
+    assert_eq!(
+        controller_config
+            .node_instance
+            .slot_bindings
+            .get(controller_link_id),
+        Some(&config::runtime::SlotBinding::FromAnyUnbound),
+        "arm_controller's `{controller_link_id}` interface slot should materialize as \
+         FromAnyUnbound when launched with no --bind",
+    );
+
+    let arm_config = arm_config.unwrap_or_else(|| {
+        panic!(
+            "robot_arm runtime config dump never appeared / parsed at {}",
+            arm_dump.display()
+        )
+    });
+    assert_eq!(
+        arm_config.node_instance.slot_bindings.get(arm_link_id),
+        Some(&config::runtime::SlotBinding::FromAnyUnbound),
+        "robot_arm's `{arm_link_id}` interface slot should materialize as \
+         FromAnyUnbound when launched with no --bind",
     );
 }

--- a/crates/peppylib/tests/topics.rs
+++ b/crates/peppylib/tests/topics.rs
@@ -184,3 +184,143 @@ async fn node_session_recovers_after_router_restart() {
          re-declare its subscription"
     );
 }
+
+/// Bidirectional `from_any` at the wire layer: two consumers each subscribe
+/// to the other's topic as a `from_any` wildcard (`is_from_any = true`,
+/// `ConsumerFilter::Any`), exactly as a generated `from_any` interface
+/// consumed-topic module does. Messages flow independently in both
+/// directions with no binding wiring the pair together, and a producer that
+/// joins *after* the consumer is already listening is picked up through the
+/// same subscription, distinguished only by its `instance_id`. This is the
+/// runtime counterpart to the launch-time `FromAnyUnbound` materialization
+/// checked in `crates/peppy/tests/stack_launch.rs`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn bidirectional_from_any_topics_with_late_producer() {
+    let instance = ZenohAdapter::start_router_ephemeral("127.0.0.1", None)
+        .await
+        .expect("failed to start zenoh router for test");
+    let (host, port) = (instance.host.clone(), instance.port);
+
+    let core_node = "test_core";
+    // One topic per direction, mirroring the docs' robot arm control loop.
+    let joint_states = "joint_states"; // emitted by robot_arm, consumed by arm_controller
+    let joint_commands = "joint_commands"; // emitted by arm_controller, consumed by robot_arm
+
+    let controller_handle = MessengerHandle::from_host_port(&host, port)
+        .await
+        .expect("failed to create arm_controller handle");
+    let arm_handle = MessengerHandle::from_host_port(&host, port)
+        .await
+        .expect("failed to create robot_arm handle");
+
+    // arm_controller consumes joint_states from any robot_arm instance.
+    let mut controller_sub = TopicMessenger::subscribe(
+        &controller_handle,
+        core_node,
+        "ctrl_1",
+        Some(test_node_target("robot_arm")),
+        true, // from_any
+        joint_states,
+        None, // from any core node
+        &ConsumerFilter::Any,
+        QoSProfile::Reliable,
+    )
+    .await
+    .expect("arm_controller subscription should succeed");
+
+    // robot_arm consumes joint_commands from any arm_controller instance.
+    let mut arm_sub = TopicMessenger::subscribe(
+        &arm_handle,
+        core_node,
+        "arm_1",
+        Some(test_node_target("arm_controller")),
+        true, // from_any
+        joint_commands,
+        None,
+        &ConsumerFilter::Any,
+        QoSProfile::Reliable,
+    )
+    .await
+    .expect("robot_arm subscription should succeed");
+
+    // Allow both subscriptions to propagate.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // Direction 1: robot_arm (arm_1) -> arm_controller.
+    let state_payload = Payload::from_static(b"joint_states@arm_1");
+    TopicMessenger::emit(
+        &arm_handle,
+        core_node,
+        "arm_1",
+        test_node_target("robot_arm"),
+        joint_states,
+        QoSProfile::Reliable,
+        state_payload.clone(),
+    )
+    .await
+    .expect("robot_arm emit should succeed");
+
+    let msg = tokio::time::timeout(Duration::from_secs(2), controller_sub.on_next_message())
+        .await
+        .expect("arm_controller should receive joint_states within timeout")
+        .expect("message should not be None");
+    assert_eq!(msg.payload(), &state_payload);
+    assert_eq!(msg.instance_id(), "arm_1");
+    assert_eq!(msg.core_node(), core_node);
+
+    // Direction 2: arm_controller (ctrl_1) -> robot_arm. The reverse stream
+    // flows independently; nothing bound the two nodes to each other.
+    let command_payload = Payload::from_static(b"joint_commands@ctrl_1");
+    TopicMessenger::emit(
+        &controller_handle,
+        core_node,
+        "ctrl_1",
+        test_node_target("arm_controller"),
+        joint_commands,
+        QoSProfile::Reliable,
+        command_payload.clone(),
+    )
+    .await
+    .expect("arm_controller emit should succeed");
+
+    let msg = tokio::time::timeout(Duration::from_secs(2), arm_sub.on_next_message())
+        .await
+        .expect("robot_arm should receive joint_commands within timeout")
+        .expect("message should not be None");
+    assert_eq!(msg.payload(), &command_payload);
+    assert_eq!(msg.instance_id(), "ctrl_1");
+
+    // A second robot_arm instance joins *after* arm_controller is already
+    // subscribed. With no binding to update, the wildcard subscription picks
+    // it up automatically; only the returned instance_id distinguishes it
+    // from the first producer.
+    let late_arm_handle = MessengerHandle::from_host_port(&host, port)
+        .await
+        .expect("failed to create late robot_arm handle");
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let late_payload = Payload::from_static(b"joint_states@arm_2");
+    TopicMessenger::emit(
+        &late_arm_handle,
+        core_node,
+        "arm_2",
+        test_node_target("robot_arm"),
+        joint_states,
+        QoSProfile::Reliable,
+        late_payload.clone(),
+    )
+    .await
+    .expect("late robot_arm emit should succeed");
+
+    let msg = tokio::time::timeout(Duration::from_secs(2), controller_sub.on_next_message())
+        .await
+        .expect("arm_controller should receive the late producer within timeout")
+        .expect("message should not be None");
+    assert_eq!(msg.payload(), &late_payload);
+    assert_eq!(
+        msg.instance_id(),
+        "arm_2",
+        "the late producer must be picked up through the same subscription, \
+         distinguished only by its instance_id",
+    );
+}

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -152,15 +152,15 @@ export default defineConfig({
 				{ slug: 'index' },
 				{
 					label: 'Guides',
-					autogenerate: { directory: 'guides' },
+					items: [{ autogenerate: { directory: 'guides' } }],
 				},
 				{
 					label: 'Advanced Guides',
-					autogenerate: { directory: 'advanced_guides' },
+					items: [{ autogenerate: { directory: 'advanced_guides' } }],
 				},
 				{
 					label: 'Reference',
-					autogenerate: { directory: 'reference' },
+					items: [{ autogenerate: { directory: 'reference' } }],
 				},
 			],
 		}),

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.0.1",
       "dependencies": {
         "@astrojs/rss": "^4.0.18",
-        "@astrojs/starlight": "^0.38.2",
-        "astro": "^6.0.0",
+        "@astrojs/starlight": "^0.39.3",
+        "astro": "^6.4.4",
         "entities": "^8.0.0",
         "marked": "^17.0.1",
         "remark-gfm": "^4.0.1",
@@ -28,26 +28,32 @@
       "license": "MIT"
     },
     "node_modules/@astrojs/internal-helpers": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.9.1.tgz",
-      "integrity": "sha512-1pWuARqYom/TzuU3+0ZugsTrKlUydWKuULmDqSMTuonY+9IRDUEGKX/8PXQ1nBxRq3w85uGtd9q9SXfqEldMIQ==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.10.0.tgz",
+      "integrity": "sha512-Ry2R3VPeIN4uPCSA4xQc+e+vsJXkalKpEbDc07hV+a/o5Bs2N/s/uDcPJH/05L19DKh9tAy7e6JM3YZ6Cxfezw==",
       "license": "MIT",
       "dependencies": {
-        "picomatch": "^4.0.4"
+        "@types/hast": "^3.0.4",
+        "@types/mdast": "^4.0.4",
+        "js-yaml": "^4.1.1",
+        "picomatch": "^4.0.4",
+        "retext-smartypants": "^6.2.0",
+        "shiki": "^4.0.2",
+        "smol-toml": "^1.6.0",
+        "unified": "^11.0.5"
       }
     },
     "node_modules/@astrojs/markdown-remark": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.1.2.tgz",
-      "integrity": "sha512-caXZ4Dc2St2dW8luEg22GlP0gupLdztCTQE4EzZOxW1pqWXz9mbeJEuHUkgDYcKWW8tjIHkydYDhWLVoxJ327Q==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.2.0.tgz",
+      "integrity": "sha512-+YxmVQu1Bd+MFfSzjq1rOJvD9+nIOJzz5YIIhdIH01RrxRkKbyKoEgyIqP3yv51MhzMDgd79QaPv+kCVPT8vHw==",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/internal-helpers": "0.9.1",
+        "@astrojs/internal-helpers": "0.10.0",
         "@astrojs/prism": "4.0.2",
         "github-slugger": "^2.0.0",
         "hast-util-from-html": "^2.0.3",
         "hast-util-to-text": "^4.0.2",
-        "js-yaml": "^4.1.1",
         "mdast-util-definitions": "^6.0.0",
         "rehype-raw": "^7.0.0",
         "rehype-stringify": "^10.0.1",
@@ -55,9 +61,6 @@
         "remark-parse": "^11.0.0",
         "remark-rehype": "^11.1.2",
         "remark-smartypants": "^3.0.2",
-        "retext-smartypants": "^6.2.0",
-        "shiki": "^4.0.0",
-        "smol-toml": "^1.6.0",
         "unified": "^11.0.5",
         "unist-util-remove-position": "^5.0.0",
         "unist-util-visit": "^5.1.0",
@@ -90,6 +93,44 @@
       },
       "peerDependencies": {
         "astro": "^6.0.0"
+      }
+    },
+    "node_modules/@astrojs/mdx/node_modules/@astrojs/internal-helpers": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.9.1.tgz",
+      "integrity": "sha512-1pWuARqYom/TzuU3+0ZugsTrKlUydWKuULmDqSMTuonY+9IRDUEGKX/8PXQ1nBxRq3w85uGtd9q9SXfqEldMIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^4.0.4"
+      }
+    },
+    "node_modules/@astrojs/mdx/node_modules/@astrojs/markdown-remark": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.1.2.tgz",
+      "integrity": "sha512-caXZ4Dc2St2dW8luEg22GlP0gupLdztCTQE4EzZOxW1pqWXz9mbeJEuHUkgDYcKWW8tjIHkydYDhWLVoxJ327Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/internal-helpers": "0.9.1",
+        "@astrojs/prism": "4.0.2",
+        "github-slugger": "^2.0.0",
+        "hast-util-from-html": "^2.0.3",
+        "hast-util-to-text": "^4.0.2",
+        "js-yaml": "^4.1.1",
+        "mdast-util-definitions": "^6.0.0",
+        "rehype-raw": "^7.0.0",
+        "rehype-stringify": "^10.0.1",
+        "remark-gfm": "^4.0.1",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.1.2",
+        "remark-smartypants": "^3.0.2",
+        "retext-smartypants": "^6.2.0",
+        "shiki": "^4.0.0",
+        "smol-toml": "^1.6.0",
+        "unified": "^11.0.5",
+        "unist-util-remove-position": "^5.0.0",
+        "unist-util-visit": "^5.1.0",
+        "unist-util-visit-parents": "^6.0.2",
+        "vfile": "^6.0.3"
       }
     },
     "node_modules/@astrojs/prism": {
@@ -136,9 +177,9 @@
       }
     },
     "node_modules/@astrojs/starlight": {
-      "version": "0.38.5",
-      "resolved": "https://registry.npmjs.org/@astrojs/starlight/-/starlight-0.38.5.tgz",
-      "integrity": "sha512-35xLSOtZDAMAilHG2zAEZoJ4AaPb+doYOvxuuRTAnmIBSOvujffOAHv3/rr6W/LJtkhBU38PjRDJ4i8QT1uGVw==",
+      "version": "0.39.3",
+      "resolved": "https://registry.npmjs.org/@astrojs/starlight/-/starlight-0.39.3.tgz",
+      "integrity": "sha512-uvAweA2DwhmLgFVfBT9NqG38Ey14k1ck3+y78XNJbceT1pMdzxCCX69RoBajb1QzTJviufsXzSc1xswgRxJfig==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/markdown-remark": "^7.1.1",
@@ -154,14 +195,14 @@
         "hast-util-select": "^6.0.4",
         "hast-util-to-string": "^3.0.1",
         "hastscript": "^9.0.1",
-        "i18next": "^23.11.5",
+        "i18next": "^26.0.7",
         "js-yaml": "^4.1.1",
         "klona": "^2.0.6",
         "magic-string": "^0.30.21",
         "mdast-util-directive": "^3.1.0",
         "mdast-util-to-markdown": "^2.1.2",
         "mdast-util-to-string": "^4.0.0",
-        "pagefind": "^1.3.0",
+        "pagefind": "^1.5.2",
         "rehype": "^13.0.2",
         "rehype-format": "^5.0.1",
         "remark-directive": "^4.0.0",
@@ -223,15 +264,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@babel/runtime": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
-      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/types": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
@@ -258,9 +290,9 @@
       }
     },
     "node_modules/@clack/core": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.3.1.tgz",
-      "integrity": "sha512-fT1qHVGAag4IEkrupZ6lRRbNCs1vS9P01KB/sG8zKgvUztbYtFBtQpjSITNwooDZ83tpsPzP0mRNs1/KVszCRA==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.4.1.tgz",
+      "integrity": "sha512-FILJa1gGKEFTGZAJE9RpVhrjKz3c3h4ar60dSv6cGuDqufQ84YEIS3GAGvZiN+H6yaLbbvTFNejjCC4tXpZEuw==",
       "license": "MIT",
       "dependencies": {
         "fast-wrap-ansi": "^0.2.0",
@@ -271,12 +303,12 @@
       }
     },
     "node_modules/@clack/prompts": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.4.0.tgz",
-      "integrity": "sha512-S0My7XPGIgpRWMDG8uRqalbgT+a6FmCUdOW+HaIOVVpUPHOb7RrpvjTjiODadKp06fsrVDJZlIzc6yCTp4AnxA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.5.1.tgz",
+      "integrity": "sha512-zccHj2z2oCCO4yrDiRSlFOxWerGqRiysP7a5jPK6uoI9URKAquwY42Dd/iUP8JWHxEzdRe4TlbvZCo8z1/mhrw==",
       "license": "MIT",
       "dependencies": {
-        "@clack/core": "1.3.1",
+        "@clack/core": "1.4.1",
         "fast-string-width": "^3.0.2",
         "fast-wrap-ansi": "^0.2.0",
         "sisteransi": "^1.0.5"
@@ -1322,9 +1354,9 @@
       }
     },
     "node_modules/@nodable/entities": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
-      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
+      "integrity": "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==",
       "funding": [
         {
           "type": "github",
@@ -1437,9 +1469,9 @@
       ]
     },
     "node_modules/@rollup/pluginutils": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
-      "integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
+      "integrity": "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==",
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0",
@@ -1465,9 +1497,9 @@
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
-      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.61.0.tgz",
+      "integrity": "sha512-dnxczajOqt0gesZlN5pGQ1s1imQVrsmCw5G2Ci4oM+0WvNz3pyRnlWrT7McoZIb8VlFwCawdmbWRmxRn7HI+VQ==",
       "cpu": [
         "arm"
       ],
@@ -1478,9 +1510,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
-      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.61.0.tgz",
+      "integrity": "sha512-Bp3JpGP00Vu3f238ivRrjf7z3xSzVPXqCmaJYA9t2c+c8vKYvOzmXF7LkkeUalTEGd6cZcSWe+PFIP3Vy48fRg==",
       "cpu": [
         "arm64"
       ],
@@ -1491,9 +1523,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
-      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.61.0.tgz",
+      "integrity": "sha512-zaYIpr670mUmmZ1tVzUFplbQbG7h3Gugx3L5FoqhsC2m/YnLlR1a7zVLmXNPy+iY1tFPEbNG+HHBXZGyId0G5w==",
       "cpu": [
         "arm64"
       ],
@@ -1504,9 +1536,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
-      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.61.0.tgz",
+      "integrity": "sha512-+P49fvkv2dSoeevUW+lgZ/I2JHSsJCK1Lyjj7Cu6E4UHG4tS9XIefzIjo5qhgELjAclnen1rLzK2PMKJdo+Dyg==",
       "cpu": [
         "x64"
       ],
@@ -1517,9 +1549,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
-      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.61.0.tgz",
+      "integrity": "sha512-l3FAAOyKJXH2ea6KNFN+MMgC/rnE94YGLXs2ehYqDcCoHt1DpvgWX75BhUJxN38XojP7Ul+4H8PRn7EdyqSDrw==",
       "cpu": [
         "arm64"
       ],
@@ -1530,9 +1562,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
-      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.61.0.tgz",
+      "integrity": "sha512-VokPN3TSctKj65cyCNPaUh4vMFA8awxOot/0sp+4J7ZlNRKQEhXhawqPwajoi8H5ZFt61i0ugZJuTKXBjGJ17Q==",
       "cpu": [
         "x64"
       ],
@@ -1543,9 +1575,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
-      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.61.0.tgz",
+      "integrity": "sha512-DxH0P3wxm+Yzs/p3zrk9dw1rURu8p0Nv5+MRK/L7OtnLNg5rLZraSBFZ8iUXOd9f2BlhJyEpIZUH/emjq4UJ4g==",
       "cpu": [
         "arm"
       ],
@@ -1559,9 +1591,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
-      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.61.0.tgz",
+      "integrity": "sha512-T6ZvMNe84kAz6TBWHC7hGAoEtzP1LWYw/AqayGWEF6uISt3Abk/st06LqRD9THd7Xz3NxzurUpzAuEAUbZf+nw==",
       "cpu": [
         "arm"
       ],
@@ -1575,9 +1607,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
-      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.61.0.tgz",
+      "integrity": "sha512-q/4hzvQkDs8b4jIBab1pnLiiM0ayTZsN2amBFPDzuyZxjEd4wDwx0UJFYM3cOZzSf5Kw8fnWSprJzIBMkcR44Q==",
       "cpu": [
         "arm64"
       ],
@@ -1591,9 +1623,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
-      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.61.0.tgz",
+      "integrity": "sha512-vvYWX3akdEAY6km+9wAqFDnk6pQsbJKVnj7xawcvs/+fdlYBGp+U+Qq/lLfpIxYIZvZLHMAKD9HLdacSx/r3dw==",
       "cpu": [
         "arm64"
       ],
@@ -1607,9 +1639,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
-      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.61.0.tgz",
+      "integrity": "sha512-DePa5cqOxDP/Zp0VOXpeWaGew5iIv5DXp9NYbzkX5PFQyWVX9184WCTh3hvr/7lhXo8ZVlbFLkz8+o/q1dU6gA==",
       "cpu": [
         "loong64"
       ],
@@ -1623,9 +1655,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
-      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.61.0.tgz",
+      "integrity": "sha512-LV8aWMB8UChglMCEzs7RkN0GsH29RJaLLqwm9fCIjlqwxQTiWAqNcc7wjBkH31hV0PU/yVxGYvrYsgfea2qw6g==",
       "cpu": [
         "loong64"
       ],
@@ -1639,9 +1671,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
-      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.61.0.tgz",
+      "integrity": "sha512-QoNSnwQtaeNu5grdBbsL0tt1uyl5EnS8DA8Mr3nluMXbhdQNyhN+G4tBax7VCdxLKj8YJ0/4OO9Ho84jMnJtKA==",
       "cpu": [
         "ppc64"
       ],
@@ -1655,9 +1687,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
-      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.61.0.tgz",
+      "integrity": "sha512-/zZp5MKapIIApE8trN8qLGNSiRN9TUoaUZ1cmVu4XnVdd5LQLOXTtyi+vtfUbNnT3iyjzpPqYeKXmvJ+gJGYWw==",
       "cpu": [
         "ppc64"
       ],
@@ -1671,9 +1703,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
-      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.61.0.tgz",
+      "integrity": "sha512-RbrzcD3aJ1k3UbtMRRBNwojdVVyXjuVAFTfn/xPa6EEl6GE9Sm/akPgFTb9aAC9pMKGJ6CtWxaGrqWcabH+ySg==",
       "cpu": [
         "riscv64"
       ],
@@ -1687,9 +1719,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
-      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.61.0.tgz",
+      "integrity": "sha512-ZF+onDsBso8PJf1XaG9lB+O9RnBpKGnY6OrzC4CSHrtC1jb6jWLTKK4bRqdoCXHd22gyr2hiYmEAm8Wns/BOCw==",
       "cpu": [
         "riscv64"
       ],
@@ -1703,9 +1735,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
-      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.61.0.tgz",
+      "integrity": "sha512-Atk0aSIk5Zx2Wuh9dgRQgLP0Koc8hOeYpbWryMXyk8G8/HmPkwPPkMqIIDhrXHHYqfUzSJA/I7IWSBv8xSmRBA==",
       "cpu": [
         "s390x"
       ],
@@ -1719,9 +1751,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
-      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.61.0.tgz",
+      "integrity": "sha512-0uMOcf3eZ5K+K4cYHkdxShFMPlPXCOdfDFEFn9dNYAEEd2cVvmOfH7zFgRVoDgmtQ1m9k5q7qfrHzyMAubKYUA==",
       "cpu": [
         "x64"
       ],
@@ -1735,9 +1767,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
-      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.61.0.tgz",
+      "integrity": "sha512-mvFtE4A/t/7hRJ7X8Ozmu8FsIkAUat2nzl12pgU337BRmq87AQUJztwHz2Zv5/tjo9/C95E66CK03SI/ToEDJw==",
       "cpu": [
         "x64"
       ],
@@ -1751,9 +1783,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
-      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.61.0.tgz",
+      "integrity": "sha512-z9b9+aTxvt8n2rNltMPvyaUfB8NJ+CVyOrGK/MdIKHx7B+lXmZpm/XbRsU7Rpf3fRqJ2uS6mBJiJveCtq8LHDg==",
       "cpu": [
         "x64"
       ],
@@ -1764,9 +1796,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
-      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.61.0.tgz",
+      "integrity": "sha512-jXaXFqKMehsOc+g8R6oo33RRC6w07G9jDBxAE5eAKX7mOcCbZloYIPNhfG9Wl+P9O9IWHFO4OJgPi1Ml2qkt7w==",
       "cpu": [
         "arm64"
       ],
@@ -1777,9 +1809,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
-      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.61.0.tgz",
+      "integrity": "sha512-OXNWVFocS2IA4+QplhTZZ2a+8hPZR7T8KuozsNmJKK8y7cp83StHvGksfHzPG3wczWTczyWHVQuqeiTUbjiyBg==",
       "cpu": [
         "arm64"
       ],
@@ -1790,9 +1822,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
-      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.61.0.tgz",
+      "integrity": "sha512-AlAbNtBO637LxSldqV43z0FfXoGfl2TW1DgAg/bs7aQswFbDewz2SJm3BUhiGfbOVtW571xbc9p+REdxhyN/Eg==",
       "cpu": [
         "ia32"
       ],
@@ -1803,9 +1835,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
-      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.61.0.tgz",
+      "integrity": "sha512-QRSrQXyJ1M4tjNXdR0/G/IgV6lzfQQJYBjlWIEYkY2Xs86DRl/iEpQ4blMDjJxSl7n19eDKKXMg0AmuBVYy8pQ==",
       "cpu": [
         "x64"
       ],
@@ -1816,9 +1848,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
-      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.61.0.tgz",
+      "integrity": "sha512-tkuFxhvKO/HlGd0VsINF6vHSYH8AF8W0TcNxKDK6JZmrehngFj78pToc8iemtnvwilDjs2G/qSzYFhe9U8q+fw==",
       "cpu": [
         "x64"
       ],
@@ -1829,13 +1861,13 @@
       ]
     },
     "node_modules/@shikijs/core": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.1.0.tgz",
-      "integrity": "sha512-jLJtSJeuFffqX6/inRE1zqU5aFv2hrszvYgq3OjbAgFRZiWv7abKMDdQzYxuSDfmUPQozZvI/kuy6VMTvnvqTQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.2.0.tgz",
+      "integrity": "sha512-Hc87Ab1Ld/vEbZRCbwx344I5v+4RU8CVToUTRkqXL1+TjbuOp9U5Xa0M23V4GEWHxVn+yO5otb+HkQVm3ptWQQ==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/primitive": "4.1.0",
-        "@shikijs/types": "4.1.0",
+        "@shikijs/primitive": "4.2.0",
+        "@shikijs/types": "4.2.0",
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4",
         "hast-util-to-html": "^9.0.5"
@@ -1845,12 +1877,12 @@
       }
     },
     "node_modules/@shikijs/engine-javascript": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.1.0.tgz",
-      "integrity": "sha512-YquhawCUgaBfhsS72e2Y/dI59gCBNPHu3fEO/tvLaXrTssxZrY5ddjtNLTwndrMgPo8b3IscE+xoICDzpTmlFQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.2.0.tgz",
+      "integrity": "sha512-fjETeq1k5ffyXqRgS6+3hpvqseLalp1kjNfRbXpUgWR8FpZ1CmQfiNHovc5lncYjt/Vg5JK/WJEmLahjwMa0og==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "4.1.0",
+        "@shikijs/types": "4.2.0",
         "@shikijs/vscode-textmate": "^10.0.2",
         "oniguruma-to-es": "^4.3.6"
       },
@@ -1859,12 +1891,12 @@
       }
     },
     "node_modules/@shikijs/engine-oniguruma": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.1.0.tgz",
-      "integrity": "sha512-axLpjVs45YBvvINa+dJF+NPW+KtFkNXsFr4SDw2BMj9GdeMnGxVB9PQb2xXlJYovslt/nz6giedAyOANkfc7hg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.2.0.tgz",
+      "integrity": "sha512-hTorK1dffPkpbMUk6Z+828PgRo7d07HbnizoP0hNPFjhxMHctj0Px/qoHeGMYafc6ju+u9iMldN4JbVzNQM++g==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "4.1.0",
+        "@shikijs/types": "4.2.0",
         "@shikijs/vscode-textmate": "^10.0.2"
       },
       "engines": {
@@ -1872,24 +1904,24 @@
       }
     },
     "node_modules/@shikijs/langs": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.1.0.tgz",
-      "integrity": "sha512-nwOMruEkbgdZfQ/b8CgpNBVOpvG1k0N5tbmgiFeqsan401+x3ILqlzZJowSla4Agmq4hG2Uf2wh5jLTEhR8VSg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.2.0.tgz",
+      "integrity": "sha512-bwrVRlJ0wUhZxAbVdvBbv2TTC9yLsh4C/IO5Ofz0T8MQntgDvyVnkbjw9vi50r1kx7RCIJdnJnjZAwmAsXFLZQ==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "4.1.0"
+        "@shikijs/types": "4.2.0"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@shikijs/primitive": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.1.0.tgz",
-      "integrity": "sha512-zx2/2Uwj2q9X3KSyYREEhXO23xBw5WUhP4orK2lE4r+t9JGITmEe0JH+wPmJhqHpOT2bRRs6lAL945+LDvOAGw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.2.0.tgz",
+      "integrity": "sha512-NOq+DtUkVBJtZMVXL5A0vI0Xk8nvDYaXetFHSJFlOqjDZIVhIPRYFdGkSoElDqNuegikcc3A76SNUa8dTqtAYA==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "4.1.0",
+        "@shikijs/types": "4.2.0",
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4"
       },
@@ -1898,21 +1930,21 @@
       }
     },
     "node_modules/@shikijs/themes": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.1.0.tgz",
-      "integrity": "sha512-emCcTnUM7yO2wltYbaxm+yLvcCI4+h8XBKc4KmJ7EZUXoSGjcCHifkI//R4OFit9ewpg7H2/9tjOuXrT2v/Knw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.2.0.tgz",
+      "integrity": "sha512-RX8IHYeLv8Cu2W6ruc3RxUqWn0IYCqSrMBzi/uRGAmfyDNOnNO5BF/Px7o97n4XTpmFTo5GbRaazuOWj+2ak2w==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "4.1.0"
+        "@shikijs/types": "4.2.0"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@shikijs/types": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.1.0.tgz",
-      "integrity": "sha512-3EQWX54fMpniOrDblzAhiwiJwpiTMW6+B9DWyUd9ska483tbayFYuw47UxwuPknI31bKnySfVQ/QW+jFL4rFdA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.2.0.tgz",
+      "integrity": "sha512-VT/MKtlpOhEPZloSH3Pb9WCZEBDoQVMa9jedp5UAwmJOar1DVc9DRODAxmYPW9M93IK4ryuqRejFfmlvlVDemw==",
       "license": "MIT",
       "dependencies": {
         "@shikijs/vscode-textmate": "^10.0.2",
@@ -2129,14 +2161,14 @@
       }
     },
     "node_modules/astro": {
-      "version": "6.3.8",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-6.3.8.tgz",
-      "integrity": "sha512-xH2UA8Z17IS+JaqSlSkBor7jO6gd7zXTLdmu06nKpfpDDJFbi/7KZEy3NDmWxmier+6XrCZ9Z4aitO8jhC9oiA==",
+      "version": "6.4.4",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-6.4.4.tgz",
+      "integrity": "sha512-hVe8tq3lqt/Dr0UyB//yUmQSlHMTU8scTiF/vQddQVahLE4TTaSdH5H0nb7OvRcwo0UmlAO8DWYar4jNaS7H+A==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler": "^4.0.0",
-        "@astrojs/internal-helpers": "0.9.1",
-        "@astrojs/markdown-remark": "7.1.2",
+        "@astrojs/internal-helpers": "0.10.0",
+        "@astrojs/markdown-remark": "7.2.0",
         "@astrojs/telemetry": "3.3.2",
         "@capsizecss/unpack": "^4.0.0",
         "@clack/prompts": "^1.1.0",
@@ -2148,7 +2180,7 @@
         "clsx": "^2.1.1",
         "common-ancestor-path": "^2.0.0",
         "cookie": "^1.1.1",
-        "devalue": "^5.6.3",
+        "devalue": "^5.8.1",
         "diff": "^8.0.3",
         "dset": "^3.1.4",
         "es-module-lexer": "^2.0.0",
@@ -3529,26 +3561,31 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/i18next": {
-      "version": "23.16.8",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.16.8.tgz",
-      "integrity": "sha512-06r/TitrM88Mg5FdUXAKL96dJMzgqLE5dv3ryBAra4KCwD9mJ4ndOTS95ZuymIGoE+2hzfdaMak2X11/es7ZWg==",
+      "version": "26.3.1",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.3.1.tgz",
+      "integrity": "sha512-txQqd5EULsqEh9OJqRH15aCaOuy/nLJyhw5EHCSKLKJE1aBbb3Zve2+uQIxgWhPm1QqUQoWyQBm2kfmmIrzkcQ==",
       "funding": [
         {
           "type": "individual",
-          "url": "https://locize.com"
-        },
-        {
-          "type": "individual",
-          "url": "https://locize.com/i18next.html"
+          "url": "https://www.locize.com/i18next"
         },
         {
           "type": "individual",
           "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.locize.com"
         }
       ],
       "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.23.2"
+      "peerDependencies": {
+        "typescript": "^5 || ^6"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/inline-style-parser": {
@@ -3695,9 +3732,19 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -5265,9 +5312,9 @@
       }
     },
     "node_modules/property-information": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
-      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -5696,12 +5743,12 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
-      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.61.0.tgz",
+      "integrity": "sha512-T9mWdbWfQtp0B5lv/HX+wrhYsmXRlcWnXXmJbXqKJhlRaoS6KMhq0gpyzW4UJfclcxrEdLnTgjT2NjruLONu0g==",
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.8"
+        "@types/estree": "1.0.9"
       },
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -5711,39 +5758,33 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.60.4",
-        "@rollup/rollup-android-arm64": "4.60.4",
-        "@rollup/rollup-darwin-arm64": "4.60.4",
-        "@rollup/rollup-darwin-x64": "4.60.4",
-        "@rollup/rollup-freebsd-arm64": "4.60.4",
-        "@rollup/rollup-freebsd-x64": "4.60.4",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
-        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
-        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
-        "@rollup/rollup-linux-arm64-musl": "4.60.4",
-        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
-        "@rollup/rollup-linux-loong64-musl": "4.60.4",
-        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
-        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
-        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
-        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
-        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
-        "@rollup/rollup-linux-x64-gnu": "4.60.4",
-        "@rollup/rollup-linux-x64-musl": "4.60.4",
-        "@rollup/rollup-openbsd-x64": "4.60.4",
-        "@rollup/rollup-openharmony-arm64": "4.60.4",
-        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
-        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
-        "@rollup/rollup-win32-x64-gnu": "4.60.4",
-        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "@rollup/rollup-android-arm-eabi": "4.61.0",
+        "@rollup/rollup-android-arm64": "4.61.0",
+        "@rollup/rollup-darwin-arm64": "4.61.0",
+        "@rollup/rollup-darwin-x64": "4.61.0",
+        "@rollup/rollup-freebsd-arm64": "4.61.0",
+        "@rollup/rollup-freebsd-x64": "4.61.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.61.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.61.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.61.0",
+        "@rollup/rollup-linux-arm64-musl": "4.61.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.61.0",
+        "@rollup/rollup-linux-loong64-musl": "4.61.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.61.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.61.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.61.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.61.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.61.0",
+        "@rollup/rollup-linux-x64-gnu": "4.61.0",
+        "@rollup/rollup-linux-x64-musl": "4.61.0",
+        "@rollup/rollup-openbsd-x64": "4.61.0",
+        "@rollup/rollup-openharmony-arm64": "4.61.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.61.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.61.0",
+        "@rollup/rollup-win32-x64-gnu": "4.61.0",
+        "@rollup/rollup-win32-x64-msvc": "4.61.0",
         "fsevents": "~2.3.2"
       }
-    },
-    "node_modules/rollup/node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "license": "MIT"
     },
     "node_modules/sax": {
       "version": "1.6.0",
@@ -5811,17 +5852,17 @@
       }
     },
     "node_modules/shiki": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.1.0.tgz",
-      "integrity": "sha512-l/ABZPUR5v70jI10EzqfMS/I96vjSGv2y0ihUV+WYFzv0EfvW4s54m0Lg8wCrrL+2IkwBzFTuxkZjPf8b2NX9Q==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.2.0.tgz",
+      "integrity": "sha512-hjNax6o/ylDy9lefQEaSDtzaT3iVNtZ3WmpQnbuQNoG4xvnSKf2kSKbihZVO4JRG1TTMejs7CmNRYlWgAL66pQ==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/core": "4.1.0",
-        "@shikijs/engine-javascript": "4.1.0",
-        "@shikijs/engine-oniguruma": "4.1.0",
-        "@shikijs/langs": "4.1.0",
-        "@shikijs/themes": "4.1.0",
-        "@shikijs/types": "4.1.0",
+        "@shikijs/core": "4.2.0",
+        "@shikijs/engine-javascript": "4.2.0",
+        "@shikijs/engine-oniguruma": "4.2.0",
+        "@shikijs/langs": "4.2.0",
+        "@shikijs/themes": "4.2.0",
+        "@shikijs/types": "4.2.0",
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4"
       },
@@ -6006,27 +6047,27 @@
       "license": "MIT"
     },
     "node_modules/tinyclip": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/tinyclip/-/tinyclip-0.1.13.tgz",
-      "integrity": "sha512-8OqlXQ35euK9+e7L68u8UwcODxkHoIkjbGsgXuARKNyQ5G6xt8nw1YPeMbxMLgCPFkToU+UEK5j05t2t8edKpQ==",
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/tinyclip/-/tinyclip-0.1.14.tgz",
+      "integrity": "sha512-F1oWdz8tjT17qe1d5JgDK6z03WGOhYYAN0lK3/D/fzNiy93xswLLEw7pk+3g05onhAy6Bsc6PLNUGhdgVjemMQ==",
       "license": "MIT",
       "engines": {
         "node": "^16.14.0 || >= 17.3.0"
       }
     },
     "node_modules/tinyexec": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.2.tgz",
-      "integrity": "sha512-M/Q0B2cp4K7kynaT/vnED1j8TlLY+Pp7C6Wl2bl/7u/F0mUVwdyOpwomQb8JpYLitHUssAJRmLZdMCGsrx7i+g==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -6438,9 +6479,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
-      "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
+      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.27.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -14,8 +14,8 @@
   },
   "dependencies": {
     "@astrojs/rss": "^4.0.18",
-    "@astrojs/starlight": "^0.38.2",
-    "astro": "^6.0.0",
+    "@astrojs/starlight": "^0.39.3",
+    "astro": "^6.4.4",
     "entities": "^8.0.0",
     "marked": "^17.0.1",
     "remark-gfm": "^4.0.1",

--- a/docs/src/content/docs/advanced_guides/bidirectional_communication.mdx
+++ b/docs/src/content/docs/advanced_guides/bidirectional_communication.mdx
@@ -1,11 +1,21 @@
 ---
 title: Bidirectional communication
-description: How to use interfaces for bidirectional data flow between two nodes without forming a dependency cycle
+description: Use from_any interfaces for optional, bidirectional data flow between two nodes, with no binding and no dependency cycle
 sidebar:
   order: 4
 ---
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { Code, Tabs, TabItem } from '@astrojs/starlight/components';
+import jointStateInterface from '../guides/snippets/interfaces/joint_state_source/peppy.json5?raw';
+import jointCommandInterface from '../guides/snippets/interfaces/joint_command_source/peppy.json5?raw';
+import robotArmPythonConfig from '../guides/snippets/python/robot_arm/peppy.json5?raw';
+import robotArmRustConfig from '../guides/snippets/rust/robot_arm/peppy.json5?raw';
+import armControllerPythonConfig from '../guides/snippets/python/arm_controller/peppy.json5?raw';
+import armControllerRustConfig from '../guides/snippets/rust/arm_controller/peppy.json5?raw';
+import robotArmPython from '../guides/snippets/python/robot_arm/src/robot_arm/__main__.py?raw';
+import robotArmRust from '../guides/snippets/rust/robot_arm/src/main.rs?raw';
+import armControllerPython from '../guides/snippets/python/arm_controller/src/arm_controller/__main__.py?raw';
+import armControllerRust from '../guides/snippets/rust/arm_controller/src/main.rs?raw';
 
 In a standard PeppyOS setup, a node subscribes to topics from its declared dependencies using `link_id`.
 This creates a directed graph: if `arm_controller` depends on `robot_arm`, it can expect topics from `robot_arm`, but not the other way around, since a return dependency would make the graph circular.
@@ -15,8 +25,10 @@ Instead of one node depending on the other, each node *depends on* an interface 
 A dependency on an interface is not an edge in the node dependency graph, so two nodes can depend on each other's interfaces without ever forming a cycle.
 This is dependency inversion: each node relies on an abstract contract, not on the concrete node that happens to fulfil it.
 
+The recommended shape is a pair of **optional, wildcard, opt-in-per-direction streams** built on [`from_any: true`](/advanced_guides/interface_conformance/#from-any-interface-bindings) interface dependencies. Each side opts into the direction it consumes independently and accepts data from any conforming producer, with no `--bind` required: a `from_any` slot with zero producers materializes unbound and the node still boots. Neither node *requires* the other to run, and producers can come and go (including ones that join after launch) without editing a manifest or a launcher.
+
 :::note
-This guide assumes you are comfortable with [Interface conformance](/advanced_guides/interface_conformance): how a producer declares `conforms_to` and a consumer references an interface through `depends_on.interfaces`. Bidirectional communication is that same mechanism applied in both directions at once, so everything stays inside the standard [binding-driven routing model](/advanced_guides/topics/#bindings-and-routing). The pattern applies to **topics only**; see [Why topics only?](#why-topics-only) for why services and actions are excluded.
+This guide assumes you are comfortable with [Interface conformance](/advanced_guides/interface_conformance): how a producer declares `conforms_to`, how a consumer references an interface through `depends_on.interfaces`, and how a [`from_any` slot](/advanced_guides/interface_conformance/#from-any-interface-bindings) accepts any number of conforming producers. Bidirectional communication is that same mechanism applied in both directions at once, so everything stays inside the standard [binding-driven routing model](/advanced_guides/topics/#bindings-and-routing). The pattern applies to **topics only**; see [Why topics only?](#why-topics-only) for why services and actions are excluded.
 :::
 
 ## Example: robot arm control loop
@@ -42,194 +54,37 @@ Two interfaces model the two directions:
 - `joint_command_source` declares the `joint_commands` topic. `arm_controller` conforms to it (emits), and `robot_arm` depends on it (consumes).
 - `joint_state_source` declares the `joint_states` topic. `robot_arm` conforms to it (emits), and `arm_controller` depends on it (consumes).
 
-Neither node lists the other in `depends_on.nodes`, so there is no cycle to break.
+Neither node lists the other in `depends_on.nodes`, so there is no cycle to break. Each node declares the direction it consumes as a `from_any` slot, so the two directions are independent, opt-in streams: a controller with no arm yet, or an arm with no controller yet, still starts and simply receives nothing until a conforming producer appears.
 
 ## Define the two interfaces
 
 Each interface is a standalone `interface_v1` document in a repository peppy scans (see [Repositories](/advanced_guides/repositories)). The `message_format` lives here once, and both the producer and the consumer inherit it by reference.
 
-```json5 title="joint_state_source/peppy.json5"
-{
-  peppy_schema: "interface_v1",
-  manifest: {
-    name: "joint_state_source",
-    tag: "v1",
-  },
-  interfaces: {
-    topics: [
-      {
-        name: "joint_states",
-        qos_profile: "sensor_data",
-        message_format: {
-          positions: { $type: "array", $items: "f64", $length: 3 },
-          velocities: { $type: "array", $items: "f64", $length: 3 },
-          timestamp: "time",
-        },
-      },
-    ],
-  },
-}
-```
+<Code code={jointStateInterface} lang="json5" title="joint_state_source/peppy.json5" />
 
-```json5 title="joint_command_source/peppy.json5"
-{
-  peppy_schema: "interface_v1",
-  manifest: {
-    name: "joint_command_source",
-    tag: "v1",
-  },
-  interfaces: {
-    topics: [
-      {
-        name: "joint_commands",
-        qos_profile: "reliable",
-        message_format: {
-          target_positions: { $type: "array", $items: "f64", $length: 3 },
-          max_velocity: "f64",
-        },
-      },
-    ],
-  },
-}
-```
+<Code code={jointCommandInterface} lang="json5" title="joint_command_source/peppy.json5" />
 
 After `peppy repo refresh`, both interfaces are cached and addressable by `(name, tag)`.
 
 ## Configure the nodes
 
-Each node conforms to the interface it emits and depends on the interface it consumes. The consumed topic references its interface dependency through `link_id`, exactly like any linked topic.
+Each node conforms to the interface it emits and depends on the interface it consumes. The consumed dependency is declared `from_any: true`: it is optional and wildcard, so the node binds no specific producer and accepts every conforming one. The consumed topic references its interface dependency through `link_id`, exactly like any linked topic.
 
 <Tabs>
   <TabItem label="Python">
-    ```json5 title="robot_arm/peppy.json5"
-    {
-      peppy_schema: "node_v1",
-      manifest: {
-        name: "robot_arm",
-        tag: "v1",
-        depends_on: {
-          interfaces: [
-            { name: "joint_command_source", tag: "v1", link_id: "controller" },
-          ],
-        },
-      },
-      interfaces: {
-        // Emits joint_states by conforming to the interface (inherited by reference)
-        conforms_to: [
-          { name: "joint_state_source", tag: "v1" },
-        ],
-        topics: {
-          consumes: [
-            { name: "joint_commands", link_id: "controller" },
-          ],
-        },
-      },
-      execution: {
-        language: "python",
-        build_cmd: ["uv", "sync"],
-        run_cmd: ["uv", "run", "robot_arm"],
-      },
-    }
-    ```
+    <Code code={robotArmPythonConfig} lang="json5" title="robot_arm/peppy.json5" />
   </TabItem>
   <TabItem label="Rust">
-    ```json5 title="robot_arm/peppy.json5"
-    {
-      peppy_schema: "node_v1",
-      manifest: {
-        name: "robot_arm",
-        tag: "v1",
-        depends_on: {
-          interfaces: [
-            { name: "joint_command_source", tag: "v1", link_id: "controller" },
-          ],
-        },
-      },
-      interfaces: {
-        // Emits joint_states by conforming to the interface (inherited by reference)
-        conforms_to: [
-          { name: "joint_state_source", tag: "v1" },
-        ],
-        topics: {
-          consumes: [
-            { name: "joint_commands", link_id: "controller" },
-          ],
-        },
-      },
-      execution: {
-        language: "rust",
-        build_cmd: ["cargo", "build", "--release"],
-        run_cmd: ["./target/release/robot_arm"],
-      },
-    }
-    ```
+    <Code code={robotArmRustConfig} lang="json5" title="robot_arm/peppy.json5" />
   </TabItem>
 </Tabs>
 
 <Tabs>
   <TabItem label="Python">
-    ```json5 title="arm_controller/peppy.json5"
-    {
-      peppy_schema: "node_v1",
-      manifest: {
-        name: "arm_controller",
-        tag: "v1",
-        depends_on: {
-          interfaces: [
-            { name: "joint_state_source", tag: "v1", link_id: "arm" },
-          ],
-        },
-      },
-      interfaces: {
-        // Emits joint_commands by conforming to the interface (inherited by reference)
-        conforms_to: [
-          { name: "joint_command_source", tag: "v1" },
-        ],
-        topics: {
-          consumes: [
-            { name: "joint_states", link_id: "arm" },
-          ],
-        },
-      },
-      execution: {
-        language: "python",
-        build_cmd: ["uv", "sync"],
-        run_cmd: ["uv", "run", "arm_controller"],
-      },
-    }
-    ```
+    <Code code={armControllerPythonConfig} lang="json5" title="arm_controller/peppy.json5" />
   </TabItem>
   <TabItem label="Rust">
-    ```json5 title="arm_controller/peppy.json5"
-    {
-      peppy_schema: "node_v1",
-      manifest: {
-        name: "arm_controller",
-        tag: "v1",
-        depends_on: {
-          interfaces: [
-            { name: "joint_state_source", tag: "v1", link_id: "arm" },
-          ],
-        },
-      },
-      interfaces: {
-        // Emits joint_commands by conforming to the interface (inherited by reference)
-        conforms_to: [
-          { name: "joint_command_source", tag: "v1" },
-        ],
-        topics: {
-          consumes: [
-            { name: "joint_states", link_id: "arm" },
-          ],
-        },
-      },
-      execution: {
-        language: "rust",
-        build_cmd: ["cargo", "build", "--release"],
-        run_cmd: ["./target/release/arm_controller"],
-      },
-    }
-    ```
+    <Code code={armControllerRustConfig} lang="json5" title="arm_controller/peppy.json5" />
   </TabItem>
 </Tabs>
 
@@ -237,138 +92,55 @@ Each node plays two roles at once:
 
 | Node | Emits (via `conforms_to`) | Consumes (via `depends_on.interfaces`) |
 |---|---|---|
-| `robot_arm` | `joint_states` (conforms to `joint_state_source`) | `joint_commands` (`link_id: controller`) |
-| `arm_controller` | `joint_commands` (conforms to `joint_command_source`) | `joint_states` (`link_id: arm`) |
+| `robot_arm` | `joint_states` (conforms to `joint_state_source`) | `joint_commands` (`from_any`, `link_id: controller`) |
+| `arm_controller` | `joint_commands` (conforms to `joint_command_source`) | `joint_states` (`from_any`, `link_id: arm`) |
 
-## Launching with mutual bindings
+## Launching (any order, no `--bind`)
 
-Both interface dependencies are pinned (the default), so each one needs an explicit binding. The launcher resolves both deployments together, which is what lets the two instances point at each other without a chicken-and-egg ordering problem.
-
-```json5 title="peppy_launcher.json5"
-{
-  peppy_schema: "launcher_v1",
-  deployments: [
-    {
-      source: { name: "robot_arm:v1" },
-      instances: [
-        {
-          instance_id: "arm_1",
-          bindings: { controller: "ctrl_1" },   // controller slot <- arm_controller instance
-        },
-      ],
-    },
-    {
-      source: { name: "arm_controller:v1" },
-      instances: [
-        {
-          instance_id: "ctrl_1",
-          bindings: { arm: "arm_1" },            // arm slot <- robot_arm instance
-        },
-      ],
-    },
-  ],
-}
-```
-
-At binding time the launcher checks conformance in both directions: `ctrl_1` must run a node that conforms to `joint_command_source` (it runs `arm_controller:v1`, which does), and `arm_1` must conform to `joint_state_source` (it runs `robot_arm:v1`, which does). A binding to a non-conforming instance is rejected with `BindingInterfaceNotConformed`.
-
-Build the generated code and launch the stack with:
+Because every consumed dependency is `from_any`, no slot needs a binding. Sync each node with `-r` so its interface references resolve from the repository cache, then start the two nodes in any order with no `--bind`. Each one boots immediately, whether or not the other is up yet, and starts receiving as soon as a conforming producer publishes.
 
 ```sh
 peppy repo refresh
 peppy node sync -r ./robot_arm
 peppy node sync -r ./arm_controller
-peppy stack launch ./peppy_launcher.json5
+peppy node run robot_arm:v1        # boots with zero controllers bound
+peppy node run arm_controller:v1   # boots with zero arms bound
 ```
+
+The order does not matter: running `arm_controller:v1` first works just as well, since neither node depends on the other being present. You can also bring both up together with a launcher that lists the two deployments and no `bindings`:
+
+```json5 title="peppy_launcher.json5"
+{
+  peppy_schema: "launcher_v1",
+  deployments: [
+    { source: { name: "robot_arm:v1" }, instances: [{ instance_id: "arm_1" }] },
+    { source: { name: "arm_controller:v1" }, instances: [{ instance_id: "ctrl_1" }] },
+  ],
+}
+```
+
+Then `peppy stack launch ./peppy_launcher.json5`. There are no `bindings` to resolve, so the launcher brings both instances up regardless of order.
+
+:::caution[`from_any` makes the dependency optional, not the node's work]
+`from_any` makes a dependency optional *at the binding layer*: the node boots with zero producers and the launcher never rejects it for a missing bind. Whether the node then does useful work is up to its own code. The control loops below block on `await …on_next_message_received(...)`, so with no producer a node never receives, and therefore never emits either. Two such loops started together would each wait for the other's first message and neither would ever publish. If a node must run open-loop (emit before it has received anything), do not gate all of its output behind a never-arriving input: seed the first message from one side, drive emission from a timer, or use a receive timeout, so the loop can start on its own.
+:::
+
+:::note[Conformance is still enforced, just not up front]
+An unbound `from_any` slot gets no launch-time [`BindingInterfaceNotConformed`](/advanced_guides/interface_conformance/#pinned-interface-bindings) rejection, because nothing is bound to check against. That trades up-front validation for flexibility, not correctness: only nodes that `conforms_to` the interface ever publish on its topic, so every message the consumer receives is still conformant. A non-conforming node never appears on the wire for that interface in the first place.
+:::
 
 ## Receiving messages
 
 After `peppy node sync`, the code generator creates a module for each consumed topic under `peppygen.consumed_topics` (Python) / `peppygen::consumed_topics` (Rust), and a module for each emitted topic under `peppygen.emitted_topics`.
-Because both consumed topics arrive through an interface dependency with a `link_id`, their module names follow the linked convention `<link_id>_<topic_name>`: `controller_joint_commands` inside `robot_arm` and `arm_joint_states` inside `arm_controller`.
+Because both consumed topics arrive through an interface dependency with a `link_id`, their module names follow the linked convention `<link_id>_<topic_name>`: `controller_joint_commands` inside `robot_arm` and `arm_joint_states` inside `arm_controller`. The `from_any` flag does not change these names; it only widens the slot to accept every conforming producer.
 Emitted topics inherited through `conforms_to` nest under their interface as `<interface_name>.<interface_tag>.<topic_name>`: `joint_state_source.v1.joint_states` inside `robot_arm` and `joint_command_source.v1.joint_commands` inside `arm_controller`. (A topic emitted natively, declared in the node's own `topics.emits`, would instead be flat `<topic_name>`.)
 
 <Tabs>
   <TabItem label="Python">
-    ```python title="src/robot_arm/__main__.py"
-    import asyncio
-    import time
-
-    from peppygen import NodeBuilder, NodeRunner
-    from peppygen.parameters import Parameters
-    from peppygen.consumed_topics import controller_joint_commands
-    from peppygen.emitted_topics.joint_state_source.v1 import joint_states
-
-
-    async def handle_commands(node_runner: NodeRunner):
-        while True:
-            instance_id, command = await controller_joint_commands.on_next_message_received(
-                node_runner,
-            )
-
-            print(
-                f"received from {instance_id}: "
-                f"target={command.target_positions} max_vel={command.max_velocity}"
-            )
-
-            # Drive the joints, then report state
-            await joint_states.emit(
-                node_runner,
-                command.target_positions,
-                [0.0, 0.0, 0.0],
-                time.time(),
-            )
-
-
-    async def setup(_params: Parameters, node_runner: NodeRunner) -> list[asyncio.Task]:
-        return [asyncio.create_task(handle_commands(node_runner))]
-
-
-    def main():
-        NodeBuilder().run(setup)
-
-
-    if __name__ == "__main__":
-        main()
-    ```
+    <Code code={robotArmPython} lang="python" title="src/robot_arm/__main__.py" />
   </TabItem>
   <TabItem label="Rust">
-    ```rust title="src/main.rs"
-    use peppygen::consumed_topics::controller_joint_commands;
-    use peppygen::emitted_topics::joint_state_source::v1::joint_states;
-    use peppygen::{NodeBuilder, Parameters, Result};
-
-    fn main() -> Result<()> {
-        NodeBuilder::new().run(|_args: Parameters, node_runner| async move {
-            let node_runner_clone = node_runner.clone();
-            tokio::spawn(async move {
-                loop {
-                    let (instance_id, command) = controller_joint_commands::on_next_message_received(
-                        &node_runner_clone,
-                        None, // from_core_node (None = any)
-                    )
-                    .await
-                    .expect("failed to receive joint command");
-
-                    println!(
-                        "received from {}: target={:?} max_vel={}",
-                        instance_id, command.target_positions, command.max_velocity
-                    );
-
-                    // Drive the joints, then report state
-                    let _ = joint_states::emit(
-                        &node_runner_clone,
-                        command.target_positions,
-                        [0.0, 0.0, 0.0],
-                        std::time::SystemTime::now(),
-                    )
-                    .await;
-                }
-            });
-
-            Ok(())
-        })
-    }
-    ```
+    <Code code={robotArmRust} lang="rust" title="src/main.rs" />
   </TabItem>
 </Tabs>
 
@@ -376,91 +148,14 @@ On the other side, `arm_controller` consumes `joint_states` and emits `joint_com
 
 <Tabs>
   <TabItem label="Python">
-    ```python title="src/arm_controller/__main__.py"
-    import asyncio
-
-    from peppygen import NodeBuilder, NodeRunner
-    from peppygen.parameters import Parameters
-    from peppygen.consumed_topics import arm_joint_states
-    from peppygen.emitted_topics.joint_command_source.v1 import joint_commands
-
-
-    def compute_next_target(current: list[float]) -> list[float]:
-        # Trajectory planning logic
-        return [current[0] + 0.1, current[1], current[2]]
-
-
-    async def control_loop(node_runner: NodeRunner):
-        while True:
-            instance_id, state = await arm_joint_states.on_next_message_received(
-                node_runner,
-            )
-
-            # Compute next target based on current state
-            target = compute_next_target(state.positions)
-
-            await joint_commands.emit(
-                node_runner,
-                target,
-                1.0,  # max_velocity
-            )
-
-
-    async def setup(_params: Parameters, node_runner: NodeRunner) -> list[asyncio.Task]:
-        return [asyncio.create_task(control_loop(node_runner))]
-
-
-    def main():
-        NodeBuilder().run(setup)
-
-
-    if __name__ == "__main__":
-        main()
-    ```
+    <Code code={armControllerPython} lang="python" title="src/arm_controller/__main__.py" />
   </TabItem>
   <TabItem label="Rust">
-    ```rust title="src/main.rs"
-    use peppygen::consumed_topics::arm_joint_states;
-    use peppygen::emitted_topics::joint_command_source::v1::joint_commands;
-    use peppygen::{NodeBuilder, Parameters, Result};
-
-    fn main() -> Result<()> {
-        NodeBuilder::new().run(|_args: Parameters, node_runner| async move {
-            let node_runner_clone = node_runner.clone();
-            tokio::spawn(async move {
-                loop {
-                    let (instance_id, state) = arm_joint_states::on_next_message_received(
-                        &node_runner_clone,
-                        None,
-                    )
-                    .await
-                    .expect("failed to receive joint state");
-
-                    // Compute next target based on current state
-                    let target = compute_next_target(&state.positions);
-
-                    let _ = joint_commands::emit(
-                        &node_runner_clone,
-                        target,
-                        1.0, // max_velocity
-                    )
-                    .await;
-                }
-            });
-
-            Ok(())
-        })
-    }
-
-    fn compute_next_target(current: &[f64; 3]) -> [f64; 3] {
-        // Trajectory planning logic
-        [current[0] + 0.1, current[1], current[2]]
-    }
-    ```
+    <Code code={armControllerRust} lang="rust" title="src/main.rs" />
   </TabItem>
 </Tabs>
 
-Both directions use the standard linked consumed-topic API. `on_next_message_received` returns the producer's `instance_id` alongside the message, and the launcher binding steers the routing, so there is no special call-site API for bidirectional topics. A node that both emits and consumes is simply a node that `conforms_to` one interface and `depends_on` another.
+Both directions use the standard linked consumed-topic API. `on_next_message_received` returns the producer's `instance_id` alongside the message, so a `from_any` consumer tells its producers apart by that id: a single arm, several arms, or one that joins late all arrive through the same module, distinguished only by `instance_id`. There is no special call-site API for bidirectional topics: a node that both emits and consumes is simply a node that `conforms_to` one interface and `depends_on` another.
 
 ## Why topics only?
 
@@ -488,7 +183,7 @@ If two nodes need a request-response exchange rather than a stream, do not try t
 Reach for this interface-based pattern when:
 
 - **A dependency cycle would otherwise form**: two nodes need to exchange data, and modelling either direction as a `depends_on.nodes` link would make the graph circular. Pointing each direction at an interface breaks the cycle.
-- **The producer should be swappable**: the consumer binds any conforming producer at launch instead of hard-coding a node. A `robot_arm` can be driven by a teleoperation node, an autonomous planner, or a calibration script, as long as each conforms to `joint_command_source`. Use a [`from_any` interface slot](/advanced_guides/interface_conformance/#from-any-interface-bindings) to accept several controllers at once.
+- **The producer should be swappable**: the consumer accepts any conforming producer through a [`from_any` slot](/advanced_guides/interface_conformance/#from-any-interface-bindings) instead of hard-coding a node. A `robot_arm` can be driven by a teleoperation node, an autonomous planner, or a calibration script, as long as each conforms to `joint_command_source`, and several can drive it at once.
 - **Both directions run continuously**: each side publishes for the whole lifetime of the nodes, with no defined start or end.
 
 For a one-way producer-to-consumer link with no back-edge, you do not need any of this: a plain [linked consumed topic](/advanced_guides/topics) is simpler. Use the bidirectional pattern only when the return direction would otherwise create a cycle.

--- a/docs/src/content/docs/advanced_guides/interface_conformance.mdx
+++ b/docs/src/content/docs/advanced_guides/interface_conformance.mdx
@@ -163,6 +163,8 @@ If `depth_cam_inst1` were instead an instance of a node with no `conforms_to`, t
 
 A `from_any: true` interface slot accepts any number of conforming producers and accumulates them under the slot's `link_id`:
 
+A `from_any` slot also needs no binding at all. With zero producers it materializes unbound and the node still boots, accepting whichever conforming producers publish (including ones that join later). That property makes it the recommended shape for optional, [bidirectional communication](/advanced_guides/bidirectional_communication), where each side consumes the other's interface without requiring it to be present.
+
 ```json5
 manifest: {
   depends_on: {

--- a/docs/src/content/docs/guides/snippets/interfaces/joint_command_source/peppy.json5
+++ b/docs/src/content/docs/guides/snippets/interfaces/joint_command_source/peppy.json5
@@ -1,0 +1,19 @@
+{
+  peppy_schema: "interface_v1",
+  manifest: {
+    name: "joint_command_source",
+    tag: "v1",
+  },
+  interfaces: {
+    topics: [
+      {
+        name: "joint_commands",
+        qos_profile: "reliable",
+        message_format: {
+          target_positions: { $type: "array", $items: "f64", $length: 3 },
+          max_velocity: "f64",
+        },
+      },
+    ],
+  },
+}

--- a/docs/src/content/docs/guides/snippets/interfaces/joint_state_source/peppy.json5
+++ b/docs/src/content/docs/guides/snippets/interfaces/joint_state_source/peppy.json5
@@ -1,0 +1,20 @@
+{
+  peppy_schema: "interface_v1",
+  manifest: {
+    name: "joint_state_source",
+    tag: "v1",
+  },
+  interfaces: {
+    topics: [
+      {
+        name: "joint_states",
+        qos_profile: "sensor_data",
+        message_format: {
+          positions: { $type: "array", $items: "f64", $length: 3 },
+          velocities: { $type: "array", $items: "f64", $length: 3 },
+          timestamp: "time",
+        },
+      },
+    ],
+  },
+}

--- a/docs/src/content/docs/guides/snippets/python/arm_controller/.gitignore
+++ b/docs/src/content/docs/guides/snippets/python/arm_controller/.gitignore
@@ -1,0 +1,29 @@
+
+# Peppy-specific files
+.peppy
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.pyc
+*.pyd
+*.pyo
+
+# Virtual environment
+.env/
+.venv/
+.pixi/
+
+
+# Editor-specific files
+.vscode/
+.idea/
+
+# Operating System files
+**/.DS_Store
+**/.Thumbs.db
+
+# Jupyter Notebook checkpoints
+.ipynb_checkpoints/
+
+# Logs
+*.log

--- a/docs/src/content/docs/guides/snippets/python/arm_controller/peppy.json5
+++ b/docs/src/content/docs/guides/snippets/python/arm_controller/peppy.json5
@@ -1,0 +1,30 @@
+{
+  peppy_schema: "node_v1",
+  manifest: {
+    name: "arm_controller",
+    tag: "v1",
+    depends_on: {
+      interfaces: [
+        // Optional, wildcard, opt-in-per-direction: consume joint_states
+        // from any conforming arm, with no binding required.
+        { name: "joint_state_source", tag: "v1", link_id: "arm", from_any: true },
+      ],
+    },
+  },
+  interfaces: {
+    // Emits joint_commands by conforming to the interface (inherited by reference)
+    conforms_to: [
+      { name: "joint_command_source", tag: "v1" },
+    ],
+    topics: {
+      consumes: [
+        { name: "joint_states", link_id: "arm" },
+      ],
+    },
+  },
+  execution: {
+    language: "python",
+    build_cmd: ["uv", "sync"],
+    run_cmd: ["uv", "run", "arm_controller"],
+  },
+}

--- a/docs/src/content/docs/guides/snippets/python/arm_controller/pyproject.toml
+++ b/docs/src/content/docs/guides/snippets/python/arm_controller/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "arm_controller"
+version = "0.1.0"
+description = "arm_controller peppy node"
+requires-python = ">=3.11,<3.14"
+dependencies = ["peppygen"]
+
+[project.scripts]
+arm_controller = "arm_controller.__main__:main"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/arm_controller"]
+
+[dependency-groups]
+dev = []
+
+[tool.uv.sources]
+peppygen = { path = ".peppy/libs/peppygen" }

--- a/docs/src/content/docs/guides/snippets/python/arm_controller/src/arm_controller/__main__.py
+++ b/docs/src/content/docs/guides/snippets/python/arm_controller/src/arm_controller/__main__.py
@@ -1,0 +1,40 @@
+import asyncio
+
+from peppygen import NodeBuilder, NodeRunner
+from peppygen.parameters import Parameters
+from peppygen.consumed_topics import arm_joint_states
+from peppygen.emitted_topics.joint_command_source.v1 import joint_commands
+
+
+def compute_next_target(current: list[float]) -> list[float]:
+    # Trajectory planning logic
+    return [current[0] + 0.1, current[1], current[2]]
+
+
+async def control_loop(node_runner: NodeRunner):
+    while True:
+        instance_id, state = await arm_joint_states.on_next_message_received(
+            node_runner,
+        )
+
+        print(f"state from {instance_id}: positions={state.positions}")
+
+        # Compute the next target from the reported state, then command it.
+        target = compute_next_target(state.positions)
+        await joint_commands.emit(
+            node_runner,
+            target,
+            1.0,  # max_velocity
+        )
+
+
+async def setup(_params: Parameters, node_runner: NodeRunner) -> list[asyncio.Task]:
+    return [asyncio.create_task(control_loop(node_runner))]
+
+
+def main():
+    NodeBuilder().run(setup)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/src/content/docs/guides/snippets/python/arm_controller/uv.lock
+++ b/docs/src/content/docs/guides/snippets/python/arm_controller/uv.lock
@@ -1,0 +1,78 @@
+version = 1
+revision = 3
+requires-python = ">=3.11, <3.14"
+
+[[package]]
+name = "arm-controller"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "peppygen" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "peppygen", directory = ".peppy/libs/peppygen" }]
+
+[package.metadata.requires-dev]
+dev = []
+
+[[package]]
+name = "peppygen"
+version = "0.1.0"
+source = { directory = ".peppy/libs/peppygen" }
+dependencies = [
+    { name = "pycapnp" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "pycapnp" }]
+
+[[package]]
+name = "pycapnp"
+version = "2.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/ed/b9557772d92ebaab796fe6560308fca81a903bacf9da972808268cdd3e67/pycapnp-2.2.3.tar.gz", hash = "sha256:91b24e94c5ffc016bcbac883d3376f9940d2b25db06e7058b13bbb2ed7cd752d", size = 731751, upload-time = "2026-05-31T00:21:51.074Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/22/588e9aafd7310723550dbc4d51a0bcaf85c7279eb397b477a9a890724789/pycapnp-2.2.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:db9c40c9e88cae152cca4ddcf7ec8cd5d393b9f0ffdc21457cd1a69957d982e1", size = 1619249, upload-time = "2026-05-31T00:19:27.879Z" },
+    { url = "https://files.pythonhosted.org/packages/93/5a/61edbe8f3af92c79dc705d5e5dc701cc02c7fc3fe671cf9b8d30099bb870/pycapnp-2.2.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:182699d42337cd59b4d14dbba35d501ef38e4f31d5bf92469106bb3dcbee0a74", size = 1492717, upload-time = "2026-05-31T00:19:29.097Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/91/99e598cd178463a185b694c1950d9da2a5de4942c5dda7cd0e8efef5e122/pycapnp-2.2.3-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:18cdfee3c7419582c6f413297c6fed35456b6a9eb8425f2e31c4e1de8ed3f59d", size = 5263450, upload-time = "2026-05-31T00:19:30.591Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/b1/8b01bb9351b1c9e78f3b7ec9a7189f008195d562dbb90a7342a1c3ab6ac4/pycapnp-2.2.3-cp311-cp311-manylinux_2_28_i686.whl", hash = "sha256:974ad52028b99c6ac82449f4af257df28b9d58d13cbafb83b1b70765dcd09470", size = 5324522, upload-time = "2026-05-31T00:19:32.117Z" },
+    { url = "https://files.pythonhosted.org/packages/21/0b/a22b9f41106844a0dfa0c18b1c659eb0db0fd42bc7ef095d33a998f22247/pycapnp-2.2.3-cp311-cp311-manylinux_2_28_ppc64le.whl", hash = "sha256:277b16daee96eb9bd8e65c2b5e453689f223d719e8d3b700854707a0cfa009c4", size = 5721521, upload-time = "2026-05-31T00:19:33.794Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/dc/ad99bb76488195f0891a1e8764cd475fa9e24ada8c6bc4a7aa643162fc8c/pycapnp-2.2.3-cp311-cp311-manylinux_2_28_s390x.whl", hash = "sha256:701c2e405386acf23e7ff12914dff8b93ba65e4ac26f7fb9cd3881057bbfa087", size = 5760715, upload-time = "2026-05-31T00:19:36.07Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/19/5b7eba5eec9a951c67f48be898baf96b42f31720bfbde36b4826d5e5d7d7/pycapnp-2.2.3-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:e651de34c170b1f66d67abeb8bdb2e4058b29f9950817ab7e34f40fb5c88d5a9", size = 5438279, upload-time = "2026-05-31T00:19:37.704Z" },
+    { url = "https://files.pythonhosted.org/packages/54/42/a32152af4c65ea8c59ebc6dbb3bb6a74d5f09c739069d6a1774c0d3cd6b1/pycapnp-2.2.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e499a837c129ba00ee537545a4c625016d9d62f5d5e92d0c3e4c8e5e18bebf5d", size = 6140010, upload-time = "2026-05-31T00:19:39.383Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/ce/419877c1702169e1cfbf2846baa10119a3e7baab04165511bc71db7c76bd/pycapnp-2.2.3-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:27e43dc754f8669fe0926062af368e3d9a541cc2262ff08cee4c4cc9bebe220f", size = 6464935, upload-time = "2026-05-31T00:19:41.268Z" },
+    { url = "https://files.pythonhosted.org/packages/67/9c/bb7d79ca73349d27c3d49fa0a8d2fff8e9e5aab843c9da2ea456d36e1a06/pycapnp-2.2.3-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:4f456ed3194603d4891e69aef7ce9385b01bf373b52c543b93f8c4c9318b629a", size = 6654492, upload-time = "2026-05-31T00:19:43.432Z" },
+    { url = "https://files.pythonhosted.org/packages/da/94/c83b28b061f4c8def492af1adc46621345f42d3f93f166a314524d54ecbb/pycapnp-2.2.3-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:5f551580faa8ab44962e1ca71ad9d2e543d13fc1d358607a6c546d958d365f5e", size = 6680982, upload-time = "2026-05-31T00:19:45.322Z" },
+    { url = "https://files.pythonhosted.org/packages/60/c9/e8243405d7bf80ba32b833f1ff486203140915ae4925f58795daabdbf675/pycapnp-2.2.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:35d3498fa297bd0541ffd8388b92f20c145eee5be7e44f6e03846457aec7dabc", size = 6407836, upload-time = "2026-05-31T00:19:47.079Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/7c/2b33a5120e251523deb36480e616f25a307859f7c53ee58b073460946757/pycapnp-2.2.3-cp311-cp311-win32.whl", hash = "sha256:0dae9e476dd726ad41e55c615e78dd99fbbb4b09280105914d801e3aedb94cbb", size = 1063874, upload-time = "2026-05-31T00:19:48.551Z" },
+    { url = "https://files.pythonhosted.org/packages/07/1a/9aa61e81c7b0b818117861dc1566d73dfed17161ad29f56c762ef9ecc2a5/pycapnp-2.2.3-cp311-cp311-win_amd64.whl", hash = "sha256:5a34c15427c7e57bd88e0286afa57ba65044573f5564b8c1353b0caf635ef007", size = 1219354, upload-time = "2026-05-31T00:19:49.999Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/4d/ccbdd403487045385ac653e11ac5644b8947ab9698408760d4f4e42f07ce/pycapnp-2.2.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a16f7db2f0c9b1109102192d264fc4da74bbbb9aa67afbb39cf4dcd772965040", size = 1609096, upload-time = "2026-05-31T00:19:51.41Z" },
+    { url = "https://files.pythonhosted.org/packages/70/9a/762ad3e6bd9696f6d6eb99f23e2804608b3875fd5c8bd9b0f13f6f2535da/pycapnp-2.2.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:06345d28564916c3ed4db607294078d093144902d1bf773babf6a7ee02ad2883", size = 1489696, upload-time = "2026-05-31T00:19:53.327Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/3d/6c33211f162d17a8f7f3cacf71ac4549dddd174d1f9bcc64af8d7e2001a1/pycapnp-2.2.3-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:e4b59f39a5dc5b4cb04af9c2c3fdb7e9714e3e906f9a9daa9ec8a59715af00da", size = 5181384, upload-time = "2026-05-31T00:19:54.875Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/59/0a60f9e95d4039da2792efd23ae6cc5439a6104c2b15b49652a3a0c27e5b/pycapnp-2.2.3-cp312-cp312-manylinux_2_28_i686.whl", hash = "sha256:d6009278cbffa9fde587c8d8d4acb8b727b83aca1f088f42f4ed4d46e276b9e0", size = 5226898, upload-time = "2026-05-31T00:19:56.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/74/8975cd4f399371d1f427454268a2c38a51c91ddcc6e4701a13ccbc9d1a09/pycapnp-2.2.3-cp312-cp312-manylinux_2_28_ppc64le.whl", hash = "sha256:b96aa8fc7e2c90b97fc11a9b74aafbff1a1f701b318f6c38c6f57d1b5992e1e7", size = 5543761, upload-time = "2026-05-31T00:19:57.969Z" },
+    { url = "https://files.pythonhosted.org/packages/05/5f/d8188b85abae4bdc6fcabd3ba4ff68deadccfd5bcdb566a671e96531d1f4/pycapnp-2.2.3-cp312-cp312-manylinux_2_28_s390x.whl", hash = "sha256:f48c26966d574b3212271a97f03d5fb24cd854bd90cce7f28f0d3cc90f43135e", size = 5652435, upload-time = "2026-05-31T00:19:59.934Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ee/4f631bdba96675b8fb7767d2eac4ebb9ee3cfb57ade98ab8555d1940b156/pycapnp-2.2.3-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:e412d1f9d6c67be1087ccff33be4f60d8d135d30ef15f2ee336772c5c3549783", size = 5403038, upload-time = "2026-05-31T00:20:01.872Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/de/bbe1d356a04af883d05cfc11a6828b61ca08e672c52fe3896e90743e35bc/pycapnp-2.2.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e0fc20d8592a8bb4f7cd4f2972fdffea2ce16920afb1b37e811c87d0f159320e", size = 6048163, upload-time = "2026-05-31T00:20:03.951Z" },
+    { url = "https://files.pythonhosted.org/packages/02/d5/c250304fd95d11d04a6d7cf04f93a0089599e33ee72fa46fa1d22b8a6e8f/pycapnp-2.2.3-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:7ab08e2f0a92da980220f4be9ca54fc59244a2be1f7a5c3df760a3080d823150", size = 6358893, upload-time = "2026-05-31T00:20:05.758Z" },
+    { url = "https://files.pythonhosted.org/packages/22/96/105544aa42acc440b9a906421705e91a32119cba15e97bc07bcd342180ed/pycapnp-2.2.3-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:6ed7030cbc6215795b0ec9469b03136c25f110dbe047074bea75b80cf7feaa57", size = 6492218, upload-time = "2026-05-31T00:20:07.76Z" },
+    { url = "https://files.pythonhosted.org/packages/76/86/dd6ce2546ad32a170c28c119d99f9c61e836b58acab75380ef41dd4d745d/pycapnp-2.2.3-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:14d59e3c1287dab32b2e208ce043036ff90629d3f06301738d7136cc1c2a3e01", size = 6578835, upload-time = "2026-05-31T00:20:09.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/fd/02bc3cd0fe92f0346d4e46a389e639a1ef28415f6aaf0543664a08c31200/pycapnp-2.2.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8d7f4dfea74246f22ac712266787c88247e7dcecdea73dec91549d18dd120c15", size = 6337940, upload-time = "2026-05-31T00:20:11.144Z" },
+    { url = "https://files.pythonhosted.org/packages/26/d5/4f81a298365402a7be7f5b420dd203fee36645f029382b447e6cf61acfbf/pycapnp-2.2.3-cp312-cp312-win32.whl", hash = "sha256:8dc637a8fecf9be561746e11dc42afc364fa8d4ab642e288748695890f1f20bb", size = 1049168, upload-time = "2026-05-31T00:20:12.772Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/05/62cdc66d7977b2efb27e68f63d671762813d83666b393d19b8e46745a391/pycapnp-2.2.3-cp312-cp312-win_amd64.whl", hash = "sha256:00bfa9d68f14b9b1596aa63d45ac071079c38f9f07a5095db744c69732dce21f", size = 1186876, upload-time = "2026-05-31T00:20:14.096Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/44/fd7d024a96cc27d944eec35675022397f8468de8ded3e0d91a660bb1049d/pycapnp-2.2.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4adfbdf45776f984de8fb2956db368d9667f5324c44850f50ed2cf50ed926b47", size = 1608162, upload-time = "2026-05-31T00:20:15.301Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/66/9c9510aa367e1091d86a8383e4d98c655a5b97a84829cc46a62cbe28084c/pycapnp-2.2.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c071b119adc3711ba66b6ef2cfbde03c63e665513afe641cfb35cfdc272eb727", size = 1489152, upload-time = "2026-05-31T00:20:16.7Z" },
+    { url = "https://files.pythonhosted.org/packages/54/6f/097ca4949fcccf81d6fd891cebfc7acf20155e5494869e8648e89c45500f/pycapnp-2.2.3-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:19c551c72e0bd13d2aab2c71659199ae22e64bf4f43b91492b628f42c3f25254", size = 5198618, upload-time = "2026-05-31T00:20:18.25Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/82/636f0a79888afd5efb1af62ddf7cb617b9f2889fad14049ed948c875d48f/pycapnp-2.2.3-cp313-cp313-manylinux_2_28_i686.whl", hash = "sha256:8fe9f2072b5420d16f7c5f8f2fe1fc72a6445a44d9803b87c711188d30be25e7", size = 5233294, upload-time = "2026-05-31T00:20:19.744Z" },
+    { url = "https://files.pythonhosted.org/packages/51/9e/7f879575ffed0383ad8b461046c8b743300759c858bcabdc86dfc72418a4/pycapnp-2.2.3-cp313-cp313-manylinux_2_28_ppc64le.whl", hash = "sha256:36a8180a0d2d434f65f79960aa28763e459c4bbb4acbb8b02438d9ca19016dfd", size = 5551143, upload-time = "2026-05-31T00:20:21.478Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/bd/a74d7297bbae1ff381af8d571216e7f5d33d2d0194f82ca6a7b3304453cf/pycapnp-2.2.3-cp313-cp313-manylinux_2_28_s390x.whl", hash = "sha256:a31c4e6be0d15728354be24abc34eea9b63c76789bd48b905dfa8c1d82ea4a06", size = 5606452, upload-time = "2026-05-31T00:20:23.008Z" },
+    { url = "https://files.pythonhosted.org/packages/81/82/6b609ffdd12a661e5d5f908566a2ba7dd744109835711b7f9059022e4edd/pycapnp-2.2.3-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:8e99c7d6e8602244798b7b49cf01ea7fc95e959955635d914e093e63972936ac", size = 5384364, upload-time = "2026-05-31T00:20:24.651Z" },
+    { url = "https://files.pythonhosted.org/packages/28/d1/e299b7bebaf56a08cc8463a05e4abe31f284ac4c91bae74bc4c66a42d9d1/pycapnp-2.2.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:84b4b54736a4e1234756f2bb060df1dabf6d3c03bd9b0af4141d941cad324ae1", size = 6062529, upload-time = "2026-05-31T00:20:26.399Z" },
+    { url = "https://files.pythonhosted.org/packages/54/00/433c33121e2af40b818a4c264d401540258313bb84f6d44d2e9f206946f7/pycapnp-2.2.3-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:65f84cdda093b31a81e99669881b0c7d9151b78c9185aa1f639cb53cb91a3c51", size = 6367154, upload-time = "2026-05-31T00:20:28.094Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/a6/572fac7c5230d1213d03ce96820dec4e66c76d79ed229b19f6757c7b89fb/pycapnp-2.2.3-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:eb504d5726a89e964fe7d242b421b02bd8b83ecce492b1145abc5189b2fb76a8", size = 6490252, upload-time = "2026-05-31T00:20:29.865Z" },
+    { url = "https://files.pythonhosted.org/packages/90/24/442d5f0eb899d6e97ec712787ed761f7c565a8eff4dce1851a7f4ca994de/pycapnp-2.2.3-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:a26cc8bdfa6ea07c23ad037e4b0703a8c58d928b2b4e8d9e70a1f40e4499081d", size = 6554077, upload-time = "2026-05-31T00:20:31.606Z" },
+    { url = "https://files.pythonhosted.org/packages/11/d1/1eba840ea8cc9552e563b4adffb281228669e207935c4b4403863fe48ac3/pycapnp-2.2.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2dccd8f6b67a089386e5115a50d07b4b4a5efe913409691506a9ed1ae90986c3", size = 6330474, upload-time = "2026-05-31T00:20:33.155Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/d1/42745d92a550037cf4ef25d3e7e1efbd5b99043e010af461692018497e26/pycapnp-2.2.3-cp313-cp313-win32.whl", hash = "sha256:5d9566f49818afa1cb075a50bd988d23e6705a394535b10381958fb56e65ff7c", size = 1048569, upload-time = "2026-05-31T00:20:34.613Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/3d/28c0da7bf881c994e37beaf0285cd433bddfeade1c73d967206c35ca2919/pycapnp-2.2.3-cp313-cp313-win_amd64.whl", hash = "sha256:2f46f071e6958e8bfaf0c332d91b055a6c52caaf7fcf0819a752e7124d990e35", size = 1186014, upload-time = "2026-05-31T00:20:36.282Z" },
+]

--- a/docs/src/content/docs/guides/snippets/python/robot_arm/.gitignore
+++ b/docs/src/content/docs/guides/snippets/python/robot_arm/.gitignore
@@ -1,0 +1,29 @@
+
+# Peppy-specific files
+.peppy
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.pyc
+*.pyd
+*.pyo
+
+# Virtual environment
+.env/
+.venv/
+.pixi/
+
+
+# Editor-specific files
+.vscode/
+.idea/
+
+# Operating System files
+**/.DS_Store
+**/.Thumbs.db
+
+# Jupyter Notebook checkpoints
+.ipynb_checkpoints/
+
+# Logs
+*.log

--- a/docs/src/content/docs/guides/snippets/python/robot_arm/peppy.json5
+++ b/docs/src/content/docs/guides/snippets/python/robot_arm/peppy.json5
@@ -1,0 +1,30 @@
+{
+  peppy_schema: "node_v1",
+  manifest: {
+    name: "robot_arm",
+    tag: "v1",
+    depends_on: {
+      interfaces: [
+        // Optional, wildcard, opt-in-per-direction: consume joint_commands
+        // from any conforming controller, with no binding required.
+        { name: "joint_command_source", tag: "v1", link_id: "controller", from_any: true },
+      ],
+    },
+  },
+  interfaces: {
+    // Emits joint_states by conforming to the interface (inherited by reference)
+    conforms_to: [
+      { name: "joint_state_source", tag: "v1" },
+    ],
+    topics: {
+      consumes: [
+        { name: "joint_commands", link_id: "controller" },
+      ],
+    },
+  },
+  execution: {
+    language: "python",
+    build_cmd: ["uv", "sync"],
+    run_cmd: ["uv", "run", "robot_arm"],
+  },
+}

--- a/docs/src/content/docs/guides/snippets/python/robot_arm/pyproject.toml
+++ b/docs/src/content/docs/guides/snippets/python/robot_arm/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "robot_arm"
+version = "0.1.0"
+description = "robot_arm peppy node"
+requires-python = ">=3.11,<3.14"
+dependencies = ["peppygen"]
+
+[project.scripts]
+robot_arm = "robot_arm.__main__:main"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/robot_arm"]
+
+[dependency-groups]
+dev = []
+
+[tool.uv.sources]
+peppygen = { path = ".peppy/libs/peppygen" }

--- a/docs/src/content/docs/guides/snippets/python/robot_arm/src/robot_arm/__main__.py
+++ b/docs/src/content/docs/guides/snippets/python/robot_arm/src/robot_arm/__main__.py
@@ -1,0 +1,39 @@
+import asyncio
+import time
+
+from peppygen import NodeBuilder, NodeRunner
+from peppygen.parameters import Parameters
+from peppygen.consumed_topics import controller_joint_commands
+from peppygen.emitted_topics.joint_state_source.v1 import joint_states
+
+
+async def handle_commands(node_runner: NodeRunner):
+    while True:
+        instance_id, command = await controller_joint_commands.on_next_message_received(
+            node_runner,
+        )
+
+        print(
+            f"received from {instance_id}: "
+            f"target={command.target_positions} max_vel={command.max_velocity}"
+        )
+
+        # Drive the joints, then report the resulting state.
+        await joint_states.emit(
+            node_runner,
+            command.target_positions,
+            [0.0, 0.0, 0.0],
+            time.time(),
+        )
+
+
+async def setup(_params: Parameters, node_runner: NodeRunner) -> list[asyncio.Task]:
+    return [asyncio.create_task(handle_commands(node_runner))]
+
+
+def main():
+    NodeBuilder().run(setup)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/src/content/docs/guides/snippets/python/robot_arm/uv.lock
+++ b/docs/src/content/docs/guides/snippets/python/robot_arm/uv.lock
@@ -1,0 +1,78 @@
+version = 1
+revision = 3
+requires-python = ">=3.11, <3.14"
+
+[[package]]
+name = "peppygen"
+version = "0.1.0"
+source = { directory = ".peppy/libs/peppygen" }
+dependencies = [
+    { name = "pycapnp" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "pycapnp" }]
+
+[[package]]
+name = "pycapnp"
+version = "2.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/ed/b9557772d92ebaab796fe6560308fca81a903bacf9da972808268cdd3e67/pycapnp-2.2.3.tar.gz", hash = "sha256:91b24e94c5ffc016bcbac883d3376f9940d2b25db06e7058b13bbb2ed7cd752d", size = 731751, upload-time = "2026-05-31T00:21:51.074Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/22/588e9aafd7310723550dbc4d51a0bcaf85c7279eb397b477a9a890724789/pycapnp-2.2.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:db9c40c9e88cae152cca4ddcf7ec8cd5d393b9f0ffdc21457cd1a69957d982e1", size = 1619249, upload-time = "2026-05-31T00:19:27.879Z" },
+    { url = "https://files.pythonhosted.org/packages/93/5a/61edbe8f3af92c79dc705d5e5dc701cc02c7fc3fe671cf9b8d30099bb870/pycapnp-2.2.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:182699d42337cd59b4d14dbba35d501ef38e4f31d5bf92469106bb3dcbee0a74", size = 1492717, upload-time = "2026-05-31T00:19:29.097Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/91/99e598cd178463a185b694c1950d9da2a5de4942c5dda7cd0e8efef5e122/pycapnp-2.2.3-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:18cdfee3c7419582c6f413297c6fed35456b6a9eb8425f2e31c4e1de8ed3f59d", size = 5263450, upload-time = "2026-05-31T00:19:30.591Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/b1/8b01bb9351b1c9e78f3b7ec9a7189f008195d562dbb90a7342a1c3ab6ac4/pycapnp-2.2.3-cp311-cp311-manylinux_2_28_i686.whl", hash = "sha256:974ad52028b99c6ac82449f4af257df28b9d58d13cbafb83b1b70765dcd09470", size = 5324522, upload-time = "2026-05-31T00:19:32.117Z" },
+    { url = "https://files.pythonhosted.org/packages/21/0b/a22b9f41106844a0dfa0c18b1c659eb0db0fd42bc7ef095d33a998f22247/pycapnp-2.2.3-cp311-cp311-manylinux_2_28_ppc64le.whl", hash = "sha256:277b16daee96eb9bd8e65c2b5e453689f223d719e8d3b700854707a0cfa009c4", size = 5721521, upload-time = "2026-05-31T00:19:33.794Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/dc/ad99bb76488195f0891a1e8764cd475fa9e24ada8c6bc4a7aa643162fc8c/pycapnp-2.2.3-cp311-cp311-manylinux_2_28_s390x.whl", hash = "sha256:701c2e405386acf23e7ff12914dff8b93ba65e4ac26f7fb9cd3881057bbfa087", size = 5760715, upload-time = "2026-05-31T00:19:36.07Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/19/5b7eba5eec9a951c67f48be898baf96b42f31720bfbde36b4826d5e5d7d7/pycapnp-2.2.3-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:e651de34c170b1f66d67abeb8bdb2e4058b29f9950817ab7e34f40fb5c88d5a9", size = 5438279, upload-time = "2026-05-31T00:19:37.704Z" },
+    { url = "https://files.pythonhosted.org/packages/54/42/a32152af4c65ea8c59ebc6dbb3bb6a74d5f09c739069d6a1774c0d3cd6b1/pycapnp-2.2.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e499a837c129ba00ee537545a4c625016d9d62f5d5e92d0c3e4c8e5e18bebf5d", size = 6140010, upload-time = "2026-05-31T00:19:39.383Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/ce/419877c1702169e1cfbf2846baa10119a3e7baab04165511bc71db7c76bd/pycapnp-2.2.3-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:27e43dc754f8669fe0926062af368e3d9a541cc2262ff08cee4c4cc9bebe220f", size = 6464935, upload-time = "2026-05-31T00:19:41.268Z" },
+    { url = "https://files.pythonhosted.org/packages/67/9c/bb7d79ca73349d27c3d49fa0a8d2fff8e9e5aab843c9da2ea456d36e1a06/pycapnp-2.2.3-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:4f456ed3194603d4891e69aef7ce9385b01bf373b52c543b93f8c4c9318b629a", size = 6654492, upload-time = "2026-05-31T00:19:43.432Z" },
+    { url = "https://files.pythonhosted.org/packages/da/94/c83b28b061f4c8def492af1adc46621345f42d3f93f166a314524d54ecbb/pycapnp-2.2.3-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:5f551580faa8ab44962e1ca71ad9d2e543d13fc1d358607a6c546d958d365f5e", size = 6680982, upload-time = "2026-05-31T00:19:45.322Z" },
+    { url = "https://files.pythonhosted.org/packages/60/c9/e8243405d7bf80ba32b833f1ff486203140915ae4925f58795daabdbf675/pycapnp-2.2.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:35d3498fa297bd0541ffd8388b92f20c145eee5be7e44f6e03846457aec7dabc", size = 6407836, upload-time = "2026-05-31T00:19:47.079Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/7c/2b33a5120e251523deb36480e616f25a307859f7c53ee58b073460946757/pycapnp-2.2.3-cp311-cp311-win32.whl", hash = "sha256:0dae9e476dd726ad41e55c615e78dd99fbbb4b09280105914d801e3aedb94cbb", size = 1063874, upload-time = "2026-05-31T00:19:48.551Z" },
+    { url = "https://files.pythonhosted.org/packages/07/1a/9aa61e81c7b0b818117861dc1566d73dfed17161ad29f56c762ef9ecc2a5/pycapnp-2.2.3-cp311-cp311-win_amd64.whl", hash = "sha256:5a34c15427c7e57bd88e0286afa57ba65044573f5564b8c1353b0caf635ef007", size = 1219354, upload-time = "2026-05-31T00:19:49.999Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/4d/ccbdd403487045385ac653e11ac5644b8947ab9698408760d4f4e42f07ce/pycapnp-2.2.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a16f7db2f0c9b1109102192d264fc4da74bbbb9aa67afbb39cf4dcd772965040", size = 1609096, upload-time = "2026-05-31T00:19:51.41Z" },
+    { url = "https://files.pythonhosted.org/packages/70/9a/762ad3e6bd9696f6d6eb99f23e2804608b3875fd5c8bd9b0f13f6f2535da/pycapnp-2.2.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:06345d28564916c3ed4db607294078d093144902d1bf773babf6a7ee02ad2883", size = 1489696, upload-time = "2026-05-31T00:19:53.327Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/3d/6c33211f162d17a8f7f3cacf71ac4549dddd174d1f9bcc64af8d7e2001a1/pycapnp-2.2.3-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:e4b59f39a5dc5b4cb04af9c2c3fdb7e9714e3e906f9a9daa9ec8a59715af00da", size = 5181384, upload-time = "2026-05-31T00:19:54.875Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/59/0a60f9e95d4039da2792efd23ae6cc5439a6104c2b15b49652a3a0c27e5b/pycapnp-2.2.3-cp312-cp312-manylinux_2_28_i686.whl", hash = "sha256:d6009278cbffa9fde587c8d8d4acb8b727b83aca1f088f42f4ed4d46e276b9e0", size = 5226898, upload-time = "2026-05-31T00:19:56.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/74/8975cd4f399371d1f427454268a2c38a51c91ddcc6e4701a13ccbc9d1a09/pycapnp-2.2.3-cp312-cp312-manylinux_2_28_ppc64le.whl", hash = "sha256:b96aa8fc7e2c90b97fc11a9b74aafbff1a1f701b318f6c38c6f57d1b5992e1e7", size = 5543761, upload-time = "2026-05-31T00:19:57.969Z" },
+    { url = "https://files.pythonhosted.org/packages/05/5f/d8188b85abae4bdc6fcabd3ba4ff68deadccfd5bcdb566a671e96531d1f4/pycapnp-2.2.3-cp312-cp312-manylinux_2_28_s390x.whl", hash = "sha256:f48c26966d574b3212271a97f03d5fb24cd854bd90cce7f28f0d3cc90f43135e", size = 5652435, upload-time = "2026-05-31T00:19:59.934Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ee/4f631bdba96675b8fb7767d2eac4ebb9ee3cfb57ade98ab8555d1940b156/pycapnp-2.2.3-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:e412d1f9d6c67be1087ccff33be4f60d8d135d30ef15f2ee336772c5c3549783", size = 5403038, upload-time = "2026-05-31T00:20:01.872Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/de/bbe1d356a04af883d05cfc11a6828b61ca08e672c52fe3896e90743e35bc/pycapnp-2.2.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e0fc20d8592a8bb4f7cd4f2972fdffea2ce16920afb1b37e811c87d0f159320e", size = 6048163, upload-time = "2026-05-31T00:20:03.951Z" },
+    { url = "https://files.pythonhosted.org/packages/02/d5/c250304fd95d11d04a6d7cf04f93a0089599e33ee72fa46fa1d22b8a6e8f/pycapnp-2.2.3-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:7ab08e2f0a92da980220f4be9ca54fc59244a2be1f7a5c3df760a3080d823150", size = 6358893, upload-time = "2026-05-31T00:20:05.758Z" },
+    { url = "https://files.pythonhosted.org/packages/22/96/105544aa42acc440b9a906421705e91a32119cba15e97bc07bcd342180ed/pycapnp-2.2.3-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:6ed7030cbc6215795b0ec9469b03136c25f110dbe047074bea75b80cf7feaa57", size = 6492218, upload-time = "2026-05-31T00:20:07.76Z" },
+    { url = "https://files.pythonhosted.org/packages/76/86/dd6ce2546ad32a170c28c119d99f9c61e836b58acab75380ef41dd4d745d/pycapnp-2.2.3-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:14d59e3c1287dab32b2e208ce043036ff90629d3f06301738d7136cc1c2a3e01", size = 6578835, upload-time = "2026-05-31T00:20:09.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/fd/02bc3cd0fe92f0346d4e46a389e639a1ef28415f6aaf0543664a08c31200/pycapnp-2.2.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8d7f4dfea74246f22ac712266787c88247e7dcecdea73dec91549d18dd120c15", size = 6337940, upload-time = "2026-05-31T00:20:11.144Z" },
+    { url = "https://files.pythonhosted.org/packages/26/d5/4f81a298365402a7be7f5b420dd203fee36645f029382b447e6cf61acfbf/pycapnp-2.2.3-cp312-cp312-win32.whl", hash = "sha256:8dc637a8fecf9be561746e11dc42afc364fa8d4ab642e288748695890f1f20bb", size = 1049168, upload-time = "2026-05-31T00:20:12.772Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/05/62cdc66d7977b2efb27e68f63d671762813d83666b393d19b8e46745a391/pycapnp-2.2.3-cp312-cp312-win_amd64.whl", hash = "sha256:00bfa9d68f14b9b1596aa63d45ac071079c38f9f07a5095db744c69732dce21f", size = 1186876, upload-time = "2026-05-31T00:20:14.096Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/44/fd7d024a96cc27d944eec35675022397f8468de8ded3e0d91a660bb1049d/pycapnp-2.2.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4adfbdf45776f984de8fb2956db368d9667f5324c44850f50ed2cf50ed926b47", size = 1608162, upload-time = "2026-05-31T00:20:15.301Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/66/9c9510aa367e1091d86a8383e4d98c655a5b97a84829cc46a62cbe28084c/pycapnp-2.2.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c071b119adc3711ba66b6ef2cfbde03c63e665513afe641cfb35cfdc272eb727", size = 1489152, upload-time = "2026-05-31T00:20:16.7Z" },
+    { url = "https://files.pythonhosted.org/packages/54/6f/097ca4949fcccf81d6fd891cebfc7acf20155e5494869e8648e89c45500f/pycapnp-2.2.3-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:19c551c72e0bd13d2aab2c71659199ae22e64bf4f43b91492b628f42c3f25254", size = 5198618, upload-time = "2026-05-31T00:20:18.25Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/82/636f0a79888afd5efb1af62ddf7cb617b9f2889fad14049ed948c875d48f/pycapnp-2.2.3-cp313-cp313-manylinux_2_28_i686.whl", hash = "sha256:8fe9f2072b5420d16f7c5f8f2fe1fc72a6445a44d9803b87c711188d30be25e7", size = 5233294, upload-time = "2026-05-31T00:20:19.744Z" },
+    { url = "https://files.pythonhosted.org/packages/51/9e/7f879575ffed0383ad8b461046c8b743300759c858bcabdc86dfc72418a4/pycapnp-2.2.3-cp313-cp313-manylinux_2_28_ppc64le.whl", hash = "sha256:36a8180a0d2d434f65f79960aa28763e459c4bbb4acbb8b02438d9ca19016dfd", size = 5551143, upload-time = "2026-05-31T00:20:21.478Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/bd/a74d7297bbae1ff381af8d571216e7f5d33d2d0194f82ca6a7b3304453cf/pycapnp-2.2.3-cp313-cp313-manylinux_2_28_s390x.whl", hash = "sha256:a31c4e6be0d15728354be24abc34eea9b63c76789bd48b905dfa8c1d82ea4a06", size = 5606452, upload-time = "2026-05-31T00:20:23.008Z" },
+    { url = "https://files.pythonhosted.org/packages/81/82/6b609ffdd12a661e5d5f908566a2ba7dd744109835711b7f9059022e4edd/pycapnp-2.2.3-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:8e99c7d6e8602244798b7b49cf01ea7fc95e959955635d914e093e63972936ac", size = 5384364, upload-time = "2026-05-31T00:20:24.651Z" },
+    { url = "https://files.pythonhosted.org/packages/28/d1/e299b7bebaf56a08cc8463a05e4abe31f284ac4c91bae74bc4c66a42d9d1/pycapnp-2.2.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:84b4b54736a4e1234756f2bb060df1dabf6d3c03bd9b0af4141d941cad324ae1", size = 6062529, upload-time = "2026-05-31T00:20:26.399Z" },
+    { url = "https://files.pythonhosted.org/packages/54/00/433c33121e2af40b818a4c264d401540258313bb84f6d44d2e9f206946f7/pycapnp-2.2.3-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:65f84cdda093b31a81e99669881b0c7d9151b78c9185aa1f639cb53cb91a3c51", size = 6367154, upload-time = "2026-05-31T00:20:28.094Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/a6/572fac7c5230d1213d03ce96820dec4e66c76d79ed229b19f6757c7b89fb/pycapnp-2.2.3-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:eb504d5726a89e964fe7d242b421b02bd8b83ecce492b1145abc5189b2fb76a8", size = 6490252, upload-time = "2026-05-31T00:20:29.865Z" },
+    { url = "https://files.pythonhosted.org/packages/90/24/442d5f0eb899d6e97ec712787ed761f7c565a8eff4dce1851a7f4ca994de/pycapnp-2.2.3-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:a26cc8bdfa6ea07c23ad037e4b0703a8c58d928b2b4e8d9e70a1f40e4499081d", size = 6554077, upload-time = "2026-05-31T00:20:31.606Z" },
+    { url = "https://files.pythonhosted.org/packages/11/d1/1eba840ea8cc9552e563b4adffb281228669e207935c4b4403863fe48ac3/pycapnp-2.2.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2dccd8f6b67a089386e5115a50d07b4b4a5efe913409691506a9ed1ae90986c3", size = 6330474, upload-time = "2026-05-31T00:20:33.155Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/d1/42745d92a550037cf4ef25d3e7e1efbd5b99043e010af461692018497e26/pycapnp-2.2.3-cp313-cp313-win32.whl", hash = "sha256:5d9566f49818afa1cb075a50bd988d23e6705a394535b10381958fb56e65ff7c", size = 1048569, upload-time = "2026-05-31T00:20:34.613Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/3d/28c0da7bf881c994e37beaf0285cd433bddfeade1c73d967206c35ca2919/pycapnp-2.2.3-cp313-cp313-win_amd64.whl", hash = "sha256:2f46f071e6958e8bfaf0c332d91b055a6c52caaf7fcf0819a752e7124d990e35", size = 1186014, upload-time = "2026-05-31T00:20:36.282Z" },
+]
+
+[[package]]
+name = "robot-arm"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "peppygen" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "peppygen", directory = ".peppy/libs/peppygen" }]
+
+[package.metadata.requires-dev]
+dev = []

--- a/docs/src/content/docs/guides/snippets/rust/arm_controller/.gitignore
+++ b/docs/src/content/docs/guides/snippets/rust/arm_controller/.gitignore
@@ -1,0 +1,20 @@
+
+# Peppy-specific files
+.peppy
+
+# Rust
+/target/
+*.swp
+*.bak
+*.orig
+
+# Editor-specific files
+.vscode/
+.idea/
+
+# Operating System files
+**/.DS_Store
+**/.Thumbs.db
+
+# Logs
+*.log

--- a/docs/src/content/docs/guides/snippets/rust/arm_controller/Cargo.toml
+++ b/docs/src/content/docs/guides/snippets/rust/arm_controller/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "arm_controller"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+peppygen = { path = ".peppy/libs/peppygen" }
+peppylib = { path = ".peppy/libs/peppylib" }
+tokio = { version = "1", features = ["rt"] }
+tracing = "0.1"
+
+[workspace]

--- a/docs/src/content/docs/guides/snippets/rust/arm_controller/peppy.json5
+++ b/docs/src/content/docs/guides/snippets/rust/arm_controller/peppy.json5
@@ -1,0 +1,30 @@
+{
+  peppy_schema: "node_v1",
+  manifest: {
+    name: "arm_controller",
+    tag: "v1",
+    depends_on: {
+      interfaces: [
+        // Optional, wildcard, opt-in-per-direction: consume joint_states
+        // from any conforming arm, with no binding required.
+        { name: "joint_state_source", tag: "v1", link_id: "arm", from_any: true },
+      ],
+    },
+  },
+  interfaces: {
+    // Emits joint_commands by conforming to the interface (inherited by reference)
+    conforms_to: [
+      { name: "joint_command_source", tag: "v1" },
+    ],
+    topics: {
+      consumes: [
+        { name: "joint_states", link_id: "arm" },
+      ],
+    },
+  },
+  execution: {
+    language: "rust",
+    build_cmd: ["cargo", "build", "--release"],
+    run_cmd: ["./target/release/arm_controller"],
+  },
+}

--- a/docs/src/content/docs/guides/snippets/rust/arm_controller/src/main.rs
+++ b/docs/src/content/docs/guides/snippets/rust/arm_controller/src/main.rs
@@ -1,0 +1,34 @@
+use peppygen::consumed_topics::arm_joint_states;
+use peppygen::emitted_topics::joint_command_source::v1::joint_commands;
+use peppygen::{NodeBuilder, Parameters, Result};
+
+// `arm_controller` plans trajectories and sends joint commands. It emits
+// `joint_commands` by conforming to `joint_command_source`, and consumes
+// `joint_states` from any conforming arm through a `from_any` interface
+// slot. With no binding required it accepts state from whichever arms are
+// present and tells them apart by the instance_id returned per message.
+fn main() -> Result<()> {
+    NodeBuilder::new().run(|_args: Parameters, node_runner| async move {
+        tokio::spawn(async move {
+            loop {
+                let (instance_id, state) =
+                    arm_joint_states::on_next_message_received(&node_runner, None)
+                        .await
+                        .expect("failed to receive joint state");
+
+                println!("state from {instance_id}: positions={:?}", state.positions);
+
+                // Compute the next target from the reported state, then command it.
+                let target = compute_next_target(&state.positions);
+                let _ = joint_commands::emit(&node_runner, target, 1.0).await;
+            }
+        });
+
+        Ok(())
+    })
+}
+
+fn compute_next_target(current: &[f64; 3]) -> [f64; 3] {
+    // Trajectory planning logic
+    [current[0] + 0.1, current[1], current[2]]
+}

--- a/docs/src/content/docs/guides/snippets/rust/robot_arm/.gitignore
+++ b/docs/src/content/docs/guides/snippets/rust/robot_arm/.gitignore
@@ -1,0 +1,20 @@
+
+# Peppy-specific files
+.peppy
+
+# Rust
+/target/
+*.swp
+*.bak
+*.orig
+
+# Editor-specific files
+.vscode/
+.idea/
+
+# Operating System files
+**/.DS_Store
+**/.Thumbs.db
+
+# Logs
+*.log

--- a/docs/src/content/docs/guides/snippets/rust/robot_arm/Cargo.toml
+++ b/docs/src/content/docs/guides/snippets/rust/robot_arm/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "robot_arm"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+peppygen = { path = ".peppy/libs/peppygen" }
+peppylib = { path = ".peppy/libs/peppylib" }
+tokio = { version = "1", features = ["rt"] }
+tracing = "0.1"
+
+[workspace]

--- a/docs/src/content/docs/guides/snippets/rust/robot_arm/peppy.json5
+++ b/docs/src/content/docs/guides/snippets/rust/robot_arm/peppy.json5
@@ -1,0 +1,30 @@
+{
+  peppy_schema: "node_v1",
+  manifest: {
+    name: "robot_arm",
+    tag: "v1",
+    depends_on: {
+      interfaces: [
+        // Optional, wildcard, opt-in-per-direction: consume joint_commands
+        // from any conforming controller, with no binding required.
+        { name: "joint_command_source", tag: "v1", link_id: "controller", from_any: true },
+      ],
+    },
+  },
+  interfaces: {
+    // Emits joint_states by conforming to the interface (inherited by reference)
+    conforms_to: [
+      { name: "joint_state_source", tag: "v1" },
+    ],
+    topics: {
+      consumes: [
+        { name: "joint_commands", link_id: "controller" },
+      ],
+    },
+  },
+  execution: {
+    language: "rust",
+    build_cmd: ["cargo", "build", "--release"],
+    run_cmd: ["./target/release/robot_arm"],
+  },
+}

--- a/docs/src/content/docs/guides/snippets/rust/robot_arm/src/main.rs
+++ b/docs/src/content/docs/guides/snippets/rust/robot_arm/src/main.rs
@@ -1,0 +1,37 @@
+use peppygen::consumed_topics::controller_joint_commands;
+use peppygen::emitted_topics::joint_state_source::v1::joint_states;
+use peppygen::{NodeBuilder, Parameters, Result};
+
+// `robot_arm` drives the physical joints and reports their state. It emits
+// `joint_states` by conforming to `joint_state_source`, and consumes
+// `joint_commands` from any conforming controller through a `from_any`
+// interface slot. With no binding required it boots with zero controllers
+// and picks up whichever ones publish, identified per message by instance_id.
+fn main() -> Result<()> {
+    NodeBuilder::new().run(|_args: Parameters, node_runner| async move {
+        tokio::spawn(async move {
+            loop {
+                let (instance_id, command) =
+                    controller_joint_commands::on_next_message_received(&node_runner, None)
+                        .await
+                        .expect("failed to receive joint command");
+
+                println!(
+                    "received from {instance_id}: target={:?} max_vel={}",
+                    command.target_positions, command.max_velocity
+                );
+
+                // Drive the joints, then report the resulting state.
+                let _ = joint_states::emit(
+                    &node_runner,
+                    command.target_positions,
+                    [0.0, 0.0, 0.0],
+                    std::time::SystemTime::now(),
+                )
+                .await;
+            }
+        });
+
+        Ok(())
+    })
+}

--- a/docs/tests/integration/src/snippet_runner.rs
+++ b/docs/tests/integration/src/snippet_runner.rs
@@ -1,6 +1,7 @@
 use crate::{peppy_binary, workspace_root};
 use config::node::NodeConfigParser;
 use peppy::test_support::ServeCommandEmulation;
+use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
@@ -8,6 +9,10 @@ const DAEMON_STATE_ENV: &str = "PEPPY_DAEMON_STATE_FILE";
 
 struct NodeSetup {
     daemon_state_path: PathBuf,
+    /// Root of the emulated daemon's directory tree (its `conf/` holds
+    /// `repositories.json5`). Captured so interface-backed snippets can
+    /// register an fs repo the daemon will scan on refresh.
+    daemon_root: PathBuf,
     node_ref: String,
     _temp_dir: tempfile::TempDir,
     _rt: tokio::runtime::Runtime,
@@ -57,6 +62,7 @@ fn setup_env(peppy: &Path, node_dir: &Path) -> NodeSetup {
     // before spawning peppy subprocesses that open new sessions.
     std::thread::sleep(std::time::Duration::from_millis(200));
     let daemon_state_path = serve.daemon_state_path().to_path_buf();
+    let daemon_root = serve.temp_dir().to_path_buf();
 
     // Create a node in a tempdir with `peppy node init`
     let temp_dir = tempfile::tempdir().expect("failed to create temp directory");
@@ -72,6 +78,7 @@ fn setup_env(peppy: &Path, node_dir: &Path) -> NodeSetup {
 
     NodeSetup {
         daemon_state_path,
+        daemon_root,
         node_ref,
         _temp_dir: temp_dir,
         _rt: rt,
@@ -79,8 +86,16 @@ fn setup_env(peppy: &Path, node_dir: &Path) -> NodeSetup {
     }
 }
 
-fn sync_and_add_node(peppy: &Path, daemon_state_path: &Path, node_dir: &Path, context: &str) {
-    let sync_output = peppy_output(peppy, daemon_state_path, node_dir, &["node", "sync"]);
+fn sync_and_add_node(
+    peppy: &Path,
+    daemon_state_path: &Path,
+    node_dir: &Path,
+    context: &str,
+    extra_sync_args: &[&str],
+) {
+    let mut sync_cmd = vec!["node", "sync"];
+    sync_cmd.extend_from_slice(extra_sync_args);
+    let sync_output = peppy_output(peppy, daemon_state_path, node_dir, &sync_cmd);
     assert_success(&sync_output, &format!("peppy node sync for {context}"));
 
     let add_output = peppy_output(
@@ -90,6 +105,32 @@ fn sync_and_add_node(peppy: &Path, daemon_state_path: &Path, node_dir: &Path, co
         &["node", "add", ".", "--force"],
     );
     assert_success(&add_output, &format!("peppy node add . for {context}"));
+}
+
+/// Registers `interfaces_root` (relative to the workspace) as a filesystem
+/// repository the emulated daemon will scan, then refreshes so that
+/// `depends_on.interfaces` and `conforms_to` references resolve from the
+/// interface cache during `node sync -r`. The serve emulation seeds an empty
+/// `repositories.json5` at startup; we overwrite it with the single fs entry.
+fn register_interface_repo(peppy: &Path, setup: &NodeSetup, interfaces_root: &str) {
+    let interfaces_dir = workspace_root().join(interfaces_root);
+    let conf_dir = setup.daemon_root.join("conf");
+    fs::create_dir_all(&conf_dir).expect("failed to create daemon conf dir");
+    // `{:?}` quotes and escapes the path into a valid JSON string literal.
+    let repos_content = format!(
+        r#"[{{ "id": 1, "type": "fs", "path": {:?} }}]"#,
+        interfaces_dir.to_string_lossy().as_ref(),
+    );
+    fs::write(conf_dir.join("repositories.json5"), repos_content)
+        .expect("failed to write repositories.json5");
+
+    let refresh_output = peppy_output(
+        peppy,
+        &setup.daemon_state_path,
+        &interfaces_dir,
+        &["repo", "refresh"],
+    );
+    assert_success(&refresh_output, "peppy repo refresh");
 }
 
 fn build_node(peppy: &Path, daemon_state_path: &Path, node_dir: &Path, node_ref: &str) {
@@ -130,12 +171,56 @@ pub fn run_snippet_with_deps(
             dep_config.manifest.name.as_str(),
             dep_config.manifest.tag
         );
-        sync_and_add_node(peppy, &setup.daemon_state_path, &dep_dir, dep);
+        sync_and_add_node(peppy, &setup.daemon_state_path, &dep_dir, dep, &[]);
         build_node(peppy, &setup.daemon_state_path, &dep_dir, &dep_ref);
     }
 
     // Now sync, add, and build the main node
-    sync_and_add_node(peppy, &setup.daemon_state_path, &node_dir, snippet_name);
+    sync_and_add_node(
+        peppy,
+        &setup.daemon_state_path,
+        &node_dir,
+        snippet_name,
+        &[],
+    );
+    build_node(peppy, &setup.daemon_state_path, &node_dir, &setup.node_ref);
+
+    let mut run_cmd = vec!["node", "run", setup.node_ref.as_str()];
+    run_cmd.extend_from_slice(start_args);
+
+    let start_output = peppy_output(peppy, &setup.daemon_state_path, &node_dir, &run_cmd);
+    assert_success(&start_output, &format!("peppy node run {}", setup.node_ref));
+}
+
+/// Run a snippet whose `depends_on.interfaces` / `conforms_to` references are
+/// resolved from an interface repository rather than from other nodes in the
+/// stack. `interfaces_root` is a workspace-relative directory of
+/// `interface_v1` documents; it is registered as an fs repo and refreshed,
+/// then the snippet is synced with `-r`, added, built, and launched with NO
+/// `--bind`. This is the launch path for an optional, `from_any` interface
+/// consumer: it must come up with zero producers present.
+pub fn run_snippet_with_interface_repo(
+    snippets_root: &str,
+    snippet_name: &str,
+    start_args: &[&str],
+    interfaces_root: &str,
+) {
+    let peppy = peppy_binary();
+    let node_dir = snippet_dir(snippets_root, snippet_name);
+
+    let setup = setup_env(peppy, &node_dir);
+
+    register_interface_repo(peppy, &setup, interfaces_root);
+
+    // `-r` lets the daemon resolve the interface deps from the repo cache
+    // populated by the refresh above (no producer node is in the stack).
+    sync_and_add_node(
+        peppy,
+        &setup.daemon_state_path,
+        &node_dir,
+        snippet_name,
+        &["-r"],
+    );
     build_node(peppy, &setup.daemon_state_path, &node_dir, &setup.node_ref);
 
     let mut run_cmd = vec!["node", "run", setup.node_ref.as_str()];

--- a/docs/tests/integration/tests/python_snippets.rs
+++ b/docs/tests/integration/tests/python_snippets.rs
@@ -1,6 +1,9 @@
-use docs_integration_tests::snippet_runner::{run_snippet, run_snippet_with_deps};
+use docs_integration_tests::snippet_runner::{
+    run_snippet, run_snippet_with_deps, run_snippet_with_interface_repo,
+};
 
 const SNIPPETS_ROOT: &str = "docs/src/content/docs/guides/snippets/python";
+const INTERFACES_ROOT: &str = "docs/src/content/docs/guides/snippets/interfaces";
 
 #[test]
 fn hello_world() {
@@ -26,4 +29,20 @@ fn standalone_node() {
 #[test]
 fn hello_world_param_and_hello_receiver() {
     run_snippet_with_deps(SNIPPETS_ROOT, "hello_receiver", &[], &["hello_world_param"]);
+}
+
+// The bidirectional pair from the "Bidirectional communication" guide. Each
+// side consumes the other's interface through a `from_any: true` slot, so it
+// builds and launches with NO `--bind` and zero producers present. Running
+// each node on its own (the other absent entirely) proves the consumed slot
+// is optional: launch must succeed with nothing bound, in any order.
+
+#[test]
+fn bidirectional_robot_arm() {
+    run_snippet_with_interface_repo(SNIPPETS_ROOT, "robot_arm", &[], INTERFACES_ROOT);
+}
+
+#[test]
+fn bidirectional_arm_controller() {
+    run_snippet_with_interface_repo(SNIPPETS_ROOT, "arm_controller", &[], INTERFACES_ROOT);
 }

--- a/docs/tests/integration/tests/rust_snippets.rs
+++ b/docs/tests/integration/tests/rust_snippets.rs
@@ -1,6 +1,9 @@
-use docs_integration_tests::snippet_runner::{run_snippet, run_snippet_with_deps};
+use docs_integration_tests::snippet_runner::{
+    run_snippet, run_snippet_with_deps, run_snippet_with_interface_repo,
+};
 
 const SNIPPETS_ROOT: &str = "docs/src/content/docs/guides/snippets/rust";
+const INTERFACES_ROOT: &str = "docs/src/content/docs/guides/snippets/interfaces";
 
 #[test]
 fn hello_world() {
@@ -25,4 +28,20 @@ fn standalone_node() {
 #[test]
 fn hello_world_param_and_hello_receiver() {
     run_snippet_with_deps(SNIPPETS_ROOT, "hello_receiver", &[], &["hello_world_param"]);
+}
+
+// The bidirectional pair from the "Bidirectional communication" guide. Each
+// side consumes the other's interface through a `from_any: true` slot, so it
+// builds and launches with NO `--bind` and zero producers present. Running
+// each node on its own (the other absent entirely) proves the consumed slot
+// is optional: launch must succeed with nothing bound, in any order.
+
+#[test]
+fn bidirectional_robot_arm() {
+    run_snippet_with_interface_repo(SNIPPETS_ROOT, "robot_arm", &[], INTERFACES_ROOT);
+}
+
+#[test]
+fn bidirectional_arm_controller() {
+    run_snippet_with_interface_repo(SNIPPETS_ROOT, "arm_controller", &[], INTERFACES_ROOT);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bidirectional communication pattern: optional wildcard consumption (from_any) so nodes can launch without explicit bindings and discover producers at runtime.

* **Documentation**
  * Expanded bidirectional and interface-conformance guides; added end-to-end Python and Rust snippet examples, manifests, and launcher workflows.
  * Updated docs site sidebar/config and build dependencies.

* **Tests**
  * New integration tests for optional bindings, late-joining producers, and end-to-end snippet runs.

* **Chores**
  * Added snippet-run helper and updated snippet packaging and ignore files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->