### PR TITLE
Deploy peppylib as a standalone installable project in Python nodes

### DIFF
--- a/crates/core-node-internal/src/services/node/init/templates.rs
+++ b/crates/core-node-internal/src/services/node/init/templates.rs
@@ -26,6 +26,7 @@ pub struct RustCargoToml<'a> {
 pub struct PythonPyprojectToml<'a> {
     pub node_name: &'a str,
     pub pepygen_path: &'a str,
+    pub pepylib_path: &'a str,
     pub python_min_version: &'a str,
     pub python_max_version: &'a str,
 }
@@ -138,6 +139,7 @@ pub fn apply_python_templates(
     let pyproject_toml = PythonPyprojectToml {
         node_name,
         pepygen_path: config::consts::PEPPYGEN_OUTPUT_PATH,
+        pepylib_path: config::consts::PEPPYLIB_OUTPUT_PATH,
         python_min_version: config::consts::PYTHON_MIN_VERSION,
         python_max_version: config::consts::PYTHON_MAX_VERSION,
     };

--- a/crates/core-node-internal/templates/node_init/python/pyproject.toml.j2
+++ b/crates/core-node-internal/templates/node_init/python/pyproject.toml.j2
@@ -7,7 +7,7 @@ name = "{{ node_name }}"
 version = "0.1.0"
 description = "{{ node_name }} peppy node"
 requires-python = ">={{ python_min_version }},<{{ python_max_version }}"
-dependencies = ["peppygen"]
+dependencies = ["peppygen", "peppylib"]
 
 [project.scripts]
 {{ node_name }} = "{{ node_name }}.__main__:main"
@@ -20,3 +20,4 @@ dev = []
 
 [tool.uv.sources]
 peppygen = { path = "{{ pepygen_path }}" }
+peppylib = { path = "{{ pepylib_path }}" }

--- a/crates/core-node-internal/tests/listen_for_node_init.rs
+++ b/crates/core-node-internal/tests/listen_for_node_init.rs
@@ -3,7 +3,7 @@ mod common;
 use common::{CALLER_INSTANCE_ID, start_core_node_with_mock_messenger};
 use config::consts::{
     DEFAULT_PYTHON_BASE_IMAGE, DEFAULT_RUST_BASE_IMAGE, NODE_CONFIG_FILE, PEPPY_OUTPUT_DIR,
-    PEPPYGEN_OUTPUT_PATH,
+    PEPPYGEN_OUTPUT_PATH, PEPPYLIB_OUTPUT_PATH,
 };
 use config::node::Toolchain;
 use config::test_helpers::assert_contains_all;
@@ -297,6 +297,16 @@ async fn listen_for_node_init_python_success() {
         "pyproject.toml should reference generated peppygen path, got:\n{}",
         pyproject_toml
     );
+    assert!(
+        pyproject_toml.contains("peppylib"),
+        "pyproject.toml should contain peppylib dependency, got:\n{}",
+        pyproject_toml
+    );
+    assert!(
+        pyproject_toml.contains(PEPPYLIB_OUTPUT_PATH),
+        "pyproject.toml should reference deployed peppylib path, got:\n{}",
+        pyproject_toml
+    );
 
     let init_py_path = node_dir.join(format!("src/{NODE_NAME}/__init__.py"));
     assert!(
@@ -390,6 +400,16 @@ async fn listen_for_node_init_python_container_success() {
     assert!(
         pyproject_toml.contains(PEPPYGEN_OUTPUT_PATH),
         "pyproject.toml should reference generated peppygen path, got:\n{}",
+        pyproject_toml
+    );
+    assert!(
+        pyproject_toml.contains("peppylib"),
+        "pyproject.toml should contain peppylib dependency, got:\n{}",
+        pyproject_toml
+    );
+    assert!(
+        pyproject_toml.contains(PEPPYLIB_OUTPUT_PATH),
+        "pyproject.toml should reference deployed peppylib path, got:\n{}",
         pyproject_toml
     );
 

--- a/crates/generator-internal/src/generator/common.rs
+++ b/crates/generator-internal/src/generator/common.rs
@@ -25,12 +25,43 @@ impl<'a> PeppyConfigTemplate<'a> {
 #[derive(Template)]
 #[template(path = "peppygen/python/pyproject.toml.j2", escape = "none")]
 struct PeppyPythonConfigTemplate<'a> {
+    peppylib_version: &'a str,
     python_min_version: &'a str,
     python_max_version: &'a str,
 }
 
 impl PeppyPythonConfigTemplate<'_> {
     pub const TEMPLATE_PATH: &'static str = "peppygen/python/pyproject.toml.j2";
+}
+
+/// Version of the deployed peppylib Python distribution.
+///
+/// A PEP 440 local version: public indexes reject local versions, so
+/// peppygen's exact `peppylib==<this>` requirement can never be satisfied
+/// from PyPI — a node missing the `.peppy/libs/peppylib` path source fails
+/// loudly instead of silently installing an outdated release. Intentionally
+/// differs from `peppylib.__version__` (which is stamped from PEPPY_GIT_TAG).
+pub(crate) const PYTHON_PEPPYLIB_VERSION: &str = concat!(env!("CARGO_PKG_VERSION"), "+peppy");
+
+#[derive(Template)]
+#[template(path = "peppylib/python/pyproject.toml.j2", escape = "none")]
+struct PeppylibPythonProjectTemplate<'a> {
+    peppylib_version: &'a str,
+    python_min_version: &'a str,
+    python_max_version: &'a str,
+}
+
+/// Renders the manifest of the standalone peppylib Python project deployed
+/// at `.peppy/libs/peppylib/pyproject.toml`. Plain setuptools packaging of
+/// the prebuilt wrappers + native extension — never maturin, since end-user
+/// machines have no Rust toolchain.
+pub(crate) fn render_peppylib_python_pyproject() -> Result<String> {
+    let tpl = PeppylibPythonProjectTemplate {
+        peppylib_version: PYTHON_PEPPYLIB_VERSION,
+        python_min_version: config::consts::PYTHON_MIN_VERSION,
+        python_max_version: config::consts::PYTHON_MAX_VERSION,
+    };
+    Ok(tpl.render()?)
 }
 
 pub(crate) fn copy_embedded_templates(prefix: &str, to: &Path, peppylib_path: &str) -> Result<()> {
@@ -95,6 +126,7 @@ fn render_template(template_path: &str, peppylib_path: &str) -> Result<String> {
         }
         PeppyPythonConfigTemplate::TEMPLATE_PATH => {
             let tpl = PeppyPythonConfigTemplate {
+                peppylib_version: PYTHON_PEPPYLIB_VERSION,
                 python_min_version: config::consts::PYTHON_MIN_VERSION,
                 python_max_version: config::consts::PYTHON_MAX_VERSION,
             };

--- a/crates/generator-internal/src/generator/python/scaffold.rs
+++ b/crates/generator-internal/src/generator/python/scaffold.rs
@@ -159,13 +159,30 @@ pub fn add_peppylib_dependencies(
         drop(lock_file);
     }
 
-    // Always copy peppylib into the output directory so each node gets the
+    // Deploy peppylib as a standalone project at `.peppy/libs/peppylib`
+    // (sibling of peppygen, mirroring the Rust layout) so each node gets the
     // correct platform binary (host or Linux) without shared symlinks.
-    let peppylib_dest = to_path.join("peppylib");
-    if peppylib_dest.exists() {
-        fs::remove_dir_all(&peppylib_dest)?;
+    // The manifest is plain-written on every generation: uv keys
+    // path-dependency rebuilds on pyproject.toml mtime, so a preserved
+    // timestamp would serve a stale cached wheel with an old `.so`.
+    let libs_dir = to_path.parent().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "peppygen path has no parent directory",
+        )
+    })?;
+    let project_dir = libs_dir.join("peppylib");
+    if project_dir.exists() {
+        fs::remove_dir_all(&project_dir)?;
     }
-    copy_dir_recursive(&cache_dir, &peppylib_dest)?;
+    fs::create_dir_all(&project_dir)?;
+    fs::write(
+        project_dir.join("pyproject.toml"),
+        crate::generator::common::render_peppylib_python_pyproject()?,
+    )?;
+    let package_dir = project_dir.join("peppylib");
+    copy_dir_recursive(&cache_dir, &package_dir)?;
+    fs::remove_file(package_dir.join(".complete"))?;
 
     Ok(())
 }

