### PR TITLE
Fix stop clock and heartbeat publishers before closing the messaging session

### DIFF
--- a/crates/core-node-internal/src/services.rs
+++ b/crates/core-node-internal/src/services.rs
@@ -36,6 +36,7 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 use tokio::sync::{Mutex, oneshot};
 use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
 use tracing::info;
 
 const CORE_NODE_TAG: &str = match option_env!("PEPPY_GIT_TAG") {
@@ -116,6 +117,11 @@ pub struct CoreNodeConfig {
     /// Daemon-global messaging mode + peer buffer sizes, injected into every
     /// spawned node's runtime config (see `node::run`).
     pub peppy_config: config::peppy_config::PeppyConfig,
+    /// Cancelled at the start of daemon shutdown to stop the core node's own
+    /// clock + heartbeat publishers before the messaging session is closed, so
+    /// they do not spin against a closed session logging a failed publish on
+    /// every tick.
+    pub shutdown_token: CancellationToken,
 }
 
 pub struct CoreNode {
@@ -135,6 +141,9 @@ pub struct CoreNode {
     /// Daemon-global messaging mode + peer buffer sizes, read once at startup.
     /// Injected into every spawned node's runtime config (see `node::run`).
     peppy_config: config::peppy_config::PeppyConfig,
+    /// Cancelled on shutdown to stop the clock + heartbeat publishers cleanly.
+    /// Cloned into each publisher task in [`CoreNode::start_with_ready`].
+    shutdown_token: CancellationToken,
     /// Flipped by [`CoreNode::start_with_ready`] so a second start on the same
     /// instance is rejected rather than silently re-registering listeners.
     started: AtomicBool,
@@ -201,6 +210,7 @@ impl CoreNode {
             root_dir,
             peppy_dirs,
             peppy_config,
+            shutdown_token,
         } = config;
 
         let manifest_name = match node_name {
@@ -258,6 +268,7 @@ impl CoreNode {
             heartbeat_interval,
             daemon_use_sim_time,
             peppy_config,
+            shutdown_token,
             started: AtomicBool::new(false),
         }
     }
@@ -365,6 +376,7 @@ impl CoreNode {
                     self.instance_id(),
                     self.node_name(),
                     Arc::clone(&clock_cache),
+                    self.shutdown_token.clone(),
                 )
                 .boxed()
             } else {
@@ -375,6 +387,7 @@ impl CoreNode {
                     self.node_name(),
                     self.clock_publish_interval,
                     Arc::clone(&clock_source),
+                    self.shutdown_token.clone(),
                 )
                 .boxed()
             },
@@ -386,6 +399,7 @@ impl CoreNode {
                 self.instance_id(),
                 self.node_name(),
                 self.heartbeat_interval,
+                self.shutdown_token.clone(),
             )
             .boxed(),
             info::listen_for_info(

--- a/crates/core-node-internal/src/services/clock.rs
+++ b/crates/core-node-internal/src/services/clock.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
 use tracing::{debug, warn};
 
 /// Failures observable from a [`ClockSource`]. Wall mode propagates a system
@@ -148,6 +149,9 @@ fn handle_clock_request_inner(
 /// Wall mode only. In sim mode the daemon does not publish; an external
 /// simulator does, and the daemon merely subscribes (see
 /// [`subscribe_external_clock`]).
+///
+/// `cancel` stops the loop on daemon shutdown so it does not spin against a
+/// closed session, logging a failed publish on every tick.
 pub async fn publish_clock(
     messenger: MessengerHandle,
     core_node_name: &str,
@@ -155,6 +159,7 @@ pub async fn publish_clock(
     node_name: &str,
     interval: Duration,
     source: Arc<dyn ClockSource>,
+    cancel: CancellationToken,
 ) -> Result<JoinHandle<Result<()>>> {
     let publisher = declare_sensor_publisher(
         &messenger,
@@ -165,7 +170,7 @@ pub async fn publish_clock(
     )
     .await?;
     Ok(tokio::spawn(run_clock_publisher(
-        publisher, interval, source,
+        publisher, interval, source, cancel,
     )))
 }
 
@@ -196,6 +201,7 @@ async fn run_clock_publisher(
     publisher: TopicPublisher,
     interval: Duration,
     source: Arc<dyn ClockSource>,
+    cancel: CancellationToken,
 ) -> Result<()> {
     let mut ticker = tokio::time::interval(interval);
     // Skip catch-up bursts after a backlog (e.g. test pause / GC stall).
@@ -203,7 +209,13 @@ async fn run_clock_publisher(
     ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
     loop {
-        ticker.tick().await;
+        tokio::select! {
+            // Check cancellation first so a shutdown that races a due tick wins,
+            // stopping the loop instead of emitting one last doomed publish.
+            biased;
+            _ = cancel.cancelled() => break,
+            _ = ticker.tick() => {}
+        }
         let now_ns = match source.now_ns() {
             Ok(t) => t,
             Err(e) => {
@@ -222,6 +234,7 @@ async fn run_clock_publisher(
             warn!("clock tick emit failed: {e}");
         }
     }
+    Ok(())
 }
 
 /// Spawns a task that emits a liveness beat on the `daemon_heartbeat` topic at
@@ -242,6 +255,7 @@ pub async fn publish_daemon_heartbeat(
     instance_id: &str,
     node_name: &str,
     interval: Duration,
+    cancel: CancellationToken,
 ) -> Result<JoinHandle<Result<()>>> {
     let publisher = declare_sensor_publisher(
         &messenger,
@@ -251,10 +265,16 @@ pub async fn publish_daemon_heartbeat(
         names::DAEMON_HEARTBEAT,
     )
     .await?;
-    Ok(tokio::spawn(run_heartbeat_publisher(publisher, interval)))
+    Ok(tokio::spawn(run_heartbeat_publisher(
+        publisher, interval, cancel,
+    )))
 }
 
-async fn run_heartbeat_publisher(publisher: TopicPublisher, interval: Duration) -> Result<()> {
+async fn run_heartbeat_publisher(
+    publisher: TopicPublisher,
+    interval: Duration,
+    cancel: CancellationToken,
+) -> Result<()> {
     // The value is never read by the node — only the message's arrival matters
     // — so encode the constant payload once, outside the loop.
     let payload = ClockTick::new(0).encode()?;
@@ -263,11 +283,17 @@ async fn run_heartbeat_publisher(publisher: TopicPublisher, interval: Duration) 
     ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
     loop {
-        ticker.tick().await;
+        tokio::select! {
+            // Stop cleanly on shutdown rather than beating into a closed session.
+            biased;
+            _ = cancel.cancelled() => break,
+            _ = ticker.tick() => {}
+        }
         if let Err(e) = publisher.publish(payload.clone()).await {
             warn!("daemon heartbeat emit failed: {e}");
         }
     }
+    Ok(())
 }
 
 /// Subscribes to the `clock` topic and feeds the latest observed timestamp
@@ -286,6 +312,7 @@ pub async fn subscribe_external_clock(
     instance_id: &str,
     node_name: &str,
     cache: Arc<AtomicU64>,
+    cancel: CancellationToken,
 ) -> Result<JoinHandle<Result<()>>> {
     let mut subscription: Subscription = TopicMessenger::subscribe(
         &messenger,
@@ -300,7 +327,18 @@ pub async fn subscribe_external_clock(
     .await?;
 
     Ok(tokio::spawn(async move {
-        while let Some(message) = subscription.on_next_message().await {
+        loop {
+            // The subscription also ends on session close, but selecting on the
+            // shutdown token makes the exit deterministic and matches the
+            // publisher loops.
+            let message = tokio::select! {
+                biased;
+                _ = cancel.cancelled() => break,
+                message = subscription.on_next_message() => match message {
+                    Some(message) => message,
+                    None => break,
+                },
+            };
             match ClockTick::decode(message.payload().as_ref()) {
                 Ok(tick) => {
                     // `0` is reserved as "not ready" — a simulator publishing
@@ -319,6 +357,69 @@ pub async fn subscribe_external_clock(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use pmi::{Messenger, MessengerAdapter, MessengerBackend, MockAdapter};
+    use tokio::sync::Mutex;
+
+    /// A messenger handle over a started in-memory mock session, enough for the
+    /// publisher loops to declare a publisher and tick.
+    async fn started_mock_messenger() -> MessengerHandle {
+        let mut messenger = Messenger::new(MessengerAdapter::Mock(MockAdapter::default()));
+        messenger
+            .start_session()
+            .await
+            .expect("mock session should start");
+        MessengerHandle::from_shared(Arc::new(Mutex::new(messenger)))
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn clock_publisher_stops_promptly_on_cancel() {
+        let cancel = CancellationToken::new();
+        let handle = publish_clock(
+            started_mock_messenger().await,
+            "test_core_node",
+            "test_instance",
+            "test_core_node",
+            Duration::from_millis(10),
+            Arc::new(WallClockSource),
+            cancel.clone(),
+        )
+        .await
+        .expect("clock publisher should spawn");
+
+        // Let it run a few ticks, then ask it to stop.
+        tokio::time::sleep(Duration::from_millis(35)).await;
+        cancel.cancel();
+
+        let outcome = tokio::time::timeout(Duration::from_secs(1), handle)
+            .await
+            .expect("publisher must stop promptly after cancel, not spin")
+            .expect("publisher task should not panic");
+        outcome.expect("publisher should exit Ok after a clean cancel");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn heartbeat_publisher_stops_promptly_on_cancel() {
+        let cancel = CancellationToken::new();
+        let handle = publish_daemon_heartbeat(
+            started_mock_messenger().await,
+            "test_core_node",
+            "test_instance",
+            "test_core_node",
+            Duration::from_millis(10),
+            cancel.clone(),
+        )
+        .await
+        .expect("heartbeat publisher should spawn");
+
+        tokio::time::sleep(Duration::from_millis(35)).await;
+        cancel.cancel();
+
+        let outcome = tokio::time::timeout(Duration::from_secs(1), handle)
+            .await
+            .expect("heartbeat must stop promptly after cancel, not spin")
+            .expect("heartbeat task should not panic");
+        outcome.expect("heartbeat should exit Ok after a clean cancel");
+    }
 
     #[test]
     fn wall_clock_source_returns_a_value() {

--- a/crates/core-node-internal/src/services/tests.rs
+++ b/crates/core-node-internal/src/services/tests.rs
@@ -40,6 +40,7 @@ fn test_core_node_config(
         root_dir: std::env::temp_dir(),
         peppy_dirs,
         peppy_config: config::peppy_config::PeppyConfig::default(),
+        shutdown_token: tokio_util::sync::CancellationToken::new(),
     }
 }
 

--- a/crates/core-node-internal/tests/common.rs
+++ b/crates/core-node-internal/tests/common.rs
@@ -1765,6 +1765,7 @@ async fn start_core_node_with_messenger(
         root_dir,
         peppy_dirs: peppy_dirs.clone(),
         peppy_config,
+        shutdown_token: tokio_util::sync::CancellationToken::new(),
     });
     let core_node_name = core_node.node_name().to_string();
     let core_node_tag = core_node.node_config().manifest.tag.clone();

--- a/crates/peppy/src/commands/service/builder.rs
+++ b/crates/peppy/src/commands/service/builder.rs
@@ -30,6 +30,10 @@ pub struct ServeCommandBuilder {
     core_node_name: Option<String>,
     clock_source: super::ClockSource,
     shutdown_token: Option<CancellationToken>,
+    /// Sender the core node runner uses to tell the messaging router that
+    /// teardown is done. Created alongside the messaging router so the router
+    /// holds the receiver; handed to the core node runner in [`Self::build`].
+    core_node_done_tx: Option<watch::Sender<bool>>,
     root_dir: PathBuf,
     peppy_config: PeppyConfig,
 }
@@ -44,6 +48,7 @@ impl ServeCommandBuilder {
             core_node_name: None,
             clock_source: super::ClockSource::default(),
             shutdown_token: None,
+            core_node_done_tx: None,
             root_dir: root_dir.into(),
             peppy_config: PeppyConfig::default(),
         })
@@ -93,13 +98,25 @@ impl ServeCommandBuilder {
         };
         let messenger = Arc::new(Mutex::new(Messenger::new(adapter)));
         let (messaging_ready_tx, messaging_ready_rx) = watch::channel(false);
+        // Shutdown-side counterpart of `messaging_ready`: the core node signals
+        // this once teardown finishes, releasing the router to close the session.
+        let (core_node_done_tx, core_node_done_rx) = watch::channel(false);
+        // Bound the router's wait on core node teardown by the core node's
+        // worst-case stop duration (cooperative grace + reap budget) plus a
+        // small margin, so a hung teardown cannot wedge the messaging shutdown.
+        let teardown_budget = Duration::from_secs(self.peppy_config.lifecycle.shutdown_grace_secs)
+            + core_node::TEARDOWN_REAP_BUDGET
+            + Duration::from_secs(1);
         self.messenger = Some(Arc::clone(&messenger));
         self.messaging_ready = Some(messaging_ready_rx);
+        self.core_node_done_tx = Some(core_node_done_tx);
         self.composite_command =
             self.composite_command
                 .add_async_command(Box::new(MessagingRouter::new(
                     messenger,
                     messaging_ready_tx,
+                    Some(core_node_done_rx),
+                    teardown_budget,
                 )));
         Ok(self)
     }
@@ -121,6 +138,13 @@ impl ServeCommandBuilder {
                 // Capture the shutdown grace before `peppy_config` is moved into
                 // the runner, so the daemon state file can advertise it to clients.
                 let shutdown_grace_secs = self.peppy_config.lifecycle.shutdown_grace_secs;
+                // The send half of the router's shutdown handshake, created in
+                // `with_messaging_router`. Present whenever a messaging router
+                // exists, which is required for a core node (checked above).
+                let core_node_done_tx = self
+                    .core_node_done_tx
+                    .take()
+                    .expect("core_node_done channel created in with_messaging_router");
                 let core_node = CoreNodeRunner::new(
                     Arc::clone(messenger),
                     self.core_node_name.clone(),
@@ -130,6 +154,7 @@ impl ServeCommandBuilder {
                     self.messaging_ready.clone(),
                     self.clock_source,
                     self.peppy_config,
+                    core_node_done_tx,
                 );
 
                 // Write the daemon state file with the core node name

--- a/crates/peppy/src/commands/service/core_node.rs
+++ b/crates/peppy/src/commands/service/core_node.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{Mutex, oneshot, watch};
+use tokio_util::sync::CancellationToken;
 use tracing::info;
 
 /// Cadence of the per-node health monitor (see
@@ -32,6 +33,13 @@ pub(crate) const DAEMON_HEARTBEAT_INTERVAL: Duration =
 pub struct CoreNodeRunner {
     core_node: CoreNode,
     messaging_ready: Option<watch::Receiver<bool>>,
+    /// Cancelled at the start of shutdown to stop the core node's clock +
+    /// heartbeat publishers before the messaging session is closed.
+    shutdown_token: CancellationToken,
+    /// Signaled (`true`) once node teardown has finished, releasing the
+    /// messaging router to close the session. The startup `messaging_ready`
+    /// watch's shutdown-side counterpart.
+    core_node_done: watch::Sender<bool>,
 }
 
 impl CoreNodeRunner {
@@ -45,6 +53,7 @@ impl CoreNodeRunner {
         messaging_ready: Option<watch::Receiver<bool>>,
         clock_source: super::ClockSource,
         peppy_config: config::peppy_config::PeppyConfig,
+        core_node_done: watch::Sender<bool>,
     ) -> Self {
         let node_arguments = CoreNodeArguments {
             node_startup_timeout,
@@ -65,6 +74,9 @@ impl CoreNodeRunner {
             eprintln!("{e}");
             std::process::exit(1);
         }
+        // The publishers select on this token; the runner cancels it at the
+        // start of shutdown so they stop before the session is closed.
+        let shutdown_token = CancellationToken::new();
         let core_node = CoreNode::new(CoreNodeConfig {
             messenger,
             node_name: core_node_name,
@@ -72,10 +84,13 @@ impl CoreNodeRunner {
             root_dir,
             peppy_dirs,
             peppy_config,
+            shutdown_token: shutdown_token.clone(),
         });
         Self {
             core_node,
             messaging_ready,
+            shutdown_token,
+            core_node_done,
         }
     }
 
@@ -89,6 +104,8 @@ impl ServeAsyncCommand for CoreNodeRunner {
         let (ready_tx, ready_rx) = oneshot::channel();
         let core_node = self.core_node;
         let mut messaging_ready = self.messaging_ready;
+        let shutdown_token = self.shutdown_token;
+        let core_node_done = self.core_node_done;
         let future = Box::pin(async move {
             let shutdown_signal = super::shutdown_signal::shutdown_signal();
             tokio::pin!(shutdown_signal);
@@ -132,6 +149,10 @@ impl ServeAsyncCommand for CoreNodeRunner {
 
             if shutdown_triggered {
                 info!("Shutting down commands listener...");
+                // Stop the daemon's own clock + heartbeat publishers first, so
+                // they don't spin against the session once the messaging router
+                // closes it (logging a failed publish on every tick).
+                shutdown_token.cancel();
                 // Catchable shutdown (ctrl+C / SIGTERM): the daemon is exiting,
                 // so tear down every spawned node now — cooperatively, then
                 // force-kill any straggler's process group — so none is left
@@ -139,7 +160,13 @@ impl ServeAsyncCommand for CoreNodeRunner {
                 // of `core_node`; `teardown_node_stack` also takes `&self`, so
                 // this second shared borrow is fine. Runs before this handler
                 // returns, so the kills complete before the daemon process exits.
+                // The cooperative stop sends SHUTDOWN_SERVICE over the messaging
+                // session, so the session must still be open here — the router
+                // waits for the `core_node_done` signal below before closing it.
                 core_node.teardown_node_stack().await;
+                // Release the messaging router to close the session now that the
+                // core node no longer needs it.
+                let _ = core_node_done.send(true);
             }
 
             result

--- a/crates/peppy/src/commands/service/messaging_router.rs
+++ b/crates/peppy/src/commands/service/messaging_router.rs
@@ -29,13 +29,30 @@ const WATCHDOG_POST_RESTART_BACKOFF: Duration = Duration::from_secs(10);
 pub struct MessagingRouter {
     messenger: Arc<Mutex<Messenger>>,
     messaging_ready: watch::Sender<bool>,
+    /// Signaled (`true`) by the core node once its teardown has finished. The
+    /// router waits on this before closing the session so cooperative node
+    /// shutdown (which sends `SHUTDOWN_SERVICE` over the session) can complete.
+    /// `None` when the daemon runs without a core node, in which case there is
+    /// nothing to wait for.
+    core_node_done: Option<watch::Receiver<bool>>,
+    /// Upper bound on the wait for `core_node_done`, so a hung teardown cannot
+    /// wedge the messaging shutdown. Sized to the core node's worst-case stop
+    /// duration (cooperative grace + reap budget) plus a small margin.
+    teardown_budget: Duration,
 }
 
 impl MessagingRouter {
-    pub fn new(messenger: Arc<Mutex<Messenger>>, messaging_ready: watch::Sender<bool>) -> Self {
+    pub fn new(
+        messenger: Arc<Mutex<Messenger>>,
+        messaging_ready: watch::Sender<bool>,
+        core_node_done: Option<watch::Receiver<bool>>,
+        teardown_budget: Duration,
+    ) -> Self {
         Self {
             messenger,
             messaging_ready,
+            core_node_done,
+            teardown_budget,
         }
     }
 }
@@ -45,6 +62,8 @@ impl ServeAsyncCommand for MessagingRouter {
         let (ready_tx, ready_rx) = oneshot::channel();
         let messenger = self.messenger;
         let messaging_ready = self.messaging_ready;
+        let core_node_done = self.core_node_done;
+        let teardown_budget = self.teardown_budget;
 
         let future = Box::pin(async move {
             {
@@ -94,6 +113,22 @@ impl ServeAsyncCommand for MessagingRouter {
                 }
             }
 
+            // Catchable shutdown fired. The core node still needs the session to
+            // stop its nodes cooperatively (it sends SHUTDOWN_SERVICE over the
+            // session), so wait for it to finish tearing down before closing the
+            // session. Bounded by `teardown_budget` so a hung teardown cannot
+            // wedge the messaging shutdown.
+            if core_node_done.is_some() {
+                info!("Waiting for core node teardown before closing the messaging session...");
+            }
+            if !await_core_node_teardown(core_node_done, teardown_budget).await {
+                warn!(
+                    "Core node teardown did not signal completion within {:?}; \
+                     closing the messaging session anyway",
+                    teardown_budget
+                );
+            }
+
             {
                 let mut messenger = messenger.lock().await;
                 info!("Shutting down the messaging router...");
@@ -117,6 +152,33 @@ impl ServeAsyncCommand for MessagingRouter {
 
         ServeAsyncHandle::new(future, Some(ready_rx))
     }
+}
+
+/// Waits (bounded by `teardown_budget`) for the core node to signal that its
+/// teardown has finished, so the caller can keep the messaging session open
+/// until cooperative node shutdown (which rides over that session) completes.
+///
+/// Returns `true` when there is nothing left to wait for — either the core node
+/// signaled completion, the daemon has no core node (`None`), or the sender was
+/// dropped without signaling (the runner is already gone). Returns `false` only
+/// when the wait exceeded the budget, so the caller logs and proceeds anyway.
+async fn await_core_node_teardown(
+    core_node_done: Option<watch::Receiver<bool>>,
+    teardown_budget: Duration,
+) -> bool {
+    let Some(mut done) = core_node_done else {
+        return true;
+    };
+    let wait = async {
+        while !*done.borrow() {
+            if done.changed().await.is_err() {
+                // The core node runner is gone without signaling (it never
+                // started, or exited early); stop waiting.
+                break;
+            }
+        }
+    };
+    tokio::time::timeout(teardown_budget, wait).await.is_ok()
 }
 
 /// Periodically probes the Zenoh router and respawns zenohd if it stops
@@ -216,4 +278,63 @@ fn warn_messaging_restarted() {
          `peppy stack list` shows a node did not rejoin.\n\
          ===================================================================="
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::await_core_node_teardown;
+    use std::time::Duration;
+    use tokio::sync::watch;
+
+    #[tokio::test]
+    async fn proceeds_once_core_node_signals_completion() {
+        let (done_tx, done_rx) = watch::channel(false);
+        let waiter = tokio::spawn(await_core_node_teardown(
+            Some(done_rx),
+            Duration::from_secs(5),
+        ));
+
+        // The core node finishes teardown and signals.
+        done_tx
+            .send(true)
+            .expect("receiver kept alive by the waiter");
+
+        let ready = tokio::time::timeout(Duration::from_secs(1), waiter)
+            .await
+            .expect("waiter should resolve promptly after the signal")
+            .expect("waiter task should not panic");
+        assert!(
+            ready,
+            "a completion signal must count as ready, not a timeout"
+        );
+    }
+
+    #[tokio::test]
+    async fn times_out_when_core_node_never_signals() {
+        // Keep the sender alive so the wait blocks on the (never-changing)
+        // value rather than resolving early on a dropped sender.
+        let (_done_tx, done_rx) = watch::channel(false);
+        let ready = await_core_node_teardown(Some(done_rx), Duration::from_millis(50)).await;
+        assert!(
+            !ready,
+            "a hung teardown must surface as a timeout so the router proceeds"
+        );
+    }
+
+    #[tokio::test]
+    async fn proceeds_immediately_without_a_core_node() {
+        let ready = await_core_node_teardown(None, Duration::from_secs(5)).await;
+        assert!(ready, "no core node means nothing to wait for");
+    }
+
+    #[tokio::test]
+    async fn proceeds_when_the_sender_is_dropped_without_signaling() {
+        let (done_tx, done_rx) = watch::channel(false);
+        drop(done_tx); // runner gone without ever signaling.
+        let ready = await_core_node_teardown(Some(done_rx), Duration::from_secs(5)).await;
+        assert!(
+            ready,
+            "a dropped sender means the runner is already gone, not a timeout"
+        );
+    }
 }

--- a/crates/peppy/src/test_support.rs
+++ b/crates/peppy/src/test_support.rs
@@ -192,6 +192,7 @@ impl ServeCommandEmulation {
             root_dir: temp_dir.path().to_path_buf(),
             peppy_dirs,
             peppy_config: config::peppy_config::PeppyConfig::default(),
+            shutdown_token: tokio_util::sync::CancellationToken::new(),
         });
         let core_node_name = core_node.node_name().to_string();
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Core node clock publishers and heartbeat tasks now shut down cleanly during daemon shutdown instead of continuing to run after the messaging session closes.

* **Chores**
  * Improved internal shutdown coordination between core node and messaging router for more reliable daemon teardown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->