### PR TITLE
Switch to Zenoh peer sessions for direct peer-to-peer data paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -694,6 +694,7 @@ dependencies = [
  "peppylib",
  "pmi",
  "rand 0.10.1",
+ "rstest",
  "rust-embed",
  "serde",
  "serde_json",
@@ -1372,6 +1373,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
+
+[[package]]
 name = "futures-util"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1402,6 +1409,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
+ "rstest",
  "rust-embed",
  "serde_json5",
  "sha2 0.11.0",
@@ -3651,6 +3659,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
 name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3745,6 +3759,36 @@ dependencies = [
  "spki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rstest"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a2c585be59b6b5dd66a9d2084aa1d8bd52fbdb806eafdeffb52791147862035"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "825ea780781b15345a146be27eaefb05085e337e869bff01b4306a4fd4a9ad5a"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn 2.0.117",
+ "unicode-ident",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2425,20 +2425,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "netdev"
-version = "0.43.0"
+name = "ndk-context"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57bacaf873ee4eab5646f99b381b271ec75e716902a67cf962c0f328c5eb5bfb"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "netdev"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d31e7286c21ceaf0ddb1d881964011214555ea0b317cc2eb1a1d68d861386fc"
 dependencies = [
  "block2",
  "dispatch2",
  "dlopen2",
  "ipnet",
+ "jni 0.21.1",
  "libc",
  "mac-addr",
+ "ndk-context",
  "netlink-packet-core",
  "netlink-packet-route",
  "netlink-sys",
+ "objc2",
  "objc2-core-foundation",
  "objc2-core-wlan",
  "objc2-foundation",
@@ -2766,7 +2775,6 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "709fe137109bd1e8b5a99390f77a7d8b2961dafc1a1c5db8f2e60329ad6d895a"
 dependencies = [
- "bitflags",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2788,11 +2796,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
 dependencies = [
  "bitflags",
- "dispatch2",
- "libc",
- "objc2",
  "objc2-core-foundation",
- "objc2-security",
 ]
 
 [[package]]
@@ -3764,21 +3768,20 @@ dependencies = [
 
 [[package]]
 name = "rstest"
-version = "0.23.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2c585be59b6b5dd66a9d2084aa1d8bd52fbdb806eafdeffb52791147862035"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
 dependencies = [
- "futures",
  "futures-timer",
+ "futures-util",
  "rstest_macros",
- "rustc_version",
 ]
 
 [[package]]
 name = "rstest_macros"
-version = "0.23.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "825ea780781b15345a146be27eaefb05085e337e869bff01b4306a4fd4a9ad5a"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
 dependencies = [
  "cfg-if",
  "glob",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3156,7 +3156,6 @@ dependencies = [
 name = "pmi"
 version = "0.0.1"
 dependencies = [
- "askama",
  "build-helpers",
  "bytes",
  "config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,6 +580,7 @@ dependencies = [
  "capnp",
  "capnpc",
  "clap",
+ "const_format",
  "dirs 6.0.0",
  "git2",
  "indexmap 2.14.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ edition = "2024"
 parking_lot = "0.12"
 # Parameterized tests: messaging e2e suites run each body under both peer and
 # router mode via `#[case]` (see crates/*/tests). Test-only.
-rstest = "0.23"
+rstest = "0.26"
 
 # Optionally define workspace-wide lints or profiles.
 # [workspace.lints.rust]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ edition = "2024"
 # Uncomment and adapt as needed.
 [workspace.dependencies]
 parking_lot = "0.12"
+# Parameterized tests: messaging e2e suites run each body under both peer and
+# router mode via `#[case]` (see crates/*/tests). Test-only.
+rstest = "0.23"
 
 # Optionally define workspace-wide lints or profiles.
 # [workspace.lints.rust]

--- a/crates/config-internal/Cargo.toml
+++ b/crates/config-internal/Cargo.toml
@@ -26,6 +26,9 @@ tempfile = "3.8"
 indexmap = { version = "2.2", features = ["serde"] }
 git2 = { version = "0.21", optional = true }
 dirs = "6"
+# Compile-time string concatenation so the bundled peppy_config template splices
+# in the buffer-size constants instead of duplicating the literals.
+const_format = "0.2"
 
 [build-dependencies]
 build-helpers = { path = "../build-helpers-internal" }

--- a/crates/config-internal/src/lib.rs
+++ b/crates/config-internal/src/lib.rs
@@ -97,7 +97,8 @@ pub mod node {
 // -- runtime --
 pub mod runtime {
     pub use crate::internal::runtime::{
-        LauncherRuntimeConfig, NodeInstanceConfig, ResolvedFramework, RuntimeConfig, SlotBinding,
+        DiscoveryConfig, LauncherRuntimeConfig, NodeInstanceConfig, ResolvedFramework,
+        RuntimeConfig, SlotBinding,
     };
 }
 

--- a/crates/config-internal/src/lib.rs
+++ b/crates/config-internal/src/lib.rs
@@ -15,6 +15,7 @@ mod internal {
     pub mod json5_pretty;
     pub mod launcher;
     pub mod node;
+    pub mod peppy_config;
     pub mod repo_node_id;
     pub mod runtime;
     pub mod schema;
@@ -99,6 +100,14 @@ pub mod runtime {
     pub use crate::internal::runtime::{
         DiscoveryConfig, LauncherRuntimeConfig, NodeInstanceConfig, ResolvedFramework,
         RuntimeConfig, SlotBinding,
+    };
+}
+
+// -- peppy_config --
+pub mod peppy_config {
+    pub use crate::internal::peppy_config::{
+        DEFAULT_HIGH_THROUGHPUT_BUFFER_SIZE, DEFAULT_STANDARD_BUFFER_SIZE, Mode, PEPPY_CONFIG_FILE,
+        PeerConfig, PeppyConfig, load_or_create,
     };
 }
 

--- a/crates/config-internal/src/peppy_config.rs
+++ b/crates/config-internal/src/peppy_config.rs
@@ -37,14 +37,15 @@ pub const DEFAULT_HIGH_THROUGHPUT_BUFFER_SIZE: usize = 1024;
 /// the template can never drift from the [`PeerConfig::default`] the parser falls
 /// back to when the `peer` block is absent.
 const DEFAULT_PEPPY_CONFIG_TEMPLATE: &str = const_format::concatcp!(
-    r#"{
-  // Messaging mode for this peppy daemon. Takes effect after a daemon restart.
+    r#"// Read once when the peppy daemon starts, so any edit below (mode or buffer
+// sizes) takes effect only after you restart the daemon.
+{
   //   "peer"   - Zenoh peer sessions with gossip: nodes form direct
   //              peer-to-peer links and data stops relaying through the router.
   //   "router" - gossip off: all traffic relays through the central zenohd
   //              router.
-  // Container nodes in a separate network namespace always use the router path
-  // regardless of this setting.
+  // Container nodes in a separate network namespace (Lima on macOS) always use 
+  // the router path regardless of this setting.
   mode: "peer",
 
   // Subscriber channel buffer sizes (number of in-flight messages) per QoS

--- a/crates/config-internal/src/peppy_config.rs
+++ b/crates/config-internal/src/peppy_config.rs
@@ -31,7 +31,13 @@ pub const DEFAULT_HIGH_THROUGHPUT_BUFFER_SIZE: usize = 1024;
 /// `config-internal` is vendored into every generated node as `src/` only, with
 /// no sibling `assets/` directory, so an external include would fail to compile
 /// inside a node build.
-const DEFAULT_PEPPY_CONFIG_TEMPLATE: &str = r#"{
+///
+/// The two buffer-size values are spliced in from [`DEFAULT_STANDARD_BUFFER_SIZE`]
+/// and [`DEFAULT_HIGH_THROUGHPUT_BUFFER_SIZE`] at compile time via `concatcp!`, so
+/// the template can never drift from the [`PeerConfig::default`] the parser falls
+/// back to when the `peer` block is absent.
+const DEFAULT_PEPPY_CONFIG_TEMPLATE: &str = const_format::concatcp!(
+    r#"{
   // Messaging mode for this peppy daemon. Takes effect after a daemon restart.
   //   "peer"   - Zenoh peer sessions with gossip: nodes form direct
   //              peer-to-peer links and data stops relaying through the router.
@@ -46,11 +52,16 @@ const DEFAULT_PEPPY_CONFIG_TEMPLATE: &str = r#"{
   // publisher and a subscriber. Defaults match peppy's built-in behavior; only
   // edit to tune backpressure.
   peer: {
-    standard_buffer_size: 128,
-    high_throughput_buffer_size: 1024,
+    standard_buffer_size: "#,
+    DEFAULT_STANDARD_BUFFER_SIZE,
+    r#",
+    high_throughput_buffer_size: "#,
+    DEFAULT_HIGH_THROUGHPUT_BUFFER_SIZE,
+    r#",
   },
 }
-"#;
+"#
+);
 
 /// The messaging topology the daemon runs in.
 ///
@@ -111,6 +122,32 @@ pub struct PeppyConfig {
     pub peer: PeerConfig,
 }
 
+impl PeppyConfig {
+    /// Rejects user-tunable numeric fields that serde cannot constrain.
+    ///
+    /// Buffer sizes feed bounded channel constructors downstream: a 0 capacity
+    /// panics `tokio::sync::mpsc::channel` and degrades `flume::bounded` into a
+    /// rendezvous channel that stalls every send. A hand-edited 0 must fail loud
+    /// at load time rather than crash or wedge a running mesh.
+    fn validate(&self) -> Result<()> {
+        let buffer_sizes = [
+            ("standard_buffer_size", self.peer.standard_buffer_size),
+            (
+                "high_throughput_buffer_size",
+                self.peer.high_throughput_buffer_size,
+            ),
+        ];
+        for (field, value) in buffer_sizes {
+            if value == 0 {
+                return Err(Error::Parsing(ParsingError::CannotParseConfig(format!(
+                    "invalid peer buffer size: {field} must be > 0"
+                ))));
+            }
+        }
+        Ok(())
+    }
+}
+
 /// Reads the global config from `~/.peppy/conf/peppy_config.json5`, creating it
 /// from the bundled default template (verbatim, so comments survive) when it
 /// does not exist.
@@ -124,21 +161,26 @@ pub fn load_or_create(peppy_dirs: &PeppyDirs) -> Result<PeppyConfig> {
     std::fs::create_dir_all(&conf_dir)?;
     let path = conf_dir.join(PEPPY_CONFIG_FILE);
 
-    if !path.exists() {
+    let config: PeppyConfig = if !path.exists() {
         std::fs::write(&path, DEFAULT_PEPPY_CONFIG_TEMPLATE)?;
         // The bundled template is a compile-time invariant; a parse failure here
         // means the shipped asset is broken, not the user's file.
-        return serde_json5::from_str(DEFAULT_PEPPY_CONFIG_TEMPLATE).map_err(|e| {
+        serde_json5::from_str(DEFAULT_PEPPY_CONFIG_TEMPLATE).map_err(|e| {
             Error::Serialize(format!("bundled default peppy_config is invalid: {e}"))
-        });
-    }
+        })?
+    } else {
+        let content = std::fs::read_to_string(&path)?;
+        serde_json5::from_str(&content).map_err(|e| {
+            Error::Parsing(ParsingError::CannotParseConfig(format!(
+                "{PEPPY_CONFIG_FILE}: {e}"
+            )))
+        })?
+    };
 
-    let content = std::fs::read_to_string(&path)?;
-    serde_json5::from_str(&content).map_err(|e| {
-        Error::Parsing(ParsingError::CannotParseConfig(format!(
-            "{PEPPY_CONFIG_FILE}: {e}"
-        )))
-    })
+    // serde parses any numeric field, so a hand-edited 0 buffer size survives
+    // the steps above; reject it before it reaches a bounded channel downstream.
+    config.validate()?;
+    Ok(config)
 }
 
 #[cfg(test)]
@@ -259,5 +301,60 @@ mod tests {
             matches!(err, Error::Parsing(ParsingError::CannotParseConfig(_))),
             "expected a parse error, got: {err:?}"
         );
+    }
+
+    #[test]
+    fn zero_standard_buffer_size_fails_loud() {
+        let tmp = tempdir().unwrap();
+        let peppy_dirs = PeppyDirs::new(tmp.path());
+        let conf_dir = peppy_dirs.conf_dir();
+        std::fs::create_dir_all(&conf_dir).unwrap();
+        std::fs::write(
+            conf_dir.join(PEPPY_CONFIG_FILE),
+            r#"{ peer: { standard_buffer_size: 0 } }"#,
+        )
+        .unwrap();
+
+        let err = load_or_create(&peppy_dirs).unwrap_err();
+        assert!(
+            matches!(err, Error::Parsing(ParsingError::CannotParseConfig(ref m)) if m.contains("standard_buffer_size")),
+            "expected a buffer-size validation error, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn zero_high_throughput_buffer_size_fails_loud() {
+        let tmp = tempdir().unwrap();
+        let peppy_dirs = PeppyDirs::new(tmp.path());
+        let conf_dir = peppy_dirs.conf_dir();
+        std::fs::create_dir_all(&conf_dir).unwrap();
+        std::fs::write(
+            conf_dir.join(PEPPY_CONFIG_FILE),
+            r#"{ peer: { high_throughput_buffer_size: 0 } }"#,
+        )
+        .unwrap();
+
+        let err = load_or_create(&peppy_dirs).unwrap_err();
+        assert!(
+            matches!(err, Error::Parsing(ParsingError::CannotParseConfig(ref m)) if m.contains("high_throughput_buffer_size")),
+            "expected a buffer-size validation error, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn accepts_minimal_nonzero_buffer_sizes() {
+        let tmp = tempdir().unwrap();
+        let peppy_dirs = PeppyDirs::new(tmp.path());
+        let conf_dir = peppy_dirs.conf_dir();
+        std::fs::create_dir_all(&conf_dir).unwrap();
+        std::fs::write(
+            conf_dir.join(PEPPY_CONFIG_FILE),
+            r#"{ peer: { standard_buffer_size: 1, high_throughput_buffer_size: 1 } }"#,
+        )
+        .unwrap();
+
+        let cfg = load_or_create(&peppy_dirs).unwrap();
+        assert_eq!(cfg.peer.standard_buffer_size, 1);
+        assert_eq!(cfg.peer.high_throughput_buffer_size, 1);
     }
 }

--- a/crates/config-internal/src/peppy_config.rs
+++ b/crates/config-internal/src/peppy_config.rs
@@ -1,0 +1,268 @@
+//! Global daemon configuration read from `~/.peppy/conf/peppy_config.json5`.
+//!
+//! This is the single user-facing switch for the messaging topology. The daemon
+//! reads it ONCE at startup (see `peppy serve`), creating the file from the
+//! bundled default template if it is missing, and applies the result to its own
+//! core-node session and to every node it spawns. Editing the file takes effect
+//! after a daemon restart.
+//!
+//! Unlike `repositories.json5`, a malformed `peppy_config.json5` fails loud at
+//! startup ([`load_or_create`] returns `Err`) instead of falling back to
+//! defaults: the mode and buffer sizes determine the whole mesh's routing model
+//! and backpressure, so a hand-edited typo must surface immediately rather than
+//! silently reverting to peer mode.
+
+use crate::consts::PeppyDirs;
+use crate::error::{Error, ParsingError, Result};
+use serde::{Deserialize, Serialize};
+
+/// File name of the global daemon config under `~/.peppy/conf`.
+pub const PEPPY_CONFIG_FILE: &str = "peppy_config.json5";
+
+/// Default subscriber channel buffer for the `Standard` QoS tier (number of
+/// in-flight messages). Mirrors the historical hardcoded value.
+pub const DEFAULT_STANDARD_BUFFER_SIZE: usize = 128;
+/// Default subscriber channel buffer for the `HighThroughput` QoS tier (e.g.
+/// sensor-data streams). Mirrors the historical hardcoded value.
+pub const DEFAULT_HIGH_THROUGHPUT_BUFFER_SIZE: usize = 1024;
+
+/// The bundled default config, written verbatim on first create so its comments
+/// survive. Kept inline (not `include_str!` from an asset file) because
+/// `config-internal` is vendored into every generated node as `src/` only, with
+/// no sibling `assets/` directory, so an external include would fail to compile
+/// inside a node build.
+const DEFAULT_PEPPY_CONFIG_TEMPLATE: &str = r#"{
+  // Messaging mode for this peppy daemon. Takes effect after a daemon restart.
+  //   "peer"   - Zenoh peer sessions with gossip: nodes form direct
+  //              peer-to-peer links and data stops relaying through the router.
+  //   "router" - gossip off: all traffic relays through the central zenohd
+  //              router.
+  // Container nodes in a separate network namespace always use the router path
+  // regardless of this setting.
+  mode: "peer",
+
+  // Subscriber channel buffer sizes (number of in-flight messages) per QoS
+  // tier, used in peer mode where there is no router relay to buffer between a
+  // publisher and a subscriber. Defaults match peppy's built-in behavior; only
+  // edit to tune backpressure.
+  peer: {
+    standard_buffer_size: 128,
+    high_throughput_buffer_size: 1024,
+  },
+}
+"#;
+
+/// The messaging topology the daemon runs in.
+///
+/// `Peer` keeps gossip on so nodes form direct peer-to-peer links; `Router`
+/// turns gossip off so every node routes through the central `zenohd`. The
+/// `gossip()` mapping is the single source of truth tying this user-facing
+/// choice to the `DiscoveryConfig.gossip` flag the sessions actually read.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Mode {
+    #[default]
+    Peer,
+    Router,
+}
+
+impl Mode {
+    /// Whether this is peer mode (direct peer-to-peer links).
+    pub fn is_peer(self) -> bool {
+        matches!(self, Mode::Peer)
+    }
+
+    /// Mode to gossip mapping: peer enables gossip, router disables it.
+    pub fn gossip(self) -> bool {
+        self.is_peer()
+    }
+}
+
+fn default_standard_buffer_size() -> usize {
+    DEFAULT_STANDARD_BUFFER_SIZE
+}
+
+fn default_high_throughput_buffer_size() -> usize {
+    DEFAULT_HIGH_THROUGHPUT_BUFFER_SIZE
+}
+
+/// Peer-mode tuning knobs. Buffer sizes are the per-QoS subscriber channel
+/// capacities used when nodes peer directly (no router relay to absorb bursts).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PeerConfig {
+    #[serde(default = "default_standard_buffer_size")]
+    pub standard_buffer_size: usize,
+    #[serde(default = "default_high_throughput_buffer_size")]
+    pub high_throughput_buffer_size: usize,
+}
+
+impl Default for PeerConfig {
+    fn default() -> Self {
+        Self {
+            standard_buffer_size: DEFAULT_STANDARD_BUFFER_SIZE,
+            high_throughput_buffer_size: DEFAULT_HIGH_THROUGHPUT_BUFFER_SIZE,
+        }
+    }
+}
+
+/// The whole `peppy_config.json5` document. Every field is serde-defaulted so a
+/// partial or older file still parses; extra unknown keys are tolerated (this is
+/// a user-edited file, forward-compat beats strictness here).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct PeppyConfig {
+    #[serde(default)]
+    pub mode: Mode,
+    #[serde(default)]
+    pub peer: PeerConfig,
+}
+
+/// Reads the global config from `~/.peppy/conf/peppy_config.json5`, creating it
+/// from the bundled default template (verbatim, so comments survive) when it
+/// does not exist.
+///
+/// Read ONCE by the daemon at startup. A malformed existing file returns `Err`
+/// (fail loud) rather than defaulting, since mode and buffer sizes are
+/// load-bearing for the whole mesh. This intentionally differs from
+/// `ensure_default_repos`, which only warns on a bad repos file.
+pub fn load_or_create(peppy_dirs: &PeppyDirs) -> Result<PeppyConfig> {
+    let conf_dir = peppy_dirs.conf_dir();
+    std::fs::create_dir_all(&conf_dir)?;
+    let path = conf_dir.join(PEPPY_CONFIG_FILE);
+
+    if !path.exists() {
+        std::fs::write(&path, DEFAULT_PEPPY_CONFIG_TEMPLATE)?;
+        // The bundled template is a compile-time invariant; a parse failure here
+        // means the shipped asset is broken, not the user's file.
+        return serde_json5::from_str(DEFAULT_PEPPY_CONFIG_TEMPLATE).map_err(|e| {
+            Error::Serialize(format!("bundled default peppy_config is invalid: {e}"))
+        });
+    }
+
+    let content = std::fs::read_to_string(&path)?;
+    serde_json5::from_str(&content).map_err(|e| {
+        Error::Parsing(ParsingError::CannotParseConfig(format!(
+            "{PEPPY_CONFIG_FILE}: {e}"
+        )))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn default_mode_is_peer_and_buffers_match_constants() {
+        let cfg = PeppyConfig::default();
+        assert_eq!(cfg.mode, Mode::Peer);
+        assert!(cfg.mode.is_peer());
+        assert!(cfg.mode.gossip());
+        assert!(!Mode::Router.gossip());
+        assert_eq!(cfg.peer.standard_buffer_size, DEFAULT_STANDARD_BUFFER_SIZE);
+        assert_eq!(
+            cfg.peer.high_throughput_buffer_size,
+            DEFAULT_HIGH_THROUGHPUT_BUFFER_SIZE
+        );
+    }
+
+    #[test]
+    fn creates_file_verbatim_on_first_run() {
+        let tmp = tempdir().unwrap();
+        let peppy_dirs = PeppyDirs::new(tmp.path());
+        let path = peppy_dirs.conf_dir().join(PEPPY_CONFIG_FILE);
+        assert!(!path.exists());
+
+        let cfg = load_or_create(&peppy_dirs).unwrap();
+
+        assert!(path.exists());
+        // Verbatim write preserves the template's comments byte-for-byte.
+        let written = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(written, DEFAULT_PEPPY_CONFIG_TEMPLATE);
+        assert_eq!(cfg, PeppyConfig::default());
+    }
+
+    #[test]
+    fn load_is_idempotent_and_reads_existing_file() {
+        let tmp = tempdir().unwrap();
+        let peppy_dirs = PeppyDirs::new(tmp.path());
+        let first = load_or_create(&peppy_dirs).unwrap();
+        let second = load_or_create(&peppy_dirs).unwrap();
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn parses_partial_file_filling_defaults() {
+        let tmp = tempdir().unwrap();
+        let peppy_dirs = PeppyDirs::new(tmp.path());
+        let conf_dir = peppy_dirs.conf_dir();
+        std::fs::create_dir_all(&conf_dir).unwrap();
+        std::fs::write(conf_dir.join(PEPPY_CONFIG_FILE), r#"{ mode: "router" }"#).unwrap();
+
+        let cfg = load_or_create(&peppy_dirs).unwrap();
+        assert_eq!(cfg.mode, Mode::Router);
+        assert!(!cfg.mode.gossip());
+        // Missing peer block falls back to the built-in defaults.
+        assert_eq!(cfg.peer.standard_buffer_size, DEFAULT_STANDARD_BUFFER_SIZE);
+        assert_eq!(
+            cfg.peer.high_throughput_buffer_size,
+            DEFAULT_HIGH_THROUGHPUT_BUFFER_SIZE
+        );
+    }
+
+    #[test]
+    fn parses_empty_object_as_all_defaults() {
+        let tmp = tempdir().unwrap();
+        let peppy_dirs = PeppyDirs::new(tmp.path());
+        let conf_dir = peppy_dirs.conf_dir();
+        std::fs::create_dir_all(&conf_dir).unwrap();
+        std::fs::write(conf_dir.join(PEPPY_CONFIG_FILE), "{}").unwrap();
+
+        let cfg = load_or_create(&peppy_dirs).unwrap();
+        assert_eq!(cfg, PeppyConfig::default());
+    }
+
+    #[test]
+    fn round_trips_custom_config() {
+        let custom = PeppyConfig {
+            mode: Mode::Router,
+            peer: PeerConfig {
+                standard_buffer_size: 64,
+                high_throughput_buffer_size: 4096,
+            },
+        };
+        let serialized = serde_json5::to_string(&custom).unwrap();
+        let reparsed: PeppyConfig = serde_json5::from_str(&serialized).unwrap();
+        assert_eq!(reparsed, custom);
+    }
+
+    #[test]
+    fn mode_serializes_snake_case() {
+        assert_eq!(
+            serde_json::to_value(Mode::Router).unwrap(),
+            serde_json::json!("router")
+        );
+        assert_eq!(
+            serde_json::to_value(Mode::Peer).unwrap(),
+            serde_json::json!("peer")
+        );
+    }
+
+    #[test]
+    fn malformed_file_fails_loud() {
+        let tmp = tempdir().unwrap();
+        let peppy_dirs = PeppyDirs::new(tmp.path());
+        let conf_dir = peppy_dirs.conf_dir();
+        std::fs::create_dir_all(&conf_dir).unwrap();
+        std::fs::write(
+            conf_dir.join(PEPPY_CONFIG_FILE),
+            r#"{ mode: "router", peer: { standard_buffer_size: "not a number" } }"#,
+        )
+        .unwrap();
+
+        let err = load_or_create(&peppy_dirs).unwrap_err();
+        assert!(
+            matches!(err, Error::Parsing(ParsingError::CannotParseConfig(_))),
+            "expected a parse error, got: {err:?}"
+        );
+    }
+}

--- a/crates/config-internal/src/peppy_config.rs
+++ b/crates/config-internal/src/peppy_config.rs
@@ -78,21 +78,16 @@ impl Mode {
     }
 }
 
-fn default_standard_buffer_size() -> usize {
-    DEFAULT_STANDARD_BUFFER_SIZE
-}
-
-fn default_high_throughput_buffer_size() -> usize {
-    DEFAULT_HIGH_THROUGHPUT_BUFFER_SIZE
-}
-
 /// Peer-mode tuning knobs. Buffer sizes are the per-QoS subscriber channel
 /// capacities used when nodes peer directly (no router relay to absorb bursts).
+///
+/// `#[serde(default)]` fills any field a partial `peer` block omits from
+/// [`PeerConfig::default`], so every per-field default flows from the single
+/// `Default` impl below rather than parallel `default = "fn"` helpers.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
 pub struct PeerConfig {
-    #[serde(default = "default_standard_buffer_size")]
     pub standard_buffer_size: usize,
-    #[serde(default = "default_high_throughput_buffer_size")]
     pub high_throughput_buffer_size: usize,
 }
 

--- a/crates/config-internal/src/runtime.rs
+++ b/crates/config-internal/src/runtime.rs
@@ -78,13 +78,26 @@ fn default_true() -> bool {
     true
 }
 
-/// Peer-discovery settings for a node's messaging session.
+fn default_standard_buffer_size() -> usize {
+    crate::peppy_config::DEFAULT_STANDARD_BUFFER_SIZE
+}
+
+fn default_high_throughput_buffer_size() -> usize {
+    crate::peppy_config::DEFAULT_HIGH_THROUGHPUT_BUFFER_SIZE
+}
+
+/// Messaging-session settings the daemon resolves once and ships to a node.
 ///
 /// Nodes open a `peer` session that connects to a seed (the router) and then
 /// forms direct peer-to-peer links with peers discovered via gossip, so data
 /// stops relaying through the router. Discovery is gossip-only; there is no
 /// multicast (it would bridge otherwise-independent peer groups on a shared
 /// host, and a known seed already covers discovery).
+///
+/// The subscriber buffer sizes live here too. They are a subscriber-channel
+/// concern rather than a discovery one, but co-locating them keeps a single
+/// struct (and a single serialized block) travelling the daemon-to-node path,
+/// since this is already the value threaded into the node's session at startup.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct DiscoveryConfig {
@@ -96,6 +109,12 @@ pub struct DiscoveryConfig {
     /// all traffic through the router (a rollback switch without a rebuild).
     #[serde(default = "default_true")]
     pub gossip: bool,
+    /// Subscriber channel buffer for the `Standard` QoS tier (in-flight messages).
+    #[serde(default = "default_standard_buffer_size")]
+    pub standard_buffer_size: usize,
+    /// Subscriber channel buffer for the `HighThroughput` QoS tier (e.g. sensor data).
+    #[serde(default = "default_high_throughput_buffer_size")]
+    pub high_throughput_buffer_size: usize,
 }
 
 impl Default for DiscoveryConfig {
@@ -103,6 +122,8 @@ impl Default for DiscoveryConfig {
         Self {
             seed_peers: Vec::new(),
             gossip: true,
+            standard_buffer_size: crate::peppy_config::DEFAULT_STANDARD_BUFFER_SIZE,
+            high_throughput_buffer_size: crate::peppy_config::DEFAULT_HIGH_THROUGHPUT_BUFFER_SIZE,
         }
     }
 }
@@ -270,6 +291,10 @@ mod tests {
         assert_eq!(legacy.discovery, DiscoveryConfig::default());
         assert!(legacy.discovery.gossip);
         assert!(legacy.discovery.seed_peers.is_empty());
+        // A launch config written before the buffer fields existed still parses
+        // and gets the built-in defaults.
+        assert_eq!(legacy.discovery.standard_buffer_size, 128);
+        assert_eq!(legacy.discovery.high_throughput_buffer_size, 1024);
 
         // Default discovery is skipped on serialize.
         let serialized = serde_json5::to_string(&legacy).unwrap();
@@ -278,7 +303,8 @@ mod tests {
             "default discovery should not be serialized: {serialized}"
         );
 
-        let custom: RuntimeConfig = serde_json5::from_str(
+        // A discovery block that omits the buffer keys still parses (defaults).
+        let no_buffers: RuntimeConfig = serde_json5::from_str(
             r#"{
                 messaging_host: "127.0.0.1",
                 messaging_port: 7448,
@@ -291,10 +317,33 @@ mod tests {
         )
         .unwrap();
         assert_eq!(
-            custom.discovery.seed_peers,
+            no_buffers.discovery.seed_peers,
             vec!["tcp/10.0.0.2:7448".to_string()]
         );
-        assert!(!custom.discovery.gossip);
+        assert!(!no_buffers.discovery.gossip);
+        assert_eq!(no_buffers.discovery.standard_buffer_size, 128);
+        assert_eq!(no_buffers.discovery.high_throughput_buffer_size, 1024);
+
+        // Explicit buffer sizes round-trip.
+        let custom: RuntimeConfig = serde_json5::from_str(
+            r#"{
+                messaging_host: "127.0.0.1",
+                messaging_port: 7448,
+                node_instance: { instance_id: "camera_front" },
+                node_name: "camera",
+                node_tag: "v1",
+                bound_core_node: "core_node",
+                discovery: {
+                    seed_peers: ["tcp/10.0.0.2:7448"],
+                    gossip: false,
+                    standard_buffer_size: 64,
+                    high_throughput_buffer_size: 4096
+                }
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(custom.discovery.standard_buffer_size, 64);
+        assert_eq!(custom.discovery.high_throughput_buffer_size, 4096);
 
         let reparsed: RuntimeConfig =
             serde_json5::from_str(&serde_json5::to_string(&custom).unwrap()).unwrap();

--- a/crates/config-internal/src/runtime.rs
+++ b/crates/config-internal/src/runtime.rs
@@ -74,6 +74,45 @@ pub struct ResolvedFramework {
     pub use_sim_time: bool,
 }
 
+fn default_true() -> bool {
+    true
+}
+
+/// Peer-discovery settings for a node's messaging session.
+///
+/// Nodes open a `peer` session that connects to a seed (the router) and then
+/// forms direct peer-to-peer links with peers discovered via gossip, so data
+/// stops relaying through the router. Discovery is gossip-only; there is no
+/// multicast (it would bridge otherwise-independent peer groups on a shared
+/// host, and a known seed already covers discovery).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct DiscoveryConfig {
+    /// Gossip seed endpoints (full Zenoh endpoints, e.g. `"tcp/127.0.0.1:7448"`).
+    /// Empty means "derive the router endpoint from `messaging_host:messaging_port`".
+    #[serde(default)]
+    pub seed_peers: Vec<String>,
+    /// Enable gossip so peers form direct links. Setting this to `false` forces
+    /// all traffic through the router (a rollback switch without a rebuild).
+    #[serde(default = "default_true")]
+    pub gossip: bool,
+}
+
+impl Default for DiscoveryConfig {
+    fn default() -> Self {
+        Self {
+            seed_peers: Vec::new(),
+            gossip: true,
+        }
+    }
+}
+
+impl DiscoveryConfig {
+    fn is_default(&self) -> bool {
+        *self == Self::default()
+    }
+}
+
 /// Configuration for the launcher to know how to configure spawned nodes' messaging.
 /// This is passed as part of a LauncherRequest.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -111,6 +150,11 @@ pub struct RuntimeConfig {
     pub node_tag: Name,
     pub bound_core_node: Name,
     pub node_instance: NodeInstanceConfig,
+    /// Peer-discovery settings. Defaulted (and omitted from serialized configs)
+    /// for the common case, so launch configs written before this field existed
+    /// still parse.
+    #[serde(default, skip_serializing_if = "DiscoveryConfig::is_default")]
+    pub discovery: DiscoveryConfig,
 }
 
 impl RuntimeConfig {
@@ -129,6 +173,7 @@ impl RuntimeConfig {
             node_name: Name::new(node_name.into())?,
             node_tag: Name::new(node_tag.into())?,
             bound_core_node: Name::new(bound_core_node.into())?,
+            discovery: DiscoveryConfig::default(),
         })
     }
 
@@ -213,6 +258,47 @@ mod tests {
 
         let legacy = runtime_config_from_json("camera_front").unwrap();
         assert!(!legacy.node_instance.framework.use_sim_time);
+    }
+
+    /// A launch config written before `discovery` existed (no `discovery` key)
+    /// parses with the gossip-on default, an explicit discovery block
+    /// round-trips, and a default discovery is omitted from the serialized form
+    /// so existing configs stay byte-identical.
+    #[test]
+    fn discovery_config_default_and_round_trip() {
+        let legacy = runtime_config_from_json("camera_front").unwrap();
+        assert_eq!(legacy.discovery, DiscoveryConfig::default());
+        assert!(legacy.discovery.gossip);
+        assert!(legacy.discovery.seed_peers.is_empty());
+
+        // Default discovery is skipped on serialize.
+        let serialized = serde_json5::to_string(&legacy).unwrap();
+        assert!(
+            !serialized.contains("discovery"),
+            "default discovery should not be serialized: {serialized}"
+        );
+
+        let custom: RuntimeConfig = serde_json5::from_str(
+            r#"{
+                messaging_host: "127.0.0.1",
+                messaging_port: 7448,
+                node_instance: { instance_id: "camera_front" },
+                node_name: "camera",
+                node_tag: "v1",
+                bound_core_node: "core_node",
+                discovery: { seed_peers: ["tcp/10.0.0.2:7448"], gossip: false }
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(
+            custom.discovery.seed_peers,
+            vec!["tcp/10.0.0.2:7448".to_string()]
+        );
+        assert!(!custom.discovery.gossip);
+
+        let reparsed: RuntimeConfig =
+            serde_json5::from_str(&serde_json5::to_string(&custom).unwrap()).unwrap();
+        assert_eq!(reparsed.discovery, custom.discovery);
     }
 
     #[test]

--- a/crates/core-node-internal/Cargo.toml
+++ b/crates/core-node-internal/Cargo.toml
@@ -58,6 +58,7 @@ node-stack = { path = "../node-stack-internal" }
 config = { path = "../config-internal", features = ["test_helpers"] }
 tempfile = "3.10"
 tokio = { version = "1", features = ["full", "test-util"] }
+rstest = { workspace = true }
 httptest = "0.16.3"
 
 [features]

--- a/crates/core-node-internal/benches/latency.rs
+++ b/crates/core-node-internal/benches/latency.rs
@@ -120,6 +120,10 @@ fn main() {
 fn print_environment() {
     let env = CpuEnvironment::detect();
     println!("\nenv: {}", env.summary_line());
+    // Nodes run as Zenoh peers: after gossip via the seed router they exchange
+    // data over direct peer-to-peer links rather than relaying through the
+    // router. Shared memory is not yet wired into the publish path.
+    println!("transport: peer (gossip discovery, shm=off)");
     if env.is_noisy() {
         println!(
             "note: turbo and/or shared-host load make absolute latency swing run-to-run regardless \

--- a/crates/core-node-internal/src/services.rs
+++ b/crates/core-node-internal/src/services.rs
@@ -106,6 +106,9 @@ pub struct CoreNode {
     health_monitor_timeout: Duration,
     clock_publish_interval: Duration,
     daemon_use_sim_time: bool,
+    /// Daemon-global messaging mode + peer buffer sizes, read once at startup.
+    /// Injected into every spawned node's runtime config (see `node::run`).
+    peppy_config: config::peppy_config::PeppyConfig,
 }
 
 /// Pre-flight checks that run once at daemon startup. Exits with a
@@ -127,6 +130,7 @@ impl CoreNode {
         node_arguments: CoreNodeArguments,
         root_dir: P,
         peppy_dirs: PeppyDirs,
+        peppy_config: config::peppy_config::PeppyConfig,
     ) -> Self {
         let manifest_name = match node_name {
             Some(name) => Name::new(name).unwrap(),
@@ -209,6 +213,7 @@ impl CoreNode {
             health_monitor_timeout,
             clock_publish_interval,
             daemon_use_sim_time,
+            peppy_config,
         }
     }
 
@@ -364,6 +369,8 @@ impl CoreNode {
                         health_monitor_timeout: self.health_monitor_timeout,
                     },
                     use_sim_time: self.daemon_use_sim_time,
+                    messaging_mode: self.peppy_config.mode,
+                    peer_buffer: self.peppy_config.peer,
                 },
             )
             .boxed(),
@@ -440,6 +447,8 @@ impl CoreNode {
                     peppy_dirs: self.peppy_dirs.clone(),
                     health_monitor_interval: self.health_monitor_interval,
                     health_monitor_timeout: self.health_monitor_timeout,
+                    messaging_mode: self.peppy_config.mode,
+                    peer_buffer: self.peppy_config.peer,
                 },
             )
             .boxed(),

--- a/crates/core-node-internal/src/services/node/run.rs
+++ b/crates/core-node-internal/src/services/node/run.rs
@@ -5,6 +5,7 @@ use crate::Result;
 use crate::names;
 use config::consts::PeppyDirs;
 use config::node::Name;
+use config::peppy_config::{Mode, PeerConfig};
 use config::runtime::RuntimeConfig;
 use config::{AnyType, apply_parameter_defaults, resolve_argument_path};
 use core_node_api::encoding::{NodeRunFeedback, NodeRunGoal, NodeRunGoalResponse, NodeRunResult};
@@ -60,6 +61,10 @@ pub struct NodeRunServiceConfig {
     pub peppy_dirs: PeppyDirs,
     pub health_monitor_interval: Duration,
     pub health_monitor_timeout: Duration,
+    /// Daemon-global messaging mode, injected into every spawned node.
+    pub messaging_mode: Mode,
+    /// Daemon-global peer buffer sizes, injected into every spawned node.
+    pub peer_buffer: PeerConfig,
 }
 
 #[derive(Clone)]
@@ -73,6 +78,24 @@ pub(crate) struct NodeRunActionContext {
     pub(crate) peppy_dirs: PeppyDirs,
     pub(crate) health_monitor_interval: Duration,
     pub(crate) health_monitor_timeout: Duration,
+    pub(crate) messaging_mode: Mode,
+    pub(crate) peer_buffer: PeerConfig,
+}
+
+/// Applies the daemon-global messaging mode and peer buffer sizes to a node's
+/// session config before it is launched. `container_separate_ns` forces the
+/// node onto the router-relay (client) path even in peer mode, because a
+/// container in a separate network namespace cannot form direct loopback peer
+/// links. So the effective gossip is "peer mode AND not separate-namespace".
+fn apply_messaging_config(
+    cfg: &mut RuntimeConfig,
+    mode: Mode,
+    peer: PeerConfig,
+    container_separate_ns: bool,
+) {
+    cfg.discovery.gossip = mode.is_peer() && !container_separate_ns;
+    cfg.discovery.standard_buffer_size = peer.standard_buffer_size;
+    cfg.discovery.high_throughput_buffer_size = peer.high_throughput_buffer_size;
 }
 
 struct ProcessNodeRunContext {
@@ -111,6 +134,8 @@ pub async fn listen_for_node_run(
             peppy_dirs: config.peppy_dirs,
             health_monitor_interval: config.health_monitor_interval,
             health_monitor_timeout: config.health_monitor_timeout,
+            messaging_mode: config.messaging_mode,
+            peer_buffer: config.peer_buffer,
         },
         gate: ConcurrencyGate::new(),
     };
@@ -647,18 +672,6 @@ async fn process_node_run(
         return NodeRunResult::failure(msg);
     }
 
-    // Re-serialize so the spawned process receives the synthesized defaults;
-    // the inbound `runtime_config_json5` from the goal still reflects the
-    // pre-defaulting state.
-    let runtime_config_json5 = match serde_json5::to_string(&runtime_config) {
-        Ok(json) => json,
-        Err(e) => {
-            let msg = format!("Failed to serialize runtime config: {}", e);
-            write_error_to_log(&ctx.log_file, &msg);
-            return NodeRunResult::failure(msg);
-        }
-    };
-
     let is_container = node_config.execution.container.is_some();
 
     let container_config = node_config.execution.container.as_ref();
@@ -683,12 +696,12 @@ async fn process_node_run(
     //    namespace. It reaches the host router only through the Lima gateway,
     //    and a loopback peer locator advertised inside the guest is unreachable
     //    from the host (and vice versa), so it cannot form direct peer links.
-    //    Rewrite `messaging_host` to the gateway and route it through the router
-    //    as a client (`discovery.gossip = false`).
+    //    Route it through the router as a client (gossip forced off) and rewrite
+    //    `messaging_host` to the gateway, regardless of the daemon's mode.
     //  - Native (Linux): `None` — Apptainer shares the host network namespace,
-    //    so `127.0.0.1` already reaches the host router and the node forms
-    //    direct peer links exactly like a process node. Leave it in peer mode.
-    let runtime_config_json5 = if is_container {
+    //    so `127.0.0.1` already reaches the host router and the node follows the
+    //    daemon's messaging mode exactly like a process node.
+    let container_gateway = if is_container {
         let apptainer = match tokio::task::spawn_blocking(containers::Apptainer::new).await {
             Ok(Ok(a)) => a,
             Ok(Err(e)) => {
@@ -702,24 +715,40 @@ async fn process_node_run(
                 return NodeRunResult::failure(msg);
             }
         };
-        match apptainer.host_gateway() {
-            Some(gateway) => {
-                let mut cfg = runtime_config.clone();
-                cfg.messaging_host = gateway.to_string();
-                cfg.discovery.gossip = false;
-                match serde_json5::to_string(&cfg) {
-                    Ok(json) => json,
-                    Err(e) => {
-                        let msg = format!("Failed to serialize runtime config: {}", e);
-                        write_error_to_log(&ctx.log_file, &msg);
-                        return NodeRunResult::failure(msg);
-                    }
-                }
-            }
-            None => runtime_config_json5,
-        }
+        apptainer.host_gateway()
     } else {
-        runtime_config_json5
+        None
+    };
+
+    // Build the config the spawned process receives: a copy of `runtime_config`
+    // with the daemon-global messaging mode + peer buffer sizes applied (and, for
+    // a separate-namespace container, the gateway host). Mutate a clone rather
+    // than `runtime_config` because `instance_id_str` still borrows the latter,
+    // and the rest of this function reads it. The container override wins: a
+    // separate-namespace container always routes through the router as a client
+    // even in peer mode.
+    let mut launch_config = runtime_config.clone();
+    apply_messaging_config(
+        &mut launch_config,
+        ctx.action.messaging_mode,
+        ctx.action.peer_buffer,
+        container_gateway.is_some(),
+    );
+    if let Some(gateway) = &container_gateway {
+        launch_config.messaging_host = gateway.to_string();
+    }
+
+    // Serialize once, after every mutation (synthesized defaults, mode + buffer
+    // sizes, and the gateway rewrite), so the spawned process receives the
+    // fully-resolved runtime config. The inbound `runtime_config_json5` from the
+    // goal still reflects the pre-defaulting state.
+    let runtime_config_json5 = match serde_json5::to_string(&launch_config) {
+        Ok(json) => json,
+        Err(e) => {
+            let msg = format!("Failed to serialize runtime config: {}", e);
+            write_error_to_log(&ctx.log_file, &msg);
+            return NodeRunResult::failure(msg);
+        }
     };
 
     // Set up the FeedbackSync + two-channel forwarder. The internal channel
@@ -1315,6 +1344,69 @@ fn spawn_health_monitor(p: HealthMonitorParams) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn runtime_config_for_test() -> RuntimeConfig {
+        let instance_id = config::launcher::Name::new("camera_front").unwrap();
+        RuntimeConfig::new(
+            "127.0.0.1",
+            7448,
+            config::runtime::NodeInstanceConfig::new(instance_id),
+            "camera",
+            "v1",
+            "core_node",
+        )
+        .expect("valid test runtime config")
+    }
+
+    /// Peer mode (no container override) keeps gossip on and applies the
+    /// configured buffer sizes.
+    #[test]
+    fn apply_messaging_config_peer_mode_enables_gossip() {
+        let mut cfg = runtime_config_for_test();
+        apply_messaging_config(&mut cfg, Mode::Peer, PeerConfig::default(), false);
+        assert!(cfg.discovery.gossip);
+        assert_eq!(cfg.discovery.standard_buffer_size, 128);
+        assert_eq!(cfg.discovery.high_throughput_buffer_size, 1024);
+    }
+
+    /// Router mode forces gossip off so all traffic relays through the router.
+    #[test]
+    fn apply_messaging_config_router_mode_disables_gossip() {
+        let mut cfg = runtime_config_for_test();
+        apply_messaging_config(&mut cfg, Mode::Router, PeerConfig::default(), false);
+        assert!(!cfg.discovery.gossip);
+    }
+
+    /// A separate-namespace container is forced onto the client path even in
+    /// peer mode (the container override wins).
+    #[test]
+    fn apply_messaging_config_container_separate_ns_forces_client_even_in_peer_mode() {
+        let mut cfg = runtime_config_for_test();
+        apply_messaging_config(&mut cfg, Mode::Peer, PeerConfig::default(), true);
+        assert!(
+            !cfg.discovery.gossip,
+            "separate-namespace container must route through the router"
+        );
+    }
+
+    /// Buffer sizes are applied regardless of mode or container placement.
+    #[test]
+    fn apply_messaging_config_always_applies_buffers() {
+        let peer = PeerConfig {
+            standard_buffer_size: 64,
+            high_throughput_buffer_size: 4096,
+        };
+        for (mode, container_separate_ns) in [
+            (Mode::Peer, false),
+            (Mode::Router, false),
+            (Mode::Peer, true),
+        ] {
+            let mut cfg = runtime_config_for_test();
+            apply_messaging_config(&mut cfg, mode, peer, container_separate_ns);
+            assert_eq!(cfg.discovery.standard_buffer_size, 64);
+            assert_eq!(cfg.discovery.high_throughput_buffer_size, 4096);
+        }
+    }
 
     #[test]
     fn test_resolve_mount_path_parameters_simple() {

--- a/crates/core-node-internal/src/services/node/run.rs
+++ b/crates/core-node-internal/src/services/node/run.rs
@@ -676,8 +676,18 @@ async fn process_node_run(
         }
     };
 
-    // Container nodes need their runtime config rewritten with the apptainer
-    // host_gateway so that requests inside the container can reach the daemon.
+    // A container's transport depends on whether it shares the host network
+    // namespace, which `host_gateway()` reports:
+    //
+    //  - Lima (macOS): `Some(gateway)` — the container runs in a VM, a separate
+    //    namespace. It reaches the host router only through the Lima gateway,
+    //    and a loopback peer locator advertised inside the guest is unreachable
+    //    from the host (and vice versa), so it cannot form direct peer links.
+    //    Rewrite `messaging_host` to the gateway and route it through the router
+    //    as a client (`discovery.gossip = false`).
+    //  - Native (Linux): `None` — Apptainer shares the host network namespace,
+    //    so `127.0.0.1` already reaches the host router and the node forms
+    //    direct peer links exactly like a process node. Leave it in peer mode.
     let runtime_config_json5 = if is_container {
         let apptainer = match tokio::task::spawn_blocking(containers::Apptainer::new).await {
             Ok(Ok(a)) => a,
@@ -696,6 +706,7 @@ async fn process_node_run(
             Some(gateway) => {
                 let mut cfg = runtime_config.clone();
                 cfg.messaging_host = gateway.to_string();
+                cfg.discovery.gossip = false;
                 match serde_json5::to_string(&cfg) {
                     Ok(json) => json,
                     Err(e) => {

--- a/crates/core-node-internal/src/services/stack/benchmark.rs
+++ b/crates/core-node-internal/src/services/stack/benchmark.rs
@@ -945,7 +945,6 @@ async fn measure_topic_delivery(
     let mut measured: u32 = 0;
     let mut out = Vec::new();
     let mut had_implausible = false;
-    let mut had_missing_ts = false;
 
     loop {
         if measured >= samples {
@@ -953,20 +952,14 @@ async fn measure_topic_delivery(
         }
         match tokio::time::timeout(per_sample_timeout, subscription.on_next_message()).await {
             Ok(Some(msg)) => {
-                let Some(src) = msg.source_timestamp_nanos() else {
-                    // No timestamp to measure against, but still advance
-                    // progress like any other observed message (respecting
-                    // warmup) so a continuous stream of timestamp-less messages
-                    // can't spin forever — the loop terminates once `measured`
-                    // reaches `samples`. Only valid samples reach `out`, so the
-                    // reported count/percentiles stay clean.
-                    had_missing_ts = true;
-                    seen += 1;
-                    if seen > warmup {
-                        measured += 1;
-                    }
-                    continue;
-                };
+                // Every session enables timestamping for its own role (see
+                // `pmi::zenoh_config`), so a delivered sample is always stamped.
+                // A missing timestamp means a session disabled it out-of-band
+                // (e.g. a custom `ZENOH_SESSION_CONFIG`) — an invariant break,
+                // surfaced loudly rather than silently dropped.
+                let src = msg.source_timestamp_nanos().expect(
+                    "delivery sample missing its producer timestamp; sessions enable timestamping",
+                );
                 seen += 1;
                 if seen <= warmup {
                     continue;
@@ -987,11 +980,7 @@ async fn measure_topic_delivery(
 
     let (confidence, mut note) = classify_clock(offset, had_implausible);
     if out.is_empty() && !had_implausible {
-        note = Some(if had_missing_ts {
-            "no source timestamps on samples (timestamping disabled?)".to_string()
-        } else {
-            "no live traffic observed within the timeout".to_string()
-        });
+        note = Some("no live traffic observed within the timeout".to_string());
     }
     row_from_samples(edge, MeasurementKind::TopicDelivery, confidence, out, note)
 }

--- a/crates/core-node-internal/src/services/stack/launch.rs
+++ b/crates/core-node-internal/src/services/stack/launch.rs
@@ -11,6 +11,7 @@ use crate::services::node::{
 use chrono::Local;
 use config::consts::{DEFAULT_MESSAGING_HOST, DEFAULT_MESSAGING_PORT, PeppyDirs};
 use config::launcher::{Deployment, DeploymentSource, PeppyLauncherParser};
+use config::peppy_config::{Mode, PeerConfig};
 use config::runtime::RuntimeConfig;
 use core_node_api::encoding::{
     LaunchFeedback, LaunchFeedbackStep, LaunchGoal, LaunchGoalResponse, LaunchResult,
@@ -79,6 +80,10 @@ pub struct StackLaunchTimeouts {
 pub struct StackLaunchDefaults {
     pub timeouts: StackLaunchTimeouts,
     pub use_sim_time: bool,
+    /// Daemon-global messaging mode, injected into every launched node.
+    pub messaging_mode: Mode,
+    /// Daemon-global peer buffer sizes, injected into every launched node.
+    pub peer_buffer: PeerConfig,
 }
 
 pub async fn listen_for_stack_launch(
@@ -103,6 +108,8 @@ pub async fn listen_for_stack_launch(
     let StackLaunchDefaults {
         timeouts,
         use_sim_time: daemon_use_sim_time,
+        messaging_mode,
+        peer_buffer,
     } = defaults;
     let handler = LaunchGoalHandler {
         context: LaunchActionContext {
@@ -113,6 +120,8 @@ pub async fn listen_for_stack_launch(
             peppy_dirs,
             timeouts,
             daemon_use_sim_time,
+            messaging_mode,
+            peer_buffer,
         },
         gate: ConcurrencyGate::new(),
     };
@@ -161,6 +170,10 @@ struct ProcessLaunchContext {
     /// Daemon-wide default for `framework.use_sim_time` applied to instances
     /// that omit the per-instance override.
     daemon_use_sim_time: bool,
+    /// Daemon-global messaging mode, injected into every launched node.
+    messaging_mode: Mode,
+    /// Daemon-global peer buffer sizes, injected into every launched node.
+    peer_buffer: PeerConfig,
 }
 
 #[derive(Clone)]
@@ -172,6 +185,8 @@ struct LaunchActionContext {
     peppy_dirs: PeppyDirs,
     timeouts: StackLaunchTimeouts,
     daemon_use_sim_time: bool,
+    messaging_mode: Mode,
+    peer_buffer: PeerConfig,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -685,6 +700,8 @@ async fn start_node_directly(
         peppy_dirs: ctx.peppy_dirs.clone(),
         health_monitor_interval: ctx.timeouts.health_monitor_interval,
         health_monitor_timeout: ctx.timeouts.health_monitor_timeout,
+        messaging_mode: ctx.messaging_mode,
+        peer_buffer: ctx.peer_buffer,
     };
 
     let log_file_for_timeout = log_file.clone();
@@ -1531,6 +1548,8 @@ async fn handle_goal_request(
             peppy_dirs,
             timeouts,
             daemon_use_sim_time,
+            messaging_mode,
+            peer_buffer,
         } = action_context;
         let env_vars = goal.env_vars.clone();
         // Compute the launch deadline once. `None` => no overall deadline (idle-only).
@@ -1555,6 +1574,8 @@ async fn handle_goal_request(
                 run: Duration::from_secs(goal.node_run_idle_timeout_secs),
             },
             daemon_use_sim_time,
+            messaging_mode,
+            peer_buffer,
         };
         // Catch panics so a panic inside the launch sequence still completes the
         // goal with a failure result, rather than leaving the client to wait out

--- a/crates/core-node-internal/src/services/tests.rs
+++ b/crates/core-node-internal/src/services/tests.rs
@@ -38,6 +38,7 @@ async fn core_node_execution_has_no_run_cmd_and_no_container() {
         node_arguments,
         std::env::temp_dir(),
         peppy_dirs,
+        config::peppy_config::PeppyConfig::default(),
     );
 
     let execution = &core_node.node_config().execution;
@@ -64,6 +65,7 @@ async fn core_node_default_name_is_deterministic_and_machine_uid_based() {
         test_node_arguments(),
         std::env::temp_dir(),
         peppy_dirs.clone(),
+        config::peppy_config::PeppyConfig::default(),
     );
     let b = CoreNode::new(
         create_mock_messenger().await,
@@ -71,6 +73,7 @@ async fn core_node_default_name_is_deterministic_and_machine_uid_based() {
         test_node_arguments(),
         std::env::temp_dir(),
         peppy_dirs,
+        config::peppy_config::PeppyConfig::default(),
     );
 
     let name_a = a.node_config().manifest.name.as_str();
@@ -101,6 +104,7 @@ async fn core_node_explicit_name_overrides_machine_uid() {
         node_arguments,
         std::env::temp_dir(),
         peppy_dirs,
+        config::peppy_config::PeppyConfig::default(),
     );
     assert_eq!(
         core_node.node_config().manifest.name.as_str(),

--- a/crates/core-node-internal/tests/clock_zenoh_e2e.rs
+++ b/crates/core-node-internal/tests/clock_zenoh_e2e.rs
@@ -11,19 +11,26 @@ mod common;
 
 use common::{
     CALLER_INSTANCE_ID, assert_clock_round_trip, assert_clock_topic_emits_monotonic_ticks,
-    start_core_node_with_real_messenger,
+    start_core_node_with_real_messenger_mode,
 };
+use config::peppy_config::Mode;
 use std::time::Duration;
 
+#[rstest::rstest]
+#[case::peer(Mode::Peer)]
+#[case::router(Mode::Router)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn clock_service_round_trip_over_real_zenoh() {
-    let started = start_core_node_with_real_messenger().await;
+async fn clock_service_round_trip_over_real_zenoh(#[case] mode: Mode) {
+    let started = start_core_node_with_real_messenger_mode(mode).await;
     assert_clock_round_trip(&started).await;
 }
 
+#[rstest::rstest]
+#[case::peer(Mode::Peer)]
+#[case::router(Mode::Router)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn clock_topic_publishes_ticks_over_real_zenoh() {
-    let started = start_core_node_with_real_messenger().await;
+async fn clock_topic_publishes_ticks_over_real_zenoh(#[case] mode: Mode) {
+    let started = start_core_node_with_real_messenger_mode(mode).await;
     assert_clock_topic_emits_monotonic_ticks(
         &started,
         &started.core_node_name,

--- a/crates/core-node-internal/tests/common.rs
+++ b/crates/core-node-internal/tests/common.rs
@@ -1353,6 +1353,7 @@ pub async fn start_core_node_with_mock_messenger() -> StartedCoreNode {
         default_node_arguments(),
         data_dir,
         peppy_dirs,
+        config::peppy_config::PeppyConfig::default(),
     )
     .await
 }
@@ -1366,7 +1367,14 @@ pub async fn start_core_node_with_sim_clock() -> StartedCoreNode {
     let shared_messenger = create_mock_messenger().await;
     let mut args = default_node_arguments();
     args.daemon_use_sim_time = true;
-    start_core_node_with_messenger(shared_messenger, args, data_dir, peppy_dirs).await
+    start_core_node_with_messenger(
+        shared_messenger,
+        args,
+        data_dir,
+        peppy_dirs,
+        config::peppy_config::PeppyConfig::default(),
+    )
+    .await
 }
 
 pub async fn start_core_node_with_real_messenger() -> StartedCoreNode {
@@ -1377,14 +1385,49 @@ pub async fn start_core_node_with_real_messenger() -> StartedCoreNode {
     .await
 }
 
+/// Convenience wrapper over [`start_core_node_with_real_messenger_in_mode`] with
+/// the default timeouts, for the dual-mode e2e tests parameterized over the mode.
+pub async fn start_core_node_with_real_messenger_mode(
+    mode: config::peppy_config::Mode,
+) -> StartedCoreNode {
+    start_core_node_with_real_messenger_in_mode(
+        Duration::from_secs(10),
+        Duration::from_secs(30),
+        mode,
+    )
+    .await
+}
+
 pub async fn start_core_node_with_real_messenger_and_timeouts(
     node_startup_timeout: Duration,
     node_start_health_timeout: Duration,
 ) -> StartedCoreNode {
+    start_core_node_with_real_messenger_in_mode(
+        node_startup_timeout,
+        node_start_health_timeout,
+        config::peppy_config::Mode::Peer,
+    )
+    .await
+}
+
+/// Like [`start_core_node_with_real_messenger_and_timeouts`] but the messaging
+/// `mode` (peer vs router) is explicit. The core node's own session is built in
+/// that mode, and its `PeppyConfig` carries it so spawned nodes are injected with
+/// the same mode (faithful to production). Used by the dual-mode e2e tests.
+pub async fn start_core_node_with_real_messenger_in_mode(
+    node_startup_timeout: Duration,
+    node_start_health_timeout: Duration,
+    mode: config::peppy_config::Mode,
+) -> StartedCoreNode {
     let (data_dir, peppy_dirs) = init_test_data_dir();
-    let mut instance = pmi::ZenohAdapter::start_router_ephemeral(DEFAULT_MESSAGING_HOST, None)
-        .await
-        .expect("failed to start zenoh router for test");
+    let mut instance = pmi::ZenohAdapter::start_router_ephemeral_in_mode(
+        DEFAULT_MESSAGING_HOST,
+        None,
+        mode.gossip(),
+        pmi::SubscriberBufferSizes::default(),
+    )
+    .await
+    .expect("failed to start zenoh router for test");
     instance
         .messenger()
         .start_session()
@@ -1394,7 +1437,11 @@ pub async fn start_core_node_with_real_messenger_and_timeouts(
     let mut args = default_node_arguments();
     args.node_startup_timeout = node_startup_timeout;
     args.node_start_health_timeout = node_start_health_timeout;
-    start_core_node_with_messenger(shared_messenger, args, data_dir, peppy_dirs).await
+    let peppy_config = config::peppy_config::PeppyConfig {
+        mode,
+        ..Default::default()
+    };
+    start_core_node_with_messenger(shared_messenger, args, data_dir, peppy_dirs, peppy_config).await
 }
 
 pub async fn start_core_node_with_health_timeout(
@@ -1404,7 +1451,14 @@ pub async fn start_core_node_with_health_timeout(
     let shared_messenger = create_mock_messenger().await;
     let mut args = default_node_arguments();
     args.node_start_health_timeout = node_start_health_timeout;
-    start_core_node_with_messenger(shared_messenger, args, data_dir, peppy_dirs).await
+    start_core_node_with_messenger(
+        shared_messenger,
+        args,
+        data_dir,
+        peppy_dirs,
+        config::peppy_config::PeppyConfig::default(),
+    )
+    .await
 }
 
 pub async fn start_core_node_with_health_monitor(
@@ -1416,7 +1470,14 @@ pub async fn start_core_node_with_health_monitor(
     let mut args = default_node_arguments();
     args.health_monitor_interval = health_monitor_interval;
     args.health_monitor_timeout = health_monitor_timeout;
-    start_core_node_with_messenger(shared_messenger, args, data_dir, peppy_dirs).await
+    start_core_node_with_messenger(
+        shared_messenger,
+        args,
+        data_dir,
+        peppy_dirs,
+        config::peppy_config::PeppyConfig::default(),
+    )
+    .await
 }
 
 async fn start_core_node_with_messenger(
@@ -1424,6 +1485,7 @@ async fn start_core_node_with_messenger(
     node_arguments: CoreNodeArguments,
     data_dir: TempDir,
     peppy_dirs: PeppyDirs,
+    peppy_config: config::peppy_config::PeppyConfig,
 ) -> StartedCoreNode {
     let caller_handle = MessengerHandle::from_shared(Arc::clone(&shared_messenger));
     let root_dir = std::env::current_dir().expect("failed to get current directory");
@@ -1433,6 +1495,7 @@ async fn start_core_node_with_messenger(
         node_arguments,
         root_dir,
         peppy_dirs.clone(),
+        peppy_config,
     );
     let core_node_name = core_node.node_name().to_string();
     let core_node_tag = core_node.node_config().manifest.tag.clone();

--- a/crates/core-node-internal/tests/datastore_zenoh_e2e.rs
+++ b/crates/core-node-internal/tests/datastore_zenoh_e2e.rs
@@ -7,10 +7,14 @@
 
 mod common;
 
-use common::{assert_datastore_binary_round_trip, start_core_node_with_real_messenger};
+use common::{assert_datastore_binary_round_trip, start_core_node_with_real_messenger_mode};
+use config::peppy_config::Mode;
 
+#[rstest::rstest]
+#[case::peer(Mode::Peer)]
+#[case::router(Mode::Router)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn datastore_round_trip_over_real_zenoh() {
-    let started = start_core_node_with_real_messenger().await;
+async fn datastore_round_trip_over_real_zenoh(#[case] mode: Mode) {
+    let started = start_core_node_with_real_messenger_mode(mode).await;
     assert_datastore_binary_round_trip(&started).await;
 }

--- a/crates/generator-internal/Cargo.toml
+++ b/crates/generator-internal/Cargo.toml
@@ -31,3 +31,4 @@ serde_json5 = "0.2.1"
 tempfile = "3.10"
 peppylib = { path = "../peppylib" }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
+rstest = { workspace = true }

--- a/crates/generator-internal/tests/helpers.rs
+++ b/crates/generator-internal/tests/helpers.rs
@@ -27,6 +27,22 @@ pub fn test_peppy_dirs() -> PeppyDirs {
 
 pub const TEST_NODE_TAG: &str = "v1";
 
+/// Re-exported so the communication test files can name the messaging mode for
+/// their `#[case]` parameterization without reaching into the internal path.
+pub use config::peppy_config::Mode;
+
+/// Applies a messaging mode to a node's runtime config before it is written and
+/// handed to a spawned node. This is the single seam the dual-mode communication
+/// tests use to run the same body under both peer (gossip on) and router (gossip
+/// off) mode without duplicating the body.
+pub fn apply_mode(
+    mut config: config::runtime::RuntimeConfig,
+    mode: Mode,
+) -> config::runtime::RuntimeConfig {
+    config.discovery.gossip = mode.gossip();
+    config
+}
+
 /// Builds a node-shaped [`SenderTarget`] with the standard test tag. Panics on
 /// invalid names — tests use known-good values only.
 pub fn test_node_target(name: &str) -> SenderTarget {

--- a/crates/generator-internal/tests/python/actions_communication.rs
+++ b/crates/generator-internal/tests/python/actions_communication.rs
@@ -152,8 +152,11 @@ const CONSUMED_ACTION_GOAL_RESPONSE_FORMAT: &str = r#"
 }
 "#;
 
+#[rstest::rstest]
+#[case::peer(crate::helpers::Mode::Peer)]
+#[case::router(crate::helpers::Mode::Router)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn actions_communication() {
+async fn actions_communication(#[case] mode: crate::helpers::Mode) {
     let instance = pmi::ZenohAdapter::start_router_ephemeral("127.0.0.1", None)
         .await
         .expect("failed to start zenoh router for test");
@@ -211,6 +214,7 @@ async fn actions_communication() {
         TEST_CORE_NODE,
     )
     .unwrap();
+    let consumer_runtime_config = crate::helpers::apply_mode(consumer_runtime_config, mode);
     let consumer_runtime_config_path = temp_dir_consumer.path().join("peppy_runtime.json5");
     consumer_runtime_config
         .save_json5_launch_config(&consumer_runtime_config_path)
@@ -280,6 +284,7 @@ if __name__ == "__main__":
         TEST_CORE_NODE,
     )
     .unwrap();
+    let exposer_runtime_config = crate::helpers::apply_mode(exposer_runtime_config, mode);
     let exposer_runtime_config_path = temp_dir_exposer.path().join("peppy_runtime.json5");
     exposer_runtime_config
         .save_json5_launch_config(&exposer_runtime_config_path)
@@ -481,8 +486,11 @@ if __name__ == "__main__":
     );
 }
 
+#[rstest::rstest]
+#[case::peer(crate::helpers::Mode::Peer)]
+#[case::router(crate::helpers::Mode::Router)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn actions_communication_cancel_goal() {
+async fn actions_communication_cancel_goal(#[case] mode: crate::helpers::Mode) {
     let instance = pmi::ZenohAdapter::start_router_ephemeral("127.0.0.1", None)
         .await
         .expect("failed to start zenoh router for test");
@@ -540,6 +548,7 @@ async fn actions_communication_cancel_goal() {
         TEST_CORE_NODE,
     )
     .unwrap();
+    let consumer_runtime_config = crate::helpers::apply_mode(consumer_runtime_config, mode);
     let consumer_runtime_config_path = temp_dir_consumer.path().join("peppy_runtime.json5");
     consumer_runtime_config
         .save_json5_launch_config(&consumer_runtime_config_path)
@@ -605,6 +614,7 @@ if __name__ == "__main__":
         TEST_CORE_NODE,
     )
     .unwrap();
+    let exposer_runtime_config = crate::helpers::apply_mode(exposer_runtime_config, mode);
     let exposer_runtime_config_path = temp_dir_exposer.path().join("peppy_runtime.json5");
     exposer_runtime_config
         .save_json5_launch_config(&exposer_runtime_config_path)
@@ -792,8 +802,11 @@ if __name__ == "__main__":
 /// returns an awaitable, so a server can `await` inside its accept/reject
 /// decision. After accepting, the worker publishes feedback through the
 /// `GoalContext` and completes the goal.
+#[rstest::rstest]
+#[case::peer(crate::helpers::Mode::Peer)]
+#[case::router(crate::helpers::Mode::Router)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn actions_communication_async_goal_decider() {
+async fn actions_communication_async_goal_decider(#[case] mode: crate::helpers::Mode) {
     let instance = pmi::ZenohAdapter::start_router_ephemeral("127.0.0.1", None)
         .await
         .expect("failed to start zenoh router for test");
@@ -851,6 +864,7 @@ async fn actions_communication_async_goal_decider() {
         TEST_CORE_NODE,
     )
     .unwrap();
+    let consumer_runtime_config = crate::helpers::apply_mode(consumer_runtime_config, mode);
     let consumer_runtime_config_path = temp_dir_consumer.path().join("peppy_runtime.json5");
     consumer_runtime_config
         .save_json5_launch_config(&consumer_runtime_config_path)
@@ -922,6 +936,7 @@ if __name__ == "__main__":
         TEST_CORE_NODE,
     )
     .unwrap();
+    let exposer_runtime_config = crate::helpers::apply_mode(exposer_runtime_config, mode);
     let exposer_runtime_config_path = temp_dir_exposer.path().join("peppy_runtime.json5");
     exposer_runtime_config
         .save_json5_launch_config(&exposer_runtime_config_path)
@@ -1130,8 +1145,13 @@ if __name__ == "__main__":
 ///
 /// The ignore-cancel branch is covered by
 /// `actions_communication_cancel_reject_keeps_feedback_open`.
+#[rstest::rstest]
+#[case::peer(crate::helpers::Mode::Peer)]
+#[case::router(crate::helpers::Mode::Router)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn actions_communication_cancel_accept_closes_feedback_stream() {
+async fn actions_communication_cancel_accept_closes_feedback_stream(
+    #[case] mode: crate::helpers::Mode,
+) {
     let instance = pmi::ZenohAdapter::start_router_ephemeral("127.0.0.1", None)
         .await
         .expect("failed to start zenoh router for test");
@@ -1189,6 +1209,7 @@ async fn actions_communication_cancel_accept_closes_feedback_stream() {
         TEST_CORE_NODE,
     )
     .unwrap();
+    let consumer_runtime_config = crate::helpers::apply_mode(consumer_runtime_config, mode);
     let consumer_runtime_config_path = temp_dir_consumer.path().join("peppy_runtime.json5");
     consumer_runtime_config
         .save_json5_launch_config(&consumer_runtime_config_path)
@@ -1262,6 +1283,7 @@ if __name__ == "__main__":
         TEST_CORE_NODE,
     )
     .unwrap();
+    let exposer_runtime_config = crate::helpers::apply_mode(exposer_runtime_config, mode);
     let exposer_runtime_config_path = temp_dir_exposer.path().join("peppy_runtime.json5");
     exposer_runtime_config
         .save_json5_launch_config(&exposer_runtime_config_path)
@@ -1479,8 +1501,13 @@ if __name__ == "__main__":
 ///
 /// The honor-cancel branch is covered by
 /// `actions_communication_cancel_accept_closes_feedback_stream`.
+#[rstest::rstest]
+#[case::peer(crate::helpers::Mode::Peer)]
+#[case::router(crate::helpers::Mode::Router)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn actions_communication_cancel_reject_keeps_feedback_open() {
+async fn actions_communication_cancel_reject_keeps_feedback_open(
+    #[case] mode: crate::helpers::Mode,
+) {
     let instance = pmi::ZenohAdapter::start_router_ephemeral("127.0.0.1", None)
         .await
         .expect("failed to start zenoh router for test");
@@ -1538,6 +1565,7 @@ async fn actions_communication_cancel_reject_keeps_feedback_open() {
         TEST_CORE_NODE,
     )
     .unwrap();
+    let consumer_runtime_config = crate::helpers::apply_mode(consumer_runtime_config, mode);
     let consumer_runtime_config_path = temp_dir_consumer.path().join("peppy_runtime.json5");
     consumer_runtime_config
         .save_json5_launch_config(&consumer_runtime_config_path)
@@ -1621,6 +1649,7 @@ if __name__ == "__main__":
         TEST_CORE_NODE,
     )
     .unwrap();
+    let exposer_runtime_config = crate::helpers::apply_mode(exposer_runtime_config, mode);
     let exposer_runtime_config_path = temp_dir_exposer.path().join("peppy_runtime.json5");
     exposer_runtime_config
         .save_json5_launch_config(&exposer_runtime_config_path)
@@ -1850,8 +1879,11 @@ if __name__ == "__main__":
 ///
 /// Rust parity is `actions_communication_drain_loop_until_end_signal` in
 /// the rust/ test module.
+#[rstest::rstest]
+#[case::peer(crate::helpers::Mode::Peer)]
+#[case::router(crate::helpers::Mode::Router)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn actions_communication_drain_loop_until_end_signal() {
+async fn actions_communication_drain_loop_until_end_signal(#[case] mode: crate::helpers::Mode) {
     let instance = pmi::ZenohAdapter::start_router_ephemeral("127.0.0.1", None)
         .await
         .expect("failed to start zenoh router for test");
@@ -1909,6 +1941,7 @@ async fn actions_communication_drain_loop_until_end_signal() {
         TEST_CORE_NODE,
     )
     .unwrap();
+    let consumer_runtime_config = crate::helpers::apply_mode(consumer_runtime_config, mode);
     let consumer_runtime_config_path = temp_dir_consumer.path().join("peppy_runtime.json5");
     consumer_runtime_config
         .save_json5_launch_config(&consumer_runtime_config_path)
@@ -1988,6 +2021,7 @@ if __name__ == "__main__":
         TEST_CORE_NODE,
     )
     .unwrap();
+    let exposer_runtime_config = crate::helpers::apply_mode(exposer_runtime_config, mode);
     let exposer_runtime_config_path = temp_dir_exposer.path().join("peppy_runtime.json5");
     exposer_runtime_config
         .save_json5_launch_config(&exposer_runtime_config_path)

--- a/crates/generator-internal/tests/python/services_communication.rs
+++ b/crates/generator-internal/tests/python/services_communication.rs
@@ -88,8 +88,11 @@ const CONSUMED_SERVICE_NO_REQUEST_RESPONSE_FORMAT_EXAMPLE: &str = r#"
 }
 "#;
 
+#[rstest::rstest]
+#[case::peer(crate::helpers::Mode::Peer)]
+#[case::router(crate::helpers::Mode::Router)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn services_communication_no_target_instance_id() {
+async fn services_communication_no_target_instance_id(#[case] mode: crate::helpers::Mode) {
     let instance = pmi::ZenohAdapter::start_router_ephemeral("127.0.0.1", None)
         .await
         .expect("failed to start zenoh router for test");
@@ -133,6 +136,7 @@ async fn services_communication_no_target_instance_id() {
         TEST_CORE_NODE,
     )
     .unwrap();
+    let consumer_runtime_config = crate::helpers::apply_mode(consumer_runtime_config, mode);
     let consumer_runtime_config_path = temp_dir_consumer.path().join("peppy_runtime.json5");
     consumer_runtime_config
         .save_json5_launch_config(&consumer_runtime_config_path)
@@ -193,6 +197,7 @@ if __name__ == "__main__":
         TEST_CORE_NODE,
     )
     .unwrap();
+    let exposer_runtime_config = crate::helpers::apply_mode(exposer_runtime_config, mode);
     let exposer_runtime_config_path = temp_dir_exposer.path().join("peppy_runtime.json5");
     exposer_runtime_config
         .save_json5_launch_config(&exposer_runtime_config_path)
@@ -402,8 +407,13 @@ if __name__ == "__main__":
     );
 }
 
+#[rstest::rstest]
+#[case::peer(crate::helpers::Mode::Peer)]
+#[case::router(crate::helpers::Mode::Router)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn services_communication_exposed_service_without_request_body() {
+async fn services_communication_exposed_service_without_request_body(
+    #[case] mode: crate::helpers::Mode,
+) {
     let instance = pmi::ZenohAdapter::start_router_ephemeral("127.0.0.1", None)
         .await
         .expect("failed to start zenoh router for test");
@@ -447,6 +457,7 @@ async fn services_communication_exposed_service_without_request_body() {
         TEST_CORE_NODE,
     )
     .unwrap();
+    let consumer_runtime_config = crate::helpers::apply_mode(consumer_runtime_config, mode);
     let consumer_runtime_config_path = temp_dir_consumer.path().join("peppy_runtime.json5");
     consumer_runtime_config
         .save_json5_launch_config(&consumer_runtime_config_path)
@@ -506,6 +517,7 @@ if __name__ == "__main__":
         TEST_CORE_NODE,
     )
     .unwrap();
+    let exposer_runtime_config = crate::helpers::apply_mode(exposer_runtime_config, mode);
     let exposer_runtime_config_path = temp_dir_exposer.path().join("peppy_runtime.json5");
     exposer_runtime_config
         .save_json5_launch_config(&exposer_runtime_config_path)
@@ -697,8 +709,13 @@ if __name__ == "__main__":
 }
 
 /// If there are multiple services of the same name and the consumer does not specify an instance_id, it's the first service that responds that connects with the consumer
+#[rstest::rstest]
+#[case::peer(crate::helpers::Mode::Peer)]
+#[case::router(crate::helpers::Mode::Router)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn services_communication_multiple_exposed_instances_same_service_no_target_instance_id() {
+async fn services_communication_multiple_exposed_instances_same_service_no_target_instance_id(
+    #[case] mode: crate::helpers::Mode,
+) {
     let instance = pmi::ZenohAdapter::start_router_ephemeral("127.0.0.1", None)
         .await
         .expect("failed to start zenoh router for test");
@@ -742,6 +759,7 @@ async fn services_communication_multiple_exposed_instances_same_service_no_targe
         TEST_CORE_NODE,
     )
     .unwrap();
+    let consumer_runtime_config = crate::helpers::apply_mode(consumer_runtime_config, mode);
     let consumer_runtime_config_path = temp_dir_consumer.path().join("peppy_runtime.json5");
     consumer_runtime_config
         .save_json5_launch_config(&consumer_runtime_config_path)
@@ -802,6 +820,7 @@ if __name__ == "__main__":
         TEST_CORE_NODE,
     )
     .unwrap();
+    let exposer1_runtime_config = crate::helpers::apply_mode(exposer1_runtime_config, mode);
     let exposer1_runtime_config_path = temp_dir_exposer1.path().join("peppy_runtime.json5");
     exposer1_runtime_config
         .save_json5_launch_config(&exposer1_runtime_config_path)
@@ -866,6 +885,7 @@ if __name__ == "__main__":
         TEST_CORE_NODE,
     )
     .unwrap();
+    let exposer2_runtime_config = crate::helpers::apply_mode(exposer2_runtime_config, mode);
     let exposer2_runtime_config_path = temp_dir_exposer2.path().join("peppy_runtime.json5");
     exposer2_runtime_config
         .save_json5_launch_config(&exposer2_runtime_config_path)

--- a/crates/generator-internal/tests/python/topics_communication.rs
+++ b/crates/generator-internal/tests/python/topics_communication.rs
@@ -77,8 +77,11 @@ const SUBSCRIBED_TOPIC_FORMAT_EXAMPLE: &str = r#"
 "#;
 
 /// Creates 2 Python projects in separate directories and checks if they can send/receive topics.
+#[rstest::rstest]
+#[case::peer(crate::helpers::Mode::Peer)]
+#[case::router(crate::helpers::Mode::Router)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn topics_communication() {
+async fn topics_communication(#[case] mode: crate::helpers::Mode) {
     let instance = pmi::ZenohAdapter::start_router_ephemeral("127.0.0.1", None)
         .await
         .expect("failed to start zenoh router for test");
@@ -123,6 +126,7 @@ async fn topics_communication() {
         TEST_CORE_NODE,
     )
     .unwrap();
+    let receiver_runtime_config = crate::helpers::apply_mode(receiver_runtime_config, mode);
     let receiver_runtime_config_path = temp_dir_proj2.path().join("peppy_runtime.json5");
     receiver_runtime_config
         .save_json5_launch_config(&receiver_runtime_config_path)
@@ -206,6 +210,7 @@ if __name__ == "__main__":
         TEST_CORE_NODE,
     )
     .unwrap();
+    let emitter_runtime_config = crate::helpers::apply_mode(emitter_runtime_config, mode);
     let emitter_runtime_config_path = temp_dir_proj1.path().join("peppy_runtime.json5");
     emitter_runtime_config
         .save_json5_launch_config(&emitter_runtime_config_path)

--- a/crates/generator-internal/tests/rust/actions_communication.rs
+++ b/crates/generator-internal/tests/rust/actions_communication.rs
@@ -116,8 +116,11 @@ const CONSUMED_ACTION_GOAL_RESPONSE_FORMAT: &str = r#"
 }
 "#;
 
+#[rstest::rstest]
+#[case::peer(crate::helpers::Mode::Peer)]
+#[case::router(crate::helpers::Mode::Router)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn actions_communication() {
+async fn actions_communication(#[case] mode: crate::helpers::Mode) {
     let instance = pmi::ZenohAdapter::start_router_ephemeral("127.0.0.1", None)
         .await
         .expect("failed to start zenoh router for test");
@@ -170,6 +173,7 @@ async fn actions_communication() {
         TEST_CORE_NODE,
     )
     .unwrap();
+    let consumer_runtime_config = crate::helpers::apply_mode(consumer_runtime_config, mode);
     let consumer_runtime_config_path = temp_dir_consumer.path().join("peppy_runtime.json5");
     consumer_runtime_config
         .save_json5_launch_config(&consumer_runtime_config_path)
@@ -248,6 +252,7 @@ fn main() -> Result<()> {
         TEST_CORE_NODE,
     )
     .unwrap();
+    let exposer_runtime_config = crate::helpers::apply_mode(exposer_runtime_config, mode);
     let exposer_runtime_config_path = temp_dir_exposer.path().join("peppy_runtime.json5");
     exposer_runtime_config
         .save_json5_launch_config(&exposer_runtime_config_path)
@@ -442,8 +447,11 @@ fn main() -> Result<()> {
     );
 }
 
+#[rstest::rstest]
+#[case::peer(crate::helpers::Mode::Peer)]
+#[case::router(crate::helpers::Mode::Router)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn actions_communication_cancel_goal() {
+async fn actions_communication_cancel_goal(#[case] mode: crate::helpers::Mode) {
     let instance = pmi::ZenohAdapter::start_router_ephemeral("127.0.0.1", None)
         .await
         .expect("failed to start zenoh router for test");
@@ -496,6 +504,7 @@ async fn actions_communication_cancel_goal() {
         TEST_CORE_NODE,
     )
     .unwrap();
+    let consumer_runtime_config = crate::helpers::apply_mode(consumer_runtime_config, mode);
     let consumer_runtime_config_path = temp_dir_consumer.path().join("peppy_runtime.json5");
     consumer_runtime_config
         .save_json5_launch_config(&consumer_runtime_config_path)
@@ -566,6 +575,7 @@ fn main() -> Result<()> {
         TEST_CORE_NODE,
     )
     .unwrap();
+    let exposer_runtime_config = crate::helpers::apply_mode(exposer_runtime_config, mode);
     let exposer_runtime_config_path = temp_dir_exposer.path().join("peppy_runtime.json5");
     exposer_runtime_config
         .save_json5_launch_config(&exposer_runtime_config_path)
@@ -775,8 +785,11 @@ fn main() -> Result<()> {
 ///
 /// Python parity is `actions_communication_drain_loop_until_end_signal`
 /// in the python/ test module.
+#[rstest::rstest]
+#[case::peer(crate::helpers::Mode::Peer)]
+#[case::router(crate::helpers::Mode::Router)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn actions_communication_drain_loop_until_end_signal() {
+async fn actions_communication_drain_loop_until_end_signal(#[case] mode: crate::helpers::Mode) {
     let instance = pmi::ZenohAdapter::start_router_ephemeral("127.0.0.1", None)
         .await
         .expect("failed to start zenoh router for test");
@@ -829,6 +842,7 @@ async fn actions_communication_drain_loop_until_end_signal() {
         TEST_CORE_NODE,
     )
     .unwrap();
+    let consumer_runtime_config = crate::helpers::apply_mode(consumer_runtime_config, mode);
     let consumer_runtime_config_path = temp_dir_consumer.path().join("peppy_runtime.json5");
     consumer_runtime_config
         .save_json5_launch_config(&consumer_runtime_config_path)
@@ -920,6 +934,7 @@ fn main() -> Result<()> {
         TEST_CORE_NODE,
     )
     .unwrap();
+    let exposer_runtime_config = crate::helpers::apply_mode(exposer_runtime_config, mode);
     let exposer_runtime_config_path = temp_dir_exposer.path().join("peppy_runtime.json5");
     exposer_runtime_config
         .save_json5_launch_config(&exposer_runtime_config_path)
@@ -1152,8 +1167,13 @@ fn main() -> Result<()> {
 /// Python parity is
 /// `actions_communication_cancel_accept_closes_feedback_stream` in the
 /// python/ test module.
+#[rstest::rstest]
+#[case::peer(crate::helpers::Mode::Peer)]
+#[case::router(crate::helpers::Mode::Router)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn actions_communication_cancel_accept_closes_feedback_stream() {
+async fn actions_communication_cancel_accept_closes_feedback_stream(
+    #[case] mode: crate::helpers::Mode,
+) {
     let instance = pmi::ZenohAdapter::start_router_ephemeral("127.0.0.1", None)
         .await
         .expect("failed to start zenoh router for test");
@@ -1206,6 +1226,7 @@ async fn actions_communication_cancel_accept_closes_feedback_stream() {
         TEST_CORE_NODE,
     )
     .unwrap();
+    let consumer_runtime_config = crate::helpers::apply_mode(consumer_runtime_config, mode);
     let consumer_runtime_config_path = temp_dir_consumer.path().join("peppy_runtime.json5");
     consumer_runtime_config
         .save_json5_launch_config(&consumer_runtime_config_path)
@@ -1292,6 +1313,7 @@ fn main() -> Result<()> {
         TEST_CORE_NODE,
     )
     .unwrap();
+    let exposer_runtime_config = crate::helpers::apply_mode(exposer_runtime_config, mode);
     let exposer_runtime_config_path = temp_dir_exposer.path().join("peppy_runtime.json5");
     exposer_runtime_config
         .save_json5_launch_config(&exposer_runtime_config_path)
@@ -1513,8 +1535,13 @@ fn main() -> Result<()> {
 /// Python parity is
 /// `actions_communication_cancel_reject_keeps_feedback_open` in the
 /// python/ test module.
+#[rstest::rstest]
+#[case::peer(crate::helpers::Mode::Peer)]
+#[case::router(crate::helpers::Mode::Router)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn actions_communication_cancel_reject_keeps_feedback_open() {
+async fn actions_communication_cancel_reject_keeps_feedback_open(
+    #[case] mode: crate::helpers::Mode,
+) {
     let instance = pmi::ZenohAdapter::start_router_ephemeral("127.0.0.1", None)
         .await
         .expect("failed to start zenoh router for test");
@@ -1567,6 +1594,7 @@ async fn actions_communication_cancel_reject_keeps_feedback_open() {
         TEST_CORE_NODE,
     )
     .unwrap();
+    let consumer_runtime_config = crate::helpers::apply_mode(consumer_runtime_config, mode);
     let consumer_runtime_config_path = temp_dir_consumer.path().join("peppy_runtime.json5");
     consumer_runtime_config
         .save_json5_launch_config(&consumer_runtime_config_path)
@@ -1665,6 +1693,7 @@ fn main() -> Result<()> {
         TEST_CORE_NODE,
     )
     .unwrap();
+    let exposer_runtime_config = crate::helpers::apply_mode(exposer_runtime_config, mode);
     let exposer_runtime_config_path = temp_dir_exposer.path().join("peppy_runtime.json5");
     exposer_runtime_config
         .save_json5_launch_config(&exposer_runtime_config_path)

--- a/crates/generator-internal/tests/rust/services_communication.rs
+++ b/crates/generator-internal/tests/rust/services_communication.rs
@@ -88,8 +88,11 @@ const CONSUMED_SERVICE_NO_REQUEST_RESPONSE_FORMAT_EXAMPLE: &str = r#"
 }
 "#;
 
+#[rstest::rstest]
+#[case::peer(crate::helpers::Mode::Peer)]
+#[case::router(crate::helpers::Mode::Router)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn services_communication_no_target_instance_id() {
+async fn services_communication_no_target_instance_id(#[case] mode: crate::helpers::Mode) {
     let instance = pmi::ZenohAdapter::start_router_ephemeral("127.0.0.1", None)
         .await
         .expect("failed to start zenoh router for test");
@@ -133,6 +136,7 @@ async fn services_communication_no_target_instance_id() {
         TEST_CORE_NODE,
     )
     .unwrap();
+    let consumer_runtime_config = crate::helpers::apply_mode(consumer_runtime_config, mode);
     let consumer_runtime_config_path = temp_dir_consumer.path().join("peppy_runtime.json5");
     consumer_runtime_config
         .save_json5_launch_config(&consumer_runtime_config_path)
@@ -193,6 +197,7 @@ fn main() -> Result<()> {
         TEST_CORE_NODE,
     )
     .unwrap();
+    let exposer_runtime_config = crate::helpers::apply_mode(exposer_runtime_config, mode);
     let exposer_runtime_config_path = temp_dir_exposer.path().join("peppy_runtime.json5");
     exposer_runtime_config
         .save_json5_launch_config(&exposer_runtime_config_path)
@@ -380,8 +385,13 @@ fn main() -> Result<()> {
     );
 }
 
+#[rstest::rstest]
+#[case::peer(crate::helpers::Mode::Peer)]
+#[case::router(crate::helpers::Mode::Router)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn services_communication_exposed_service_without_request_body() {
+async fn services_communication_exposed_service_without_request_body(
+    #[case] mode: crate::helpers::Mode,
+) {
     let instance = pmi::ZenohAdapter::start_router_ephemeral("127.0.0.1", None)
         .await
         .expect("failed to start zenoh router for test");
@@ -425,6 +435,7 @@ async fn services_communication_exposed_service_without_request_body() {
         TEST_CORE_NODE,
     )
     .unwrap();
+    let consumer_runtime_config = crate::helpers::apply_mode(consumer_runtime_config, mode);
     let consumer_runtime_config_path = temp_dir_consumer.path().join("peppy_runtime.json5");
     consumer_runtime_config
         .save_json5_launch_config(&consumer_runtime_config_path)
@@ -482,6 +493,7 @@ fn main() -> Result<()> {
         TEST_CORE_NODE,
     )
     .unwrap();
+    let exposer_runtime_config = crate::helpers::apply_mode(exposer_runtime_config, mode);
     let exposer_runtime_config_path = temp_dir_exposer.path().join("peppy_runtime.json5");
     exposer_runtime_config
         .save_json5_launch_config(&exposer_runtime_config_path)
@@ -660,8 +672,13 @@ fn main() -> Result<()> {
 }
 
 /// If there are multiple services of the same name and the consumer does not specify an instance_id, it's the first service that respond that connects with the consumer
+#[rstest::rstest]
+#[case::peer(crate::helpers::Mode::Peer)]
+#[case::router(crate::helpers::Mode::Router)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn services_communication_multiple_exposed_instances_same_service_no_target_instance_id() {
+async fn services_communication_multiple_exposed_instances_same_service_no_target_instance_id(
+    #[case] mode: crate::helpers::Mode,
+) {
     let instance = pmi::ZenohAdapter::start_router_ephemeral("127.0.0.1", None)
         .await
         .expect("failed to start zenoh router for test");
@@ -705,6 +722,7 @@ async fn services_communication_multiple_exposed_instances_same_service_no_targe
         TEST_CORE_NODE,
     )
     .unwrap();
+    let consumer_runtime_config = crate::helpers::apply_mode(consumer_runtime_config, mode);
     let consumer_runtime_config_path = temp_dir_consumer.path().join("peppy_runtime.json5");
     consumer_runtime_config
         .save_json5_launch_config(&consumer_runtime_config_path)
@@ -764,6 +782,7 @@ fn main() -> Result<()> {
         TEST_CORE_NODE,
     )
     .unwrap();
+    let exposer1_runtime_config = crate::helpers::apply_mode(exposer1_runtime_config, mode);
     let exposer1_runtime_config_path = temp_dir_exposer1.path().join("peppy_runtime.json5");
     exposer1_runtime_config
         .save_json5_launch_config(&exposer1_runtime_config_path)
@@ -823,6 +842,7 @@ fn main() -> Result<()> {
         TEST_CORE_NODE,
     )
     .unwrap();
+    let exposer2_runtime_config = crate::helpers::apply_mode(exposer2_runtime_config, mode);
     let exposer2_runtime_config_path = temp_dir_exposer2.path().join("peppy_runtime.json5");
     exposer2_runtime_config
         .save_json5_launch_config(&exposer2_runtime_config_path)

--- a/crates/generator-internal/tests/rust/topics_communication.rs
+++ b/crates/generator-internal/tests/rust/topics_communication.rs
@@ -69,9 +69,13 @@ const SUBSCRIBED_TOPIC_FORMAT_EXAMPLE: &str = r#"
 }
 "#;
 
-/// Creates 2 projects in separate directory and check if they can send/receive topics
+/// Creates 2 projects in separate directory and check if they can send/receive topics.
+/// Runs under both peer (gossip on) and router (gossip off) messaging modes.
+#[rstest::rstest]
+#[case::peer(crate::helpers::Mode::Peer)]
+#[case::router(crate::helpers::Mode::Router)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn topics_communication() {
+async fn topics_communication(#[case] mode: crate::helpers::Mode) {
     let instance = pmi::ZenohAdapter::start_router_ephemeral("127.0.0.1", None)
         .await
         .expect("failed to start zenoh router for test");
@@ -111,6 +115,7 @@ async fn topics_communication() {
         TEST_CORE_NODE,
     )
     .unwrap();
+    let receiver_runtime_config = crate::helpers::apply_mode(receiver_runtime_config, mode);
     let receiver_runtime_config_path = temp_dir_proj2.path().join("peppy_runtime.json5");
     receiver_runtime_config
         .save_json5_launch_config(&receiver_runtime_config_path)
@@ -179,6 +184,7 @@ fn main() -> Result<()> {
         TEST_CORE_NODE,
     )
     .unwrap();
+    let emitter_runtime_config = crate::helpers::apply_mode(emitter_runtime_config, mode);
     let emitter_runtime_config_path = temp_dir_proj1.path().join("peppy_runtime.json5");
     emitter_runtime_config
         .save_json5_launch_config(&emitter_runtime_config_path)

--- a/crates/peppy/Cargo.toml
+++ b/crates/peppy/Cargo.toml
@@ -31,7 +31,7 @@ derive_more = { version = "2", features = ["from"] }
 rayon = "1.11.0"
 service-manager = "0.11"
 ipnet = "2.11"
-netdev = "0.43"
+netdev = "0.44"
 libc = "0.2"
 dirs = "6"
 names-generator2 = "0.2.1"

--- a/crates/peppy/src/commands/service/builder.rs
+++ b/crates/peppy/src/commands/service/builder.rs
@@ -3,9 +3,11 @@ use super::messaging_router::MessagingRouter;
 use super::serve::{CompositeCommand, Serve};
 use crate::daemon_state::DaemonState;
 use crate::error::{Error, Result};
+use config::peppy_config::PeppyConfig;
 use pmi::Messenger;
 use pmi::MessengerAdapter;
 use pmi::MockAdapter;
+use pmi::SubscriberBufferSizes;
 use pmi::{ZenohAdapter, ZenohNetProtocol};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -29,6 +31,7 @@ pub struct ServeCommandBuilder {
     clock_source: super::ClockSource,
     shutdown_token: Option<CancellationToken>,
     root_dir: PathBuf,
+    peppy_config: PeppyConfig,
 }
 
 impl ServeCommandBuilder {
@@ -42,7 +45,17 @@ impl ServeCommandBuilder {
             clock_source: super::ClockSource::default(),
             shutdown_token: None,
             root_dir: root_dir.into(),
+            peppy_config: PeppyConfig::default(),
         })
+    }
+
+    /// Supplies the daemon-global config (messaging mode + peer buffer sizes)
+    /// read once at startup. Must be called before [`with_messaging_router`]
+    /// (Self::with_messaging_router) so the daemon's own session is built in the
+    /// configured mode.
+    pub fn with_peppy_config(mut self, peppy_config: PeppyConfig) -> Self {
+        self.peppy_config = peppy_config;
+        self
     }
 
     pub fn with_shutdown_token(mut self, token: CancellationToken) -> Self {
@@ -58,10 +71,21 @@ impl ServeCommandBuilder {
             "zenoh" => {
                 // Reconnecting session: if the router watchdog respawns zenohd,
                 // the daemon's own session re-establishes (and re-declares the
-                // core node's services) instead of going silent.
-                let adapter =
-                    ZenohAdapter::with_router(ZenohNetProtocol::Tcp, "0.0.0.0", listening_port)?
-                        .with_session_reconnect();
+                // core node's services) instead of going silent. The session's
+                // mode (peer vs router-relay) and buffer sizes come from the
+                // daemon-global config read at startup.
+                let buffer_sizes = SubscriberBufferSizes {
+                    standard: self.peppy_config.peer.standard_buffer_size,
+                    high_throughput: self.peppy_config.peer.high_throughput_buffer_size,
+                };
+                let adapter = ZenohAdapter::with_router(
+                    ZenohNetProtocol::Tcp,
+                    "0.0.0.0",
+                    listening_port,
+                    self.peppy_config.mode.gossip(),
+                    buffer_sizes,
+                )?
+                .with_session_reconnect();
                 MessengerAdapter::Zenoh(adapter)
             }
             "mock" => MessengerAdapter::Mock(MockAdapter::default()),
@@ -105,6 +129,7 @@ impl ServeCommandBuilder {
                     self.root_dir.clone(),
                     self.messaging_ready.clone(),
                     self.clock_source,
+                    self.peppy_config,
                 );
 
                 // Write the daemon state file with the core node name

--- a/crates/peppy/src/commands/service/builder.rs
+++ b/crates/peppy/src/commands/service/builder.rs
@@ -74,10 +74,7 @@ impl ServeCommandBuilder {
                 // core node's services) instead of going silent. The session's
                 // mode (peer vs router-relay) and buffer sizes come from the
                 // daemon-global config read at startup.
-                let buffer_sizes = SubscriberBufferSizes {
-                    standard: self.peppy_config.peer.standard_buffer_size,
-                    high_throughput: self.peppy_config.peer.high_throughput_buffer_size,
-                };
+                let buffer_sizes = SubscriberBufferSizes::from(self.peppy_config.peer);
                 let adapter = ZenohAdapter::with_router(
                     ZenohNetProtocol::Tcp,
                     "0.0.0.0",

--- a/crates/peppy/src/commands/service/core_node.rs
+++ b/crates/peppy/src/commands/service/core_node.rs
@@ -26,6 +26,7 @@ pub struct CoreNodeRunner {
 }
 
 impl CoreNodeRunner {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         messenger: Arc<Mutex<Messenger>>,
         core_node_name: Option<String>,
@@ -34,6 +35,7 @@ impl CoreNodeRunner {
         root_dir: PathBuf,
         messaging_ready: Option<watch::Receiver<bool>>,
         clock_source: super::ClockSource,
+        peppy_config: config::peppy_config::PeppyConfig,
     ) -> Self {
         let node_arguments = CoreNodeArguments {
             node_startup_timeout,
@@ -52,6 +54,7 @@ impl CoreNodeRunner {
             node_arguments,
             root_dir,
             peppy_dirs,
+            peppy_config,
         );
         Self {
             core_node,

--- a/crates/peppy/src/commands/service/serve.rs
+++ b/crates/peppy/src/commands/service/serve.rs
@@ -189,7 +189,17 @@ pub struct ServeCommand {
 
 impl Command for ServeCommand {
     fn execute(self, ctx: &Arc<AppContext>) -> Result<()> {
+        // Read the daemon-global config once at startup, creating it with
+        // defaults if missing. Resolved from `PeppyDirs::default()` (the same
+        // ~/.peppy the core node uses), and applied to the daemon's own session
+        // and every spawned node. Fails loud on a malformed config.
+        let peppy_dirs = config::consts::PeppyDirs::default();
+        let peppy_config = config::peppy_config::load_or_create(&peppy_dirs).map_err(|e| {
+            Error::ExecutionFailed(format!("Failed to load peppy_config.json5: {e}"))
+        })?;
+
         let mut builder = ServeCommandBuilder::new(&ctx.root_dir)?
+            .with_peppy_config(peppy_config)
             .with_messaging_router(self.messaging_engine)?
             .with_core_node(self.core_node_name, self.clock_source)?;
 

--- a/crates/peppy/src/test_support.rs
+++ b/crates/peppy/src/test_support.rs
@@ -183,6 +183,7 @@ impl ServeCommandEmulation {
             },
             temp_dir.path().to_path_buf(),
             peppy_dirs,
+            config::peppy_config::PeppyConfig::default(),
         );
         let core_node_name = core_node.node_name().to_string();
 

--- a/crates/peppylib/src/messaging.rs
+++ b/crates/peppylib/src/messaging.rs
@@ -275,12 +275,19 @@ impl MessengerHandle {
         port: u16,
         discovery: &config::runtime::DiscoveryConfig,
     ) -> Result<Self> {
+        // Convert the daemon-resolved buffer sizes to pmi's type at this
+        // boundary (config-internal must not depend on pmi).
+        let buffer_sizes = pmi::SubscriberBufferSizes {
+            standard: discovery.standard_buffer_size,
+            high_throughput: discovery.high_throughput_buffer_size,
+        };
         let adapter = ZenohAdapter::connect_to_with_discovery(
             ZenohNetProtocol::Tcp,
             host,
             port,
             discovery.seed_peers.clone(),
             discovery.gossip,
+            buffer_sizes,
         )?
         .with_session_reconnect();
         let messenger = Self::new_session(adapter).await?;

--- a/crates/peppylib/src/messaging.rs
+++ b/crates/peppylib/src/messaging.rs
@@ -462,16 +462,18 @@ impl MessengerHandle {
                         if received_ack {
                             return Err(timed_out());
                         }
-                        match deadline {
-                            Some(deadline) => {
-                                let remaining = deadline.saturating_duration_since(Instant::now());
-                                if remaining.is_zero() {
-                                    return Err(unreachable());
-                                }
-                                sleep(COLD_START_BACKOFF.min(remaining)).await;
-                            }
-                            None => sleep(COLD_START_BACKOFF).await,
+                        // Cold-start retry only makes sense against a bounded
+                        // budget. With no timeout there is nothing to bound the
+                        // retry, so fail fast (matching the pre-retry behavior)
+                        // rather than re-probing forever.
+                        let Some(deadline) = deadline else {
+                            return Err(unreachable());
+                        };
+                        let remaining = deadline.saturating_duration_since(Instant::now());
+                        if remaining.is_zero() {
+                            return Err(unreachable());
                         }
+                        sleep(COLD_START_BACKOFF.min(remaining)).await;
                         continue 'attempts;
                     }
                 }

--- a/crates/peppylib/src/messaging.rs
+++ b/crates/peppylib/src/messaging.rs
@@ -275,12 +275,7 @@ impl MessengerHandle {
         port: u16,
         discovery: &config::runtime::DiscoveryConfig,
     ) -> Result<Self> {
-        // Convert the daemon-resolved buffer sizes to pmi's type at this
-        // boundary (config-internal must not depend on pmi).
-        let buffer_sizes = pmi::SubscriberBufferSizes {
-            standard: discovery.standard_buffer_size,
-            high_throughput: discovery.high_throughput_buffer_size,
-        };
+        let buffer_sizes = pmi::SubscriberBufferSizes::from(discovery);
         let adapter = ZenohAdapter::connect_to_with_discovery(
             ZenohNetProtocol::Tcp,
             host,

--- a/crates/peppylib/src/messaging.rs
+++ b/crates/peppylib/src/messaging.rs
@@ -50,7 +50,7 @@ use std::sync::{
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::{
     sync::Mutex,
-    time::{Duration, Instant, timeout},
+    time::{Duration, Instant, sleep, timeout},
 };
 
 // services
@@ -63,8 +63,16 @@ pub const SHUTDOWN_SERVICE: &str = "shutdown";
 /// `node_health`, this triggers no user code.
 pub const CLOCK_OFFSET_SERVICE: &str = "clock_offset";
 
-/// Timeout for reachability probes sent by `is_reachable`.
+/// Timeout for a single reachability probe sent by `is_reachable`.
 pub(crate) const PROBE_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// Budget for the wildcard / from_any discover-then-pin step (capped by the
+/// caller's own timeout). Larger than [`PROBE_TIMEOUT`] because a
+/// freshly-connected peer learns producers' queryables via gossip, which is not
+/// instantaneous like the old client/router star — `discover_producer` re-probes
+/// within this budget so a from_any `poll`/`send_goal` waits for discovery to
+/// settle instead of failing the moment it runs ahead of it.
+pub(crate) const DISCOVERY_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// Key in [`MessengerHandle::active_from_any_topics`]. Two from_any topic
 /// subscriptions conflict only when they would observe the same producer
@@ -257,6 +265,31 @@ impl MessengerHandle {
         })
     }
 
+    /// Like [`from_host_port_reconnecting`](Self::from_host_port_reconnecting)
+    /// but applies the node's [`DiscoveryConfig`](config::runtime::DiscoveryConfig):
+    /// an explicit gossip seed list (falling back to `host:port`) and the gossip
+    /// toggle. Used by the node runtime so peers form direct links per the
+    /// daemon-supplied discovery settings.
+    pub async fn from_host_port_reconnecting_with_discovery(
+        host: &str,
+        port: u16,
+        discovery: &config::runtime::DiscoveryConfig,
+    ) -> Result<Self> {
+        let adapter = ZenohAdapter::connect_to_with_discovery(
+            ZenohNetProtocol::Tcp,
+            host,
+            port,
+            discovery.seed_peers.clone(),
+            discovery.gossip,
+        )?
+        .with_session_reconnect();
+        let messenger = Self::new_session(adapter).await?;
+        Ok(Self {
+            messenger: Arc::new(Mutex::new(messenger)),
+            active_from_any_topics: Arc::new(StdMutex::new(HashSet::new())),
+        })
+    }
+
     async fn new_session(adapter: ZenohAdapter) -> Result<Messenger> {
         let mut messenger = Messenger::new(MessengerAdapter::Zenoh(adapter));
         messenger
@@ -293,6 +326,29 @@ impl MessengerHandle {
             .map_err(Error::PeppyMessagingInterface)
     }
 
+    /// Waits (deterministically, via Zenoh matching status) until a subscriber
+    /// for `sender`'s topic is known to this session, or `timeout` elapses;
+    /// returns whether a match was observed. A freshly-connected peer learns
+    /// remote subscriptions through gossip, which is not instantaneous, so its
+    /// first reliable publish can be dropped before discovery propagates; awaiting
+    /// a match closes that window without a fixed sleep. The mock backend has no
+    /// propagation delay and returns `true` immediately.
+    pub(crate) async fn wait_for_matching_subscriber(
+        &self,
+        sender: &TopicWireSender,
+        timeout: Duration,
+    ) -> Result<bool> {
+        let messenger = self.messenger.lock().await;
+        match &messenger.adapter {
+            #[cfg(feature = "zenoh")]
+            MessengerAdapter::Zenoh(adapter) => adapter
+                .wait_for_topic_subscriber(sender, timeout)
+                .await
+                .map_err(Error::PeppyMessagingInterface),
+            _ => Ok(true),
+        }
+    }
+
     pub(crate) async fn expose_service(
         &self,
         recv: &ServiceWireReceiver,
@@ -316,27 +372,6 @@ impl MessengerHandle {
     ) -> Result<Message> {
         let response_timeout: Option<Duration> = response_timeout.into();
 
-        let mut response_subscription = {
-            let messenger = self.messenger.lock().await;
-            messenger
-                .call_service(
-                    sender,
-                    request_payload.into_inner().into(),
-                    kind,
-                    response_timeout,
-                )
-                .await
-                .map_err(Error::PeppyMessagingInterface)?
-        };
-
-        // Wait for the response, filtering replies by their attachment-side
-        // `ServiceReplyKind`. The producer sends `Ack` immediately on receiving
-        // a real user request (before the handler runs) and a terminal
-        // `Response` or `HandlerError` once the handler returns. With a
-        // timeout, ack-without-response → ServiceTimeout, no ack at all →
-        // ServiceUnreachable. Probes get a single `Response` reply with an
-        // empty payload (no ACK), so a probe consumer is guaranteed to break
-        // the loop on the first reply.
         let to_service_name = sender.to_service_name().to_string();
         let target_instance_id = sender.target_instance_id().map(str::to_string);
         let unreachable = || Error::ServiceUnreachable {
@@ -348,52 +383,99 @@ impl MessengerHandle {
             service_name: to_service_name.clone(),
         };
 
-        let reply = match response_timeout {
-            Some(response_timeout) => {
-                let deadline = Instant::now() + response_timeout;
-                let mut received_ack = false;
+        // Re-issue the query (cheap `Bytes` clone per attempt) on a cold-start
+        // miss; see the retry rationale below.
+        let request_bytes = request_payload.into_inner();
+        const COLD_START_BACKOFF: Duration = Duration::from_millis(50);
+        let deadline = response_timeout.map(|t| Instant::now() + t);
 
-                loop {
-                    let remaining = deadline.saturating_duration_since(Instant::now());
-                    if remaining.is_zero() {
-                        return Err(if received_ack {
-                            timed_out()
-                        } else {
-                            unreachable()
-                        });
-                    }
+        // Each attempt issues the query and waits for its first terminal reply.
+        // The producer sends `Ack` immediately on receiving a real user request
+        // (before the handler runs) and a terminal `Response` / `HandlerError`
+        // once the handler returns. Probes get a single `Response` (no Ack).
+        //
+        // Cold-start retry (peer mode): a freshly-connected caller may not have
+        // learned the target's queryable yet, so the query finalizes with no
+        // reply (`Ok(None)`) the instant it runs ahead of discovery. When that
+        // happens *before any Ack* — the target was never reached — re-issue the
+        // query within the caller's remaining budget so the call deterministically
+        // waits for discovery to settle instead of failing immediately. Once an
+        // Ack arrives the target is reachable, so a later miss is a genuine
+        // `ServiceTimeout`, never a retry. This adds no happy-path overhead:
+        // retries only fire on an actual cold-start miss.
+        let reply = 'attempts: loop {
+            if let Some(deadline) = deadline
+                && Instant::now() >= deadline
+            {
+                return Err(unreachable());
+            }
 
-                    match timeout(remaining, response_subscription.rx.recv()).await {
-                        Ok(Some(reply)) => match reply.kind() {
-                            ServiceReplyKind::Ack => {
-                                received_ack = true;
-                                continue;
-                            }
-                            ServiceReplyKind::Response | ServiceReplyKind::HandlerError => {
-                                break reply;
-                            }
-                        },
-                        Ok(None) | Err(_) => {
+            let attempt_timeout = deadline.map(|d| d.saturating_duration_since(Instant::now()));
+            let mut response_subscription = {
+                let messenger = self.messenger.lock().await;
+                messenger
+                    .call_service(sender, request_bytes.clone().into(), kind, attempt_timeout)
+                    .await
+                    .map_err(Error::PeppyMessagingInterface)?
+            };
+
+            let mut received_ack = false;
+            loop {
+                let received = match deadline {
+                    Some(deadline) => {
+                        let remaining = deadline.saturating_duration_since(Instant::now());
+                        if remaining.is_zero() {
                             return Err(if received_ack {
                                 timed_out()
                             } else {
                                 unreachable()
                             });
                         }
+                        match timeout(remaining, response_subscription.rx.recv()).await {
+                            Ok(maybe) => maybe,
+                            // Deadline elapsed with the query still open: a real
+                            // timeout (slow/absent target), not a cold-start miss.
+                            Err(_) => {
+                                return Err(if received_ack {
+                                    timed_out()
+                                } else {
+                                    unreachable()
+                                });
+                            }
+                        }
+                    }
+                    None => response_subscription.rx.recv().await,
+                };
+
+                match received {
+                    Some(reply) => match reply.kind() {
+                        ServiceReplyKind::Ack => {
+                            received_ack = true;
+                            continue;
+                        }
+                        ServiceReplyKind::Response | ServiceReplyKind::HandlerError => {
+                            break 'attempts reply;
+                        }
+                    },
+                    // Query finalized with no reply.
+                    None => {
+                        if received_ack {
+                            return Err(timed_out());
+                        }
+                        match deadline {
+                            Some(deadline) => {
+                                let remaining = deadline.saturating_duration_since(Instant::now());
+                                if remaining.is_zero() {
+                                    return Err(unreachable());
+                                }
+                                sleep(COLD_START_BACKOFF.min(remaining)).await;
+                            }
+                            None => sleep(COLD_START_BACKOFF).await,
+                        }
+                        continue 'attempts;
                     }
                 }
             }
-            None => loop {
-                match response_subscription.rx.recv().await {
-                    Some(reply) => match reply.kind() {
-                        ServiceReplyKind::Ack => continue,
-                        ServiceReplyKind::Response | ServiceReplyKind::HandlerError => {
-                            break reply;
-                        }
-                    },
-                    None => return Err(unreachable()),
-                }
-            },
         };
 
         let kind = reply.kind();

--- a/crates/peppylib/src/messaging/actions.rs
+++ b/crates/peppylib/src/messaging/actions.rs
@@ -1,7 +1,10 @@
 use super::discovery::discover_producer;
 use super::generate_short_id;
 use super::topics::Subscription;
-use super::{MessengerHandle, PROBE_TIMEOUT, ServiceEndpoint, ServiceResponder, TopicPublisher};
+use super::{
+    DISCOVERY_TIMEOUT, MessengerHandle, PROBE_TIMEOUT, ServiceEndpoint, ServiceResponder,
+    TopicPublisher,
+};
 use crate::error::{Error, Result};
 use crate::runtime::{CancellationToken, TaskHandle, spawn};
 use crate::types::{Message, Payload};
@@ -507,10 +510,11 @@ impl ActionMessenger {
                     to_target.clone(),
                     to_action_name,
                 )?;
-                // Cap discovery at PROBE_TIMEOUT or the caller's goal budget,
-                // whichever is shorter, so a tight `goal_timeout` still fails
-                // fast against unreachable producers.
-                let discovery_timeout = goal_timeout.min(PROBE_TIMEOUT);
+                // Cap discovery at DISCOVERY_TIMEOUT or the caller's goal budget,
+                // whichever is shorter: a tight `goal_timeout` still fails fast
+                // against unreachable producers, while a generous one lets
+                // peer-mode gossip discovery settle (see `discover_producer`).
+                let discovery_timeout = goal_timeout.min(DISCOVERY_TIMEOUT);
                 let (core, inst) =
                     discover_producer(messenger, &probe_sender.goal_service(), discovery_timeout)
                         .await?;

--- a/crates/peppylib/src/messaging/discovery.rs
+++ b/crates/peppylib/src/messaging/discovery.rs
@@ -29,6 +29,11 @@ pub(super) async fn discover_producer(
     probe_sender: &ServiceWireSender,
     discovery_timeout: Duration,
 ) -> Result<(String, String)> {
+    // `poll_service` itself retries on a peer-mode cold-start miss (the probe's
+    // `QueryTarget::All` finalizing with no reply before discovery has settled),
+    // bounded by `discovery_timeout`, so a single probe call here waits for a
+    // producer to appear rather than failing the instant it runs ahead of
+    // discovery.
     let response = messenger
         .poll_service(
             probe_sender,

--- a/crates/peppylib/src/messaging/services.rs
+++ b/crates/peppylib/src/messaging/services.rs
@@ -1,5 +1,5 @@
 use super::discovery::discover_producer;
-use super::{MessengerHandle, PROBE_TIMEOUT, generate_short_id};
+use super::{DISCOVERY_TIMEOUT, MessengerHandle, PROBE_TIMEOUT, generate_short_id};
 use crate::error::{Error, Result};
 use crate::runtime::{TaskHandle, spawn};
 use crate::types::{Message, Payload};
@@ -368,13 +368,14 @@ impl ServiceMessenger {
                     to_service_name,
                     ServiceKind::Service,
                 )?;
-                // Discovery is capped at PROBE_TIMEOUT or the caller's response
-                // budget, whichever is shorter; this preserves the user contract
-                // that a tight `response_timeout` fails fast against unreachable
-                // targets.
+                // Discovery is capped at DISCOVERY_TIMEOUT or the caller's
+                // response budget, whichever is shorter; a tight
+                // `response_timeout` still fails fast against unreachable
+                // targets, while a generous one lets peer-mode gossip discovery
+                // settle (see `discover_producer`).
                 let discovery_timeout = response_timeout
-                    .map(|t| t.min(PROBE_TIMEOUT))
-                    .unwrap_or(PROBE_TIMEOUT);
+                    .map(|t| t.min(DISCOVERY_TIMEOUT))
+                    .unwrap_or(DISCOVERY_TIMEOUT);
                 let (core, inst) =
                     discover_producer(messenger, &probe_sender, discovery_timeout).await?;
                 (Some(core), Some(inst))

--- a/crates/peppylib/src/messaging/tests.rs
+++ b/crates/peppylib/src/messaging/tests.rs
@@ -79,17 +79,30 @@ fn ensure_test_fd_limit() {
     });
 }
 
+/// Serializes the zenoh router/peer tests in this binary. Running several
+/// independent peer meshes at once starves peer-mode gossip discovery (every
+/// peer opens listeners and forms links), which makes cold-start delivery flaky;
+/// one mesh at a time keeps discovery fast and deterministic. Mirrors pmi's
+/// `ZENOH_SERIAL`. The guard is held for each test's lifetime via the field
+/// below, so acquiring the context is all a test needs to opt in.
+static ZENOH_SERIAL: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
 struct TestRouterContext {
     instance: ZenohdInstance,
+    _serial: tokio::sync::MutexGuard<'static, ()>,
 }
 
 impl TestRouterContext {
     async fn start() -> Self {
+        let serial = ZENOH_SERIAL.lock().await;
         ensure_test_fd_limit();
         let instance = ZenohAdapter::start_router_ephemeral("127.0.0.1", None)
             .await
             .expect("failed to start zenoh router for tests");
-        Self { instance }
+        Self {
+            instance,
+            _serial: serial,
+        }
     }
 
     fn host(&self) -> &str {
@@ -166,12 +179,21 @@ async fn topic_publish_subscribe_no_from_instance_id() {
     .await
     .expect("Should subscribe to the topic");
 
-    // Allow subscription to propagate before publishing
-    tokio::time::sleep(Duration::from_millis(50)).await;
-
     let emitter_core_node = "core_node_emit";
     let emitter_instance_id = "emitter_instance";
     let emitter_handle = router.messenger().await;
+    // Deterministically wait for the subscriber before the first publish so it
+    // is not dropped during peer-mode discovery propagation.
+    TopicMessenger::wait_for_subscriber(
+        &emitter_handle,
+        emitter_core_node,
+        emitter_instance_id,
+        test_node_target(node_name),
+        topic,
+        Duration::from_secs(5),
+    )
+    .await
+    .expect("subscriber should become reachable");
     TopicMessenger::emit(
         &emitter_handle,
         emitter_core_node,
@@ -251,10 +273,19 @@ async fn topic_publish_subscribe_with_from_instance_id() {
     .await
     .expect("Should subscribe to the topic");
 
-    // Allow subscriptions to propagate before publishing
-    tokio::time::sleep(Duration::from_millis(50)).await;
-
     let emitter_handle1 = router.messenger().await;
+    // Deterministically wait for the matching subscriber (subscription2) before
+    // the first publish so it is not dropped during peer-mode discovery.
+    TopicMessenger::wait_for_subscriber(
+        &emitter_handle1,
+        emitter_core_node,
+        emitter_instance_id2,
+        test_node_target(node_name),
+        topic,
+        Duration::from_secs(5),
+    )
+    .await
+    .expect("subscriber should become reachable");
     TopicMessenger::emit(
         &emitter_handle1,
         emitter_core_node,
@@ -342,10 +373,19 @@ async fn topic_publish_subscribe_with_from_core_node() {
     .await
     .expect("Should subscribe to the topic");
 
-    // Allow subscriptions to propagate before publishing
-    tokio::time::sleep(Duration::from_millis(50)).await;
-
     let emitter_handle1 = router.messenger().await;
+    // Deterministically wait for the matching subscriber (subscription2) before
+    // the first publish so it is not dropped during peer-mode discovery.
+    TopicMessenger::wait_for_subscriber(
+        &emitter_handle1,
+        emitter_core_node2,
+        emitter_instance_id,
+        test_node_target(node_name),
+        topic,
+        Duration::from_secs(5),
+    )
+    .await
+    .expect("subscriber should become reachable");
     TopicMessenger::emit(
         &emitter_handle1,
         emitter_core_node2,
@@ -418,9 +458,22 @@ async fn consumer_filter_only_from_set_admits_listed_producers_and_drops_others(
     .await
     .expect("subscribe should succeed");
 
-    tokio::time::sleep(Duration::from_millis(50)).await;
-
     let emitter_handle = router.messenger().await;
+    // Deterministically wait until the subscriber is known to this fresh emitter
+    // peer before publishing, so the first emits are not dropped during peer-mode
+    // discovery propagation. The from_any subscriber matches any producer, so
+    // waiting on one producer's key expression confirms it is reachable.
+    TopicMessenger::wait_for_subscriber(
+        &emitter_handle,
+        core,
+        p1,
+        test_node_target(node_name),
+        topic,
+        Duration::from_secs(5),
+    )
+    .await
+    .expect("subscriber should become reachable");
+
     for (producer, body) in [
         (p1, b"from-p1".as_ref()),
         (p3, b"from-p3"),
@@ -510,9 +563,21 @@ async fn consumer_filter_any_except_drops_excluded_and_admits_rest() {
     .await
     .expect("subscribe should succeed");
 
-    tokio::time::sleep(Duration::from_millis(50)).await;
-
     let emitter_handle = router.messenger().await;
+    // Wait until the subscriber is known to this fresh emitter peer before
+    // publishing (peer-mode discovery is not instantaneous). The from_any
+    // subscription matches any producer, so waiting on one suffices.
+    TopicMessenger::wait_for_subscriber(
+        &emitter_handle,
+        core,
+        unclaimed,
+        test_node_target(node_name),
+        topic,
+        Duration::from_secs(5),
+    )
+    .await
+    .expect("subscriber should become reachable");
+
     for (producer, body) in [
         (claimed, b"from-claimed".as_ref()),
         (unclaimed, b"from-unclaimed"),
@@ -575,15 +640,25 @@ async fn topic_publish_reliable_5000hz_messages() {
     .await
     .expect("Should subscribe to the topic");
 
-    // Allow subscription to propagate before publishing
-    tokio::time::sleep(Duration::from_millis(50)).await;
-
     let message_count = 5000;
     let emitter_core_node = "emitter_core_node";
     let emitter_instance_id = "emitter_instance";
     let mut message_ids: Vec<u32> = (0..message_count as u32).collect();
     let mut rng = rand::rng();
     message_ids.shuffle(&mut rng);
+
+    // Deterministically wait for the subscriber before the publish loop so the
+    // first messages are not dropped during peer-mode discovery propagation.
+    TopicMessenger::wait_for_subscriber(
+        &sender_handle,
+        emitter_core_node,
+        emitter_instance_id,
+        test_node_target(node_name),
+        topic,
+        Duration::from_secs(5),
+    )
+    .await
+    .expect("subscriber should become reachable");
 
     for &message_id in &message_ids {
         let payload = Payload::from(message_id.to_le_bytes().to_vec());
@@ -1392,7 +1467,7 @@ async fn sized_probe_gets_sized_reply_without_running_the_handler() {
             listener_service_name,
             None,
             None,
-            Duration::from_secs(1),
+            Duration::from_secs(5),
             128, // request_size
             256, // response_size
         )
@@ -1694,7 +1769,7 @@ async fn service_handle_request_processes_multiple_messages() {
                 None,
                 Some(listener_instance_id),
                 request_payload.clone(),
-                Duration::from_secs(2),
+                Duration::from_secs(5),
             )
             .await
             .expect("caller should receive response");
@@ -1735,8 +1810,12 @@ async fn single_service_communication_multiple_polls_and_callers() {
     // Caller core node (shared by all callers)
     const CALLER_CORE_NODE: &str = "caller_core_node";
 
-    // TODO: 500 callers saturate Zenohd, it shouldn't
-    let caller_count = 100;
+    // Peer-mode sessions are heavier than the old client sessions: each caller
+    // opens its own peer that forms direct links and discovers via gossip, so
+    // many fresh peers connecting at once is far more load than the client/router
+    // star. Keep the concurrency modest; this still exercises many unique
+    // concurrent request/response pairs across independent caller sessions.
+    let caller_count = 20;
     let requests_per_caller = 5;
     let total_requests = caller_count * requests_per_caller;
     let call_count = Arc::new(AtomicUsize::new(0));
@@ -1836,7 +1915,7 @@ async fn single_service_communication_multiple_polls_and_callers() {
                         None,
                         Some(listener_instance_id),
                         request_payload.clone(),
-                        Duration::from_secs(1),
+                        Duration::from_secs(5),
                     )
                     .await
                     .expect("caller should receive response");
@@ -2938,9 +3017,19 @@ async fn topic_duplicate_from_any_subscription_is_rejected() {
     .await
     .expect("from_any subscribe should succeed after the first guard dropped");
 
-    tokio::time::sleep(Duration::from_millis(100)).await;
-
     let emitter_handle = router.messenger().await;
+    // Deterministically wait for the surviving from_any subscriber before the
+    // publish so it is not dropped during peer-mode discovery propagation.
+    TopicMessenger::wait_for_subscriber(
+        &emitter_handle,
+        "pub_core",
+        "pub_inst",
+        target(),
+        "frames",
+        Duration::from_secs(5),
+    )
+    .await
+    .expect("subscriber should become reachable");
     TopicMessenger::emit(
         &emitter_handle,
         "pub_core",

--- a/crates/peppylib/src/messaging/tests.rs
+++ b/crates/peppylib/src/messaging/tests.rs
@@ -660,20 +660,29 @@ async fn topic_publish_reliable_5000hz_messages() {
     .await
     .expect("subscriber should become reachable");
 
-    for &message_id in &message_ids {
-        let payload = Payload::from(message_id.to_le_bytes().to_vec());
-        TopicMessenger::emit(
-            &sender_handle,
-            emitter_core_node,
-            emitter_instance_id,
-            test_node_target(node_name),
-            topic,
-            qos.clone(),
-            payload,
-        )
-        .await
-        .expect("Should send the payload");
-    }
+    // Drain concurrently with publishing. Peer mode removes the router buffer
+    // that used to sit between publisher and subscriber, so publishing all
+    // messages before draining would block a Reliable (Block-congestion)
+    // publisher once the subscriber's bounded channel fills. A real stream is
+    // drained continuously, so emit in a background task while the main task
+    // receives.
+    let emit_ids = message_ids.clone();
+    let emitter = tokio::spawn(async move {
+        for &message_id in &emit_ids {
+            let payload = Payload::from(message_id.to_le_bytes().to_vec());
+            TopicMessenger::emit(
+                &sender_handle,
+                emitter_core_node,
+                emitter_instance_id,
+                test_node_target(node_name),
+                topic,
+                qos.clone(),
+                payload,
+            )
+            .await
+            .expect("Should send the payload");
+        }
+    });
 
     // Identity check runs once on the first received message — the wire-format
     // contract is pinned in `pmi::wire::zenoh_format::tests`, so this loop only needs
@@ -706,6 +715,8 @@ async fn topic_publish_reliable_5000hz_messages() {
 
         received_ids.push(received_id);
     }
+
+    emitter.await.expect("emitter task should not panic");
 
     assert_eq!(
         received_ids.len(),

--- a/crates/peppylib/src/messaging/topics.rs
+++ b/crates/peppylib/src/messaging/topics.rs
@@ -190,6 +190,30 @@ impl TopicMessenger {
         Ok(())
     }
 
+    /// Waits until a subscriber for this topic is known to the publisher's
+    /// session, or `timeout` elapses; returns whether a match was observed.
+    ///
+    /// In peer mode a freshly-connected publisher learns about existing
+    /// subscribers through gossip, which is not instantaneous, so its first
+    /// [`emit`](Self::emit) can be dropped before discovery propagates. Call
+    /// this first when the very first publish must reach an already-running
+    /// subscriber; it returns as soon as a match is observed (no fixed sleep).
+    /// A `false` return means no subscriber appeared within `timeout`.
+    pub async fn wait_for_subscriber(
+        messenger: &MessengerHandle,
+        as_core_node: &str,
+        as_instance_id: &str,
+        as_target: SenderTarget,
+        as_topic_name: &str,
+        timeout: std::time::Duration,
+    ) -> Result<bool> {
+        let sender =
+            TopicWireSender::new(as_core_node, as_instance_id, as_target, None, as_topic_name)?;
+        messenger
+            .wait_for_matching_subscriber(&sender, timeout)
+            .await
+    }
+
     /// Pre-binds a topic publisher under a single producer-side link_id,
     /// bypassing the central `Messenger` mutex on every subsequent publish.
     /// Use this in publish loops; use [`emit`] for one-shot publishes.

--- a/crates/peppylib/src/runtime/node_runner.rs
+++ b/crates/peppylib/src/runtime/node_runner.rs
@@ -30,10 +30,12 @@ impl NodeRunner {
     ) -> Result<Self> {
         // Nodes are long-lived: use a reconnecting session so a router restart
         // (e.g. the daemon's watchdog respawning zenohd) is recovered
-        // transparently instead of leaving the node off the bus.
-        let messenger = MessengerHandle::from_host_port_reconnecting(
+        // transparently instead of leaving the node off the bus. The session is
+        // a peer that forms direct links per the node's discovery settings.
+        let messenger = MessengerHandle::from_host_port_reconnecting_with_discovery(
             processor.messaging_host(),
             processor.messaging_port(),
+            processor.discovery(),
         )
         .await?;
 

--- a/crates/peppylib/src/runtime/processor.rs
+++ b/crates/peppylib/src/runtime/processor.rs
@@ -180,6 +180,11 @@ impl Processor {
         self.runtime_config.messaging_port
     }
 
+    /// Peer-discovery settings for this node's messaging session.
+    pub(crate) fn discovery(&self) -> &config::runtime::DiscoveryConfig {
+        &self.runtime_config.discovery
+    }
+
     /// Daemon-resolved framework `use_sim_time` flag for this instance.
     /// Read by [`crate::core_node::clock::clock_for_node`] to pick between
     /// the wall-time and sim-time `PeppyClock` implementations.

--- a/crates/peppylib/tests/actions.rs
+++ b/crates/peppylib/tests/actions.rs
@@ -1278,6 +1278,7 @@ async fn action_from_any_send_goal_runs_handler_on_winner_only() {
         spec: ProducerSpec,
         goal_count: Arc<AtomicUsize>,
         ready: oneshot::Sender<()>,
+        mut shutdown: tokio::sync::watch::Receiver<bool>,
     ) -> tokio::task::JoinHandle<()> {
         let handle = MessengerHandle::from_host_port(&host, port)
             .await
@@ -1295,22 +1296,23 @@ async fn action_from_any_send_goal_runs_handler_on_winner_only() {
             let mut goal_service = action.goal_service;
             ready.send(()).expect("ready signal");
 
-            // The loser must time out here; the winner returns immediately.
-            match tokio::time::timeout(
-                Duration::from_millis(1000),
-                goal_service.recv_next_request(),
-            )
-            .await
-            {
-                Ok(Ok(Some((_ctx, responder)))) => {
-                    goal_count.fetch_add(1, Ordering::SeqCst);
-                    responder
-                        .respond(Payload::from(spec.inst.as_bytes().to_vec()))
-                        .await
-                        .expect("goal respond");
+            // The winner receives the goal and responds; the loser never does
+            // (the caller pins to one producer) and is released by `shutdown`
+            // once the winner has been serviced. Using an explicit signal rather
+            // than a fixed timeout keeps the test deterministic regardless of
+            // how long peer-mode discovery takes to settle.
+            tokio::select! {
+                res = goal_service.recv_next_request() => {
+                    if let Ok(Some((_ctx, responder))) = res {
+                        goal_count.fetch_add(1, Ordering::SeqCst);
+                        responder
+                            .respond(Payload::from(spec.inst.as_bytes().to_vec()))
+                            .await
+                            .expect("goal respond");
+                    }
                 }
-                _ => {
-                    // Loser of the discovery race — expected outcome.
+                _ = shutdown.changed() => {
+                    // Loser of the discovery race — released without a goal.
                 }
             }
         })
@@ -1320,6 +1322,7 @@ async fn action_from_any_send_goal_runs_handler_on_winner_only() {
     let goal_b = Arc::new(AtomicUsize::new(0));
     let (ready_a_tx, ready_a_rx) = oneshot::channel();
     let (ready_b_tx, ready_b_rx) = oneshot::channel();
+    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
 
     let task_a = spawn_producer(
         host.clone(),
@@ -1332,6 +1335,7 @@ async fn action_from_any_send_goal_runs_handler_on_winner_only() {
         },
         Arc::clone(&goal_a),
         ready_a_tx,
+        shutdown_rx.clone(),
     )
     .await;
     let task_b = spawn_producer(
@@ -1345,17 +1349,21 @@ async fn action_from_any_send_goal_runs_handler_on_winner_only() {
         },
         Arc::clone(&goal_b),
         ready_b_tx,
+        shutdown_rx,
     )
     .await;
 
     ready_a_rx.await.expect("producer A ready");
     ready_b_rx.await.expect("producer B ready");
-    tokio::time::sleep(Duration::from_millis(100)).await;
 
     let caller_handle = MessengerHandle::from_host_port(&host, port)
         .await
         .expect("caller connect");
 
+    // send_goal performs a from_any discover-then-pin internally. In peer mode
+    // discover_producer re-probes within its budget until the producers'
+    // queryables propagate to this freshly-connected caller, so no external
+    // readiness gate is needed — this exercises that cold-start retry directly.
     let goal_handle = ActionMessenger::send_goal(
         &caller_handle,
         "caller_core",
@@ -1366,10 +1374,13 @@ async fn action_from_any_send_goal_runs_handler_on_winner_only() {
         None,
         Payload::from_static(b"go"),
         QoSProfile::Reliable,
-        Duration::from_secs(2),
+        Duration::from_secs(5),
     )
     .await
     .expect("send_goal should succeed");
+
+    // Winner has been serviced; release the loser from its `recv_next_request`.
+    shutdown_tx.send(true).expect("signal producers to stop");
 
     let winner_inst = goal_handle.goal_response().instance_id().to_string();
     assert!(

--- a/crates/peppylib/tests/services.rs
+++ b/crates/peppylib/tests/services.rs
@@ -298,6 +298,7 @@ async fn service_from_any_poll_runs_handler_on_winner_only() {
         spec: ProducerSpec,
         handler_count: Arc<AtomicUsize>,
         ready: oneshot::Sender<()>,
+        mut shutdown: tokio::sync::watch::Receiver<bool>,
     ) -> tokio::task::JoinHandle<()> {
         let handle = MessengerHandle::from_host_port(&host, port)
             .await
@@ -314,18 +315,23 @@ async fn service_from_any_poll_runs_handler_on_winner_only() {
             .expect("listen should succeed");
             ready.send(()).expect("ready signal");
 
-            let _ = tokio::time::timeout(Duration::from_millis(1500), async {
-                endpoint
-                    .handle_next_request(|_req| {
-                        let counter = Arc::clone(&handler_count);
-                        async move {
-                            counter.fetch_add(1, Ordering::SeqCst);
-                            Ok(Payload::from(spec.inst.as_bytes().to_vec()))
-                        }
-                    })
-                    .await
-            })
-            .await;
+            // The winner handles the request; the loser only ever sees the
+            // (server-filtered) discovery probe and is released by `shutdown`
+            // once the winner has been serviced. An explicit signal rather than
+            // a fixed timeout keeps the test deterministic regardless of how
+            // long peer-mode discovery takes to settle.
+            tokio::select! {
+                res = endpoint.handle_next_request(|_req| {
+                    let counter = Arc::clone(&handler_count);
+                    async move {
+                        counter.fetch_add(1, Ordering::SeqCst);
+                        Ok(Payload::from(spec.inst.as_bytes().to_vec()))
+                    }
+                }) => {
+                    let _ = res;
+                }
+                _ = shutdown.changed() => {}
+            }
         })
     }
 
@@ -333,6 +339,7 @@ async fn service_from_any_poll_runs_handler_on_winner_only() {
     let handler_b = Arc::new(AtomicUsize::new(0));
     let (ready_a_tx, ready_a_rx) = oneshot::channel();
     let (ready_b_tx, ready_b_rx) = oneshot::channel();
+    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
 
     let task_a = spawn_producer(
         host.clone(),
@@ -345,6 +352,7 @@ async fn service_from_any_poll_runs_handler_on_winner_only() {
         },
         Arc::clone(&handler_a),
         ready_a_tx,
+        shutdown_rx.clone(),
     )
     .await;
     let task_b = spawn_producer(
@@ -358,17 +366,21 @@ async fn service_from_any_poll_runs_handler_on_winner_only() {
         },
         Arc::clone(&handler_b),
         ready_b_tx,
+        shutdown_rx,
     )
     .await;
 
     ready_a_rx.await.expect("producer A ready");
     ready_b_rx.await.expect("producer B ready");
-    tokio::time::sleep(Duration::from_millis(100)).await;
 
     let caller_handle = MessengerHandle::from_host_port(&host, port)
         .await
         .expect("caller connect");
 
+    // poll performs a from_any discover-then-pin internally. In peer mode
+    // discover_producer re-probes within its budget until the producers'
+    // queryables propagate to this freshly-connected caller, so no external
+    // readiness gate is needed — this exercises that cold-start retry directly.
     let response = ServiceMessenger::poll(
         &caller_handle,
         "caller_core",
@@ -378,10 +390,13 @@ async fn service_from_any_poll_runs_handler_on_winner_only() {
         None, // wildcard target_core_node
         None, // wildcard target_instance_id
         Payload::from_static(b"go"),
-        Duration::from_secs(2),
+        Duration::from_secs(5),
     )
     .await
     .expect("wildcard poll should succeed");
+
+    // Winner has been serviced; release the loser from its request wait.
+    shutdown_tx.send(true).expect("signal producers to stop");
 
     let winner_inst = response.instance_id().to_string();
     assert!(

--- a/crates/pmi-internal/Cargo.toml
+++ b/crates/pmi-internal/Cargo.toml
@@ -6,7 +6,6 @@ edition.workspace = true
 
 [dependencies]
 config = { path = "../config-internal" }
-askama = "0.16"
 bytes = "1"
 serde_json = "1.0"
 tokio = { version = "1", features = ["sync", "rt"] }

--- a/crates/pmi-internal/src/adapters/mock.rs
+++ b/crates/pmi-internal/src/adapters/mock.rs
@@ -2,7 +2,8 @@ use super::super::error::{Error, Result};
 use super::super::types::{
     AbortOnDrop, IncomingRequest, Message, Messenger, MessengerAdapter, MessengerBackend,
     MockResponseToken, NO_TIMEOUT_SENTINEL, Payload, PublisherQoS, ReplyStream, ResponseToken,
-    ServiceQueryable, ServiceReply, SubscriberQoS, Subscription, TopicMessage,
+    ServiceQueryable, ServiceReply, SubscriberBufferSizes, SubscriberQoS, Subscription,
+    TopicMessage,
 };
 use super::super::wire::zenoh_format::ZenohWireFormat;
 use super::super::wire::{
@@ -161,7 +162,9 @@ impl MessengerBackend for MockAdapter {
             });
         }
 
-        let (tx, rx) = flume::bounded::<IncomingRequest>(SubscriberQoS::Standard.channel_size());
+        let (tx, rx) = flume::bounded::<IncomingRequest>(
+            SubscriberBufferSizes::default().size_for(SubscriberQoS::Standard),
+        );
 
         // One queryable per listen call (see `ZenohAdapter::listen_service`
         // for the rationale — the same shape applies here so peppylib tests
@@ -196,8 +199,9 @@ impl MessengerBackend for MockAdapter {
         let attachment = ZenohWireFormat::service_get_selector_attachment(sender, kind);
         let timeout = timeout.unwrap_or(NO_TIMEOUT_SENTINEL);
 
-        let (reply_tx, mut reply_rx) =
-            mpsc::channel::<ServiceReply>(SubscriberQoS::Standard.channel_size());
+        let (reply_tx, mut reply_rx) = mpsc::channel::<ServiceReply>(
+            SubscriberBufferSizes::default().size_for(SubscriberQoS::Standard),
+        );
 
         // Snapshot matching queryable channels under the map lock, then dispatch
         // outside the lock so async send doesn't hold a sync mutex across await.
@@ -225,8 +229,9 @@ impl MessengerBackend for MockAdapter {
         // dropped — typically after the user handler's final `respond` call.
         drop(reply_tx);
 
-        let (output_tx, output_rx) =
-            mpsc::channel::<ServiceReply>(SubscriberQoS::Standard.channel_size());
+        let (output_tx, output_rx) = mpsc::channel::<ServiceReply>(
+            SubscriberBufferSizes::default().size_for(SubscriberQoS::Standard),
+        );
         let pump_task = tokio::spawn(async move {
             let _ = tokio::time::timeout(timeout, async move {
                 while let Some(msg) = reply_rx.recv().await {
@@ -446,7 +451,8 @@ impl MockAdapter {
     /// closed senders rather than garbage-collecting them, mirroring the
     /// topic [`SubscriptionMap`] convention.
     fn declare_queryable_keyexpr(&self, declared_keyexpr: String) -> mpsc::Receiver<MockQuery> {
-        let (tx, rx) = mpsc::channel(SubscriberQoS::Standard.channel_size());
+        let (tx, rx) =
+            mpsc::channel(SubscriberBufferSizes::default().size_for(SubscriberQoS::Standard));
         let mut queryables = self.queryables.lock().unwrap();
         queryables.entry(declared_keyexpr).or_default().push(tx);
         rx
@@ -464,7 +470,7 @@ impl MockAdapter {
             });
         }
 
-        let (tx, rx) = flume::bounded(qos.channel_size());
+        let (tx, rx) = flume::bounded(SubscriberBufferSizes::default().size_for(qos));
 
         {
             let mut subscriptions = self.subscriptions.lock().unwrap();

--- a/crates/pmi-internal/src/adapters/zenoh.rs
+++ b/crates/pmi-internal/src/adapters/zenoh.rs
@@ -26,7 +26,8 @@
 use crate::error::{Error, Result};
 use crate::types::{
     IncomingRequest, NO_TIMEOUT_SENTINEL, Payload, PublisherQoS, ReplyStream, ResponseToken,
-    ServiceQueryable, ServiceReply, SubscriberQoS, TopicMessage, ZenohResponseToken,
+    ServiceQueryable, ServiceReply, SubscriberBufferSizes, SubscriberQoS, TopicMessage,
+    ZenohResponseToken,
 };
 use crate::wire::zenoh_format::{ServiceReplyAttachment, TopicAttachment, ZenohWireFormat};
 use crate::wire::{
@@ -146,6 +147,8 @@ pub struct ZenohClientConfig {
     seed_peers: Vec<String>,
     /// Whether gossip-based direct peer linking is enabled for this session.
     gossip: bool,
+    /// Per-QoS subscriber channel buffer sizes for this session.
+    buffer_sizes: SubscriberBufferSizes,
 }
 
 pub struct ZenohAdapter {
@@ -160,12 +163,21 @@ pub struct ZenohAdapter {
 
 impl ZenohAdapter {
     /// Creates a ZenohAdapter that owns and manages its own zenohd router.
-    /// Use this when you need to start a new router instance.
+    /// Use this when you need to start a new router instance. `gossip` selects
+    /// the daemon session's own routing model (peer vs router-relay) and
+    /// `buffer_sizes` its subscriber channel capacities, both resolved from
+    /// `peppy_config.json5`.
     #[cfg(feature = "router")]
-    pub fn with_router(protocol: ZenohNetProtocol, host: &str, port: u16) -> Result<Self> {
+    pub fn with_router(
+        protocol: ZenohNetProtocol,
+        host: &str,
+        port: u16,
+        gossip: bool,
+        buffer_sizes: SubscriberBufferSizes,
+    ) -> Result<Self> {
         let zenohd_config_path = zenohd::router_config_path(protocol, host, port)?;
         let facade = zenohd::ZenohdFacade::new(zenohd_config_path)?;
-        let client_config = Self::derive_client_config_from_zenohd(&facade);
+        let client_config = Self::derive_client_config_from_zenohd(&facade, gossip, buffer_sizes);
 
         Ok(Self {
             zenohd: Some(facade),
@@ -176,25 +188,41 @@ impl ZenohAdapter {
     }
 
     /// Creates a ZenohAdapter that joins the mesh seeded by an existing zenohd
-    /// router, using the default discovery (gossip on, seed = `host:port`). The
-    /// session runs in `peer` mode so data forms direct links instead of
-    /// relaying through the router.
+    /// router, using the default discovery (gossip on, seed = `host:port`) and
+    /// default subscriber buffers. The session runs in `peer` mode so data forms
+    /// direct links instead of relaying through the router.
     pub fn connect_to(protocol: ZenohNetProtocol, host: &str, port: u16) -> Result<Self> {
-        Self::connect_to_with_discovery(protocol, host, port, Vec::new(), true)
+        Self::connect_to_with_discovery(
+            protocol,
+            host,
+            port,
+            Vec::new(),
+            true,
+            SubscriberBufferSizes::default(),
+        )
     }
 
     /// Like [`connect_to`](Self::connect_to) but with an explicit gossip seed
-    /// list and gossip toggle. The node runtime passes its `DiscoveryConfig`
-    /// here. An empty `seed_peers` falls back to the single `host:port` seed.
+    /// list, gossip toggle, and subscriber buffer sizes. The node runtime passes
+    /// its `DiscoveryConfig` here. An empty `seed_peers` falls back to the single
+    /// `host:port` seed.
     pub fn connect_to_with_discovery(
         protocol: ZenohNetProtocol,
         host: &str,
         port: u16,
         seed_peers: Vec<String>,
         gossip: bool,
+        buffer_sizes: SubscriberBufferSizes,
     ) -> Result<Self> {
-        let client_config =
-            Self::create_client_config(protocol, host, port, false, seed_peers, gossip);
+        let client_config = Self::create_client_config(
+            protocol,
+            host,
+            port,
+            false,
+            seed_peers,
+            gossip,
+            buffer_sizes,
+        );
 
         Ok(Self {
             #[cfg(feature = "router")]
@@ -217,6 +245,18 @@ impl ZenohAdapter {
     }
 
     /// Starts a zenohd router with an ephemeral port, retrying on bind failures.
+    /// The hosted session is a peer with default subscriber buffers; use
+    /// [`start_router_ephemeral_in_mode`](Self::start_router_ephemeral_in_mode)
+    /// to pick the session's gossip mode and buffer sizes.
+    #[cfg(feature = "router")]
+    pub async fn start_router_ephemeral(host: &str, port: Option<u16>) -> Result<ZenohdInstance> {
+        Self::start_router_ephemeral_in_mode(host, port, true, SubscriberBufferSizes::default())
+            .await
+    }
+
+    /// Like [`start_router_ephemeral`](Self::start_router_ephemeral) but the
+    /// hosted session's `gossip` (peer vs router-relay) and subscriber buffer
+    /// sizes are explicit. Used by tests to exercise both messaging modes.
     ///
     /// When `port` is `None`, automatically selects an available port and retries
     /// up to 32 times if the port becomes unavailable. When `port` is `Some`,
@@ -224,7 +264,12 @@ impl ZenohAdapter {
     ///
     /// Returns a [`ZenohdInstance`] that automatically stops the router when dropped.
     #[cfg(feature = "router")]
-    pub async fn start_router_ephemeral(host: &str, port: Option<u16>) -> Result<ZenohdInstance> {
+    pub async fn start_router_ephemeral_in_mode(
+        host: &str,
+        port: Option<u16>,
+        gossip: bool,
+        buffer_sizes: SubscriberBufferSizes,
+    ) -> Result<ZenohdInstance> {
         let max_attempts = if port.is_some() { 1 } else { 32 };
 
         for attempt in 0..max_attempts {
@@ -237,7 +282,8 @@ impl ZenohAdapter {
                 }
             };
 
-            let adapter = Self::with_router(ZenohNetProtocol::Tcp, host, port)?;
+            let adapter =
+                Self::with_router(ZenohNetProtocol::Tcp, host, port, gossip, buffer_sizes)?;
             // A lightweight client probe (no listener, no peer discovery) is the
             // cheapest reliable "router accepts sessions yet?" check.
             let probe_config = render_probe_config(ZenohNetProtocol::Tcp, host, port);
@@ -313,6 +359,7 @@ impl ZenohAdapter {
         reconnect: bool,
         seed_peers: Vec<String>,
         gossip: bool,
+        buffer_sizes: SubscriberBufferSizes,
     ) -> ZenohClientConfig {
         let connect_host = connectable_host(host);
         let seeds = if seed_peers.is_empty() {
@@ -321,6 +368,11 @@ impl ZenohAdapter {
             seed_peers
         };
 
+        // `ZENOH_SESSION_CONFIG` overrides the generated zenoh session config
+        // wholesale, including the `gossip`/mode rendering below, so the operator
+        // file wins on routing model. It does NOT affect `buffer_sizes`, which
+        // are applied later at the flume/mpsc layer (subscribe / listen / call),
+        // so peer-mode buffer tuning from `peppy_config.json5` still takes effect.
         let zenoh_config = match std::env::var("ZENOH_SESSION_CONFIG") {
             Ok(path) if !path.trim().is_empty() => zenoh::config::Config::from_file(path.trim())
                 .unwrap_or_else(|e| {
@@ -360,23 +412,32 @@ impl ZenohAdapter {
             protocol,
             seed_peers: seeds,
             gossip,
+            buffer_sizes,
         }
     }
 
     #[cfg(feature = "router")]
-    fn derive_client_config_from_zenohd(zenohd: &zenohd::ZenohdFacade) -> ZenohClientConfig {
-        // The daemon joins the mesh it hosts as a peer, seeded by its own router,
-        // so peers can reach its core-node/daemon services directly. Its
-        // long-lived session is rebuilt as reconnecting in `start_session` when
-        // `reconnect_session` is set; the readiness probe in
-        // `start_router_ephemeral` builds its own client probe config.
+    fn derive_client_config_from_zenohd(
+        zenohd: &zenohd::ZenohdFacade,
+        gossip: bool,
+        buffer_sizes: SubscriberBufferSizes,
+    ) -> ZenohClientConfig {
+        // The daemon joins the mesh it hosts, seeded by its own router, so peers
+        // can reach its core-node/daemon services. `gossip` (from
+        // `peppy_config.json5`) selects whether that session is a peer (direct
+        // links) or a client (router relay); router mode makes the daemon a
+        // plain client of its own loopback router. Its long-lived session is
+        // rebuilt as reconnecting in `start_session` when `reconnect_session` is
+        // set; the readiness probe in `start_router_ephemeral` builds its own
+        // client probe config.
         Self::create_client_config(
             zenohd.zenoh_endpoint.protocol,
             &zenohd.zenoh_endpoint.host,
             zenohd.zenoh_endpoint.port,
             false,
             Vec::new(),
-            true,
+            gossip,
+            buffer_sizes,
         )
     }
 }
@@ -395,6 +456,7 @@ impl MessengerBackend for ZenohAdapter {
                 true,
                 self.client_config.seed_peers.clone(),
                 self.client_config.gossip,
+                self.client_config.buffer_sizes,
             )
             .zenoh_config
         } else {
@@ -476,7 +538,11 @@ impl MessengerBackend for ZenohAdapter {
             .as_ref()
             .ok_or_else(|| Error::MessagingSessionError("Session not initialized".to_string()))?;
 
-        let (tx, rx) = flume::bounded::<IncomingRequest>(SubscriberQoS::Standard.channel_size());
+        let (tx, rx) = flume::bounded::<IncomingRequest>(
+            self.client_config
+                .buffer_sizes
+                .size_for(SubscriberQoS::Standard),
+        );
 
         // One queryable per listen call. The declared keyexpr has `*` at the
         // link_id slot so a single queryable absorbs every bound link_id —
@@ -518,8 +584,11 @@ impl MessengerBackend for ZenohAdapter {
 
         let timeout = timeout.unwrap_or(NO_TIMEOUT_SENTINEL);
 
-        let (tx, rx) =
-            tokio::sync::mpsc::channel::<ServiceReply>(SubscriberQoS::Standard.channel_size());
+        let (tx, rx) = tokio::sync::mpsc::channel::<ServiceReply>(
+            self.client_config
+                .buffer_sizes
+                .size_for(SubscriberQoS::Standard),
+        );
 
         // `try_send` (not `send`) because the callback runs synchronously on
         // a zenoh worker thread that we must not block. Two drop conditions
@@ -527,7 +596,7 @@ impl MessengerBackend for ZenohAdapter {
         //   1. receiver dropped — caller has the first valid reply and has
         //      released the `ReplyStream`; sibling producers' late replies
         //      go nowhere, which is intentional;
-        //   2. channel full (capacity = `SubscriberQoS::Standard.channel_size`)
+        //   2. channel full (capacity = the Standard subscriber buffer size)
         //      — would only happen if the consumer's `poll_service` loop
         //      stalls for thousands of replies; in practice the consumer
         //      drains the channel as fast as zenoh fills it, so this branch
@@ -792,7 +861,7 @@ impl ZenohAdapter {
         qos: SubscriberQoS,
         drop_secondary: bool,
     ) -> Result<Subscription> {
-        let (tx, rx) = flume::bounded(qos.channel_size());
+        let (tx, rx) = flume::bounded(self.client_config.buffer_sizes.size_for(qos));
 
         let session = self
             .session
@@ -978,6 +1047,7 @@ mod tests {
             true,
             Vec::new(),
             true,
+            SubscriberBufferSizes::default(),
         );
         assert_eq!(reconnecting.host, "127.0.0.1");
         assert_eq!(
@@ -988,7 +1058,7 @@ mod tests {
     }
 
     #[test]
-    fn create_client_config_honors_an_explicit_seed_list() {
+    fn create_client_config_honors_an_explicit_seed_list_and_buffer_sizes() {
         let cfg = ZenohAdapter::create_client_config(
             ZenohNetProtocol::Tcp,
             "127.0.0.1",
@@ -996,8 +1066,14 @@ mod tests {
             false,
             vec!["tcp/10.0.0.2:7448".to_string()],
             false,
+            SubscriberBufferSizes {
+                standard: 64,
+                high_throughput: 4096,
+            },
         );
         assert_eq!(cfg.seed_peers, vec!["tcp/10.0.0.2:7448".to_string()]);
         assert!(!cfg.gossip);
+        assert_eq!(cfg.buffer_sizes.standard, 64);
+        assert_eq!(cfg.buffer_sizes.high_throughput, 4096);
     }
 }

--- a/crates/pmi-internal/src/adapters/zenoh.rs
+++ b/crates/pmi-internal/src/adapters/zenoh.rs
@@ -329,12 +329,27 @@ impl ZenohAdapter {
                         path.trim()
                     )
                 }),
-            _ => render_config(&ZenohConfigSpec {
+            // `gossip` selects the routing model. Enabled: a `peer` that binds a
+            // loopback listener and forms direct peer-to-peer links via gossip.
+            // Disabled: a plain `client` that routes only through the router (no
+            // listener, no peer discovery). Nodes that cannot form direct
+            // loopback links with their peers (e.g. container nodes in a
+            // separate network namespace) use the client path so they reach the
+            // rest of the system through the router instead of advertising an
+            // unreachable loopback locator and churning on failed autoconnects.
+            _ if gossip => render_config(&ZenohConfigSpec {
                 mode: SessionMode::Peer,
                 connect_endpoints: seeds.clone(),
                 listen_endpoints: vec![loopback_listen_endpoint(protocol)],
                 reconnect,
-                gossip,
+                gossip: true,
+            }),
+            _ => render_config(&ZenohConfigSpec {
+                mode: SessionMode::Client,
+                connect_endpoints: seeds.clone(),
+                listen_endpoints: Vec::new(),
+                reconnect,
+                gossip: false,
             }),
         };
 

--- a/crates/pmi-internal/src/adapters/zenoh.rs
+++ b/crates/pmi-internal/src/adapters/zenoh.rs
@@ -33,11 +33,14 @@ use crate::wire::{
     ActionWireReceiver, ActionWireSender, ServiceQueryKind, ServiceWireReceiver, ServiceWireSender,
     TopicWireReceiver, TopicWireSender,
 };
+use crate::zenoh_config::{
+    SessionMode, ZenohConfigSpec, connectable_host, loopback_listen_endpoint, render_config,
+    render_probe_config,
+};
 use crate::zenohd::{self, ZenohNetProtocol};
 #[cfg(feature = "router")]
 use crate::{Messenger, MessengerAdapter};
 use crate::{MessengerBackend, Subscription};
-use askama::Template;
 
 use std::net::SocketAddr;
 #[cfg(feature = "router")]
@@ -131,89 +134,18 @@ impl Drop for ZenohdInstance {
 use zenoh::qos::{CongestionControl, Priority};
 use zenoh::sample::SampleFields;
 
-#[derive(Template)]
-#[template(
-    source = r#"{
-    "mode": "client",
-    "connect": {
-        "endpoints": ["{{ protocol }}/{{ host }}:{{ port }}"]
-    },
-    "timestamping": {
-        "enabled": { "client": true }
-    }
-}"#,
-    ext = "txt"
-)]
-pub struct ZenohClientConfigTemplate {
-    pub host: String,
-    pub port: u16,
-    pub protocol: zenohd::ZenohNetProtocol,
-}
-
-/// Client config for the daemon's long-lived session. Unlike the fail-fast
-/// default, this retries the connection forever (`timeout_ms: -1`,
-/// `exit_on_failure: false`) so the session re-establishes — and re-declares
-/// its subscriptions/queryables — if the router is restarted under it (e.g. by
-/// the router watchdog respawning zenohd).
-#[derive(Template)]
-#[template(
-    source = r#"{
-    "mode": "client",
-    "connect": {
-        "endpoints": ["{{ protocol }}/{{ host }}:{{ port }}"],
-        "timeout_ms": -1,
-        "exit_on_failure": false,
-        "retry": {
-            "period_init_ms": 1000,
-            "period_max_ms": 4000,
-            "period_increase_factor": 2.0
-        }
-    },
-    "timestamping": {
-        "enabled": { "client": true }
-    }
-}"#,
-    ext = "txt"
-)]
-pub struct ZenohReconnectingClientConfigTemplate {
-    pub host: String,
-    pub port: u16,
-    pub protocol: ZenohNetProtocol,
-}
-
-/// Client config for the router watchdog's liveness probe. Scouting is
-/// disabled so the probe only ever tries the configured router endpoint (never
-/// a multicast-discovered peer), making "is *our* router responsive?" a
-/// deterministic question.
-#[derive(Template)]
-#[template(
-    source = r#"{
-    "mode": "client",
-    "connect": {
-        "endpoints": ["{{ protocol }}/{{ host }}:{{ port }}"]
-    },
-    "scouting": {
-        "multicast": {
-            "enabled": false
-        }
-    },
-    "timestamping": {
-        "enabled": { "client": true }
-    }
-}"#,
-    ext = "txt"
-)]
-pub struct ZenohProbeClientConfigTemplate {
-    pub host: String,
-    pub port: u16,
-    pub protocol: ZenohNetProtocol,
-}
-
+/// Resolved config for a node/daemon peer session, plus the inputs needed to
+/// rebuild it (the reconnecting session is re-derived on every
+/// [`start_session`](MessengerBackend::start_session)).
 pub struct ZenohClientConfig {
     zenoh_config: zenoh::config::Config,
     host: String,
     port: u16,
     protocol: ZenohNetProtocol,
+    /// Resolved gossip seed endpoints (defaults to the router endpoint).
+    seed_peers: Vec<String>,
+    /// Whether gossip-based direct peer linking is enabled for this session.
+    gossip: bool,
 }
 
 pub struct ZenohAdapter {
@@ -243,10 +175,26 @@ impl ZenohAdapter {
         })
     }
 
-    /// Creates a ZenohAdapter that connects to an existing zenohd router.
-    /// Use this when you want to connect to a router that's already running.
+    /// Creates a ZenohAdapter that joins the mesh seeded by an existing zenohd
+    /// router, using the default discovery (gossip on, seed = `host:port`). The
+    /// session runs in `peer` mode so data forms direct links instead of
+    /// relaying through the router.
     pub fn connect_to(protocol: ZenohNetProtocol, host: &str, port: u16) -> Result<Self> {
-        let client_config = Self::create_client_config(protocol, host, port, false);
+        Self::connect_to_with_discovery(protocol, host, port, Vec::new(), true)
+    }
+
+    /// Like [`connect_to`](Self::connect_to) but with an explicit gossip seed
+    /// list and gossip toggle. The node runtime passes its `DiscoveryConfig`
+    /// here. An empty `seed_peers` falls back to the single `host:port` seed.
+    pub fn connect_to_with_discovery(
+        protocol: ZenohNetProtocol,
+        host: &str,
+        port: u16,
+        seed_peers: Vec<String>,
+        gossip: bool,
+    ) -> Result<Self> {
+        let client_config =
+            Self::create_client_config(protocol, host, port, false, seed_peers, gossip);
 
         Ok(Self {
             #[cfg(feature = "router")]
@@ -290,7 +238,9 @@ impl ZenohAdapter {
             };
 
             let adapter = Self::with_router(ZenohNetProtocol::Tcp, host, port)?;
-            let probe_config = adapter.client_config.zenoh_config.clone();
+            // A lightweight client probe (no listener, no peer discovery) is the
+            // cheapest reliable "router accepts sessions yet?" check.
+            let probe_config = render_probe_config(ZenohNetProtocol::Tcp, host, port);
             let mut messenger = Messenger::new(MessengerAdapter::Zenoh(adapter));
 
             // Drop the port reservation before starting the router so zenohd can bind to it
@@ -345,74 +295,73 @@ impl ZenohAdapter {
     /// central messenger lock.
     #[cfg(feature = "router")]
     pub fn router_health_checker(&self) -> zenohd::RouterHealthChecker {
-        let probe_str = ZenohProbeClientConfigTemplate {
-            host: self.client_config.host.clone(),
-            port: self.client_config.port,
-            protocol: self.client_config.protocol,
-        }
-        .render()
-        .expect("Failed to render probe client config template");
-        let probe_config = zenoh::config::Config::from_json5(&probe_str)
-            .expect("Failed to create probe client config");
+        let probe_config = render_probe_config(
+            self.client_config.protocol,
+            &self.client_config.host,
+            self.client_config.port,
+        );
         zenohd::RouterHealthChecker::new(probe_config)
     }
 
+    /// Builds a peer-session config seeded by `host:port` (or `seed_peers` when
+    /// non-empty). An operator can override the whole session config without a
+    /// rebuild via `ZENOH_SESSION_CONFIG` (mirrors the router's `ZENOH_CONFIG`).
     fn create_client_config(
         protocol: ZenohNetProtocol,
         host: &str,
         port: u16,
         reconnect: bool,
+        seed_peers: Vec<String>,
+        gossip: bool,
     ) -> ZenohClientConfig {
-        let connect_host = if host == "0.0.0.0" {
-            "127.0.0.1".to_string()
+        let connect_host = connectable_host(host);
+        let seeds = if seed_peers.is_empty() {
+            vec![format!("{protocol}/{connect_host}:{port}")]
         } else {
-            host.to_string()
+            seed_peers
         };
 
-        // The long-lived daemon session uses the reconnecting template so it
-        // survives a router restart; everything else (CLI connects, readiness
-        // probes) uses the fail-fast template so a down router errors quickly
-        // instead of blocking on retries.
-        let client_config_str = if reconnect {
-            ZenohReconnectingClientConfigTemplate {
-                host: connect_host.clone(),
-                port,
-                protocol,
-            }
-            .render()
-            .expect("Failed to render reconnecting client config template")
-        } else {
-            ZenohClientConfigTemplate {
-                host: connect_host.clone(),
-                port,
-                protocol,
-            }
-            .render()
-            .expect("Failed to render client config template")
+        let zenoh_config = match std::env::var("ZENOH_SESSION_CONFIG") {
+            Ok(path) if !path.trim().is_empty() => zenoh::config::Config::from_file(path.trim())
+                .unwrap_or_else(|e| {
+                    panic!(
+                        "ZENOH_SESSION_CONFIG ({}) is not a readable zenoh config: {e}",
+                        path.trim()
+                    )
+                }),
+            _ => render_config(&ZenohConfigSpec {
+                mode: SessionMode::Peer,
+                connect_endpoints: seeds.clone(),
+                listen_endpoints: vec![loopback_listen_endpoint(protocol)],
+                reconnect,
+                gossip,
+            }),
         };
-
-        let client_config = zenoh::config::Config::from_json5(&client_config_str)
-            .expect("Failed to create client config");
 
         ZenohClientConfig {
-            zenoh_config: client_config,
+            zenoh_config,
             host: connect_host,
             port,
             protocol,
+            seed_peers: seeds,
+            gossip,
         }
     }
 
     #[cfg(feature = "router")]
     fn derive_client_config_from_zenohd(zenohd: &zenohd::ZenohdFacade) -> ZenohClientConfig {
-        // Fail-fast: this config also backs the ephemeral readiness probe in
-        // `start_router_ephemeral`, which relies on `zenoh::open` erroring
-        // quickly. The daemon's reconnecting session is built separately in
-        // `start_session` when `reconnect_session` is set.
+        // The daemon joins the mesh it hosts as a peer, seeded by its own router,
+        // so peers can reach its core-node/daemon services directly. Its
+        // long-lived session is rebuilt as reconnecting in `start_session` when
+        // `reconnect_session` is set; the readiness probe in
+        // `start_router_ephemeral` builds its own client probe config.
         Self::create_client_config(
             zenohd.zenoh_endpoint.protocol,
             &zenohd.zenoh_endpoint.host,
             zenohd.zenoh_endpoint.port,
             false,
+            Vec::new(),
+            true,
         )
     }
 }
@@ -429,6 +378,8 @@ impl MessengerBackend for ZenohAdapter {
                 &self.client_config.host,
                 self.client_config.port,
                 true,
+                self.client_config.seed_peers.clone(),
+                self.client_config.gossip,
             )
             .zenoh_config
         } else {
@@ -718,6 +669,78 @@ impl ZenohAdapter {
         })
     }
 
+    /// Waits until a subscriber whose key expression matches `keyexpr` is known
+    /// to this session, or `timeout` elapses; returns whether a match was seen.
+    ///
+    /// Peer-mode gossip discovery is not instantaneous, so a freshly-connected
+    /// publisher may not yet know about an existing subscriber and would drop
+    /// its first send. Awaiting Zenoh's matching status (event-driven via the
+    /// matching listener) makes that first reliable send deterministic. A
+    /// short-lived publisher is declared purely to observe matching; the publish
+    /// path itself is unchanged.
+    pub async fn wait_for_matching_subscriber(
+        &self,
+        keyexpr: &str,
+        timeout: std::time::Duration,
+    ) -> Result<bool> {
+        let session = self
+            .session
+            .as_ref()
+            .ok_or_else(|| Error::MessagingSessionError("Session not initialized".to_string()))?;
+        let publisher = session
+            .declare_publisher(keyexpr.to_string())
+            .await
+            .map_err(|e| Error::MessagingSessionError(e.to_string()))?;
+
+        if publisher
+            .matching_status()
+            .await
+            .map_err(|e| Error::BackendError(e.to_string()))?
+            .matching()
+        {
+            return Ok(true);
+        }
+        // Subscribe to changes, then re-check once: this closes the race where a
+        // matching subscriber appears between the first query and the listener
+        // being installed.
+        let listener = publisher
+            .matching_listener()
+            .await
+            .map_err(|e| Error::BackendError(e.to_string()))?;
+        if publisher
+            .matching_status()
+            .await
+            .map_err(|e| Error::BackendError(e.to_string()))?
+            .matching()
+        {
+            return Ok(true);
+        }
+
+        let matched = tokio::time::timeout(timeout, async {
+            loop {
+                match listener.recv_async().await {
+                    Ok(status) if status.matching() => return true,
+                    Ok(_) => continue,
+                    Err(_) => return false,
+                }
+            }
+        })
+        .await
+        .unwrap_or(false);
+        Ok(matched)
+    }
+
+    /// [`wait_for_matching_subscriber`](Self::wait_for_matching_subscriber) for a
+    /// topic, building the publish key expression from `sender`.
+    pub async fn wait_for_topic_subscriber(
+        &self,
+        sender: &TopicWireSender,
+        timeout: std::time::Duration,
+    ) -> Result<bool> {
+        self.wait_for_matching_subscriber(&ZenohWireFormat::topic_publish(sender), timeout)
+            .await
+    }
+
     async fn publish_keyexpr(
         &self,
         keyexpr: &str,
@@ -929,26 +952,37 @@ mod tests {
     use super::*;
 
     #[test]
-    fn reconnecting_and_probe_configs_parse() {
-        // Guards the JSON5 schemas: a malformed connect/scouting block would
-        // otherwise panic at daemon startup inside `create_client_config` /
-        // `router_health_checker` (both `.expect()` on parse).
-        let reconnecting =
-            ZenohAdapter::create_client_config(ZenohNetProtocol::Tcp, "0.0.0.0", 7448, true);
-        // `0.0.0.0` must be rewritten to a connectable loopback host.
+    fn create_client_config_rewrites_wildcard_host_and_defaults_the_seed() {
+        // `0.0.0.0` must be rewritten to a connectable loopback host, and an
+        // empty seed list falls back to the single `host:port` endpoint. A
+        // malformed config would panic here (parse is `.expect()`).
+        let reconnecting = ZenohAdapter::create_client_config(
+            ZenohNetProtocol::Tcp,
+            "0.0.0.0",
+            7448,
+            true,
+            Vec::new(),
+            true,
+        );
         assert_eq!(reconnecting.host, "127.0.0.1");
+        assert_eq!(
+            reconnecting.seed_peers,
+            vec!["tcp/127.0.0.1:7448".to_string()]
+        );
+        assert!(reconnecting.gossip);
+    }
 
-        let fail_fast =
-            ZenohAdapter::create_client_config(ZenohNetProtocol::Tcp, "127.0.0.1", 7448, false);
-        assert_eq!(fail_fast.port, 7448);
-
-        let probe_str = ZenohProbeClientConfigTemplate {
-            host: "127.0.0.1".to_string(),
-            port: 7448,
-            protocol: ZenohNetProtocol::Tcp,
-        }
-        .render()
-        .expect("probe template renders");
-        zenoh::config::Config::from_json5(&probe_str).expect("probe config parses");
+    #[test]
+    fn create_client_config_honors_an_explicit_seed_list() {
+        let cfg = ZenohAdapter::create_client_config(
+            ZenohNetProtocol::Tcp,
+            "127.0.0.1",
+            7448,
+            false,
+            vec!["tcp/10.0.0.2:7448".to_string()],
+            false,
+        );
+        assert_eq!(cfg.seed_peers, vec!["tcp/10.0.0.2:7448".to_string()]);
+        assert!(!cfg.gossip);
     }
 }

--- a/crates/pmi-internal/src/lib.rs
+++ b/crates/pmi-internal/src/lib.rs
@@ -5,6 +5,8 @@ mod error;
 mod types;
 mod wire;
 #[cfg(feature = "zenoh")]
+mod zenoh_config;
+#[cfg(feature = "zenoh")]
 mod zenohd;
 
 pub use error::Error as PeppyMessagingInterfaceError;

--- a/crates/pmi-internal/src/lib.rs
+++ b/crates/pmi-internal/src/lib.rs
@@ -15,7 +15,8 @@ pub use types::ZenohResponseToken;
 pub use types::{
     IncomingRequest, Message, Messenger, MessengerAdapter, MessengerBackend, MessengerPublisher,
     MockResponseToken, Payload, PayloadSlices, PublisherQoS, ReplyStream, ResponseToken,
-    ServiceQueryable, ServiceReply, SubscriberQoS, Subscription, TopicMessage,
+    ServiceQueryable, ServiceReply, SubscriberBufferSizes, SubscriberQoS, Subscription,
+    TopicMessage,
 };
 pub use wire::{
     ActionWireReceiver, ActionWireSender, DEFAULT_LINK_ID, InterfaceIdentifier, NodeIdentifier,

--- a/crates/pmi-internal/src/types.rs
+++ b/crates/pmi-internal/src/types.rs
@@ -100,6 +100,27 @@ impl SubscriberBufferSizes {
     }
 }
 
+// The daemon resolves buffer sizes as config types (config-internal must not
+// depend on pmi), so the field mapping lives here on pmi's side of the boundary
+// instead of being re-inlined at each session-construction call site.
+impl From<config::peppy_config::PeerConfig> for SubscriberBufferSizes {
+    fn from(peer: config::peppy_config::PeerConfig) -> Self {
+        Self {
+            standard: peer.standard_buffer_size,
+            high_throughput: peer.high_throughput_buffer_size,
+        }
+    }
+}
+
+impl From<&config::runtime::DiscoveryConfig> for SubscriberBufferSizes {
+    fn from(discovery: &config::runtime::DiscoveryConfig) -> Self {
+        Self {
+            standard: discovery.standard_buffer_size,
+            high_throughput: discovery.high_throughput_buffer_size,
+        }
+    }
+}
+
 impl From<QoSProfile> for SubscriberQoS {
     fn from(qos: QoSProfile) -> Self {
         match qos {

--- a/crates/pmi-internal/src/types.rs
+++ b/crates/pmi-internal/src/types.rs
@@ -68,12 +68,34 @@ pub enum SubscriberQoS {
     HighThroughput,
 }
 
-impl SubscriberQoS {
-    /// Returns the channel buffer size for this QoS setting
-    pub fn channel_size(&self) -> usize {
-        match self {
-            SubscriberQoS::Standard => 128,
-            SubscriberQoS::HighThroughput => 1024,
+/// Per-QoS subscriber channel buffer sizes (flume / mpsc capacities).
+///
+/// `Default` equals the historical hardcoded behavior (`Standard` = 128,
+/// `HighThroughput` = 1024), so a session built without explicit sizes is
+/// unchanged. The daemon overrides these from `peppy_config.json5`, mainly to
+/// tune backpressure in peer mode where there is no router relay to buffer
+/// between a publisher and a subscriber.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SubscriberBufferSizes {
+    pub standard: usize,
+    pub high_throughput: usize,
+}
+
+impl Default for SubscriberBufferSizes {
+    fn default() -> Self {
+        Self {
+            standard: 128,
+            high_throughput: 1024,
+        }
+    }
+}
+
+impl SubscriberBufferSizes {
+    /// The channel buffer size for the given subscriber QoS tier.
+    pub fn size_for(&self, qos: SubscriberQoS) -> usize {
+        match qos {
+            SubscriberQoS::Standard => self.standard,
+            SubscriberQoS::HighThroughput => self.high_throughput,
         }
     }
 }
@@ -912,5 +934,30 @@ impl MessengerBackend for Messenger {
 
     fn get_host(&self) -> SocketAddr {
         dispatch_sync!(&self.adapter, get_host)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SubscriberBufferSizes, SubscriberQoS};
+
+    /// The default buffer sizes must match the historical hardcoded values, so
+    /// that removing `SubscriberQoS::channel_size()` changed no behavior for any
+    /// session built without explicit sizes.
+    #[test]
+    fn default_buffer_sizes_match_legacy_values() {
+        let sizes = SubscriberBufferSizes::default();
+        assert_eq!(sizes.size_for(SubscriberQoS::Standard), 128);
+        assert_eq!(sizes.size_for(SubscriberQoS::HighThroughput), 1024);
+    }
+
+    #[test]
+    fn custom_buffer_sizes_map_per_qos() {
+        let sizes = SubscriberBufferSizes {
+            standard: 64,
+            high_throughput: 4096,
+        };
+        assert_eq!(sizes.size_for(SubscriberQoS::Standard), 64);
+        assert_eq!(sizes.size_for(SubscriberQoS::HighThroughput), 4096);
     }
 }

--- a/crates/pmi-internal/src/zenoh_config.rs
+++ b/crates/pmi-internal/src/zenoh_config.rs
@@ -88,10 +88,19 @@ pub(crate) fn build_zenoh_config(spec: &ZenohConfigSpec) -> serde_json::Value {
         config["listen"] = json!({ "endpoints": { role: spec.listen_endpoints } });
     }
 
-    config["timestamping"] = if spec.mode == SessionMode::Router {
-        json!({ "enabled": { "router": true }, "drop_future_timestamp": false })
-    } else {
-        json!({ "enabled": { "client": true } })
+    // Stamp data at the producer so consumers can measure real delivery latency.
+    // Zenoh matches `enabled` against the session's OWN mode, so the key must
+    // match `mode` above — a `peer` session ignores an `enabled.client` entry.
+    // Stamping at the source keeps peer mode (no router in the direct path) on
+    // par with router mode, where the client/router already stamps.
+    config["timestamping"] = match spec.mode {
+        SessionMode::Router => {
+            json!({ "enabled": { "router": true }, "drop_future_timestamp": false })
+        }
+        SessionMode::Peer => json!({ "enabled": { "peer": true }, "drop_future_timestamp": false }),
+        SessionMode::Client => {
+            json!({ "enabled": { "client": true }, "drop_future_timestamp": false })
+        }
     };
 
     config
@@ -167,7 +176,12 @@ mod tests {
         // Discovery is gossip-only.
         assert_eq!(cfg["scouting"]["multicast"]["enabled"], false);
         assert_eq!(cfg["scouting"]["gossip"]["enabled"], true);
-        assert_eq!(cfg["timestamping"]["enabled"]["client"], true);
+        // A peer session stamps under its own role, not `client` — Zenoh reads
+        // `enabled` against the session's mode, so an `enabled.client` entry here
+        // would be silently ignored and leave samples unstamped.
+        assert_eq!(cfg["timestamping"]["enabled"]["peer"], true);
+        assert_eq!(cfg["timestamping"]["drop_future_timestamp"], false);
+        assert!(cfg["timestamping"]["enabled"].get("client").is_none());
         // Fail-fast: no infinite-retry connect block.
         assert!(cfg["connect"].get("timeout_ms").is_none());
     }
@@ -201,6 +215,9 @@ mod tests {
 
         assert_eq!(cfg["mode"], "client");
         assert_eq!(cfg["scouting"]["multicast"]["enabled"], false);
+        // A client stamps under its own role so its outgoing data carries a
+        // source timestamp without depending on the router to add one.
+        assert_eq!(cfg["timestamping"]["enabled"]["client"], true);
         // A client never listens for inbound peers.
         assert!(cfg.get("listen").is_none());
     }

--- a/crates/pmi-internal/src/zenoh_config.rs
+++ b/crates/pmi-internal/src/zenoh_config.rs
@@ -80,10 +80,15 @@ pub(crate) fn build_zenoh_config(spec: &ZenohConfigSpec) -> serde_json::Value {
     }
 
     if !spec.listen_endpoints.is_empty() {
-        let role = if spec.mode == SessionMode::Router {
-            "router"
-        } else {
-            "peer"
+        // Zenoh reads `listen.endpoints` against the session's OWN mode, so the
+        // key must match `mode` above — the same per-role-map rule as
+        // `timestamping` below. Deriving it exhaustively (rather than
+        // `else => "peer"`) keeps a client's endpoints from being silently
+        // misfiled under `peer` if one ever listens.
+        let role = match spec.mode {
+            SessionMode::Router => "router",
+            SessionMode::Peer => "peer",
+            SessionMode::Client => "client",
         };
         config["listen"] = json!({ "endpoints": { role: spec.listen_endpoints } });
     }
@@ -220,6 +225,25 @@ mod tests {
         assert_eq!(cfg["timestamping"]["enabled"]["client"], true);
         // A client never listens for inbound peers.
         assert!(cfg.get("listen").is_none());
+    }
+
+    #[test]
+    fn client_listen_endpoints_land_under_the_client_key() {
+        // Clients do not listen today, so this guards the per-role-map rule
+        // directly: were a client ever given a listen endpoint, it must land
+        // under its own `client` key, not be silently misfiled under `peer`
+        // (the same mismatch that left peer-mode samples unstamped).
+        let cfg = build_zenoh_config(&ZenohConfigSpec {
+            mode: SessionMode::Client,
+            connect_endpoints: vec!["tcp/127.0.0.1:7448".to_string()],
+            listen_endpoints: vec!["tcp/127.0.0.1:0".to_string()],
+            reconnect: false,
+            gossip: false,
+        });
+
+        assert_eq!(cfg["mode"], "client");
+        assert_eq!(cfg["listen"]["endpoints"]["client"][0], "tcp/127.0.0.1:0");
+        assert!(cfg["listen"]["endpoints"].get("peer").is_none());
     }
 
     #[test]

--- a/crates/pmi-internal/src/zenoh_config.rs
+++ b/crates/pmi-internal/src/zenoh_config.rs
@@ -1,0 +1,234 @@
+//! Generation of Zenoh session and router configs.
+//!
+//! This is the single source of truth that replaced the former set of per-shape
+//! Askama templates (one each for the fail-fast client, the reconnecting client,
+//! the watchdog probe, and the router). A typed [`ZenohConfigSpec`] keeps the
+//! mode / connect / listen / scouting / timestamping settings in one place so
+//! adding a knob touches one struct instead of four string templates.
+//!
+//! ## Discovery model: gossip-only, multicast off
+//!
+//! Every generated config disables multicast scouting and relies on gossip
+//! seeded by the configured connect endpoints (the router). Nodes open a `peer`
+//! session that connects to the router, learn each other's locators via gossip,
+//! and then form direct peer-to-peer links so data no longer relays through the
+//! router. Multicast is left off on purpose: on a shared host it bridges
+//! otherwise-independent peer groups (and would cross-link unrelated test runs),
+//! and with a known seed it adds nothing gossip does not already cover.
+
+use crate::zenohd::ZenohNetProtocol;
+use serde_json::json;
+
+/// The Zenoh roles this codebase generates configs for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SessionMode {
+    /// A node/daemon session: connects to a seed (the router), then forms direct
+    /// peer-to-peer links with peers discovered via gossip.
+    Peer,
+    /// A short-lived liveness probe: connects to exactly one router endpoint and
+    /// never discovers peers, so "is *our* router up?" stays deterministic.
+    Client,
+    /// The zenohd router itself.
+    Router,
+}
+
+/// Inputs for [`build_zenoh_config`].
+pub(crate) struct ZenohConfigSpec {
+    pub mode: SessionMode,
+    /// Seed endpoints to dial (`<proto>/<host>:<port>`). Empty for the router.
+    pub connect_endpoints: Vec<String>,
+    /// Endpoints to listen on. Empty leaves Zenoh's default (clients do not
+    /// listen). Peers listen on a loopback ephemeral port by default.
+    pub listen_endpoints: Vec<String>,
+    /// Retry the connection forever (`timeout_ms: -1`, `exit_on_failure: false`)
+    /// instead of failing fast. Used by long-lived sessions so a router restart
+    /// is recovered transparently.
+    pub reconnect: bool,
+    /// Enable gossip scouting so peers sharing a seed discover each other and
+    /// form direct links. Multicast scouting is always off (see module docs).
+    pub gossip: bool,
+}
+
+/// Builds the JSON5-equivalent config value for a session or the router.
+pub(crate) fn build_zenoh_config(spec: &ZenohConfigSpec) -> serde_json::Value {
+    let mode = match spec.mode {
+        SessionMode::Peer => "peer",
+        SessionMode::Client => "client",
+        SessionMode::Router => "router",
+    };
+
+    let mut config = json!({
+        "mode": mode,
+        "scouting": {
+            "multicast": { "enabled": false },
+            "gossip": { "enabled": spec.gossip }
+        }
+    });
+
+    if !spec.connect_endpoints.is_empty() {
+        let mut connect = json!({ "endpoints": spec.connect_endpoints });
+        if spec.reconnect {
+            connect["timeout_ms"] = json!(-1);
+            connect["exit_on_failure"] = json!(false);
+            connect["retry"] = json!({
+                "period_init_ms": 1000,
+                "period_max_ms": 4000,
+                "period_increase_factor": 2.0
+            });
+        }
+        config["connect"] = connect;
+    }
+
+    if !spec.listen_endpoints.is_empty() {
+        let role = if spec.mode == SessionMode::Router {
+            "router"
+        } else {
+            "peer"
+        };
+        config["listen"] = json!({ "endpoints": { role: spec.listen_endpoints } });
+    }
+
+    config["timestamping"] = if spec.mode == SessionMode::Router {
+        json!({ "enabled": { "router": true }, "drop_future_timestamp": false })
+    } else {
+        json!({ "enabled": { "client": true } })
+    };
+
+    config
+}
+
+/// Serializes a spec to a JSON string (valid JSON5) for the zenohd config file.
+pub(crate) fn render_config_string(spec: &ZenohConfigSpec) -> String {
+    serde_json::to_string(&build_zenoh_config(spec)).expect("zenoh config value serializes to JSON")
+}
+
+/// Renders a spec into a parsed [`zenoh::config::Config`] for opening a session.
+pub(crate) fn render_config(spec: &ZenohConfigSpec) -> zenoh::config::Config {
+    zenoh::config::Config::from_json5(&render_config_string(spec))
+        .expect("generated zenoh config parses")
+}
+
+/// Rewrites the unroutable wildcard bind address to a connectable loopback host.
+pub(crate) fn connectable_host(host: &str) -> String {
+    if host == "0.0.0.0" {
+        "127.0.0.1".to_string()
+    } else {
+        host.to_string()
+    }
+}
+
+/// The liveness-probe config shared by the router watchdog and the
+/// ephemeral-router readiness check: a plain client targeting one router
+/// endpoint, no peer discovery.
+pub(crate) fn render_probe_config(
+    protocol: ZenohNetProtocol,
+    host: &str,
+    port: u16,
+) -> zenoh::config::Config {
+    render_config(&ZenohConfigSpec {
+        mode: SessionMode::Client,
+        connect_endpoints: vec![format!("{protocol}/{}:{port}", connectable_host(host))],
+        listen_endpoints: Vec::new(),
+        reconnect: false,
+        gossip: false,
+    })
+}
+
+/// The loopback ephemeral listen endpoint a peer binds. Loopback-only by design:
+/// it keeps the new inbound socket off the network (co-located peering only).
+/// Cross-host peering is a deliberate opt-in that lives behind a custom
+/// `ZENOH_SESSION_CONFIG`, not this default.
+pub(crate) fn loopback_listen_endpoint(protocol: ZenohNetProtocol) -> String {
+    format!("{protocol}/127.0.0.1:0")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn peer_spec(reconnect: bool, gossip: bool) -> ZenohConfigSpec {
+        ZenohConfigSpec {
+            mode: SessionMode::Peer,
+            connect_endpoints: vec!["tcp/127.0.0.1:7448".to_string()],
+            listen_endpoints: vec![loopback_listen_endpoint(ZenohNetProtocol::Tcp)],
+            reconnect,
+            gossip,
+        }
+    }
+
+    #[test]
+    fn peer_config_has_peer_mode_listen_and_gossip_only_scouting() {
+        let cfg = build_zenoh_config(&peer_spec(false, true));
+
+        assert_eq!(cfg["mode"], "peer");
+        assert_eq!(cfg["connect"]["endpoints"][0], "tcp/127.0.0.1:7448");
+        // Peers listen on a loopback ephemeral port under the per-mode key.
+        assert_eq!(cfg["listen"]["endpoints"]["peer"][0], "tcp/127.0.0.1:0");
+        // Discovery is gossip-only.
+        assert_eq!(cfg["scouting"]["multicast"]["enabled"], false);
+        assert_eq!(cfg["scouting"]["gossip"]["enabled"], true);
+        assert_eq!(cfg["timestamping"]["enabled"]["client"], true);
+        // Fail-fast: no infinite-retry connect block.
+        assert!(cfg["connect"].get("timeout_ms").is_none());
+    }
+
+    #[test]
+    fn reconnecting_peer_config_retries_forever() {
+        let cfg = build_zenoh_config(&peer_spec(true, true));
+
+        assert_eq!(cfg["mode"], "peer");
+        assert_eq!(cfg["connect"]["timeout_ms"], -1);
+        assert_eq!(cfg["connect"]["exit_on_failure"], false);
+        assert_eq!(cfg["connect"]["retry"]["period_init_ms"], 1000);
+        assert_eq!(cfg["connect"]["retry"]["period_max_ms"], 4000);
+    }
+
+    #[test]
+    fn gossip_can_be_disabled_to_force_router_relay() {
+        let cfg = build_zenoh_config(&peer_spec(false, false));
+        assert_eq!(cfg["scouting"]["gossip"]["enabled"], false);
+    }
+
+    #[test]
+    fn probe_config_is_a_multicast_free_client() {
+        let cfg = build_zenoh_config(&ZenohConfigSpec {
+            mode: SessionMode::Client,
+            connect_endpoints: vec!["tcp/127.0.0.1:7448".to_string()],
+            listen_endpoints: Vec::new(),
+            reconnect: false,
+            gossip: false,
+        });
+
+        assert_eq!(cfg["mode"], "client");
+        assert_eq!(cfg["scouting"]["multicast"]["enabled"], false);
+        // A client never listens for inbound peers.
+        assert!(cfg.get("listen").is_none());
+    }
+
+    #[test]
+    fn router_config_listens_under_router_key_with_router_timestamping() {
+        let cfg = build_zenoh_config(&ZenohConfigSpec {
+            mode: SessionMode::Router,
+            connect_endpoints: Vec::new(),
+            listen_endpoints: vec!["tcp/0.0.0.0:7448".to_string()],
+            reconnect: false,
+            gossip: true,
+        });
+
+        assert_eq!(cfg["mode"], "router");
+        assert_eq!(cfg["listen"]["endpoints"]["router"][0], "tcp/0.0.0.0:7448");
+        assert_eq!(cfg["timestamping"]["enabled"]["router"], true);
+        assert_eq!(cfg["timestamping"]["drop_future_timestamp"], false);
+        // Routers do not dial out.
+        assert!(cfg.get("connect").is_none());
+    }
+
+    #[test]
+    fn generated_session_configs_parse_as_zenoh_config() {
+        // Guards the JSON5 schema: a malformed block would otherwise only
+        // surface as a panic at session/router open.
+        render_config(&peer_spec(true, true));
+        render_config(&peer_spec(false, true));
+        render_probe_config(ZenohNetProtocol::Tcp, "0.0.0.0", 7448);
+    }
+}

--- a/crates/pmi-internal/src/zenohd/router_config.rs
+++ b/crates/pmi-internal/src/zenohd/router_config.rs
@@ -1,33 +1,12 @@
 //! Generation of the zenohd router's own config file. This is the daemon's
 //! deployment config (how to run the router), distinct from the client session
-//! configs that live with the messaging adapter.
+//! configs that live with the messaging adapter. Both are produced by the
+//! shared [`crate::zenoh_config`] builder.
 
 use super::ZenohNetProtocol;
 use crate::error::{Error, Result};
-use askama::Template;
+use crate::zenoh_config::{SessionMode, ZenohConfigSpec, render_config_string};
 use std::path::PathBuf;
-
-#[derive(Template)]
-#[template(
-    source = r#"{
-    "mode": "router",
-    "listen": {
-        "endpoints": {
-            "router": ["{{ protocol }}/{{ host }}:{{ port }}"]
-        }
-    },
-    "timestamping": {
-        "enabled": { "router": true },
-        "drop_future_timestamp": false
-    }
-}"#,
-    ext = "txt"
-)]
-struct ZenohRouterConfigTemplate {
-    host: String,
-    port: u16,
-    protocol: ZenohNetProtocol,
-}
 
 /// Resolves the zenohd router config path. Honors a `ZENOH_CONFIG` override;
 /// otherwise renders a router config to a temp file keyed by messaging port and
@@ -43,15 +22,16 @@ pub(crate) fn router_config_path(
 
     let config_path = std::env::temp_dir().join(format!("zenohd_config_{}.json5", messaging_port));
 
-    let config_content = ZenohRouterConfigTemplate {
-        host: host.to_string(),
-        port: messaging_port,
-        protocol,
-    }
-    .render()
-    .map_err(|e| {
-        Error::ConfigurationError(format!("Failed to render zenohd config template: {}", e))
-    })?;
+    // The router seeds gossip discovery for the peer mesh, so gossip stays on;
+    // multicast is off everywhere (see `crate::zenoh_config`). The router listens
+    // on `host` as given (typically `0.0.0.0`) so nodes can reach it.
+    let config_content = render_config_string(&ZenohConfigSpec {
+        mode: SessionMode::Router,
+        connect_endpoints: Vec::new(),
+        listen_endpoints: vec![format!("{protocol}/{host}:{messaging_port}")],
+        reconnect: false,
+        gossip: true,
+    });
 
     std::fs::write(&config_path, config_content)
         .map_err(|e| Error::ConfigurationError(format!("Failed to write zenohd config: {}", e)))?;

--- a/crates/pmi-internal/tests/feature_flags.rs
+++ b/crates/pmi-internal/tests/feature_flags.rs
@@ -2,7 +2,10 @@
 #[test]
 fn test_with_zenoh_feature() {
     use bytes::Bytes;
-    use pmi::{Message, PeppyMessagingInterfaceError, SubscriberQoS, ZenohNetProtocol};
+    use pmi::{
+        Message, PeppyMessagingInterfaceError, SubscriberBufferSizes, SubscriberQoS,
+        ZenohNetProtocol,
+    };
 
     const { assert!(cfg!(feature = "zenoh"), "zenoh feature should be enabled") };
 
@@ -11,7 +14,7 @@ fn test_with_zenoh_feature() {
     assert_eq!(&message.payload()[..], b"test payload");
 
     let qos = SubscriberQoS::Standard;
-    assert_eq!(qos.channel_size(), 128);
+    assert_eq!(SubscriberBufferSizes::default().size_for(qos), 128);
 
     assert_eq!(ZenohNetProtocol::default(), ZenohNetProtocol::Tcp);
 
@@ -29,7 +32,7 @@ fn test_with_zenoh_feature() {
 #[test]
 fn test_without_zenoh_feature() {
     use bytes::Bytes;
-    use pmi::{Message, PeppyMessagingInterfaceError, SubscriberQoS};
+    use pmi::{Message, PeppyMessagingInterfaceError, SubscriberBufferSizes, SubscriberQoS};
 
     assert!(
         !cfg!(feature = "zenoh"),
@@ -41,7 +44,7 @@ fn test_without_zenoh_feature() {
     assert_eq!(&message.payload()[..], b"test payload");
 
     let qos = SubscriberQoS::HighThroughput;
-    assert_eq!(qos.channel_size(), 1024);
+    assert_eq!(SubscriberBufferSizes::default().size_for(qos), 1024);
 
     let err = PeppyMessagingInterfaceError::UnsupportedEngine;
     assert_eq!(format!("{err}"), "UnsupportedEngine");

--- a/crates/pmi-internal/tests/zenoh.rs
+++ b/crates/pmi-internal/tests/zenoh.rs
@@ -343,6 +343,92 @@ mod zenoh_tests {
         drop(instance);
     }
 
+    /// Source timestamps must be present on delivered samples in BOTH peer and
+    /// router mode. The benchmark's `delivery` measurement reads
+    /// `source_timestamp_nanos()` off each sample, so a session that fails to
+    /// stamp its outgoing data silently zeroes those rows. `gossip=true`
+    /// exercises the direct peer path (the regression); `gossip=false` the
+    /// router relay.
+    async fn assert_topic_carries_source_timestamp(gossip: bool) {
+        const TOPIC: &str = "source_timestamp_topic";
+        let _lock = ZENOH_SERIAL.lock().await;
+
+        let instance = ZenohAdapter::start_router_ephemeral("127.0.0.1", None)
+            .await
+            .expect("Failed to start zenohd process");
+        let host = instance.host.clone();
+        let port = instance.port;
+
+        let mut subscriber = ZenohAdapter::connect_to_with_discovery(
+            ZenohNetProtocol::Tcp,
+            &host,
+            port,
+            Vec::new(),
+            gossip,
+            SubscriberBufferSizes::default(),
+        )
+        .expect("subscriber adapter");
+        subscriber
+            .start_session()
+            .await
+            .expect("subscriber start_session");
+        let mut subscription = subscriber
+            .subscribe_topic(&receiver(TOPIC), SubscriberQoS::Standard)
+            .await
+            .expect("subscribe");
+
+        let mut publisher = ZenohAdapter::connect_to_with_discovery(
+            ZenohNetProtocol::Tcp,
+            &host,
+            port,
+            Vec::new(),
+            gossip,
+            SubscriberBufferSizes::default(),
+        )
+        .expect("publisher adapter");
+        publisher
+            .start_session()
+            .await
+            .expect("publisher start_session");
+
+        wait_for_subscriber_discovery().await;
+        publisher
+            .publish_topic(
+                &sender(TOPIC),
+                Payload::from_bytes(Bytes::from_static(b"stamped")),
+                PublisherQoS::Standard,
+                true,
+            )
+            .await
+            .expect("publish");
+        let msg = recv_or_timeout(&mut subscription.rx, "stamped").await;
+        assert_eq!(msg.payload(), &Bytes::from_static(b"stamped"));
+        assert!(
+            msg.source_timestamp_nanos().is_some(),
+            "delivered sample must carry a source timestamp (gossip={gossip}): the producing \
+             session did not stamp its outgoing data, so delivery latency can't be measured"
+        );
+
+        // Keep the router alive until the end: client-mode delivery depends on it.
+        drop(instance);
+    }
+
+    /// Peer mode (gossip on → direct peer links) stamps outgoing samples. This is
+    /// the regression guard for the peer-mode timestamping fix: before it, the
+    /// peer session enabled timestamping under the wrong role and samples arrived
+    /// unstamped.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn peer_mode_samples_carry_source_timestamp() {
+        assert_topic_carries_source_timestamp(true).await;
+    }
+
+    /// Router mode (gossip off → client sessions relayed through zenohd) stamps
+    /// outgoing samples too. Companion to the peer-mode guard, pinning parity.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn router_mode_samples_carry_source_timestamp() {
+        assert_topic_carries_source_timestamp(false).await;
+    }
+
     /// A peer session built with custom (tiny) subscriber buffers still delivers
     /// end-to-end. This pins that the buffer sizes are threaded through
     /// `connect_to_with_discovery` without breaking delivery; exact-capacity

--- a/crates/pmi-internal/tests/zenoh.rs
+++ b/crates/pmi-internal/tests/zenoh.rs
@@ -185,6 +185,98 @@ mod zenoh_tests {
         );
     }
 
+    /// Proves peer-to-peer data flow: two `peer` sessions that share a router
+    /// discover each other via gossip and form a direct link, and topic
+    /// delivery between them survives the router being stopped. If data still
+    /// relayed through the router, stopping it would cut delivery; that delivery
+    /// continues shows the router hop is gone.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn peers_keep_delivering_after_router_stops() {
+        const TOPIC: &str = "direct_link_topic";
+        let _lock = ZENOH_SERIAL.lock().await;
+
+        let mut instance = ZenohAdapter::start_router_ephemeral("127.0.0.1", None)
+            .await
+            .expect("Failed to start zenohd process");
+        let host = instance.host.clone();
+        let port = instance.port;
+
+        // Two non-reconnecting peers seeded by the router: a subscriber and a
+        // publisher. `connect_to` opens peer-mode sessions.
+        let mut subscriber = ZenohAdapter::connect_to(ZenohNetProtocol::Tcp, &host, port)
+            .expect("subscriber adapter");
+        subscriber
+            .start_session()
+            .await
+            .expect("subscriber start_session");
+        let mut subscription = subscriber
+            .subscribe_topic(&receiver(TOPIC), SubscriberQoS::Standard)
+            .await
+            .expect("subscribe");
+
+        let mut publisher = ZenohAdapter::connect_to(ZenohNetProtocol::Tcp, &host, port)
+            .expect("publisher adapter");
+        publisher
+            .start_session()
+            .await
+            .expect("publisher start_session");
+
+        // Baseline delivery, then give gossip ample time to establish the direct
+        // peer-to-peer link before the router is removed.
+        wait_for_subscriber_discovery().await;
+        publisher
+            .publish_topic(
+                &sender(TOPIC),
+                Payload::from_bytes(Bytes::from_static(b"before-stop")),
+                PublisherQoS::Standard,
+                true,
+            )
+            .await
+            .expect("baseline publish");
+        let baseline = recv_or_timeout(&mut subscription.rx, "baseline").await;
+        assert_eq!(baseline.payload(), &Bytes::from_static(b"before-stop"));
+        tokio::time::sleep(Duration::from_secs(3)).await;
+
+        // Remove the router. Any delivery from here on is over the direct link.
+        instance
+            .messenger()
+            .stop_router()
+            .await
+            .expect("stop_router");
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        // Poll-publish until a post-stop payload arrives (or give up). Only an
+        // `after-stop-*` payload counts; a stale relayed `before-stop` must not.
+        let deadline = Instant::now() + Duration::from_secs(15);
+        let mut attempt = 0u32;
+        let mut delivered = false;
+        while Instant::now() < deadline {
+            attempt += 1;
+            let body = Bytes::from(format!("after-stop-{attempt}"));
+            let _ = publisher
+                .publish_topic(
+                    &sender(TOPIC),
+                    Payload::from_bytes(body),
+                    PublisherQoS::Standard,
+                    true,
+                )
+                .await;
+            if let Ok(Ok(msg)) =
+                tokio::time::timeout(Duration::from_millis(500), subscription.rx.recv_async()).await
+                && msg.payload().as_bytes().starts_with(b"after-stop-")
+            {
+                delivered = true;
+                break;
+            }
+        }
+
+        assert!(
+            delivered,
+            "no message was delivered after the router was stopped: data was relaying through the \
+             router instead of flowing peer-to-peer"
+        );
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_publish_before_start_session_fails() {
         let _lock = ZENOH_SERIAL.lock().await;

--- a/crates/pmi-internal/tests/zenoh.rs
+++ b/crates/pmi-internal/tests/zenoh.rs
@@ -8,8 +8,8 @@ mod zenoh_tests {
     };
     use bytes::Bytes;
     use pmi::{
-        MessengerBackend, Payload, PublisherQoS, SubscriberQoS, TopicWireReceiver, TopicWireSender,
-        ZenohAdapter, ZenohNetProtocol,
+        MessengerBackend, Payload, PublisherQoS, SubscriberBufferSizes, SubscriberQoS,
+        TopicWireReceiver, TopicWireSender, ZenohAdapter, ZenohNetProtocol,
     };
     use std::time::{Duration, Instant};
 
@@ -277,6 +277,135 @@ mod zenoh_tests {
         );
     }
 
+    /// Router mode (gossip off → plain client sessions) still delivers, with the
+    /// traffic relayed through the running zenohd router. Positive companion to
+    /// `peers_keep_delivering_after_router_stops`, which proves the peer path;
+    /// here the router is required and kept alive for the whole test.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn router_mode_delivers_through_router() {
+        const TOPIC: &str = "router_mode_topic";
+        let _lock = ZENOH_SERIAL.lock().await;
+
+        let instance = ZenohAdapter::start_router_ephemeral("127.0.0.1", None)
+            .await
+            .expect("Failed to start zenohd process");
+        let host = instance.host.clone();
+        let port = instance.port;
+
+        // gossip=false → plain client sessions with no peer listener, so all
+        // traffic routes through the central router.
+        let mut subscriber = ZenohAdapter::connect_to_with_discovery(
+            ZenohNetProtocol::Tcp,
+            &host,
+            port,
+            Vec::new(),
+            false,
+            SubscriberBufferSizes::default(),
+        )
+        .expect("subscriber adapter");
+        subscriber
+            .start_session()
+            .await
+            .expect("subscriber start_session");
+        let mut subscription = subscriber
+            .subscribe_topic(&receiver(TOPIC), SubscriberQoS::Standard)
+            .await
+            .expect("subscribe");
+
+        let mut publisher = ZenohAdapter::connect_to_with_discovery(
+            ZenohNetProtocol::Tcp,
+            &host,
+            port,
+            Vec::new(),
+            false,
+            SubscriberBufferSizes::default(),
+        )
+        .expect("publisher adapter");
+        publisher
+            .start_session()
+            .await
+            .expect("publisher start_session");
+
+        wait_for_subscriber_discovery().await;
+        publisher
+            .publish_topic(
+                &sender(TOPIC),
+                Payload::from_bytes(Bytes::from_static(b"router-mode")),
+                PublisherQoS::Standard,
+                true,
+            )
+            .await
+            .expect("publish");
+        let msg = recv_or_timeout(&mut subscription.rx, "router-mode").await;
+        assert_eq!(msg.payload(), &Bytes::from_static(b"router-mode"));
+
+        // Keep the router alive until the end: client-mode delivery depends on it.
+        drop(instance);
+    }
+
+    /// A peer session built with custom (tiny) subscriber buffers still delivers
+    /// end-to-end. This pins that the buffer sizes are threaded through
+    /// `connect_to_with_discovery` without breaking delivery; exact-capacity
+    /// backpressure is covered by the `SubscriberBufferSizes` unit tests.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn peer_session_uses_custom_buffer_sizes() {
+        const TOPIC: &str = "custom_buffer_topic";
+        let _lock = ZENOH_SERIAL.lock().await;
+
+        let instance = ZenohAdapter::start_router_ephemeral("127.0.0.1", None)
+            .await
+            .expect("Failed to start zenohd process");
+        let host = instance.host.clone();
+        let port = instance.port;
+
+        let tiny = SubscriberBufferSizes {
+            standard: 2,
+            high_throughput: 2,
+        };
+        let mut subscriber = ZenohAdapter::connect_to_with_discovery(
+            ZenohNetProtocol::Tcp,
+            &host,
+            port,
+            Vec::new(),
+            true,
+            tiny,
+        )
+        .expect("subscriber adapter");
+        subscriber
+            .start_session()
+            .await
+            .expect("subscriber start_session");
+        let mut subscription = subscriber
+            .subscribe_topic(&receiver(TOPIC), SubscriberQoS::Standard)
+            .await
+            .expect("subscribe");
+
+        let mut publisher = ZenohAdapter::connect_to(ZenohNetProtocol::Tcp, &host, port)
+            .expect("publisher adapter");
+        publisher
+            .start_session()
+            .await
+            .expect("publisher start_session");
+
+        wait_for_subscriber_discovery().await;
+        // Publish and drain one at a time so the tiny buffer never overflows.
+        for i in 0..5 {
+            let body = Bytes::from(format!("msg-{i}"));
+            publisher
+                .publish_topic(
+                    &sender(TOPIC),
+                    Payload::from_bytes(body.clone()),
+                    PublisherQoS::Standard,
+                    true,
+                )
+                .await
+                .expect("publish");
+            let msg = recv_or_timeout(&mut subscription.rx, "custom-buffer").await;
+            assert_eq!(msg.payload(), &body);
+        }
+        drop(instance);
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_publish_before_start_session_fails() {
         let _lock = ZENOH_SERIAL.lock().await;
@@ -503,7 +632,14 @@ mod zenoh_tests {
         let port = listener.local_addr().unwrap().port();
         drop(listener);
 
-        let adapter = ZenohAdapter::with_router(ZenohNetProtocol::Tcp, "127.0.0.1", port).unwrap();
+        let adapter = ZenohAdapter::with_router(
+            ZenohNetProtocol::Tcp,
+            "127.0.0.1",
+            port,
+            true,
+            SubscriberBufferSizes::default(),
+        )
+        .unwrap();
         let (host, adapter_port) = adapter.client_endpoint();
         assert_eq!(host, "127.0.0.1");
         assert_eq!(adapter_port, port);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable peer discovery (seed endpoints + gossip toggle) with defaults and daemon config file created on first run
  * Discovery-aware reconnects, explicit publisher/subscriber matching, and runtime-generated session/router configs
  * Configurable per-subscriber buffer sizing wired from daemon/runtime config

* **Bug Fixes**
  * Improved service discovery reliability with cold-start retries
  * Host-gateway runs now disable gossip to avoid cross-namespace leaks

* **Tests**
  * Deterministic, parameterized networking tests across peer/router modes; increased timeouts to stabilize CI

* **Chores**
  * Removed unused dependency; workspace test tooling added (rstest)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->