--- a/crates/generator-internal/templates/peppygen/python/pyproject.toml.j2
+++ b/crates/generator-internal/templates/peppygen/python/pyproject.toml.j2
@@ -2,17 +2,13 @@
 name = "peppygen"
 version = "0.1.0"
 requires-python = ">={{ python_min_version }},<{{ python_max_version }}"
-dependencies = ["pycapnp"]
+dependencies = ["pycapnp", "peppylib=={{ peppylib_version }}"]
 
 [tool.setuptools.packages.find]
-include = ["peppygen*", "peppylib*"]
+include = ["peppygen*"]
 
 [tool.setuptools.package-data]
 peppygen = ["capnp/*.capnp"]
-peppylib = ["*.so"]
-
-[tool.ruff]
-exclude = ["peppylib"]
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]

--- a/crates/generator-internal/templates/peppylib/python/pyproject.toml.j2
+++ b/crates/generator-internal/templates/peppylib/python/pyproject.toml.j2
@@ -1,0 +1,12 @@
+[project]
+name = "peppylib"
+version = "{{ peppylib_version }}"
+description = "The peppyOS control library (prebuilt, deployed by peppy)"
+requires-python = ">={{ python_min_version }},<{{ python_max_version }}"
+dependencies = []
+
+[tool.setuptools.packages.find]
+include = ["peppylib*"]
+
+[tool.setuptools.package-data]
+peppylib = ["*.so"]

