### PR TITLE
docs: sync with PR #234

### DIFF
--- a/docs/src/content/docs/advanced_guides/core_node_functions.mdx
+++ b/docs/src/content/docs/advanced_guides/core_node_functions.mdx
@@ -97,7 +97,7 @@ The second argument is a timeout. Rust accepts anything that converts to `Option
 
 Each node entry carries its `name`, `tag`, `config_path`, optional `artifact_path`, `stage` (`Added`, `Building`, `Ready`, or `Root`), and its `instances`.
 Each instance has an `instance_id` and a `state` (`starting` or `running`).
-The graph's `edges` list the dependency relationships, with each edge pointing from one node entry to another.
+The graph's `edges` list the dependency relationships, with each edge pointing from one node entry to another. The list covers both direct `depends_on.nodes` dependencies and those resolved through [interface conformance](/advanced_guides/interface_conformance): a conformance edge carries a `via_interface` of `name:tag` (the interface it was resolved through), while a direct edge has none.
 
 Rust and Python expose the graph differently:
 

--- a/docs/src/content/docs/advanced_guides/interface_conformance.mdx
+++ b/docs/src/content/docs/advanced_guides/interface_conformance.mdx
@@ -367,7 +367,7 @@ A launcher can wire the three slots to any mix of conforming producers:
 
 Swapping `realsense_d405:v1` for `mujoco_depth_camera_sim:v1` in the launcher requires no change to the consumer node, since both producers conform to the same interface and the binding works unchanged.
 
-Once the stack is running, these conformance-resolved dependencies surface in the tooling alongside direct ones. `peppy stack list` includes them in its **Dependencies** section, annotated `(via depth_camera:v1 interface conformance)`, and [`peppy stack benchmark`](/advanced_guides/stack_benchmark/) measures each consumed topic and service across the resolved edge. Both draw a heavy `➔` arrow for a conformance edge to distinguish it from a direct `depends_on.nodes` edge (`→`).
+Once the stack is running, these conformance-resolved dependencies surface in the tooling alongside direct ones. `peppy stack list` includes them in its **Dependencies** section, annotated `(via depth_camera:v1 interface conformance)`, and [`peppy stack benchmark`](/advanced_guides/stack_benchmark/) measures each consumed topic, service, and action across the resolved edge. Both draw a heavy `➔` arrow for a conformance edge to distinguish it from a direct `depends_on.nodes` edge (`→`).
 
 ## Caller-driven cycles are rejected
 


### PR DESCRIPTION
Automated doc update generated by `scripts/docs/update_docs.py`
in response to code changes in #234.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that `stack.list` edges include both direct dependencies and relationships resolved through interface conformance, with conformance edges annotated
  * Updated benchmark documentation to specify that measurements now include topics, services, and actions across conformance-resolved edges

<!-- end of auto-generated comment: release notes by coderabbit.ai -->