### PR TITLE
Fix `node stop` targeting wildcard core nodes

### DIFF
--- a/crates/core-node-internal/src/services/node/remove.rs
+++ b/crates/core-node-internal/src/services/node/remove.rs
@@ -4,7 +4,9 @@ use config::node::Name;
 use core_node_api::encoding::{NodeRemoveRequest, NodeRemoveResponse};
 use node_stack::NodeStack;
 use peppylib::messaging::SenderTarget;
-use peppylib::messaging::{SHUTDOWN_SERVICE, ServiceMessenger, ServiceRequestContext};
+use peppylib::messaging::{
+    SHUTDOWN_SERVICE, ServiceMessenger, ServiceRequestContext, ServiceTarget,
+};
 use peppylib::types::Payload;
 use peppylib::{MessengerHandle, PeppyError, PeppyResult};
 use std::sync::Arc;
@@ -177,7 +179,7 @@ async fn handle_node_remove_request_inner(
                     core_instance_id,
                     SenderTarget::node_from_validated(&target.node_name, &target.node_tag),
                     SHUTDOWN_SERVICE,
-                    Some(&producer),
+                    ServiceTarget::Producer(&producer),
                 )
                 .await
             }
@@ -259,7 +261,7 @@ async fn handle_node_remove_request_inner(
                     core_instance_id,
                     SenderTarget::node_from_validated(&target.node_name, &target.node_tag),
                     SHUTDOWN_SERVICE,
-                    Some(&producer),
+                    ServiceTarget::Producer(&producer),
                     Payload::from_static(b"shutdown"),
                     SHUTDOWN_TIMEOUT,
                 )

--- a/crates/core-node-internal/src/services/node/run.rs
+++ b/crates/core-node-internal/src/services/node/run.rs
@@ -16,7 +16,8 @@ use peppylib::encoding::health::NodeHealthRequest;
 use peppylib::encoding::ready::NodeReadyRequest;
 use peppylib::messaging::SenderTarget;
 use peppylib::messaging::{
-    ActionFeedbackPublisher, ConcurrentAction, NODE_HEALTH_SERVICE, NODE_READY_SERVICE, PendingGoal,
+    ActionFeedbackPublisher, ConcurrentAction, NODE_HEALTH_SERVICE, NODE_READY_SERVICE,
+    PendingGoal, ServiceTarget,
 };
 use peppylib::types::Payload;
 use peppylib::{MessengerHandle, PeppyError, PeppyResult, ServiceMessenger};