--- a/crates/generator-internal/tests/helpers.rs
+++ b/crates/generator-internal/tests/helpers.rs
@@ -1,7 +1,8 @@
 #![allow(dead_code)]
 
 use config::consts::{
-    NODE_CONFIG_FILE, PEPPYGEN_OUTPUT_PATH, PYTHON_MAX_VERSION, PYTHON_MIN_VERSION, PeppyDirs,
+    NODE_CONFIG_FILE, PEPPYGEN_OUTPUT_PATH, PEPPYLIB_OUTPUT_PATH, PYTHON_MAX_VERSION,
+    PYTHON_MIN_VERSION, PeppyDirs,
 };
 use config::node::PeppygenLanguage;
 use generator::generate_peppygen_lib;
@@ -857,7 +858,8 @@ pub const STUB_PYTHON_NODE_CONFIG: &str = r#"{
 /// Initialises a Python user-node project at `to_dir`.
 ///
 /// Creates a minimal `pyproject.toml` that depends on the generated `peppygen`
-/// package (located at [`PEPPYGEN_OUTPUT_PATH`] relative to the project root).
+/// and `peppylib` packages (located at [`PEPPYGEN_OUTPUT_PATH`] and
+/// [`PEPPYLIB_OUTPUT_PATH`] relative to the project root).
 pub fn init_python_user_node(to_dir: impl AsRef<Path>) {
     let project_dir = to_dir.as_ref();
     fs::create_dir_all(project_dir).expect("failed to create Python user node directory");
@@ -867,12 +869,12 @@ pub fn init_python_user_node(to_dir: impl AsRef<Path>) {
 name = "user_node"
 version = "0.1.0"
 requires-python = ">={PYTHON_MIN_VERSION},<{PYTHON_MAX_VERSION}"
-dependencies = ["peppygen"]
+dependencies = ["peppygen", "peppylib"]
 
 [tool.uv.sources]
-peppygen = {{ path = "{}" }}
-"#,
-        PEPPYGEN_OUTPUT_PATH
+peppygen = {{ path = "{PEPPYGEN_OUTPUT_PATH}" }}
+peppylib = {{ path = "{PEPPYLIB_OUTPUT_PATH}" }}
+"#
     );
     fs::write(project_dir.join("pyproject.toml"), pyproject)
         .expect("failed to write Python user node pyproject.toml");

--- a/crates/generator-internal/tests/python/generate_lib.rs
+++ b/crates/generator-internal/tests/python/generate_lib.rs
@@ -1,6 +1,6 @@
 use crate::helpers;
 use config::{
-    consts::{NODE_CONFIG_FILE, PEPPYGEN_OUTPUT_PATH},
+    consts::{NODE_CONFIG_FILE, PEPPYGEN_OUTPUT_PATH, PEPPYLIB_OUTPUT_PATH},
     node::{ConsumedAction, ConsumedService, ConsumedTopic, MessageFormat, PeppygenLanguage},
 };
 use generator::generate_peppygen_lib;
@@ -117,6 +117,159 @@ fn generate_peppygen_lib_emits_clock_module() {
     assert!(
         init_contents.contains("from . import clock"),
         "__init__.py must import the clock module"
+    );
+}
+
+/// Expected version of the deployed peppylib Python distribution: a PEP 440
+/// local version that public indexes can never serve, so peppygen's exact pin
+/// is only satisfiable from the `.peppy/libs/peppylib` path source.
+const PEPPYLIB_DIST_VERSION: &str = concat!(env!("CARGO_PKG_VERSION"), "+peppy");
+
+/// peppylib must be deployed as a standalone installable project at
+/// `.peppy/libs/peppylib` (sibling of peppygen, mirroring the Rust layout),
+/// and no longer nested inside the peppygen project.
+#[test]
+fn generate_peppygen_lib_deploys_standalone_peppylib_project() {
+    let (_temp_dir, peppygen_dir) =
+        helpers::run_generate_peppygen_lib_test(PeppygenLanguage::Python, PEPPY_JSON5_CONFIG);
+    let libs_dir = peppygen_dir.parent().expect("peppygen dir has a parent");
+    let project_dir = libs_dir.join("peppylib");
+
+    let pyproject = fs::read_to_string(project_dir.join("pyproject.toml"))
+        .expect("standalone peppylib pyproject.toml should exist");
+    assert!(
+        pyproject.contains(r#"name = "peppylib""#),
+        "peppylib project must be named so the uv path source matches:\n{pyproject}"
+    );
+    assert!(
+        pyproject.contains(&format!(r#"version = "{PEPPYLIB_DIST_VERSION}""#)),
+        "peppylib project must carry the local version sentinel:\n{pyproject}"
+    );
+
+    assert!(
+        project_dir.join("peppylib/__init__.py").exists(),
+        "peppylib package wrappers should be deployed"
+    );
+    assert!(
+        project_dir.join("peppylib/_peppylib.abi3.so").exists(),
+        "canonical native extension should be deployed"
+    );
+    assert!(
+        !project_dir.join("peppylib/.complete").exists(),
+        "cache completeness marker must not be deployed"
+    );
+
+    assert!(
+        !peppygen_dir.join("peppylib").exists(),
+        "peppylib must no longer be nested inside the peppygen project"
+    );
+
+    let peppygen_pyproject = fs::read_to_string(peppygen_dir.join("pyproject.toml"))
+        .expect("peppygen pyproject.toml should exist");
+    assert!(
+        peppygen_pyproject.contains(&format!("peppylib=={PEPPYLIB_DIST_VERSION}")),
+        "peppygen must pin the deployed peppylib version:\n{peppygen_pyproject}"
+    );
+    assert!(
+        !peppygen_pyproject.contains("peppylib*"),
+        "peppygen must not package the peppylib package anymore:\n{peppygen_pyproject}"
+    );
+    assert!(
+        !peppygen_pyproject.contains(r#"exclude = ["peppylib"]"#),
+        "the ruff exclude for the nested peppylib copy should be gone:\n{peppygen_pyproject}"
+    );
+}
+
+/// Re-generating into the same node directory must succeed and produce the
+/// same layout (the deploy step removes and re-creates the standalone
+/// peppylib project each time).
+#[test]
+fn generate_peppygen_lib_python_repeat_generation_is_idempotent() {
+    let temp_dir =
+        TempDir::new_in(crate::helpers::test_tmp_root()).expect("failed to create temp directory");
+    let node_dir = temp_dir.path();
+    fs::write(node_dir.join(NODE_CONFIG_FILE), PEPPY_JSON5_CONFIG)
+        .expect("failed to write peppy.json5");
+
+    for run in 1..=2 {
+        generate_peppygen_lib(
+            PeppygenLanguage::Python,
+            node_dir,
+            Vec::new(),
+            "test-hash",
+            &helpers::test_peppy_dirs(),
+            Default::default(),
+            None,
+        )
+        .unwrap_or_else(|e| panic!("generation run {run} failed: {e}"));
+    }
+
+    let peppygen_dir = node_dir.join(PEPPYGEN_OUTPUT_PATH);
+    let project_dir = node_dir.join(PEPPYLIB_OUTPUT_PATH);
+    assert!(project_dir.join("pyproject.toml").exists());
+    assert!(project_dir.join("peppylib/_peppylib.abi3.so").exists());
+    assert!(!peppygen_dir.join("peppylib").exists());
+}
+
+/// End-to-end: `uv sync` in a Python node project must install peppylib from
+/// the deployed path source — `import peppylib` works directly (the raw
+/// messaging API, without going through peppygen) and the installed
+/// distribution is the locally deployed one, never a PyPI release.
+#[test]
+fn python_node_venv_installs_local_peppylib() {
+    let temp_dir =
+        TempDir::new_in(crate::helpers::test_tmp_root()).expect("failed to create temp directory");
+    let node_dir = temp_dir.path().join("user_node");
+    helpers::init_python_user_node(&node_dir);
+    fs::write(
+        node_dir.join(NODE_CONFIG_FILE),
+        helpers::STUB_PYTHON_NODE_CONFIG,
+    )
+    .expect("failed to write peppy.json5");
+
+    generate_peppygen_lib(
+        PeppygenLanguage::Python,
+        &node_dir,
+        Vec::new(),
+        "test-hash",
+        &helpers::test_peppy_dirs(),
+        Default::default(),
+        None,
+    )
+    .expect("failed to generate peppygen lib");
+
+    helpers::init_python_project_venv(&node_dir);
+
+    let output = std::process::Command::new(node_dir.join(".venv/bin/python"))
+        .args([
+            "-c",
+            "import importlib.metadata\n\
+             import peppylib\n\
+             from peppylib import QoSProfile\n\
+             print(peppylib.__file__)\n\
+             print(importlib.metadata.version('peppylib'))",
+        ])
+        .current_dir(&node_dir)
+        .output()
+        .expect("failed to run venv python");
+    assert!(
+        output.status.success(),
+        "importing peppylib from the venv failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut lines = stdout.lines();
+    let module_path = lines.next().expect("missing peppylib.__file__ line");
+    let dist_version = lines.next().expect("missing version line");
+    assert!(
+        module_path.contains(".venv") && module_path.contains("site-packages"),
+        "peppylib must be installed into the project venv, got: {module_path}"
+    );
+    assert_eq!(
+        dist_version, PEPPYLIB_DIST_VERSION,
+        "installed peppylib must be the locally deployed distribution, not a PyPI release"
     );
 }
 

--- a/docs/src/content/docs/guides/first_node.mdx
+++ b/docs/src/content/docs/guides/first_node.mdx
@@ -42,7 +42,7 @@ Run:
     </Steps>
     :::note
     [`uv`](https://docs.astral.sh/uv/) is the default Python toolchain in PeppyOS, but you can use any toolchain you prefer ([`pixi`](https://prefix.dev/), [`poetry`](https://python-poetry.org/), [`pip`](https://pip.pypa.io/en/stable), etc.). 
-    To do so, first initialize the node with `peppy node init --toolchain uv`, then add `peppygen = { path = ".peppy/libs/peppygen" }` as a dependency in your toolchain's configuration, 
+    To do so, first initialize the node with `peppy node init --toolchain uv`, then add `peppygen = { path = ".peppy/libs/peppygen" }` and `peppylib = { path = ".peppy/libs/peppylib" }` as dependencies in your toolchain's configuration, 
     and update `build_cmd` and `run_cmd` in `peppy.json5` to match your toolchain's commands. PeppyOS is designed to work with whichever tools you prefer.
     :::
   </TabItem>

--- a/docs/src/content/docs/guides/snippets/python/arm_controller/pyproject.toml
+++ b/docs/src/content/docs/guides/snippets/python/arm_controller/pyproject.toml
@@ -7,7 +7,7 @@ name = "arm_controller"
 version = "0.1.0"
 description = "arm_controller peppy node"
 requires-python = ">=3.11,<3.14"
-dependencies = ["peppygen"]
+dependencies = ["peppygen", "peppylib"]
 
 [project.scripts]
 arm_controller = "arm_controller.__main__:main"
@@ -20,3 +20,4 @@ dev = []
 
 [tool.uv.sources]
 peppygen = { path = ".peppy/libs/peppygen" }
+peppylib = { path = ".peppy/libs/peppylib" }

--- a/docs/src/content/docs/guides/snippets/python/arm_controller/uv.lock
+++ b/docs/src/content/docs/guides/snippets/python/arm_controller/uv.lock
@@ -8,10 +8,14 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "peppygen" },
+    { name = "peppylib" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "peppygen", directory = ".peppy/libs/peppygen" }]
+requires-dist = [
+    { name = "peppygen", directory = ".peppy/libs/peppygen" },
+    { name = "peppylib", directory = ".peppy/libs/peppylib" },
+]
 
 [package.metadata.requires-dev]
 dev = []
@@ -21,11 +25,20 @@ name = "peppygen"
 version = "0.1.0"
 source = { directory = ".peppy/libs/peppygen" }
 dependencies = [
+    { name = "peppylib" },
     { name = "pycapnp" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "pycapnp" }]
+requires-dist = [
+    { name = "peppylib", specifier = "==0.0.1+peppy" },
+    { name = "pycapnp" },
+]
+
+[[package]]
+name = "peppylib"
+version = "0.0.1+peppy"
+source = { directory = ".peppy/libs/peppylib" }
 
 [[package]]
 name = "pycapnp"

--- a/docs/src/content/docs/guides/snippets/python/hello_receiver/pyproject.toml
+++ b/docs/src/content/docs/guides/snippets/python/hello_receiver/pyproject.toml
@@ -7,7 +7,7 @@ name = "hello_receiver"
 version = "0.1.0"
 description = "hello_receiver peppy node"
 requires-python = ">=3.11,<3.14"
-dependencies = ["peppygen"]
+dependencies = ["peppygen", "peppylib"]
 
 [project.scripts]
 hello_receiver = "hello_receiver.__main__:main"
@@ -20,3 +20,4 @@ dev = []
 
 [tool.uv.sources]
 peppygen = { path = ".peppy/libs/peppygen" }
+peppylib = { path = ".peppy/libs/peppylib" }

--- a/docs/src/content/docs/guides/snippets/python/hello_receiver/uv.lock
+++ b/docs/src/content/docs/guides/snippets/python/hello_receiver/uv.lock
@@ -8,10 +8,14 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "peppygen" },
+    { name = "peppylib" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "peppygen", directory = ".peppy/libs/peppygen" }]
+requires-dist = [
+    { name = "peppygen", directory = ".peppy/libs/peppygen" },
+    { name = "peppylib", directory = ".peppy/libs/peppylib" },
+]
 
 [package.metadata.requires-dev]
 dev = []
@@ -21,11 +25,20 @@ name = "peppygen"
 version = "0.1.0"
 source = { directory = ".peppy/libs/peppygen" }
 dependencies = [
+    { name = "peppylib" },
     { name = "pycapnp" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "pycapnp" }]
+requires-dist = [
+    { name = "peppylib", specifier = "==0.0.1+peppy" },
+    { name = "pycapnp" },
+]
+
+[[package]]
+name = "peppylib"
+version = "0.0.1+peppy"
+source = { directory = ".peppy/libs/peppylib" }
 
 [[package]]
 name = "pycapnp"

--- a/docs/src/content/docs/guides/snippets/python/hello_world/pyproject.toml
+++ b/docs/src/content/docs/guides/snippets/python/hello_world/pyproject.toml
@@ -7,7 +7,7 @@ name = "hello_world"
 version = "0.1.0"
 description = "hello_world peppy node"
 requires-python = ">=3.11,<3.14"
-dependencies = ["peppygen"]
+dependencies = ["peppygen", "peppylib"]
 
 [project.scripts]
 hello_world = "hello_world.__main__:main"
@@ -20,3 +20,4 @@ dev = []
 
 [tool.uv.sources]
 peppygen = { path = ".peppy/libs/peppygen" }
+peppylib = { path = ".peppy/libs/peppylib" }

--- a/docs/src/content/docs/guides/snippets/python/hello_world/uv.lock
+++ b/docs/src/content/docs/guides/snippets/python/hello_world/uv.lock
@@ -8,10 +8,14 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "peppygen" },
+    { name = "peppylib" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "peppygen", directory = ".peppy/libs/peppygen" }]
+requires-dist = [
+    { name = "peppygen", directory = ".peppy/libs/peppygen" },
+    { name = "peppylib", directory = ".peppy/libs/peppylib" },
+]
 
 [package.metadata.requires-dev]
 dev = []
@@ -21,11 +25,20 @@ name = "peppygen"
 version = "0.1.0"
 source = { directory = ".peppy/libs/peppygen" }
 dependencies = [
+    { name = "peppylib" },
     { name = "pycapnp" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "pycapnp" }]
+requires-dist = [
+    { name = "peppylib", specifier = "==0.0.1+peppy" },
+    { name = "pycapnp" },
+]
+
+[[package]]
+name = "peppylib"
+version = "0.0.1+peppy"
+source = { directory = ".peppy/libs/peppylib" }
 
 [[package]]
 name = "pycapnp"

--- a/docs/src/content/docs/guides/snippets/python/hello_world_param/pyproject.toml
+++ b/docs/src/content/docs/guides/snippets/python/hello_world_param/pyproject.toml
@@ -7,7 +7,7 @@ name = "hello_world_param"
 version = "0.1.0"
 description = "hello_world_param peppy node"
 requires-python = ">=3.11,<3.14"
-dependencies = ["peppygen"]
+dependencies = ["peppygen", "peppylib"]
 
 [project.scripts]
 hello_world_param = "hello_world_param.__main__:main"
@@ -20,3 +20,4 @@ dev = []
 
 [tool.uv.sources]
 peppygen = { path = ".peppy/libs/peppygen" }
+peppylib = { path = ".peppy/libs/peppylib" }

--- a/docs/src/content/docs/guides/snippets/python/hello_world_param/uv.lock
+++ b/docs/src/content/docs/guides/snippets/python/hello_world_param/uv.lock
@@ -8,10 +8,14 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "peppygen" },
+    { name = "peppylib" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "peppygen", directory = ".peppy/libs/peppygen" }]
+requires-dist = [
+    { name = "peppygen", directory = ".peppy/libs/peppygen" },
+    { name = "peppylib", directory = ".peppy/libs/peppylib" },
+]
 
 [package.metadata.requires-dev]
 dev = []
