### PR TITLE
refactor(pmi): harden public API, purify session-config builder, forbid unsafe

### DIFF
--- a/crates/pmi-internal/Cargo.toml
+++ b/crates/pmi-internal/Cargo.toml
@@ -8,6 +8,9 @@ edition.workspace = true
 config = { path = "../config-internal" }
 bytes = "1"
 serde_json = "1.0"
+# `sync` + `rt` are what pmi's own code names directly. The MockAdapter also uses
+# tokio `time` and the multi-thread runtime; those arrive transitively via zenoh,
+# so the mock is not built as a standalone zenoh-less backend (see lib.rs).
 tokio = { version = "1", features = ["sync", "rt"] }
 # Used for Subscription / ServiceQueryable channels: a flume bounded
 # channel lets the zenoh reception callback `send` synchronously (with

--- a/crates/pmi-internal/src/adapters/mock.rs
+++ b/crates/pmi-internal/src/adapters/mock.rs
@@ -104,10 +104,10 @@ struct MockLivelinessState {
 type LivelinessState = Arc<Mutex<MockLivelinessState>>;
 
 pub struct MockAdapter {
-    pub is_session_connected: bool,
-    pub is_router_started: bool,
-    pub messages: MessageLog,
-    pub subscriptions: SubscriptionMap,
+    pub(crate) is_session_connected: bool,
+    pub(crate) is_router_started: bool,
+    pub(crate) messages: MessageLog,
+    pub(crate) subscriptions: SubscriptionMap,
     pub(crate) queryables: QueryableMap,
     liveliness: LivelinessState,
 }
@@ -1254,5 +1254,109 @@ mod tests {
             .await
             .expect("pinned right receives");
         assert_eq!(right.payload().to_bytes().as_ref(), b"frame-0");
+    }
+
+    #[tokio::test]
+    async fn messenger_declare_topic_publisher_delivers_to_a_subscriber() {
+        // Exercises the `Messenger` dispatch wrapper (not the adapter directly):
+        // a pre-bound publisher must reach a subscriber on the same topic and be
+        // marked primary so a wildcard subscriber keeps it.
+        use crate::wire::{SenderTarget, TopicWireReceiver, TopicWireSender};
+
+        let mut messenger = Messenger::new(MessengerAdapter::Mock(MockAdapter::default()));
+        messenger
+            .start_session()
+            .await
+            .expect("session should start");
+
+        let target = SenderTarget::interface("depth_camera", "v1").expect("iface target");
+        let sender = TopicWireSender::new(
+            "pub_core",
+            "pub_inst",
+            target.clone(),
+            Some("wrist"),
+            "frames",
+        )
+        .expect("sender");
+        let receiver = TopicWireReceiver::new(
+            "sub_core",
+            "sub_inst",
+            None,
+            None,
+            Some(target),
+            None,
+            "frames",
+        )
+        .expect("receiver");
+
+        let subscription = messenger
+            .subscribe_topic(&receiver, SubscriberQoS::Standard)
+            .await
+            .expect("subscribe");
+
+        let publisher = messenger
+            .declare_topic_publisher(&sender, PublisherQoS::Standard)
+            .expect("declare publisher");
+        publisher
+            .publish(bytes::Bytes::from_static(b"frame-0"))
+            .await
+            .expect("publish");
+
+        let received = subscription
+            .rx
+            .recv_async()
+            .await
+            .expect("subscriber receives the published frame");
+        assert_eq!(received.payload().to_bytes().as_ref(), b"frame-0");
+    }
+
+    #[tokio::test]
+    async fn messenger_declare_action_feedback_publisher_reaches_goal_subscriber() {
+        // The action-feedback dispatch wrapper: feedback pre-bound for a
+        // specific (link_id, goal_id) must reach a consumer subscribed to that
+        // producer's feedback for the same goal.
+        use crate::wire::{ActionWireReceiver, ActionWireSender, SenderTarget};
+
+        let mut messenger = Messenger::new(MessengerAdapter::Mock(MockAdapter::default()));
+        messenger
+            .start_session()
+            .await
+            .expect("session should start");
+
+        let target = SenderTarget::node("arm", "v1").expect("node target");
+        let receiver =
+            ActionWireReceiver::new("server_core", "server_inst", target.clone(), "move")
+                .expect("receiver");
+        let sender = ActionWireSender::new(
+            "caller_core",
+            "caller_inst",
+            Some(&config::runtime::ProducerRef::new(
+                "server_core",
+                "server_inst",
+            )),
+            target,
+            "move",
+        )
+        .expect("sender");
+
+        let subscription = messenger
+            .subscribe_action_feedback(&sender, "g7", SubscriberQoS::Standard)
+            .await
+            .expect("subscribe feedback");
+
+        let publisher = messenger
+            .declare_action_feedback_publisher(&receiver, "_", "g7", PublisherQoS::Standard)
+            .expect("declare feedback publisher");
+        publisher
+            .publish(bytes::Bytes::from_static(b"progress-50"))
+            .await
+            .expect("publish feedback");
+
+        let received = subscription
+            .rx
+            .recv_async()
+            .await
+            .expect("feedback subscriber receives the goal update");
+        assert_eq!(received.payload().to_bytes().as_ref(), b"progress-50");
     }
 }