@@ -1148,7 +1149,7 @@ async fn perform_health_check(
             target.caller_instance_id,
             SenderTarget::node_from_validated(target.to_node_name, target.to_node_tag),
             NODE_HEALTH_SERVICE,
-            Some(&peppylib::messaging::ProducerRef::new(
+            ServiceTarget::Producer(&peppylib::messaging::ProducerRef::new(
                 target.target_core_node,
                 target.target_instance_id,
             )),
@@ -1216,7 +1217,7 @@ async fn wait_for_ready_signal(
             target.caller_instance_id,
             SenderTarget::node_from_validated(target.to_node_name, target.to_node_tag),
             NODE_READY_SERVICE,
-            Some(&peppylib::messaging::ProducerRef::new(
+            ServiceTarget::Producer(&peppylib::messaging::ProducerRef::new(
                 target.target_core_node,
                 target.target_instance_id,
             )),
@@ -1302,7 +1303,7 @@ fn spawn_health_monitor(p: HealthMonitorParams) {
                 &p.caller_instance_id,
                 SenderTarget::node_from_validated(&p.to_node_name, &p.node_tag),
                 NODE_HEALTH_SERVICE,
-                Some(&peppylib::messaging::ProducerRef::new(
+                ServiceTarget::Producer(&peppylib::messaging::ProducerRef::new(
                     p.target_core_node.as_str(),
                     p.target_instance_id.as_str(),
                 )),

--- a/crates/core-node-internal/src/services/node/stop.rs
+++ b/crates/core-node-internal/src/services/node/stop.rs
@@ -4,7 +4,9 @@ use config::node::Name;
 use core_node_api::encoding::{NodeStopRequest, NodeStopResponse};
 use node_stack::NodeStack;
 use peppylib::messaging::SenderTarget;
-use peppylib::messaging::{SHUTDOWN_SERVICE, ServiceMessenger, ServiceRequestContext};
+use peppylib::messaging::{
+    SHUTDOWN_SERVICE, ServiceMessenger, ServiceRequestContext, ServiceTarget,
+};
 use peppylib::types::Payload;
 use peppylib::{MessengerHandle, PeppyError, PeppyResult};
 use std::sync::Arc;
@@ -245,7 +247,7 @@ async fn send_shutdown_signal(
         core_instance_id,
         SenderTarget::node(node_name, node_tag).map_err(|e| e.to_string())?,
         SHUTDOWN_SERVICE,
-        Some(&peppylib::messaging::ProducerRef::new(
+        ServiceTarget::Producer(&peppylib::messaging::ProducerRef::new(
             core_node_node,
             instance_id_str,
         )),

--- a/crates/core-node-internal/src/services/stack/benchmark.rs
+++ b/crates/core-node-internal/src/services/stack/benchmark.rs
@@ -36,7 +36,7 @@ use latency_report::stats::summarize;
 use node_stack::NodeStack;
 use peppylib::messaging::{
     CLOCK_OFFSET_SERVICE, ConcurrentAction, ConsumerFilter, NODE_HEALTH_SERVICE, PendingGoal,
-    SenderTarget,
+    SenderTarget, ServiceTarget,
 };
 use peppylib::types::Payload;
 use peppylib::{
@@ -858,7 +858,7 @@ async fn measure_probe(
                     &ctx.core_instance_id,
                     target.clone(),
                     service_name,
-                    None, // wildcard: the edge's producers all live on this daemon
+                    ServiceTarget::Any, // the edge's producers all live on this daemon
                     timeout,
                     request_size,
                     response_size,
@@ -925,7 +925,7 @@ async fn poll_producer_offset(
             &ctx.core_instance_id,
             target.clone(),
             CLOCK_OFFSET_SERVICE,
-            None, // wildcard: the node's clock_offset endpoint lives on this daemon
+            ServiceTarget::Any, // the node's clock_offset endpoint lives on this daemon
             request,
             timeout,
         )

--- a/crates/core-node-internal/tests/common.rs
+++ b/crates/core-node-internal/tests/common.rs
@@ -18,7 +18,7 @@ use core_node_api::encoding::{
 use gix_url::Url as GitUrl;
 use node_stack::NodeStack;
 use peppylib::messaging::{
-    ActionGoalHandle, MessengerHandle, ResultStatus, SenderTarget, TopicMessenger,
+    ActionGoalHandle, MessengerHandle, ResultStatus, SenderTarget, ServiceTarget, TopicMessenger,
 };
 use peppylib::runtime::{TaskHandle, spawn};
 use peppylib::services::health::listen_for_node_health;
@@ -61,7 +61,7 @@ async fn poll_datastore(started: &StartedCoreNode, service: &str, payload: Paylo
         CALLER_INSTANCE_ID,
         core_node_target(&started.core_node_name),
         service,
-        None, // discover the daemon's random per-boot service instance
+        ServiceTarget::Any, // discover the daemon's random per-boot service instance
         payload,
         Duration::from_secs(5),
     )
@@ -220,7 +220,7 @@ pub async fn wait_until_service_reachable(
             "ready_probe",
             test_node_target(to_node_name),
             to_service_name,
-            Some(&peppylib::messaging::ProducerRef::new(
+            ServiceTarget::Producer(&peppylib::messaging::ProducerRef::new(
                 target_core_node,
                 target_instance_id,
             )),
@@ -256,7 +256,7 @@ pub async fn assert_clock_round_trip(started: &StartedCoreNode) {
         CALLER_INSTANCE_ID,
         core_node_target(&started.core_node_name),
         names::CLOCK,
-        None, // discover the daemon's random per-boot service instance
+        ServiceTarget::Any, // discover the daemon's random per-boot service instance
         request_payload,
         Duration::from_secs(5),
     )

--- a/crates/core-node-internal/tests/latency/harness.rs
+++ b/crates/core-node-internal/tests/latency/harness.rs
@@ -31,7 +31,7 @@ use config::launcher::Name;
 use config::runtime::{NodeInstanceConfig, RuntimeConfig};
 use generator::LanguageGenerator;
 use peppylib::MessengerHandle;
-use peppylib::messaging::{SenderTarget, ServiceMessenger};
+use peppylib::messaging::{SenderTarget, ServiceMessenger, ServiceTarget};
 use peppylib::types::Payload;
 use tempfile::TempDir;
 
@@ -515,7 +515,7 @@ impl Scenario {
             HARNESS_INST,
             SenderTarget::node(DRIVER_NODE, TAG).expect("driver target"),
             BENCH_CONTROL_SERVICE,
-            Some(&peppylib::messaging::ProducerRef::new(CORE, DRIVER_INST)),
+            ServiceTarget::Producer(&peppylib::messaging::ProducerRef::new(CORE, DRIVER_INST)),
             Payload::from(request),
             CONTROL_TIMEOUT,
         )
@@ -604,7 +604,7 @@ pub async fn run_once(lang: Lang, transport: Transport, warmup: u64, iters: u64)
 const DRIVER_MAIN_RS: &str = r####"
 use peppygen::{NodeBuilder, Result};
 use peppylib::config::QoSProfile;
-use peppylib::messaging::{ConsumerFilter, SenderTarget, ServiceMessenger, Subscription, TopicMessenger};
+use peppylib::messaging::{ConsumerFilter, SenderTarget, ServiceMessenger, ServiceTarget, Subscription, TopicMessenger};
 use peppylib::types::Payload;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -657,7 +657,7 @@ async fn run_service(
             inst,
             SenderTarget::node(RESPONDER_NODE, TAG)?,
             "echo",
-            Some(&peppylib::messaging::ProducerRef::new(CORE, RESPONDER_INST)),
+            ServiceTarget::Producer(&peppylib::messaging::ProducerRef::new(CORE, RESPONDER_INST)),
             payload,
             RPC_TIMEOUT,
         )

--- a/crates/core-node-internal/tests/listen_for_info.rs
+++ b/crates/core-node-internal/tests/listen_for_info.rs
@@ -5,6 +5,7 @@ use config::consts::DEFAULT_MESSAGING_PORT;
 use core_node::names;
 use core_node_api::encoding::{InfoRequest, InfoResponse};
 use peppylib::ServiceMessenger;
+use peppylib::messaging::ServiceTarget;
 use std::time::Duration;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -21,7 +22,7 @@ async fn listen_for_info_success() {
         CALLER_INSTANCE_ID,
         common::core_node_target(&started.core_node_name),
         names::INFO,
-        None,
+        ServiceTarget::Any,
         request_payload,
         Duration::from_secs(5),
     )

--- a/crates/core-node-internal/tests/listen_for_node_stop.rs
+++ b/crates/core-node-internal/tests/listen_for_node_stop.rs
@@ -8,11 +8,13 @@ use common::{
     start_core_node_with_real_messenger, write_peppy_json5,
 };
 use config::node::Name;
-use core_node_api::encoding::NodeStopRequest;
+use core_node_api::encoding::{NodeStopRequest, NodeStopResponse};
+use core_node_api::names;
 use peppylib::core_node::transport::poll_node_stop;
-use peppylib::messaging::MessengerHandle;
+use peppylib::messaging::{MessengerHandle, ServiceMessenger};
 use peppylib::services::shutdown::listen_for_shutdown;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -425,5 +427,114 @@ async fn node_stop_reports_graceful_for_real_node_builder_node() {
     assert!(
         node_stack.find_by_instance_id(&instance_id).is_none(),
         "instance should be removed from the node stack after a graceful stop"
+    );
+}
+
+/// Regression for `node_stop` routing on a multi-daemon network: user node
+/// names are not unique across core nodes, so two `node_stop` listeners with
+/// the SAME node name + tag can coexist on DIFFERENT core nodes (the
+/// per-instance-listener case `node_stop` is hand-written for). The service
+/// root encodes only name + tag, so an unscoped discovery could be won by the
+/// foreign core node's listener — which would answer "unknown instance" while
+/// the right reply is dropped. `poll_node_stop` scopes its discovery to the
+/// caller's bound core node, so the foreign listener must never answer.
+///
+/// Before the scoping fix, each iteration was a discovery race the foreign
+/// listener (registered first, to bias the race against us) could win.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn node_stop_scoped_to_bound_core_node_ignores_foreign_listener() {
+    const NODE_NAME: &str = "camera";
+    const LOCAL_CORE_NODE: &str = "local_core_node";
+    const LOCAL_LISTENER_INSTANCE_ID: &str = "local_listener_instance";
+    const FOREIGN_CORE_NODE: &str = "foreign_core_node";
+    const FOREIGN_LISTENER_INSTANCE_ID: &str = "foreign_listener_instance";
+    const TARGET_INSTANCE_ID: &str = "doomed_instance";
+
+    // One mock messaging network shared by both core nodes and the caller —
+    // the multi-daemon topology where both listeners' queryables would match
+    // an unscoped `node_stop` selector.
+    let shared_messenger = common::create_mock_messenger().await;
+
+    // Foreign listener FIRST: same node name + tag as the local one, hosted
+    // by a different core node. It must never see a scoped request; if it
+    // ever answers, the distinctive failure below fails the assertions.
+    let foreign_hits = Arc::new(AtomicUsize::new(0));
+    let _foreign_listener = {
+        let handle = MessengerHandle::from_shared(Arc::clone(&shared_messenger));
+        let mut endpoint = ServiceMessenger::listen(
+            &handle,
+            FOREIGN_CORE_NODE,
+            FOREIGN_LISTENER_INSTANCE_ID,
+            common::test_node_target(NODE_NAME),
+            names::NODE_STOP,
+        )
+        .await
+        .expect("foreign node_stop listener should start");
+        let foreign_hits = Arc::clone(&foreign_hits);
+        AbortOnDrop(peppylib::runtime::spawn(async move {
+            endpoint
+                .handle_requests(move |_context| {
+                    foreign_hits.fetch_add(1, Ordering::SeqCst);
+                    async move {
+                        NodeStopResponse::failure(
+                            "foreign core node must never answer a scoped node_stop",
+                        )
+                        .encode()
+                        .map_err(Into::into)
+                    }
+                })
+                .await
+        }))
+    };
+
+    let _local_listener = {
+        let handle = MessengerHandle::from_shared(Arc::clone(&shared_messenger));
+        let mut endpoint = ServiceMessenger::listen(
+            &handle,
+            LOCAL_CORE_NODE,
+            LOCAL_LISTENER_INSTANCE_ID,
+            common::test_node_target(NODE_NAME),
+            names::NODE_STOP,
+        )
+        .await
+        .expect("local node_stop listener should start");
+        AbortOnDrop(peppylib::runtime::spawn(async move {
+            endpoint
+                .handle_requests(|_context| async move {
+                    NodeStopResponse::success().encode().map_err(Into::into)
+                })
+                .await
+        }))
+    };
+
+    // Allow both listeners to fully establish their queryables.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // Each iteration runs a fresh discover-then-pin sequence; without the
+    // bound-core-node scope the foreign listener could win any of them.
+    let caller_handle = MessengerHandle::from_shared(Arc::clone(&shared_messenger));
+    for i in 0..10 {
+        let response = poll_node_stop(
+            &NodeStopRequest::new(TARGET_INSTANCE_ID),
+            &caller_handle,
+            LOCAL_CORE_NODE,
+            CALLER_INSTANCE_ID,
+            common::test_node_target(NODE_NAME),
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("scoped node_stop request should complete");
+
+        assert!(
+            response.success,
+            "scoped node_stop #{i} was answered by the foreign core node: {:?}",
+            response.error_message
+        );
+    }
+
+    assert_eq!(
+        foreign_hits.load(Ordering::SeqCst),
+        0,
+        "the foreign core node's node_stop handler must never see a scoped request"
     );
 }

--- a/crates/core-node-internal/tests/listen_for_ping.rs
+++ b/crates/core-node-internal/tests/listen_for_ping.rs
@@ -4,6 +4,7 @@ use common::{CALLER_INSTANCE_ID, start_core_node_with_mock_messenger};
 use core_node::names;
 use core_node_api::encoding::{PingRequest, PingResponse};
 use peppylib::ServiceMessenger;
+use peppylib::messaging::ServiceTarget;
 use std::time::Duration;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -21,7 +22,7 @@ async fn listen_for_ping_roundtrip_succeed() {
         CALLER_INSTANCE_ID,
         common::core_node_target(&started.core_node_name),
         names::PING,
-        None,
+        ServiceTarget::Any,
         request_payload,
         Duration::from_secs(5),
     )

--- a/crates/core-node-internal/tests/sim_clock.rs
+++ b/crates/core-node-internal/tests/sim_clock.rs
@@ -12,6 +12,7 @@ use common::{CALLER_INSTANCE_ID, start_core_node_with_sim_clock};
 use config::node::QoSProfile;
 use core_node::names;
 use core_node_api::encoding::{ClockRequest, ClockResponse, ClockTick};
+use peppylib::messaging::ServiceTarget;
 use peppylib::{ServiceMessenger, TopicMessenger};
 use std::time::{Duration, Instant};
 
@@ -26,7 +27,7 @@ async fn sim_clock_service_returns_not_ready_until_first_tick() {
         CALLER_INSTANCE_ID,
         common::core_node_target(&started.core_node_name),
         names::CLOCK,
-        None,
+        ServiceTarget::Any,
         request_payload,
         Duration::from_secs(2),
     )
@@ -81,7 +82,7 @@ async fn sim_clock_service_serves_external_tick_after_publish() {
             CALLER_INSTANCE_ID,
             common::core_node_target(&started.core_node_name),
             names::CLOCK,
-            None,
+            ServiceTarget::Any,
             request_payload,
             attempt_timeout,
         )

--- a/crates/generator-internal/src/generator/rust.rs
+++ b/crates/generator-internal/src/generator/rust.rs
@@ -1262,11 +1262,13 @@ impl LanguageGenerator for RustGenerator {
         // The `to_target` matches the producer's emission shape: if the
         // dependency exposes the service via `conforms_to`, address it as the
         // interface; otherwise as the dependency's node identity. The
-        // `target` — the producer's full `(core_node, instance_id)` — is
-        // resolved at runtime from the consumer's binding map; pinned slots
-        // address it directly and skip discovery.
+        // `target` — the producer scope, resolved at runtime from the
+        // consumer's binding map — pins the full `(core_node, instance_id)`
+        // for bound slots (no discovery) and falls back to
+        // `ServiceTarget::Any` otherwise.
         let to_target_expr = consumed_to_target_expression(dependency);
-        let target_expr = crate::generator::rust::topics::consumed_target_expression(dependency);
+        let target_expr =
+            crate::generator::rust::topics::consumed_service_target_expression(dependency);
         let poll_call = quote! {
             peppylib::ServiceMessenger::poll(
                 node_runner.messenger(),

--- a/crates/generator-internal/src/generator/rust/tests/services.rs
+++ b/crates/generator-internal/src/generator/rust/tests/services.rs
@@ -272,10 +272,9 @@ fn consumed_service() {
 
     // Poll function signature. The fixture's `DependencyContext::native`
     // defaults to `WireLinkId::wildcard()` (no manifest link_id), so the
-    // poll call splices a typed
-    // `Option::<&peppylib::messaging::ProducerRef>::None` at the single
-    // target slot and the user-facing `target_instance_id` parameter is
-    // gone. `target_core_node` is never exposed in the generated API.
+    // poll call splices `peppylib::messaging::ServiceTarget::Any` at the
+    // single target slot and the user-facing `target_instance_id` parameter
+    // is gone. `target_core_node` is never exposed in the generated API.
     assert_contains_all(
         &rendered,
         &["pub async fn poll(", "-> crate::Result<Response>"],
@@ -289,14 +288,15 @@ fn consumed_service() {
         "target_core_node should not appear in the generated API; got: {rendered}"
     );
 
-    // Request serialization and messenger integration, including the typed
-    // `None` spliced at the poll call's single target slot.
+    // Request serialization and messenger integration, including the
+    // wildcard `ServiceTarget::Any` spliced at the poll call's single
+    // target slot.
     assert_contains_all(
         &rendered,
         &[
             "root.set_enable(enable);",
             "peppylib::ServiceMessenger::poll(",
-            "Option::<&peppylib::messaging::ProducerRef>::None,",
+            "peppylib::messaging::ServiceTarget::Any,",
             "fn deserialize_response(payload: &[u8]) -> crate::Result<ResponseData>",
         ],
     );

--- a/crates/generator-internal/src/generator/rust/topics.rs
+++ b/crates/generator-internal/src/generator/rust/topics.rs
@@ -273,7 +273,6 @@ pub fn consumed_consumer_filter_expression(
 }
 
 /// Returns the `Option<&ProducerRef>` expression spliced into a generated
-/// [`peppylib::ServiceMessenger::poll`] /
 /// [`peppylib::ActionMessenger::send_goal`] call at the single `target`
 /// slot. When `dependency.wire_link_id()` is `Some(link_id)` — i.e., any
 /// real manifest dep, whether pinned or `from_any` — the emitted
@@ -293,6 +292,36 @@ pub fn consumed_target_expression(
             quote!(node_runner.processor().consumer_filter(#literal).pinned_target())
         }
         None => quote!(Option::<&peppylib::messaging::ProducerRef>::None),
+    }
+}
+
+/// Returns the `peppylib::messaging::ServiceTarget` expression spliced into
+/// a generated [`peppylib::ServiceMessenger::poll`] call at the `target`
+/// slot. Same producer-resolution rules as [`consumed_target_expression`],
+/// mapped onto the service target enum: a pinned slot (or a `from_any` slot
+/// bound to a single producer) resolves to `ServiceTarget::Producer` and
+/// the call addresses it directly with no discovery; other variants
+/// (multi-pin, wildcards) give `ServiceTarget::Any` and the call site falls
+/// back to wildcard discovery. Synthetic test fixtures with no manifest dep
+/// skip the lookup and emit `ServiceTarget::Any` directly.
+pub fn consumed_service_target_expression(
+    dependency: &crate::generator::types::DependencyContext,
+) -> TokenStream {
+    match dependency.wire_link_id() {
+        Some(link_id) => {
+            let literal = Literal::string(link_id);
+            quote! {
+                node_runner
+                    .processor()
+                    .consumer_filter(#literal)
+                    .pinned_target()
+                    .map_or(
+                        peppylib::messaging::ServiceTarget::Any,
+                        peppylib::messaging::ServiceTarget::Producer,
+                    )
+            }
+        }
+        None => quote!(peppylib::messaging::ServiceTarget::Any),
     }
 }
 

--- a/crates/generator-internal/tests/helpers.rs
+++ b/crates/generator-internal/tests/helpers.rs
@@ -7,6 +7,7 @@ use config::consts::{
 use config::node::PeppygenLanguage;
 use generator::generate_peppygen_lib;
 use peppylib::messaging::SenderTarget;
+use peppylib::messaging::ServiceTarget;
 use peppylib::messaging::{ActionMessenger, NODE_HEALTH_SERVICE, SHUTDOWN_SERVICE};
 use peppylib::{MessengerHandle, ServiceMessenger};
 use std::io::Read;
@@ -657,7 +658,9 @@ pub async fn wait_for_service_reachable_or_exit(
             ctx.caller_instance_id,
             test_node_target(to_node_name),
             to_service_name,
-            target.as_ref(),
+            target
+                .as_ref()
+                .map_or(ServiceTarget::Any, ServiceTarget::Producer),
         )
         .await
         .unwrap_or_else(|err| {
@@ -804,7 +807,7 @@ pub async fn send_shutdown(
         sender_instance_id,
         test_node_target(to_node_name),
         SHUTDOWN_SERVICE,
-        Some(&peppylib::messaging::ProducerRef::new(
+        ServiceTarget::Producer(&peppylib::messaging::ProducerRef::new(
             target_core_node,
             target_instance_id,
         )),
@@ -838,7 +841,7 @@ pub async fn try_send_shutdown(
         sender_instance_id,
         test_node_target(to_node_name),
         SHUTDOWN_SERVICE,
-        Some(&peppylib::messaging::ProducerRef::new(
+        ServiceTarget::Producer(&peppylib::messaging::ProducerRef::new(
             target_core_node,
             target_instance_id,
         )),

--- a/crates/peppylib-py/src/messaging/services.rs
+++ b/crates/peppylib-py/src/messaging/services.rs
@@ -1,5 +1,5 @@
 use peppylib::ServiceMessenger;
-use peppylib::messaging::{ServiceEndpoint, ServiceRequestContext};
+use peppylib::messaging::{ServiceEndpoint, ServiceRequestContext, ServiceTarget};
 use peppylib::types::Payload;
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
@@ -221,7 +221,9 @@ impl PyServiceMessenger {
                 &as_instance_id,
                 to_target,
                 &to_service_name,
-                target.as_ref(),
+                target
+                    .as_ref()
+                    .map_or(ServiceTarget::Any, ServiceTarget::Producer),
             )
             .await
             .map_err(to_py_err)?;
@@ -261,7 +263,9 @@ impl PyServiceMessenger {
                 &as_instance_id,
                 to_target,
                 &to_service_name,
-                target.as_ref(),
+                target
+                    .as_ref()
+                    .map_or(ServiceTarget::Any, ServiceTarget::Producer),
                 Payload::from(request_payload),
                 response_timeout,
             )

--- a/crates/peppylib/src/core_node/transport.rs
+++ b/crates/peppylib/src/core_node/transport.rs
@@ -17,18 +17,22 @@ use core_node_api::encoding::*;
 use core_node_api::names;
 
 use crate::error::Result;
-use crate::messaging::{ActionGoalHandle, SenderTarget};
+use crate::messaging::{ActionGoalHandle, SenderTarget, ServiceTarget};
 use crate::{ActionMessenger, MessengerHandle, ServiceMessenger};
 
 /// Routing parameters for a single service poll. Bundled into a struct so
 /// [`poll_core_node_service`] doesn't need a `clippy::too_many_arguments`
 /// escape hatch — the helper otherwise reaches 9 positional args.
 ///
-/// Control-plane calls always discover (`target: None` at the messenger):
+/// Control-plane calls always discover (no producer pin at the messenger):
 /// the daemon's services listen under a random per-boot instance_id no
 /// caller can know up front, and the daemon stays addressed through
 /// `to_target` (its identity rides in the service root), so discovery
-/// resolves exactly that daemon's endpoint.
+/// resolves exactly that daemon's endpoint. The exception is `node_stop`,
+/// whose listener may be hosted by a per-instance node: user node names
+/// are not unique across daemons, so its service root cannot pin the
+/// route by itself and the discovery is additionally scoped to the
+/// caller's bound core node (`ServiceTarget::CoreNode`).
 struct ServiceRoute<'a> {
     messenger: &'a MessengerHandle,
     bound_core_node: &'a str,
@@ -38,6 +42,10 @@ struct ServiceRoute<'a> {
     /// services (e.g. `node_stop`) it carries the target node's name+tag.
     to_target: SenderTarget,
     service_name: &'a str,
+    /// Producer scope of the discovery. `ServiceTarget::Any` for daemon
+    /// services (the service root already pins the route); `node_stop`
+    /// narrows it to the bound core node, see the struct doc.
+    target: ServiceTarget<'a>,
 }
 
 /// Routing parameters for a single goal send. Same rationale as
@@ -65,7 +73,7 @@ async fn poll_core_node_service<Response>(
         route.as_instance_id,
         route.to_target,
         route.service_name,
-        None,
+        route.target,
         request_payload,
         response_timeout,
     )
@@ -112,6 +120,7 @@ macro_rules! poll_service {
                     as_instance_id,
                     to_target: SenderTarget::node(to_core_node, names::CORE_NODE_TAG)?,
                     service_name: $service,
+                    target: ServiceTarget::Any,
                 },
                 request.encode()?,
                 <$resp>::decode,
@@ -178,6 +187,15 @@ send_goal!(pub send_stack_benchmark, StackBenchmarkGoal, names::STACK_BENCHMARK_
 /// per-instance node rather than the daemon, so it routes by an explicit
 /// `to_target` (name + tag) instead of defaulting to the daemon's core_node
 /// identity. Hand-written for that reason.
+///
+/// User node names are not unique across daemons, so the `to_target`
+/// service root alone cannot pin the route: on a multi-daemon network a
+/// wildcard discovery could be won by a same-named listener on a foreign
+/// core node, which would answer "unknown instance" while the right reply
+/// is dropped. The discovery is therefore scoped to `bound_core_node` —
+/// the caller stops an instance through the daemon it is bound to, so its
+/// bound core node is the correct scope for both daemon-hosted and
+/// per-instance listeners.
 pub async fn poll_node_stop(
     request: &NodeStopRequest,
     messenger: &MessengerHandle,
@@ -193,6 +211,7 @@ pub async fn poll_node_stop(
             as_instance_id,
             to_target,
             service_name: names::NODE_STOP,
+            target: ServiceTarget::CoreNode(bound_core_node),
         },
         request.encode()?,
         NodeStopResponse::decode,

--- a/crates/peppylib/src/messaging.rs
+++ b/crates/peppylib/src/messaging.rs
@@ -13,7 +13,9 @@ pub use actions::{
     encode_cancel_ack, generate_goal_id, unwrap_goal_payload, unwrap_result_outcome,
     wrap_goal_payload, wrap_result_outcome,
 };
-pub use services::{ServiceEndpoint, ServiceMessenger, ServiceRequestContext, ServiceResponder};
+pub use services::{
+    ServiceEndpoint, ServiceMessenger, ServiceRequestContext, ServiceResponder, ServiceTarget,
+};
 pub use topics::{Subscription, TopicMessenger, TopicPublisher};
 
 mod filter;

--- a/crates/peppylib/src/messaging/services.rs
+++ b/crates/peppylib/src/messaging/services.rs
@@ -46,6 +46,61 @@ async fn deliver_outcome(responder: ServiceResponder, outcome: HandlerOutcome) -
 
 pub struct ServiceMessenger;
 
+/// Producer scope of a [`ServiceMessenger::poll`] / [`ServiceMessenger::is_reachable`]
+/// / [`ServiceMessenger::probe_latency`] call: how much of the producer's
+/// `(core_node, instance_id)` wire address the caller pins up front. Maps
+/// onto [`ServiceWireSender`]'s two independent target slots; an enum rather
+/// than two `Option`s so the invalid "instance without core" half-address is
+/// unrepresentable.
+#[derive(Debug, Clone, Copy)]
+pub enum ServiceTarget<'a> {
+    /// Genuine wildcard: any producer whose service root matches answers.
+    /// `poll` runs a discover-then-pin sequence so only one producer's user
+    /// handler ever sees the request.
+    Any,
+    /// Scope to producers hosted by this core node, leaving the instance
+    /// slot wildcarded. For callers that know which core node must answer
+    /// but cannot know the producer's per-boot instance_id — e.g.
+    /// `node_stop`, whose service root (node name + tag) is not unique
+    /// across daemons. `poll` still discovers, but only among that core
+    /// node's producers.
+    CoreNode(&'a str),
+    /// Full `(core_node, instance_id)` pin: addresses that producer
+    /// directly, no discovery probe and no discovery timeout.
+    Producer(&'a ProducerRef),
+}
+
+impl ServiceTarget<'_> {
+    /// Builds the wire sender for this scope, mapping the enum onto
+    /// [`ServiceWireSender`]'s two target slots:
+    /// `Any` → `(None, None)`, `CoreNode` → `(Some, None)`,
+    /// `Producer` → `(Some, Some)`.
+    fn wire_sender(
+        &self,
+        bound_core_node: &str,
+        as_instance_id: &str,
+        to_target: SenderTarget,
+        to_service_name: &str,
+    ) -> Result<ServiceWireSender> {
+        let pinned = match self {
+            ServiceTarget::Producer(producer) => Some(*producer),
+            ServiceTarget::Any | ServiceTarget::CoreNode(_) => None,
+        };
+        let sender = ServiceWireSender::new(
+            bound_core_node,
+            as_instance_id,
+            pinned,
+            to_target,
+            to_service_name,
+            ServiceKind::Service,
+        )?;
+        match self {
+            ServiceTarget::CoreNode(core_node) => Ok(sender.scoped_to_core_node(core_node)?),
+            ServiceTarget::Any | ServiceTarget::Producer(_) => Ok(sender),
+        }
+    }
+}
+
 /// Server-side endpoint for a single service. Wraps the per-link-id queryable
 /// fan-in produced by [`pmi::MessengerBackend::listen_service`]: each inbound
 /// request carries its own [`ResponseToken`], so responding no longer needs
@@ -324,16 +379,19 @@ impl ServiceMessenger {
     /// producers advertise under the reserved `_` segment and Zenoh's
     /// matcher unifies the two.
     ///
-    /// `target` is the producer's full `(core_node, instance_id)` wire
-    /// address. `Some(target)` — a pinned slot, or a `from_any` slot
+    /// `target` scopes which producer answers.
+    /// [`ServiceTarget::Producer`] — a pinned slot, or a `from_any` slot
     /// bound to exactly one producer — addresses that producer directly:
     /// **no discovery probe is issued and no discovery timeout applies**;
     /// the call has the caller's whole `response_timeout` to itself.
-    /// `None` is a genuine wildcard (`from_any`): a discover-then-pin
-    /// sequence sends a lightweight probe to identify a single responding
-    /// producer, then delivers the real request pinned to it. The probe
-    /// is answered by the transport adapter before the user handler runs,
-    /// so non-winning producers never see the request.
+    /// [`ServiceTarget::Any`] is a genuine wildcard (`from_any`): a
+    /// discover-then-pin sequence sends a lightweight probe to identify a
+    /// single responding producer, then delivers the real request pinned
+    /// to it. The probe is answered by the transport adapter before the
+    /// user handler runs, so non-winning producers never see the request.
+    /// [`ServiceTarget::CoreNode`] discovers the same way, but the probe's
+    /// selector is scoped to that core node, so producers hosted elsewhere
+    /// can never win the pin even when their service root matches.
     ///
     /// `to_target` must match the [`SenderTarget`] the responder used in
     /// [`Self::listen`].
@@ -344,7 +402,7 @@ impl ServiceMessenger {
         as_instance_id: &str,
         to_target: SenderTarget,
         to_service_name: &str,
-        target: Option<&ProducerRef>,
+        target: ServiceTarget<'_>,
         request_payload: Payload,
         response_timeout: impl Into<Option<Duration>>,
     ) -> Result<Message> {
@@ -352,15 +410,13 @@ impl ServiceMessenger {
 
         let started_at = Instant::now();
         let resolved: ProducerRef = match target {
-            Some(producer) => producer.clone(),
-            None => {
-                let probe_sender = ServiceWireSender::new(
+            ServiceTarget::Producer(producer) => producer.clone(),
+            ServiceTarget::Any | ServiceTarget::CoreNode(_) => {
+                let probe_sender = target.wire_sender(
                     bound_core_node,
                     as_instance_id,
-                    None,
                     to_target.clone(),
                     to_service_name,
-                    ServiceKind::Service,
                 )?;
                 // Discovery is capped at DISCOVERY_TIMEOUT or the caller's
                 // response budget, whichever is shorter; a tight
@@ -392,13 +448,11 @@ impl ServiceMessenger {
             None => None,
         };
 
-        let sender = ServiceWireSender::new(
+        let sender = ServiceTarget::Producer(&resolved).wire_sender(
             bound_core_node,
             as_instance_id,
-            Some(&resolved),
             to_target,
             to_service_name,
-            ServiceKind::Service,
         )?;
         messenger
             .poll_service(
@@ -410,9 +464,9 @@ impl ServiceMessenger {
             .await
     }
 
-    /// Sends a lightweight probe to check whether a service is listening at
-    /// the targeted producer (`Some` = a full `(core_node, instance_id)`
-    /// pin, `None` = any matching producer). The probe is answered by the
+    /// Sends a lightweight probe to check whether a service is listening
+    /// within the [`ServiceTarget`] scope (a full producer pin, one core
+    /// node, or any matching producer). The probe is answered by the
     /// transport adapter; the user handler is never invoked. Returns
     /// `true` if the service responds within [`PROBE_TIMEOUT`], `false` if
     /// unreachable.
@@ -427,16 +481,10 @@ impl ServiceMessenger {
         as_instance_id: &str,
         to_target: SenderTarget,
         to_service_name: &str,
-        target: Option<&ProducerRef>,
+        target: ServiceTarget<'_>,
     ) -> Result<bool> {
-        let sender = ServiceWireSender::new(
-            bound_core_node,
-            as_instance_id,
-            target,
-            to_target,
-            to_service_name,
-            ServiceKind::Service,
-        )?;
+        let sender =
+            target.wire_sender(bound_core_node, as_instance_id, to_target, to_service_name)?;
         match messenger
             .poll_service(
                 &sender,
@@ -479,19 +527,13 @@ impl ServiceMessenger {
         as_instance_id: &str,
         to_target: SenderTarget,
         to_service_name: &str,
-        target: Option<&ProducerRef>,
+        target: ServiceTarget<'_>,
         response_timeout: Duration,
         request_size: usize,
         response_size: u32,
     ) -> Result<(Duration, usize)> {
-        let sender = ServiceWireSender::new(
-            bound_core_node,
-            as_instance_id,
-            target,
-            to_target,
-            to_service_name,
-            ServiceKind::Service,
-        )?;
+        let sender =
+            target.wire_sender(bound_core_node, as_instance_id, to_target, to_service_name)?;
         let request = Payload::from(pmi::build_sized_probe_request(request_size, response_size));
         let started = Instant::now();
         let reply = messenger

--- a/crates/peppylib/src/messaging/tests.rs
+++ b/crates/peppylib/src/messaging/tests.rs
@@ -11,7 +11,7 @@ use tokio::sync::oneshot;
 use crate::error::Error;
 use crate::messaging::{
     ActionMessenger, ConsumerFilter, MessengerHandle, ProducerRef, ResultStatus, SenderTarget,
-    ServiceMessenger, TopicMessenger,
+    ServiceMessenger, ServiceTarget, TopicMessenger,
 };
 
 /// Builds a node-shaped [`SenderTarget`] with the standard test tag. Panics on
@@ -893,7 +893,7 @@ async fn service_communication_poll_no_instance_id_target() {
             CALLER_INSTANCE_ID,
             test_node_target(listener_node_name),
             listener_service_name,
-            None, // Fully wildcard: we don't pin any target producer
+            ServiceTarget::Any, // Fully wildcard: we don't pin any target producer
             request_payload.clone(),
             Duration::from_secs(2),
         )
@@ -1076,7 +1076,7 @@ async fn service_communication_poll_specific_instance_id() {
             test_node_target(listener_node_name),
             listener_service_name,
             // We pin listener 2's producer as the target
-            Some(&ProducerRef::new(
+            ServiceTarget::Producer(&ProducerRef::new(
                 listener_core_node2,
                 listener_instance_id2,
             )),
@@ -1204,7 +1204,7 @@ async fn service_communication_poll_wrong_node() {
                 test_node_target(listener_node_name),
                 listener_service_name,
                 // Use a wrong instance_id here (the core_node is the real one)
-                Some(&ProducerRef::new(listener_core_node, "wrong_node")),
+                ServiceTarget::Producer(&ProducerRef::new(listener_core_node, "wrong_node")),
                 request_payload.clone(),
                 Duration::from_secs(1),
             )
@@ -1346,7 +1346,7 @@ async fn service_communication_poll_wrong_core_node() {
             test_node_target(listener_node_name),
             listener_service_name,
             // Pin a producer on the wrong core_node (the instance_id is the real one)
-            Some(&ProducerRef::new("wrong_core_node", listener_instance_id)),
+            ServiceTarget::Producer(&ProducerRef::new("wrong_core_node", listener_instance_id)),
             request_payload.clone(),
             Duration::from_millis(200),
         )
@@ -1394,6 +1394,116 @@ async fn service_communication_poll_wrong_core_node() {
         .expect("router shutdown timed out");
 }
 
+/// `ServiceTarget::CoreNode` scopes discovery to one core node: with two
+/// listeners exposing the SAME service shape (same node name + tag + service)
+/// on DIFFERENT core nodes, a core-node-scoped poll must always be answered
+/// by the listener on that core node — the foreign one can never win the
+/// discovery probe because the scoped selector never matches its queryable.
+/// With `ServiceTarget::Any` this would be a wire-level race either listener
+/// could win (see `service_communication_poll_no_instance_id_target`).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn service_communication_poll_core_node_scoped() {
+    let router = TestRouterContext::start().await;
+
+    let listener_node_name = "camera";
+    let listener_service_name = "enable_camera";
+
+    const CALLER_INSTANCE_ID: &str = "caller_instance";
+    const CALLER_CORE_NODE: &str = "caller_core_node";
+
+    let request_payload = Payload::from_static(b"enable=true");
+    let foreign_call_count = Arc::new(AtomicUsize::new(0));
+
+    // The foreign listener is registered FIRST so that, without scoping, it
+    // would be at least as likely to win the discovery race as the scoped one.
+    let foreign_core_node = "foreign_core_node";
+    let foreign_instance_id = "foreign_instance";
+    let foreign_task = {
+        let service_expose_handle = router.messenger().await;
+        let mut service = ServiceMessenger::listen(
+            &service_expose_handle,
+            foreign_core_node,
+            foreign_instance_id,
+            test_node_target(listener_node_name),
+            listener_service_name,
+        )
+        .await
+        .expect("foreign service should start");
+
+        let foreign_call_count = Arc::clone(&foreign_call_count);
+        tokio::spawn(async move {
+            service
+                .handle_requests(|_request| {
+                    foreign_call_count.fetch_add(1, Ordering::SeqCst);
+                    async move { Ok(Payload::from_static(b"foreign")) }
+                })
+                .await
+        })
+    };
+
+    let scoped_core_node = "scoped_core_node";
+    let scoped_instance_id = "scoped_instance";
+    let scoped_task = {
+        let service_expose_handle = router.messenger().await;
+        let mut service = ServiceMessenger::listen(
+            &service_expose_handle,
+            scoped_core_node,
+            scoped_instance_id,
+            test_node_target(listener_node_name),
+            listener_service_name,
+        )
+        .await
+        .expect("scoped service should start");
+
+        tokio::spawn(async move {
+            service
+                .handle_requests(|_request| async move { Ok(Payload::from_static(b"scoped")) })
+                .await
+        })
+    };
+
+    // Allow both services to fully establish their listeners
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // Each iteration runs a fresh discover-then-pin sequence; without the
+    // core-node scope the foreign listener would win some of these races.
+    let caller_handle = router.messenger().await;
+    for i in 0..10 {
+        let response = ServiceMessenger::poll(
+            &caller_handle,
+            CALLER_CORE_NODE,
+            CALLER_INSTANCE_ID,
+            test_node_target(listener_node_name),
+            listener_service_name,
+            ServiceTarget::CoreNode(scoped_core_node),
+            request_payload.clone(),
+            Duration::from_secs(2),
+        )
+        .await
+        .expect("scoped poll should receive a response");
+
+        assert_eq!(
+            response.core_node(),
+            scoped_core_node,
+            "scoped poll #{i} was answered by a foreign core node"
+        );
+        assert_eq!(response.instance_id(), scoped_instance_id);
+        assert_eq!(response.payload(), &Payload::from_static(b"scoped"));
+    }
+
+    assert_eq!(
+        foreign_call_count.load(Ordering::SeqCst),
+        0,
+        "the foreign core node's handler must never see a scoped request"
+    );
+
+    foreign_task.abort();
+    scoped_task.abort();
+    tokio::time::timeout(Duration::from_secs(2), router.shutdown())
+        .await
+        .expect("router shutdown timed out");
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn service_communication_fails_service_not_started() {
     let router = TestRouterContext::start().await;
@@ -1416,7 +1526,7 @@ async fn service_communication_fails_service_not_started() {
             CALLER_INSTANCE_ID,
             test_node_target(listener_node_name),
             listener_service_name,
-            None,
+            ServiceTarget::Any,
             Payload::from_static(b"enable=true"),
             Duration::from_secs(1),
         )
@@ -1506,7 +1616,7 @@ async fn sized_probe_gets_sized_reply_without_running_the_handler() {
             CALLER_INSTANCE_ID,
             test_node_target(listener_node_name),
             listener_service_name,
-            None,
+            ServiceTarget::Any,
             Duration::from_secs(5),
             128, // request_size
             256, // response_size
@@ -1661,7 +1771,7 @@ async fn service_communication_fails_service_timeouts() {
             CALLER_INSTANCE_ID,
             test_node_target(listener_node_name),
             listener_service_name,
-            None,
+            ServiceTarget::Any,
             request_payload.clone(),
             caller_success_timeout,
         )
@@ -1680,7 +1790,7 @@ async fn service_communication_fails_service_timeouts() {
             CALLER_INSTANCE_ID,
             test_node_target(listener_node_name),
             listener_service_name,
-            None,
+            ServiceTarget::Any,
             request_payload,
             caller_failure_timeout,
         )
@@ -1804,7 +1914,10 @@ async fn service_handle_request_processes_multiple_messages() {
                 CALLER_INSTANCE_ID,
                 test_node_target(listener_node_name),
                 listener_service_name,
-                Some(&ProducerRef::new(listener_core_node, listener_instance_id)),
+                ServiceTarget::Producer(&ProducerRef::new(
+                    listener_core_node,
+                    listener_instance_id,
+                )),
                 request_payload.clone(),
                 Duration::from_secs(5),
             )
@@ -1949,7 +2062,10 @@ async fn single_service_communication_multiple_polls_and_callers() {
                         &caller_id,
                         test_node_target(listener_node_name),
                         listener_service_name,
-                        Some(&ProducerRef::new(listener_core_node, listener_instance_id)),
+                        ServiceTarget::Producer(&ProducerRef::new(
+                            listener_core_node,
+                            listener_instance_id,
+                        )),
                         request_payload.clone(),
                         Duration::from_secs(5),
                     )
@@ -3391,7 +3507,7 @@ async fn service_communication_poll_full_wildcard_discovers() {
             CALLER_INSTANCE_ID,
             test_node_target(listener_node_name),
             listener_service_name,
-            None, // full-wildcard target — must trigger discovery
+            ServiceTarget::Any, // full-wildcard target — must trigger discovery
             request_payload.clone(),
             Duration::from_secs(1),
         )
@@ -3647,7 +3763,7 @@ async fn service_poll_same_core_distinct_instances_pinned_routes_to_pinned() {
             test_node_target(node_name),
             service_name,
             // fully pinned: no discovery probe is issued
-            Some(&ProducerRef::new(shared_core, pinned_inst)),
+            ServiceTarget::Producer(&ProducerRef::new(shared_core, pinned_inst)),
             Payload::from_static(b"mode=position"),
             Duration::from_secs(2),
         )
@@ -3748,7 +3864,7 @@ async fn service_poll_same_core_pinned_producer_busy_waits_caller_budget() {
         test_node_target(node_name),
         service_name,
         // fully pinned: no discovery probe is issued
-        Some(&ProducerRef::new(shared_core, left_inst)),
+        ServiceTarget::Producer(&ProducerRef::new(shared_core, left_inst)),
         Payload::from_static(b"mode=position"),
         caller_budget,
     )
@@ -4176,7 +4292,7 @@ async fn pinned_calls_issue_zero_probes() {
         test_node_target(node_name),
         pinned_service_name,
         // fully pinned: must issue zero discovery probes
-        Some(&pinned),
+        ServiceTarget::Producer(&pinned),
         Payload::from_static(b"enable=true"),
         Duration::from_secs(5),
     )
@@ -4270,7 +4386,7 @@ async fn pinned_calls_issue_zero_probes() {
         "caller_instance",
         test_node_target(node_name),
         control_service_name,
-        None, // full wildcard: discover-then-pin must probe
+        ServiceTarget::Any, // full wildcard: discover-then-pin must probe
         Payload::from_static(b"enable=true"),
         Duration::from_secs(5),
     )
@@ -4571,7 +4687,7 @@ async fn probes_answered_while_pinned_producer_is_busy() {
         "caller_instance",
         test_node_target(node_name),
         service_name,
-        None,
+        ServiceTarget::Any,
     )
     .await
     .expect("is_reachable should not error");
@@ -4592,7 +4708,7 @@ async fn probes_answered_while_pinned_producer_is_busy() {
         "caller_instance",
         test_node_target(node_name),
         service_name,
-        None,
+        ServiceTarget::Any,
         Duration::from_secs(2),
         64,   // request_size
         4096, // response_size
@@ -4612,7 +4728,7 @@ async fn probes_answered_while_pinned_producer_is_busy() {
         "caller_instance",
         test_node_target(node_name),
         service_name,
-        Some(&ProducerRef::new(busy_core, busy_inst)),
+        ServiceTarget::Producer(&ProducerRef::new(busy_core, busy_inst)),
         Payload::from_static(b"enable=true"),
         Duration::from_secs(10),
     )

--- a/crates/peppylib/tests/core_node/common.rs
+++ b/crates/peppylib/tests/core_node/common.rs
@@ -8,7 +8,7 @@ use std::time::{Duration, Instant};
 
 use core_node_api::names;
 use peppylib::messaging::SenderTarget;
-use peppylib::messaging::{MessengerHandle, ProducerRef, ServiceMessenger};
+use peppylib::messaging::{MessengerHandle, ProducerRef, ServiceMessenger, ServiceTarget};
 use peppylib::runtime::{NodeRunner, Processor, StandaloneConfig};
 use pmi::{ZenohAdapter, ZenohdInstance};
 use tempfile::TempDir;
@@ -52,7 +52,7 @@ pub(crate) async fn wait_until_reachable(client: &MessengerHandle, service_name:
             CLIENT_INSTANCE,
             test_node_target(CORE_NODE),
             service_name,
-            Some(&ProducerRef::new(CORE_NODE, SERVER_INSTANCE)),
+            ServiceTarget::Producer(&ProducerRef::new(CORE_NODE, SERVER_INSTANCE)),
         )
         .await
         .expect("reachability check should succeed")

--- a/crates/peppylib/tests/node_health_service.rs
+++ b/crates/peppylib/tests/node_health_service.rs
@@ -6,7 +6,7 @@ use common::{
 };
 use peppylib::{
     encoding::health::{NodeHealthRequest, NodeHealthResponse},
-    messaging::{MessengerHandle, ProducerRef, ServiceMessenger},
+    messaging::{MessengerHandle, ProducerRef, ServiceMessenger, ServiceTarget},
     services::health::listen_for_node_health,
 };
 use std::sync::Arc;
@@ -42,7 +42,7 @@ async fn node_health_request_response_roundtrip() {
         CALLER_INSTANCE_ID,
         test_node_target(TEST_NODE_NAME),
         peppylib::messaging::NODE_HEALTH_SERVICE,
-        Some(&ProducerRef::new(
+        ServiceTarget::Producer(&ProducerRef::new(
             client.core_node_name.as_str(),
             client.instance_id.as_str(),
         )),

--- a/crates/peppylib/tests/ready_node.rs
+++ b/crates/peppylib/tests/ready_node.rs
@@ -5,7 +5,7 @@ use common::{
     test_node_target,
 };
 use peppylib::{
-    messaging::{MessengerHandle, ProducerRef, ServiceMessenger},
+    messaging::{MessengerHandle, ProducerRef, ServiceMessenger, ServiceTarget},
     services::ready::listen_for_node_ready,
     types::Payload,
 };
@@ -36,7 +36,7 @@ async fn ready_node() {
     // - fully pinned producer (core_node + instance_id)
     // - full broadcast (no target producer)
     let pinned = ProducerRef::new(client.core_node_name.as_str(), client.instance_id.as_str());
-    let to_combinations = [Some(&pinned), None];
+    let to_combinations = [ServiceTarget::Producer(&pinned), ServiceTarget::Any];
 
     for target in to_combinations {
         let response = ServiceMessenger::poll(

--- a/crates/peppylib/tests/runner.rs
+++ b/crates/peppylib/tests/runner.rs
@@ -5,7 +5,9 @@ use config::consts::PEPPYGEN_OUTPUT_PATH;
 use config::launcher::Name;
 use config::runtime::{NodeInstanceConfig, RuntimeConfig};
 use peppylib::encoding::health::{NodeHealthRequest, NodeHealthResponse};
-use peppylib::messaging::{NODE_HEALTH_SERVICE, NODE_READY_SERVICE, ProducerRef, SHUTDOWN_SERVICE};
+use peppylib::messaging::{
+    NODE_HEALTH_SERVICE, NODE_READY_SERVICE, ProducerRef, SHUTDOWN_SERVICE, ServiceTarget,
+};
 use peppylib::runtime::CancellationToken;
 use peppylib::runtime::NodeBuilder;
 use peppylib::types::Payload;
@@ -179,7 +181,7 @@ async fn daemon_runner_succeed() {
             SHUTDOWN_SENDER_INSTANCE_ID,
             test_node_target(TEST_NODE_NAME),
             SHUTDOWN_SERVICE,
-            Some(&ProducerRef::new(TEST_CORE_NODE, TEST_INSTANCE_ID)),
+            ServiceTarget::Producer(&ProducerRef::new(TEST_CORE_NODE, TEST_INSTANCE_ID)),
         )
         .await
         .expect("reachability check should succeed")
@@ -203,7 +205,7 @@ async fn daemon_runner_succeed() {
         SHUTDOWN_SENDER_INSTANCE_ID,
         test_node_target(TEST_NODE_NAME),
         NODE_HEALTH_SERVICE,
-        Some(&ProducerRef::new(TEST_CORE_NODE, TEST_INSTANCE_ID)),
+        ServiceTarget::Producer(&ProducerRef::new(TEST_CORE_NODE, TEST_INSTANCE_ID)),
         health_request,
         Duration::from_secs(2),
     )
@@ -218,7 +220,7 @@ async fn daemon_runner_succeed() {
         SHUTDOWN_SENDER_INSTANCE_ID,
         test_node_target(TEST_NODE_NAME),
         SHUTDOWN_SERVICE,
-        Some(&ProducerRef::new(TEST_CORE_NODE, TEST_INSTANCE_ID)),
+        ServiceTarget::Producer(&ProducerRef::new(TEST_CORE_NODE, TEST_INSTANCE_ID)),
         shutdown_payload.clone(),
         Duration::from_secs(2),
     )
@@ -383,7 +385,7 @@ async fn node_ready_but_not_healthy() {
             SHUTDOWN_SENDER_INSTANCE_ID,
             test_node_target(TEST_NODE_NAME),
             NODE_READY_SERVICE,
-            Some(&ProducerRef::new(TEST_CORE_NODE, TEST_INSTANCE_ID)),
+            ServiceTarget::Producer(&ProducerRef::new(TEST_CORE_NODE, TEST_INSTANCE_ID)),
         )
         .await
         .expect("reachability check should succeed")
@@ -405,7 +407,7 @@ async fn node_ready_but_not_healthy() {
         SHUTDOWN_SENDER_INSTANCE_ID,
         test_node_target(TEST_NODE_NAME),
         NODE_READY_SERVICE,
-        Some(&ProducerRef::new(TEST_CORE_NODE, TEST_INSTANCE_ID)),
+        ServiceTarget::Producer(&ProducerRef::new(TEST_CORE_NODE, TEST_INSTANCE_ID)),
         ready_payload.clone(),
         Duration::from_secs(2),
     )
@@ -426,7 +428,7 @@ async fn node_ready_but_not_healthy() {
             SHUTDOWN_SENDER_INSTANCE_ID,
             test_node_target(TEST_NODE_NAME),
             SHUTDOWN_SERVICE,
-            Some(&ProducerRef::new(TEST_CORE_NODE, TEST_INSTANCE_ID)),
+            ServiceTarget::Producer(&ProducerRef::new(TEST_CORE_NODE, TEST_INSTANCE_ID)),
         )
         .await
         .expect("reachability check should succeed")
@@ -448,7 +450,7 @@ async fn node_ready_but_not_healthy() {
             SHUTDOWN_SENDER_INSTANCE_ID,
             test_node_target(TEST_NODE_NAME),
             NODE_HEALTH_SERVICE,
-            Some(&ProducerRef::new(TEST_CORE_NODE, TEST_INSTANCE_ID)),
+            ServiceTarget::Producer(&ProducerRef::new(TEST_CORE_NODE, TEST_INSTANCE_ID)),
         )
         .await
         .expect("reachability check should succeed"),
@@ -464,7 +466,7 @@ async fn node_ready_but_not_healthy() {
         SHUTDOWN_SENDER_INSTANCE_ID,
         test_node_target(TEST_NODE_NAME),
         NODE_HEALTH_SERVICE,
-        Some(&ProducerRef::new(TEST_CORE_NODE, TEST_INSTANCE_ID)),
+        ServiceTarget::Producer(&ProducerRef::new(TEST_CORE_NODE, TEST_INSTANCE_ID)),
         health_request.clone(),
         Duration::from_millis(200),
     )
@@ -494,7 +496,7 @@ async fn node_ready_but_not_healthy() {
             SHUTDOWN_SENDER_INSTANCE_ID,
             test_node_target(TEST_NODE_NAME),
             NODE_HEALTH_SERVICE,
-            Some(&ProducerRef::new(TEST_CORE_NODE, TEST_INSTANCE_ID)),
+            ServiceTarget::Producer(&ProducerRef::new(TEST_CORE_NODE, TEST_INSTANCE_ID)),
         )
         .await
         .expect("reachability check should succeed")
@@ -515,7 +517,7 @@ async fn node_ready_but_not_healthy() {
         SHUTDOWN_SENDER_INSTANCE_ID,
         test_node_target(TEST_NODE_NAME),
         NODE_HEALTH_SERVICE,
-        Some(&ProducerRef::new(TEST_CORE_NODE, TEST_INSTANCE_ID)),
+        ServiceTarget::Producer(&ProducerRef::new(TEST_CORE_NODE, TEST_INSTANCE_ID)),
         health_request,
         Duration::from_secs(2),
     )
@@ -530,7 +532,7 @@ async fn node_ready_but_not_healthy() {
         SHUTDOWN_SENDER_INSTANCE_ID,
         test_node_target(TEST_NODE_NAME),
         SHUTDOWN_SERVICE,
-        Some(&ProducerRef::new(TEST_CORE_NODE, TEST_INSTANCE_ID)),
+        ServiceTarget::Producer(&ProducerRef::new(TEST_CORE_NODE, TEST_INSTANCE_ID)),
         shutdown_payload.clone(),
         Duration::from_secs(2),
     )
@@ -636,7 +638,7 @@ async fn daemon_cancellation_token_cancelled_on_shutdown() {
             SHUTDOWN_SENDER_INSTANCE_ID,
             test_node_target(TEST_NODE_NAME),
             SHUTDOWN_SERVICE,
-            Some(&ProducerRef::new(TEST_CORE_NODE, TEST_INSTANCE_ID)),
+            ServiceTarget::Producer(&ProducerRef::new(TEST_CORE_NODE, TEST_INSTANCE_ID)),
         )
         .await
         .expect("reachability check should succeed")
@@ -659,7 +661,7 @@ async fn daemon_cancellation_token_cancelled_on_shutdown() {
         SHUTDOWN_SENDER_INSTANCE_ID,
         test_node_target(TEST_NODE_NAME),
         SHUTDOWN_SERVICE,
-        Some(&ProducerRef::new(TEST_CORE_NODE, TEST_INSTANCE_ID)),
+        ServiceTarget::Producer(&ProducerRef::new(TEST_CORE_NODE, TEST_INSTANCE_ID)),
         shutdown_payload,
         Duration::from_secs(2),
     )
@@ -776,7 +778,7 @@ async fn daemon_shutdown_during_setup_cancels_token_and_exits() {
             SHUTDOWN_SENDER_INSTANCE_ID,
             test_node_target(TEST_NODE_NAME),
             SHUTDOWN_SERVICE,
-            Some(&ProducerRef::new(TEST_CORE_NODE, TEST_INSTANCE_ID)),
+            ServiceTarget::Producer(&ProducerRef::new(TEST_CORE_NODE, TEST_INSTANCE_ID)),
         )
         .await
         .expect("reachability check should succeed")
@@ -799,7 +801,7 @@ async fn daemon_shutdown_during_setup_cancels_token_and_exits() {
         SHUTDOWN_SENDER_INSTANCE_ID,
         test_node_target(TEST_NODE_NAME),
         SHUTDOWN_SERVICE,
-        Some(&ProducerRef::new(TEST_CORE_NODE, TEST_INSTANCE_ID)),
+        ServiceTarget::Producer(&ProducerRef::new(TEST_CORE_NODE, TEST_INSTANCE_ID)),
         shutdown_payload,
         Duration::from_secs(2),
     )
@@ -998,7 +1000,7 @@ async fn send_shutdown_when_reachable<T: std::fmt::Debug>(
             SHUTDOWN_SENDER_INSTANCE_ID,
             test_node_target(TEST_NODE_NAME),
             SHUTDOWN_SERVICE,
-            Some(&ProducerRef::new(TEST_CORE_NODE, TEST_INSTANCE_ID)),
+            ServiceTarget::Producer(&ProducerRef::new(TEST_CORE_NODE, TEST_INSTANCE_ID)),
         )
         .await
         .expect("reachability check should succeed")
@@ -1019,7 +1021,7 @@ async fn send_shutdown_when_reachable<T: std::fmt::Debug>(
         SHUTDOWN_SENDER_INSTANCE_ID,
         test_node_target(TEST_NODE_NAME),
         SHUTDOWN_SERVICE,
-        Some(&ProducerRef::new(TEST_CORE_NODE, TEST_INSTANCE_ID)),
+        ServiceTarget::Producer(&ProducerRef::new(TEST_CORE_NODE, TEST_INSTANCE_ID)),
         Payload::from_static(b"shutdown"),
         Duration::from_secs(2),
     )

--- a/crates/peppylib/tests/services.rs
+++ b/crates/peppylib/tests/services.rs
@@ -1,7 +1,9 @@
 mod common;
 
 use common::test_node_target;
-use peppylib::messaging::{MessengerHandle, ProducerRef, SenderTarget, ServiceMessenger};
+use peppylib::messaging::{
+    MessengerHandle, ProducerRef, SenderTarget, ServiceMessenger, ServiceTarget,
+};
 use peppylib::types::Payload;
 use pmi::ZenohAdapter;
 use std::time::Duration;
@@ -58,7 +60,7 @@ async fn service_messenger_communication() {
         instance_id,
         test_node_target(node_name),
         service_name,
-        Some(&ProducerRef::new(core_node, instance_id)),
+        ServiceTarget::Producer(&ProducerRef::new(core_node, instance_id)),
         request_payload,
         Duration::from_secs(2),
     )
@@ -155,7 +157,7 @@ async fn service_iface_scoped_native_and_conformed_do_not_collide() {
         instance_id,
         test_node_target(node_name),
         service_name,
-        Some(&ProducerRef::new(core_node, instance_id)),
+        ServiceTarget::Producer(&ProducerRef::new(core_node, instance_id)),
         Payload::from_static(b"ping_native"),
         Duration::from_secs(2),
     )
@@ -174,7 +176,7 @@ async fn service_iface_scoped_native_and_conformed_do_not_collide() {
         instance_id,
         SenderTarget::interface(iface_name, iface_tag).expect("test target"),
         service_name,
-        Some(&ProducerRef::new(core_node, instance_id)),
+        ServiceTarget::Producer(&ProducerRef::new(core_node, instance_id)),
         Payload::from_static(b"ping_iface"),
         Duration::from_secs(2),
     )
@@ -242,7 +244,7 @@ async fn service_iface_tag_hyphen_normalized() {
         instance_id,
         SenderTarget::interface(iface_name, "v2_stable").expect("test target"),
         service_name,
-        Some(&ProducerRef::new(core_node, instance_id)),
+        ServiceTarget::Producer(&ProducerRef::new(core_node, instance_id)),
         Payload::from_static(b"ping"),
         Duration::from_secs(2),
     )
@@ -383,7 +385,7 @@ async fn service_from_any_poll_runs_handler_on_winner_only() {
         "caller_inst",
         test_node_target(producer_node_name),
         service_name,
-        None, // wildcard target producer
+        ServiceTarget::Any, // wildcard target producer
         Payload::from_static(b"go"),
         Duration::from_secs(5),
     )

--- a/crates/peppylib/tests/shutdown_node.rs
+++ b/crates/peppylib/tests/shutdown_node.rs
@@ -6,7 +6,7 @@ use common::{
 };
 use peppylib::types::Payload;
 use peppylib::{
-    messaging::{MessengerHandle, ProducerRef, SHUTDOWN_SERVICE, ServiceMessenger},
+    messaging::{MessengerHandle, ProducerRef, SHUTDOWN_SERVICE, ServiceMessenger, ServiceTarget},
     services::shutdown::listen_for_shutdown,
 };
 use std::sync::Arc;
@@ -41,7 +41,7 @@ async fn shutdown_node() {
         CALLER_INSTANCE_ID,
         test_node_target(TEST_NODE_NAME),
         SHUTDOWN_SERVICE,
-        Some(&ProducerRef::new(
+        ServiceTarget::Producer(&ProducerRef::new(
             client.core_node_name.as_str(),
             client.instance_id.as_str(),
         )),

--- a/crates/pmi-internal/src/wire.rs
+++ b/crates/pmi-internal/src/wire.rs
@@ -454,9 +454,11 @@ impl TopicWireReceiver {
 
 /// Caller-side addressing for a service. `target` is the producer's full
 /// `(core_node, instance_id)` wire address; `None` is a genuine wildcard
-/// on both slots (the discovery probe shape). Half-addresses are
-/// unrepresentable at this boundary — the internal per-slot `Option`s
-/// exist only so the formatter can wildcard each keyexpr chunk.
+/// on both slots (the discovery probe shape). The one representable
+/// half-address is core-without-instance via [`Self::scoped_to_core_node`]
+/// — for callers that know which core node must answer but cannot know
+/// the producer's per-boot instance_id. Instance-without-core stays
+/// unrepresentable at this boundary.
 /// The link_id wire slot is always emitted as `*` — producers advertise under
 /// the reserved `_` segment, and Zenoh's matcher unifies the two.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -492,6 +494,16 @@ impl ServiceWireSender {
             to_service_name: Segment::try_from(to_service_name)?,
             kind,
         })
+    }
+
+    /// Scopes the selector's target core_node slot to `target_core_node`
+    /// while leaving the instance slot wildcarded — the core-without-instance
+    /// half-address. The selector then matches only producers hosted by that
+    /// core node, regardless of their per-boot instance_id.
+    pub fn scoped_to_core_node(mut self, target_core_node: &str) -> crate::error::Result<Self> {
+        self.target_core_node = Some(Segment::try_from(target_core_node)?);
+        self.target_instance_id = None;
+        Ok(self)
     }
 
     pub fn to_service_name(&self) -> &str {

--- a/crates/pmi-internal/src/wire/zenoh_format/tests.rs
+++ b/crates/pmi-internal/src/wire/zenoh_format/tests.rs
@@ -364,6 +364,20 @@ fn service_get_selector_full_broadcast() {
 }
 
 #[test]
+fn service_get_selector_scoped_to_core_node() {
+    // The core-without-instance half-address: `scoped_to_core_node` pins the
+    // target core slot and wildcards the instance slot, regardless of what
+    // the sender carried before.
+    let sender = sample_service_sender(ServiceKind::Service)
+        .scoped_to_core_node("other_core")
+        .expect("valid core node segment");
+    assert_eq!(
+        ZenohWireFormat::service_get_selector(&sender),
+        "other_core/caller_core/*/caller_inst/service/node/robot_arm/v1/*/ping"
+    );
+}
+
+#[test]
 fn service_get_selector_always_wildcards_link_id_slot() {
     // The link_id wire slot is always `*` — producers advertise under `_`
     // and Zenoh's matcher unifies the two. There is no caller-side knob to


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Restructured service discovery and targeting to use explicit scoping modes for better control over service routing
  * Enhanced core node-scoped service communication to improve isolation in multi-node deployments

* **Tests**
  * Expanded test coverage for core node-scoped service scenarios and multi-daemon messaging topologies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->