@@ -21,11 +25,20 @@ name = "peppygen"
 version = "0.1.0"
 source = { directory = ".peppy/libs/peppygen" }
 dependencies = [
+    { name = "peppylib" },
     { name = "pycapnp" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "pycapnp" }]
+requires-dist = [
+    { name = "peppylib", specifier = "==0.0.1+peppy" },
+    { name = "pycapnp" },
+]
+
+[[package]]
+name = "peppylib"
+version = "0.0.1+peppy"
+source = { directory = ".peppy/libs/peppylib" }
 
 [[package]]
 name = "pycapnp"

--- a/docs/src/content/docs/guides/snippets/python/robot_arm/pyproject.toml
+++ b/docs/src/content/docs/guides/snippets/python/robot_arm/pyproject.toml
@@ -7,7 +7,7 @@ name = "robot_arm"
 version = "0.1.0"
 description = "robot_arm peppy node"
 requires-python = ">=3.11,<3.14"
-dependencies = ["peppygen"]
+dependencies = ["peppygen", "peppylib"]
 
 [project.scripts]
 robot_arm = "robot_arm.__main__:main"
@@ -20,3 +20,4 @@ dev = []
 
 [tool.uv.sources]
 peppygen = { path = ".peppy/libs/peppygen" }
+peppylib = { path = ".peppy/libs/peppylib" }