--- a/crates/pmi-internal/src/adapters/zenoh.rs
+++ b/crates/pmi-internal/src/adapters/zenoh.rs
@@ -150,6 +150,12 @@ pub struct ZenohClientConfig {
     gossip: bool,
     /// Per-QoS subscriber channel buffer sizes for this session.
     buffer_sizes: SubscriberBufferSizes,
+    /// Operator override (`ZENOH_SESSION_CONFIG`), resolved once at the
+    /// constructor boundary. `Some` replaces the rendered config wholesale,
+    /// including on the reconnecting-session rebuild in `start_session`, so the
+    /// operator file wins regardless of the routing model. `None` renders from
+    /// the fields above.
+    override_config: Option<zenoh::config::Config>,
 }
 
 pub struct ZenohAdapter {
@@ -178,7 +184,7 @@ impl ZenohAdapter {
     ) -> Result<Self> {
         let zenohd_config_path = zenohd::router_config_path(protocol, host, port)?;
         let facade = zenohd::ZenohdFacade::new(zenohd_config_path)?;
-        let client_config = Self::derive_client_config_from_zenohd(&facade, gossip, buffer_sizes);
+        let client_config = Self::derive_client_config_from_zenohd(&facade, gossip, buffer_sizes)?;
 
         Ok(Self {
             zenohd: Some(facade),
@@ -215,6 +221,7 @@ impl ZenohAdapter {
         gossip: bool,
         buffer_sizes: SubscriberBufferSizes,
     ) -> Result<Self> {
+        let override_config = Self::resolve_session_config_override()?;
         let client_config = Self::create_client_config(
             protocol,
             host,
@@ -223,6 +230,7 @@ impl ZenohAdapter {
             seed_peers,
             gossip,
             buffer_sizes,
+            override_config,
         );
 
         Ok(Self {
@@ -350,9 +358,40 @@ impl ZenohAdapter {
         zenohd::RouterHealthChecker::new(probe_config)
     }
 
+    /// Resolves the `ZENOH_SESSION_CONFIG` operator override into an optional
+    /// parsed config. When the env var names a non-empty path the file is
+    /// loaded, and an unreadable or invalid file becomes an
+    /// [`Error::ConfigurationError`] rather than a panic. `Ok(None)` when the
+    /// var is unset or blank, in which case the session config is rendered from
+    /// the explicit constructor arguments. Resolved once at the constructor
+    /// boundary so [`create_client_config`](Self::create_client_config) stays a
+    /// pure, env-free builder; mirrors the router's `ZENOH_CONFIG` resolution in
+    /// `zenohd::router_config_path`.
+    fn resolve_session_config_override() -> Result<Option<zenoh::config::Config>> {
+        match std::env::var("ZENOH_SESSION_CONFIG") {
+            Ok(path) if !path.trim().is_empty() => {
+                let path = path.trim();
+                zenoh::config::Config::from_file(path)
+                    .map(Some)
+                    .map_err(|e| {
+                        Error::ConfigurationError(format!(
+                            "ZENOH_SESSION_CONFIG ({path}) is not a readable zenoh config: {e}"
+                        ))
+                    })
+            }
+            _ => Ok(None),
+        }
+    }
+
     /// Builds a peer-session config seeded by `host:port` (or `seed_peers` when
-    /// non-empty). An operator can override the whole session config without a
-    /// rebuild via `ZENOH_SESSION_CONFIG` (mirrors the router's `ZENOH_CONFIG`).
+    /// non-empty). Pure: the operator override is resolved by the caller via
+    /// [`Self::resolve_session_config_override`] and passed in as
+    /// `override_config`. When present it replaces the rendered config wholesale
+    /// (including the `gossip`/mode rendering below), so the operator file wins
+    /// on routing model. The override does NOT affect `buffer_sizes`, which are
+    /// applied later at the flume/mpsc layer (subscribe / listen / call), so
+    /// peer-mode buffer tuning from `peppy_config.json5` still takes effect.
+    #[allow(clippy::too_many_arguments)]
     fn create_client_config(
         protocol: ZenohNetProtocol,
         host: &str,
@@ -361,6 +400,7 @@ impl ZenohAdapter {
         seed_peers: Vec<String>,
         gossip: bool,
         buffer_sizes: SubscriberBufferSizes,
+        override_config: Option<zenoh::config::Config>,
     ) -> ZenohClientConfig {
         let connect_host = connectable_host(host);
         let seeds = if seed_peers.is_empty() {
@@ -369,19 +409,8 @@ impl ZenohAdapter {
             seed_peers
         };
 
-        // `ZENOH_SESSION_CONFIG` overrides the generated zenoh session config
-        // wholesale, including the `gossip`/mode rendering below, so the operator
-        // file wins on routing model. It does NOT affect `buffer_sizes`, which
-        // are applied later at the flume/mpsc layer (subscribe / listen / call),
-        // so peer-mode buffer tuning from `peppy_config.json5` still takes effect.
-        let zenoh_config = match std::env::var("ZENOH_SESSION_CONFIG") {
-            Ok(path) if !path.trim().is_empty() => zenoh::config::Config::from_file(path.trim())
-                .unwrap_or_else(|e| {
-                    panic!(
-                        "ZENOH_SESSION_CONFIG ({}) is not a readable zenoh config: {e}",
-                        path.trim()
-                    )
-                }),
+        let zenoh_config = match &override_config {
+            Some(config) => config.clone(),
             // `gossip` selects the routing model. Enabled: a `peer` that binds a
             // loopback listener and forms direct peer-to-peer links via gossip.
             // Disabled: a plain `client` that routes only through the router (no
@@ -390,14 +419,14 @@ impl ZenohAdapter {
             // separate network namespace) use the client path so they reach the
             // rest of the system through the router instead of advertising an
             // unreachable loopback locator and churning on failed autoconnects.
-            _ if gossip => render_config(&ZenohConfigSpec {
+            None if gossip => render_config(&ZenohConfigSpec {
                 mode: SessionMode::Peer,
                 connect_endpoints: seeds.clone(),
                 listen_endpoints: vec![loopback_listen_endpoint(protocol)],
                 reconnect,
                 gossip: true,
             }),
-            _ => render_config(&ZenohConfigSpec {
+            None => render_config(&ZenohConfigSpec {
                 mode: SessionMode::Client,
                 connect_endpoints: seeds.clone(),
                 listen_endpoints: Vec::new(),
@@ -414,6 +443,7 @@ impl ZenohAdapter {
             seed_peers: seeds,
             gossip,
             buffer_sizes,
+            override_config,
         }
     }
 
@@ -422,7 +452,7 @@ impl ZenohAdapter {
         zenohd: &zenohd::ZenohdFacade,
         gossip: bool,
         buffer_sizes: SubscriberBufferSizes,
-    ) -> ZenohClientConfig {
+    ) -> Result<ZenohClientConfig> {
         // The daemon joins the mesh it hosts, seeded by its own router, so peers
         // can reach its core-node/daemon services. `gossip` (from
         // `peppy_config.json5`) selects whether that session is a peer (direct
@@ -431,7 +461,8 @@ impl ZenohAdapter {
         // rebuilt as reconnecting in `start_session` when `reconnect_session` is
         // set; the readiness probe in `start_router_ephemeral` builds its own
         // client probe config.
-        Self::create_client_config(
+        let override_config = Self::resolve_session_config_override()?;
+        Ok(Self::create_client_config(
             zenohd.zenoh_endpoint.protocol,
             &zenohd.zenoh_endpoint.host,
             zenohd.zenoh_endpoint.port,
@@ -439,7 +470,8 @@ impl ZenohAdapter {
             Vec::new(),
             gossip,
             buffer_sizes,
-        )
+            override_config,
+        ))
     }
 }
 
@@ -458,6 +490,7 @@ impl MessengerBackend for ZenohAdapter {
                 self.client_config.seed_peers.clone(),
                 self.client_config.gossip,
                 self.client_config.buffer_sizes,
+                self.client_config.override_config.clone(),
             )
             .zenoh_config
         } else {
@@ -1153,6 +1186,7 @@ mod tests {
             Vec::new(),
             true,
             SubscriberBufferSizes::default(),
+            None,
         );
         assert_eq!(reconnecting.host, "127.0.0.1");
         assert_eq!(
@@ -1175,6 +1209,7 @@ mod tests {
                 standard: 64,
                 high_throughput: 4096,
             },
+            None,
         );
         assert_eq!(cfg.seed_peers, vec!["tcp/10.0.0.2:7448".to_string()]);
         assert!(!cfg.gossip);

--- a/crates/pmi-internal/src/lib.rs
+++ b/crates/pmi-internal/src/lib.rs
@@ -1,4 +1,11 @@
-// Mock backend is always available as a fallback when zenoh is not enabled
+// The MockAdapter in-process backend is compiled into every build alongside the
+// zenoh transport, but it is not a standalone zenoh-less build target: the mock
+// uses tokio's `time` and multi-thread runtime, which this crate only obtains
+// transitively through the `zenoh` dependency. A `--no-default-features` build
+// (no zenoh) therefore does not compile. Every supported configuration enables
+// `zenoh` (the default). See the `tokio` note in Cargo.toml.
+
+#![forbid(unsafe_code)]
 
 mod adapters;
 mod error;
@@ -16,14 +23,15 @@ mod zenohd;
 pub use config::runtime::ProducerRef;
 pub use error::Error as PeppyMessagingInterfaceError;
 pub use probe::{MAX_PROBE_REPLY_SIZE, build_sized_probe_request};
-#[cfg(feature = "zenoh")]
-pub use types::ZenohResponseToken;
+// `ZenohResponseToken` / `MockResponseToken` are intentionally NOT re-exported:
+// they are opaque, non-constructible payloads of the public `ResponseToken` enum
+// (reached only through `ResponseToken`'s methods), so naming them directly is
+// not part of the crate's public surface.
 pub use types::{
     ActionLivelinessEvent, ActionLivelinessProbe, ActionLivelinessToken, ActionLivelinessWatch,
-    IncomingRequest, Message, Messenger, MessengerAdapter, MessengerBackend, MessengerPublisher,
-    MockResponseToken, Payload, PayloadSlices, PublisherQoS, ReplyStream, ResponseToken,
-    ServiceQueryable, ServiceReply, SubscriberBufferSizes, SubscriberQoS, Subscription,
-    TopicMessage,
+    IncomingRequest, Messenger, MessengerAdapter, MessengerBackend, MessengerPublisher, Payload,
+    PublisherQoS, ReplyStream, ResponseToken, ServiceQueryable, ServiceReply,
+    SubscriberBufferSizes, SubscriberQoS, Subscription, TopicMessage,
 };
 pub use wire::{
     ActionWireReceiver, ActionWireSender, DEFAULT_LINK_ID, InterfaceIdentifier, NodeIdentifier,

--- a/crates/pmi-internal/src/types.rs
+++ b/crates/pmi-internal/src/types.rs
@@ -278,10 +278,10 @@ pub(crate) type Guard = Box<dyn std::any::Any + Send + Sync>;
 /// `AbortHandle` alone does not abort on drop — only the explicit `.abort()`
 /// call does — so adapters that need that semantics wrap their handle in
 /// this type before stashing it in a [`Guard`].
-pub struct AbortOnDrop(tokio::task::AbortHandle);
+pub(crate) struct AbortOnDrop(tokio::task::AbortHandle);
 
 impl AbortOnDrop {
-    pub fn new(handle: tokio::task::AbortHandle) -> Self {
+    pub(crate) fn new(handle: tokio::task::AbortHandle) -> Self {
         Self(handle)
     }
 }
@@ -559,7 +559,7 @@ pub struct ZenohResponseToken {
 
 #[cfg(feature = "zenoh")]
 impl ZenohResponseToken {
-    pub fn new(query: zenoh::query::Query, reply_keyexpr: String) -> Self {
+    pub(crate) fn new(query: zenoh::query::Query, reply_keyexpr: String) -> Self {
         Self {
             query,
             reply_keyexpr,
@@ -586,7 +586,10 @@ pub struct MockResponseToken {
 }
 
 impl MockResponseToken {
-    pub fn new(reply_tx: tokio::sync::mpsc::Sender<ServiceReply>, reply_keyexpr: String) -> Self {
+    pub(crate) fn new(
+        reply_tx: tokio::sync::mpsc::Sender<ServiceReply>,
+        reply_keyexpr: String,
+    ) -> Self {
         Self {
             reply_tx,
             reply_keyexpr,
@@ -603,26 +606,28 @@ impl MockResponseToken {
     }
 }
 
-/// Core message structure
+/// Internal in-process message envelope used by the mock adapter's message log
+/// and routing. Not part of the public API: consumers use [`TopicMessage`] (the
+/// real transport envelope); only the mock backend records [`Message`]s.
 #[derive(Clone)]
-pub struct Message {
+pub(crate) struct Message {
     identifier: String,
     payload: bytes::Bytes,
 }
 
 impl Message {
-    pub fn new(identifier: &str, payload: impl AsRef<[u8]>) -> Self {
+    pub(crate) fn new(identifier: &str, payload: impl AsRef<[u8]>) -> Self {
         Self {
             identifier: identifier.to_string(),
             payload: bytes::Bytes::copy_from_slice(payload.as_ref()),
         }
     }
 
-    pub fn identifier(&self) -> &str {
+    pub(crate) fn identifier(&self) -> &str {
         &self.identifier
     }
 
-    pub fn payload(&self) -> &bytes::Bytes {
+    pub(crate) fn payload(&self) -> &bytes::Bytes {
         &self.payload
     }
 }
@@ -694,15 +699,6 @@ impl Payload {
         }
     }
 
-    /// Iterate over the underlying slices without forcing contiguity.
-    pub fn slices(&self) -> PayloadSlices<'_> {
-        match &self.inner {
-            PayloadInner::Bytes(b) => PayloadSlices::BytesSlice(std::iter::once(b.as_ref())),
-            #[cfg(feature = "zenoh")]
-            PayloadInner::Zenoh(z) => PayloadSlices::ZenohSlices(z.slices()),
-        }
-    }
-
     #[cfg(feature = "zenoh")]
     pub fn from_zbytes(zbytes: ZBytes) -> Self {
         Self {
@@ -722,24 +718,6 @@ impl Payload {
 impl From<bytes::Bytes> for Payload {
     fn from(value: bytes::Bytes) -> Self {
         Payload::from_bytes(value)
-    }
-}
-
-pub enum PayloadSlices<'a> {
-    BytesSlice(std::iter::Once<&'a [u8]>),
-    #[cfg(feature = "zenoh")]
-    ZenohSlices(zenoh::bytes::ZBytesSliceIterator<'a>),
-}
-
-impl<'a> Iterator for PayloadSlices<'a> {
-    type Item = &'a [u8];
-
-    fn next(&mut self) -> Option<Self::Item> {
-        match self {
-            PayloadSlices::BytesSlice(iter) => iter.next(),
-            #[cfg(feature = "zenoh")]
-            PayloadSlices::ZenohSlices(iter) => iter.next(),
-        }
     }
 }
 
@@ -1079,7 +1057,8 @@ impl MessengerBackend for Messenger {
 
 #[cfg(test)]
 mod tests {
-    use super::{SubscriberBufferSizes, SubscriberQoS};
+    use super::{Payload, ServiceReply, SubscriberBufferSizes, SubscriberQoS, TopicMessage};
+    use crate::wire::ServiceReplyKind;
 
     /// The default buffer sizes must match the historical hardcoded values, so
     /// that removing `SubscriberQoS::channel_size()` changed no behavior for any
@@ -1099,5 +1078,64 @@ mod tests {
         };
         assert_eq!(sizes.size_for(SubscriberQoS::Standard), 64);
         assert_eq!(sizes.size_for(SubscriberQoS::HighThroughput), 4096);
+    }
+
+    #[test]
+    fn payload_from_bytes_exposes_len_emptiness_and_views() {
+        let payload = Payload::from_bytes(bytes::Bytes::from_static(b"frame"));
+        assert_eq!(payload.len(), 5);
+        assert!(!payload.is_empty());
+        assert_eq!(payload.as_bytes().as_ref(), b"frame");
+        assert_eq!(payload.to_bytes(), bytes::Bytes::from_static(b"frame"));
+        // into_bytes is zero-copy for the Bytes-backed payload but still yields
+        // the same contents.
+        assert_eq!(payload.into_bytes(), bytes::Bytes::from_static(b"frame"));
+
+        let empty = Payload::from_bytes(bytes::Bytes::new());
+        assert!(empty.is_empty());
+        assert_eq!(empty.len(), 0);
+    }
+
+    #[test]
+    fn payload_equality_with_raw_bytes_is_symmetric() {
+        let raw = bytes::Bytes::from_static(b"ping");
+        let payload = Payload::from_bytes(raw.clone());
+        assert_eq!(payload, raw);
+        assert_eq!(raw, payload);
+        assert_ne!(payload, bytes::Bytes::from_static(b"pong"));
+    }
+
+    #[test]
+    fn topic_message_from_parts_sets_identity_and_leaves_wire_fields_empty() {
+        // The non-keyexpr service path: caller identity comes straight from the
+        // queryable selector, so key_expr and link_id are intentionally empty
+        // and no keyexpr parsing happens.
+        let message = TopicMessage::from_parts(
+            "caller_core".to_string(),
+            "caller_inst".to_string(),
+            bytes::Bytes::from_static(b"body"),
+        );
+        assert_eq!(message.core_node(), "caller_core");
+        assert_eq!(message.instance_id(), "caller_inst");
+        assert_eq!(message.key_expr(), "");
+        assert_eq!(message.link_id(), "");
+        assert_eq!(message.source_timestamp_nanos(), None);
+        assert_eq!(message.payload().as_bytes().as_ref(), b"body");
+    }
+
+    #[test]
+    fn service_reply_exposes_kind_and_borrows_then_consumes_its_message() {
+        let message = TopicMessage::from_parts(
+            "responder_core".to_string(),
+            "responder_inst".to_string(),
+            bytes::Bytes::from_static(b"pong"),
+        );
+        let reply = ServiceReply::new(message, ServiceReplyKind::Response);
+        assert_eq!(reply.kind(), ServiceReplyKind::Response);
+        // message() borrows without consuming...
+        assert_eq!(reply.message().core_node(), "responder_core");
+        // ...then into_message() hands ownership to the caller.
+        let consumed = reply.into_message();
+        assert_eq!(consumed.payload().as_bytes().as_ref(), b"pong");
     }
 }

--- a/crates/pmi-internal/src/wire.rs
+++ b/crates/pmi-internal/src/wire.rs
@@ -360,6 +360,20 @@ impl ServiceKind {
     }
 }
 
+/// The precomputed `[root, discriminator, name, tag]` prefix segments of a
+/// service_root. Built once at receiver construction so the inbound-query
+/// parser can match without rebuilding strings. Single source of truth for the
+/// prefix shape, shared by [`ServiceWireReceiver::new`] and the action
+/// sub-service derivation in [`ActionWireReceiver`].
+fn service_root_prefix(identity: &SenderTarget, kind: ServiceKind) -> [String; 4] {
+    [
+        kind.root_segment().to_string(),
+        identity.discriminator().to_string(),
+        identity.name().to_string(),
+        identity.tag().to_string(),
+    ]
+}
+
 // ─── Topics ──────────────────────────────────────────────────────────────────
 
 /// Publisher-side addressing for a topic emit. Fields are `pub(crate)` so
@@ -540,12 +554,7 @@ impl ServiceWireReceiver {
         as_service_name: &str,
         kind: ServiceKind,
     ) -> crate::error::Result<Self> {
-        let service_root_prefix = [
-            kind.root_segment().to_string(),
-            as_identity.discriminator().to_string(),
-            as_identity.name().to_string(),
-            as_identity.tag().to_string(),
-        ];
+        let service_root_prefix = service_root_prefix(&as_identity, kind);
         Ok(Self {
             bound_core_node: Segment::try_from(bound_core_node)?,
             as_instance_id: Segment::try_from(as_instance_id)?,
@@ -692,12 +701,7 @@ impl ActionWireReceiver {
     }
 
     fn action_service(&self, kind: ServiceKind) -> ServiceWireReceiver {
-        let service_root_prefix = [
-            kind.root_segment().to_string(),
-            self.as_identity.discriminator().to_string(),
-            self.as_identity.name().to_string(),
-            self.as_identity.tag().to_string(),
-        ];
+        let service_root_prefix = service_root_prefix(&self.as_identity, kind);
         ServiceWireReceiver {
             bound_core_node: self.bound_core_node.clone(),
             as_instance_id: self.as_instance_id.clone(),

--- a/crates/pmi-internal/src/wire/tests.rs
+++ b/crates/pmi-internal/src/wire/tests.rs
@@ -255,3 +255,29 @@ fn action_receiver_all_three_variants_have_consistent_addressing() {
     assert_eq!(cancel.kind, ServiceKind::ActionCancel);
     assert_eq!(result.kind, ServiceKind::ActionResult);
 }
+
+// ─── from_validated panic contract ──────────────────────────────────────────
+
+#[test]
+fn node_from_validated_builds_a_node_target_for_safe_segments() {
+    let target = SenderTarget::node_from_validated("uvc_camera", "v1");
+    assert!(target.is_node());
+    assert_eq!(target.name(), "uvc_camera");
+    assert_eq!(target.tag(), "v1");
+}
+
+#[test]
+fn node_from_validated_normalizes_hyphenated_tag_like_new() {
+    // from_validated funnels through new(), so the hyphen-to-underscore tag
+    // normalization still applies to the validated path.
+    let target = SenderTarget::node_from_validated("arm", "v1-beta");
+    assert_eq!(target.tag(), "v1_beta");
+}
+
+#[test]
+#[should_panic(expected = "validated name and tag should be wire-segment safe")]
+fn node_from_validated_panics_on_reserved_sentinel() {
+    // The documented panic contract: a degenerate name that collides with a
+    // reserved wire sentinel must blow up rather than produce a bad target.
+    let _ = NodeIdentifier::from_validated("_", "v1");
+}

--- a/crates/pmi-internal/src/zenohd.rs
+++ b/crates/pmi-internal/src/zenohd.rs
@@ -3,7 +3,11 @@ use std::fmt;
 /// Network protocol for the Zenoh transport endpoint. Needed by the client
 /// session config (so it lives under the base `zenoh` feature, not `router`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-#[allow(dead_code)]
+// Udp/Quic/Ws are constructed only by the router config parser in the
+// `router`-gated `facade` module, so a `zenoh`-without-`router` build sees them
+// as never-constructed. Scope the allow to that combo so the default (router)
+// build still warns if a variant genuinely goes dead.
+#[cfg_attr(not(feature = "router"), allow(dead_code))]
 pub enum ZenohNetProtocol {
     #[default]
     Tcp,

--- a/crates/pmi-internal/tests/feature_flags.rs
+++ b/crates/pmi-internal/tests/feature_flags.rs
@@ -3,15 +3,15 @@
 fn test_with_zenoh_feature() {
     use bytes::Bytes;
     use pmi::{
-        Message, PeppyMessagingInterfaceError, SubscriberBufferSizes, SubscriberQoS,
+        Payload, PeppyMessagingInterfaceError, SubscriberBufferSizes, SubscriberQoS,
         ZenohNetProtocol,
     };
 
     const { assert!(cfg!(feature = "zenoh"), "zenoh feature should be enabled") };
 
-    let message = Message::new("test/topic", Bytes::from_static(b"test payload"));
-    assert_eq!(message.identifier(), "test/topic");
-    assert_eq!(&message.payload()[..], b"test payload");
+    let payload = Payload::from_bytes(Bytes::from_static(b"test payload"));
+    assert_eq!(payload.len(), b"test payload".len());
+    assert_eq!(payload.as_bytes().as_ref(), b"test payload");
 
     let qos = SubscriberQoS::Standard;
     assert_eq!(SubscriberBufferSizes::default().size_for(qos), 128);
@@ -32,16 +32,16 @@ fn test_with_zenoh_feature() {
 #[test]
 fn test_without_zenoh_feature() {
     use bytes::Bytes;
-    use pmi::{Message, PeppyMessagingInterfaceError, SubscriberBufferSizes, SubscriberQoS};
+    use pmi::{Payload, PeppyMessagingInterfaceError, SubscriberBufferSizes, SubscriberQoS};
 
     assert!(
         !cfg!(feature = "zenoh"),
         "zenoh feature should be disabled for this test"
     );
 
-    let message = Message::new("test/topic", Bytes::from_static(b"test payload"));
-    assert_eq!(message.identifier(), "test/topic");
-    assert_eq!(&message.payload()[..], b"test payload");
+    let payload = Payload::from_bytes(Bytes::from_static(b"test payload"));
+    assert_eq!(payload.len(), b"test payload".len());
+    assert_eq!(payload.as_bytes().as_ref(), b"test payload");
 
     let qos = SubscriberQoS::HighThroughput;
     assert_eq!(SubscriberBufferSizes::default().size_for(qos), 1024);


### PR DESCRIPTION
Audit-driven cleanup of the `pmi` crate (`crates/pmi-internal`). Driven by a per-goal audit (separation of concerns, DRY, test coverage/determinism, init/boundaries, unsafe, `forbid(unsafe_code)`, lean `lib.rs`).

## Behavior
No change to observed behavior **except** one deliberate improvement: an unreadable `ZENOH_SESSION_CONFIG` override now returns `Error::ConfigurationError` instead of panicking.

## What changed

**Safety / boundaries**
- Add `#![forbid(unsafe_code)]` — the crate has no `unsafe`; this makes the property compiler-enforced.
- Lift the `ZENOH_SESSION_CONFIG` env read out of `create_client_config` to the constructor boundary. The builder is now pure (takes the resolved override as a parameter) and unit-testable without ambient env; the panic-on-bad-file is replaced with a structured error. The resolved override is stored so the reconnecting-session rebuild reuses it without re-reading the environment.

**Public-surface narrowing** (no consumer referenced the removed names — full-workspace `cargo check` passes)
- `Message` → `pub(crate)` and dropped from re-exports (it is the mock's internal log type; the real envelope consumers use is `TopicMessage`).
- `ZenohResponseToken` / `MockResponseToken`: constructors made `pub(crate)` and the types dropped from re-exports. They remain opaque, non-constructible payloads of the public `ResponseToken` enum, so `zenoh::query::Query` no longer appears in any public signature.
- `MockAdapter` bookkeeping fields and `AbortOnDrop` → `pub(crate)`.

**Dead code / DRY / cfg hygiene**
- Remove the unused `Payload::slices()` method and `PayloadSlices` enum (zero callers anywhere in the workspace).
- Extract a shared `service_root_prefix()` helper (the `[String; 4]` build was duplicated in `wire.rs`).
- Scope the `ZenohNetProtocol` `#[allow(dead_code)]` to `not(feature = "router")` so the default build still warns if a variant genuinely goes dead.

**Docs**
- Correct the inaccurate "mock is always available without zenoh" comment: the mock relies on tokio `time`/`rt` features pulled in transitively via `zenoh`, so a `--no-default-features` build does not compile. Documented in `lib.rs` and the `tokio` dependency note.

**Tests** (+9, all deterministic / mock-based)
- `NodeIdentifier::from_validated` panic contract, `Payload` accessors + equality, `TopicMessage::from_parts`, `ServiceReply`, and the `Messenger::declare_*` dispatch wrappers.

## Reviewer notes
- **Verification:** `cargo test -p pmi` → 131 unit + 1 integration test pass; `cargo clippy -p pmi --all-targets` clean; builds on `default`, `--no-default-features --features zenoh`, and `--features build_zenoh` (all 4 gated e2e test binaries compile); `cargo check --workspace` passes (no consumer broken by the API narrowing).
- **Intentionally not done:** the two adapters' mirrored inbound-query dispatch was left un-extracted (different sync/async + token types; a shared helper fights the `ResponseToken` seam). The `build_zenoh`-gated e2e tests keep their sleeps — they coordinate real zenohd/network timing, not wall-clock assertions, so they can't be de-timed without destroying what they test. The `zenoh`-without-`router` cfg-hygiene warnings were left as-is (no consumer ships that combo; the default build is warning-clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Zenoh session configuration overrides via environment settings, resolved at adapter initialization.

* **Bug Fixes**
  * Fixed configuration override to persist correctly across session reconnections.

* **Tests**
  * Expanded test coverage for mock adapter messaging workflows and wire receiver validation.

* **Refactor**
  * Restricted internal API surface to reduce public exposure; removed payload slicing method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->