--- a/docs/src/content/docs/guides/snippets/python/robot_arm/uv.lock
+++ b/docs/src/content/docs/guides/snippets/python/robot_arm/uv.lock
@@ -7,11 +7,20 @@ name = "peppygen"
 version = "0.1.0"
 source = { directory = ".peppy/libs/peppygen" }
 dependencies = [
+    { name = "peppylib" },
     { name = "pycapnp" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "pycapnp" }]
+requires-dist = [
+    { name = "peppylib", specifier = "==0.0.1+peppy" },
+    { name = "pycapnp" },
+]
+
+[[package]]
+name = "peppylib"
+version = "0.0.1+peppy"
+source = { directory = ".peppy/libs/peppylib" }
 
 [[package]]
 name = "pycapnp"
@@ -69,10 +78,14 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "peppygen" },
+    { name = "peppylib" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "peppygen", directory = ".peppy/libs/peppygen" }]
+requires-dist = [
+    { name = "peppygen", directory = ".peppy/libs/peppygen" },
+    { name = "peppylib", directory = ".peppy/libs/peppylib" },
+]
 
 [package.metadata.requires-dev]
 dev = []

--- a/docs/src/content/docs/guides/snippets/python/standalone/pyproject.toml
+++ b/docs/src/content/docs/guides/snippets/python/standalone/pyproject.toml
@@ -7,7 +7,7 @@ name = "standalone"
 version = "0.1.0"
 description = "standalone peppy node"
 requires-python = ">=3.11,<3.14"
-dependencies = ["peppygen"]
+dependencies = ["peppygen", "peppylib"]
 
 [project.scripts]
 standalone = "standalone.__main__:main"
@@ -20,3 +20,4 @@ dev = []
 
 [tool.uv.sources]
 peppygen = { path = ".peppy/libs/peppygen" }
+peppylib = { path = ".peppy/libs/peppylib" }

--- a/docs/src/content/docs/guides/snippets/python/standalone/uv.lock
+++ b/docs/src/content/docs/guides/snippets/python/standalone/uv.lock
@@ -7,11 +7,20 @@ name = "peppygen"
 version = "0.1.0"
 source = { directory = ".peppy/libs/peppygen" }
 dependencies = [
+    { name = "peppylib" },
     { name = "pycapnp" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "pycapnp" }]
+requires-dist = [
+    { name = "peppylib", specifier = "==0.0.1+peppy" },
+    { name = "pycapnp" },
+]
+
+[[package]]
+name = "peppylib"
+version = "0.0.1+peppy"
+source = { directory = ".peppy/libs/peppylib" }
 
 [[package]]
 name = "pycapnp"
@@ -69,10 +78,14 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "peppygen" },
+    { name = "peppylib" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "peppygen", directory = ".peppy/libs/peppygen" }]
+requires-dist = [
+    { name = "peppygen", directory = ".peppy/libs/peppygen" },
+    { name = "peppylib", directory = ".peppy/libs/peppylib" },
+]
 
 [package.metadata.requires-dev]
 dev = []


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Python projects now include `peppylib` as an explicit runtime dependency alongside `peppygen`.
  * `peppylib` is deployed as a standalone local package, enabling improved dependency management.

* **Documentation**
  * Updated all Python project examples and initialization guides to reflect the new dependency structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->