### PR TITLE
Fix topics public API

### DIFF
--- a/crates/containers-internal/src/apptainer/facade.rs
+++ b/crates/containers-internal/src/apptainer/facade.rs
@@ -977,6 +977,27 @@ impl<'a> ApptainerCommand<'a> {
         self
     }
 
+    /// Run with `--cleanenv`: the container does NOT inherit the host (daemon)
+    /// process environment. Only the explicit `--env` vars set on this command
+    /// and the image's own `%environment` are visible inside.
+    ///
+    /// Two reasons a spawned node wants this. First, hygiene and security: the
+    /// daemon's environment can hold secrets (ssh-agent sockets, tokens) and
+    /// host-specific noise that have no business inside a node. Second,
+    /// robustness: without it, apptainer folds the inherited environment into a
+    /// generated `/.inject-apptainer-env.sh` that the container sources at
+    /// startup, and a single host var whose name is not a shell identifier (for
+    /// example a bash exported function `BASH_FUNC_x%%`) makes that `source`
+    /// abort with "invalid var name", silently dropping every later var,
+    /// including `PEPPY_RUNTIME_CONFIG`. The node then falls back to its
+    /// standalone defaults instead of the daemon-provided parameters. Passing
+    /// the node's environment explicitly via `--env` (which still applies under
+    /// `--cleanenv`) keeps the curated set while removing both hazards.
+    pub fn clean_env(mut self) -> Self {
+        self.flags.push("--cleanenv".to_string());
+        self
+    }
+
     /// Add extra arguments passed to `limactl shell` (before the `--` separator).
     ///
     /// These are only effective when running under the Lima backend (macOS).

--- a/crates/core-node-internal/tests/latency/harness.rs
+++ b/crates/core-node-internal/tests/latency/harness.rs
@@ -691,20 +691,21 @@ async fn run_topic(
     iters: u64,
 ) -> Result<Vec<u64>> {
     let messenger = node_runner.messenger();
+    let publisher = TopicMessenger::declare_publisher(
+        messenger,
+        core,
+        inst,
+        SenderTarget::node(DRIVER_NODE, TAG)?,
+        None,
+        "ping",
+        QoSProfile::Reliable,
+    )
+    .await?;
     let mut samples = Vec::with_capacity(iters as usize);
     for i in 0..(warmup + iters) {
         let payload = Payload::from(i.to_le_bytes().to_vec());
         let mut start = Instant::now();
-        TopicMessenger::emit(
-            messenger,
-            core,
-            inst,
-            SenderTarget::node(DRIVER_NODE, TAG)?,
-            "ping",
-            QoSProfile::Reliable,
-            payload.clone(),
-        )
-        .await?;
+        publisher.publish(payload.clone()).await?;
         loop {
             match tokio::time::timeout(PONG_TIMEOUT, sub.on_next_message()).await {
                 Ok(Some(msg)) => {
@@ -715,18 +716,9 @@ async fn run_topic(
                 }
                 Ok(None) => return Ok(samples),
                 Err(_) => {
-                    // Lost ping (warmup-phase propagation): re-emit, reset clock.
+                    // Lost ping (warmup-phase propagation): re-publish, reset clock.
                     start = Instant::now();
-                    TopicMessenger::emit(
-                        messenger,
-                        core,
-                        inst,
-                        SenderTarget::node(DRIVER_NODE, TAG)?,
-                        "ping",
-                        QoSProfile::Reliable,
-                        payload.clone(),
-                    )
-                    .await?;
+                    publisher.publish(payload.clone()).await?;
                 }
             }
         }
@@ -876,17 +868,19 @@ fn main() -> Result<()> {
                 )
                 .await
                 .expect("subscribe ping");
+                let pong = TopicMessenger::declare_publisher(
+                    runner.messenger(),
+                    &core,
+                    &inst,
+                    SenderTarget::node(RESPONDER_NODE, TAG).expect("responder target"),
+                    None,
+                    "pong",
+                    QoSProfile::Reliable,
+                )
+                .await
+                .expect("declare pong publisher");
                 while let Some(msg) = sub.on_next_message().await {
-                    let _ = TopicMessenger::emit(
-                        runner.messenger(),
-                        &core,
-                        &inst,
-                        SenderTarget::node(RESPONDER_NODE, TAG).expect("responder target"),
-                        "pong",
-                        QoSProfile::Reliable,
-                        msg.payload().clone(),
-                    )
-                    .await;
+                    let _ = pong.publish(msg.payload().clone()).await;
                 }
             });
         }
@@ -936,19 +930,19 @@ async def echo_topic(node_runner):
         None,
         QoSProfile.Reliable,
     )
+    pong = await TopicMessenger.declare_publisher(
+        handle,
+        core,
+        inst,
+        SenderTarget.node(RESPONDER_NODE, TAG),
+        "pong",
+        QoSProfile.Reliable,
+    )
     while True:
         message = await subscription.on_next_message()
         if message is None:
             break
-        await TopicMessenger.emit(
-            handle,
-            core,
-            inst,
-            SenderTarget.node(RESPONDER_NODE, TAG),
-            "pong",
-            QoSProfile.Reliable,
-            message.payload,
-        )
+        await pong.publish(message.payload)
 
 
 def abort_on_task_failure(task):

--- a/crates/core-node-internal/tests/latency/harness.rs
+++ b/crates/core-node-internal/tests/latency/harness.rs
@@ -880,7 +880,9 @@ fn main() -> Result<()> {
                 .await
                 .expect("declare pong publisher");
                 while let Some(msg) = sub.on_next_message().await {
-                    let _ = pong.publish(msg.payload().clone()).await;
+                    pong.publish(msg.payload().clone())
+                        .await
+                        .expect("publish pong");
                 }
             });
         }

--- a/crates/generator-internal/src/generator/python/tests/topics.rs
+++ b/crates/generator-internal/src/generator/python/tests/topics.rs
@@ -156,11 +156,12 @@ fn emit_topic() {
         ],
     );
 
-    // emit function signature with typed parameters
+    // build_message signature carries the typed message fields (no node_runner);
+    // declare_publisher takes the node_runner.
     assert_contains_all(
         &rendered,
         &[
-            "async def emit(",
+            "def build_message(",
             "node_runner: peppylib.NodeRunner",
             "header: MessageHeader",
             "encoding: str",
@@ -189,9 +190,8 @@ fn emit_topic() {
         ],
     );
 
-    // Pure serializer, declared (lock-free) publisher, and one-shot emit are all
-    // generated; emit delegates to build_message so the serialization is not
-    // duplicated.
+    // Pure serializer and a declared (lock-free) publisher are generated; the
+    // declared publisher is the only publish path (no one-shot emit).
     assert_contains_all(
         &rendered,
         &[
@@ -200,9 +200,15 @@ fn emit_topic() {
             "def build_message(",
             "async def declare_publisher(node_runner: peppylib.NodeRunner) -> peppylib.TopicPublisher:",
             "peppylib.TopicMessenger.declare_publisher(",
-            "peppylib.TopicMessenger.emit(",
-            "build_message(header, encoding, width, height, frame),",
         ],
+    );
+    assert!(
+        !rendered.contains("async def emit("),
+        "emit() should no longer be generated; declare_publisher is the only publish path; rendered:\n{rendered}"
+    );
+    assert!(
+        !rendered.contains("TopicMessenger.emit"),
+        "TopicMessenger.emit should no longer be generated; rendered:\n{rendered}"
     );
 }
 
@@ -285,7 +291,7 @@ fn emit_topic_escapes_python_keyword_fields() {
     assert_contains_all(
         &rendered,
         &[
-            "async def emit(",
+            "def build_message(",
             "class_: int",
             "from_: str",
             "setattr(capnp_msg, \"class\", class_)",

--- a/crates/generator-internal/src/generator/python/tests/topics.rs
+++ b/crates/generator-internal/src/generator/python/tests/topics.rs
@@ -185,19 +185,23 @@ fn emit_topic() {
             "capnp_msg.width = width",
             "capnp_msg.height = height",
             "capnp_msg.frame = frame",
-            "payload = capnp_msg.to_bytes()",
+            "return capnp_msg.to_bytes()",
         ],
     );
 
-    // Topic metadata and messenger call
+    // Pure serializer, declared (lock-free) publisher, and one-shot emit are all
+    // generated; emit delegates to build_message so the serialization is not
+    // duplicated.
     assert_contains_all(
         &rendered,
         &[
             "TOPIC_NAME = \"video_stream\"",
-            "peppylib.QoSProfile.SensorData",
+            "QOS = peppylib.QoSProfile.SensorData",
+            "def build_message(",
+            "async def declare_publisher(node_runner: peppylib.NodeRunner) -> peppylib.TopicPublisher:",
+            "peppylib.TopicMessenger.declare_publisher(",
             "peppylib.TopicMessenger.emit(",
-            "TOPIC_NAME,",
-            "payload,",
+            "build_message(header, encoding, width, height, frame),",
         ],
     );
 }

--- a/crates/generator-internal/src/generator/python/topics.rs
+++ b/crates/generator-internal/src/generator/python/topics.rs
@@ -89,20 +89,15 @@ pub fn build_emitted_topic(
     let target_expr =
         sender_target_python_expr(origin, "node_runner.node_name()", "node_runner.node_tag()");
 
-    // Field params shared by build_message and emit (emit also takes node_runner).
+    // Field params for build_message.
     let field_params: Vec<String> = fields
         .iter()
         .map(|field| format!("{}: {}", field.name, field.type_str))
         .collect();
     let field_params_str = field_params.join(", ");
-    let field_names = fields
-        .iter()
-        .map(|field| field.name.clone())
-        .collect::<Vec<_>>()
-        .join(", ");
 
-    // Module-level topic constants, shared by build_message, declare_publisher,
-    // and emit.
+    // Module-level topic constants, shared by build_message and
+    // declare_publisher.
     builder.line(&format!("TOPIC_NAME = \"{}\"", topic.name));
     builder.line(&format!("QOS = {qos}"));
     builder.blank_line();
@@ -130,9 +125,9 @@ pub fn build_emitted_topic(
     builder.blank_line();
 
     // declare_publisher: take the central messenger lock ONCE and return a
-    // lock-free publisher whose publish(payload) never re-takes that lock. Use
-    // this for publish loops (a camera streaming frames, a sensor at rate),
-    // paired with build_message; use emit for one-shot publishes.
+    // lock-free publisher whose publish(payload) never re-takes that lock.
+    // Declare once, then publish per message (a camera streaming frames, a
+    // sensor at rate), paired with build_message.
     builder.line(
         "async def declare_publisher(node_runner: peppylib.NodeRunner) -> peppylib.TopicPublisher:",
     );
@@ -145,27 +140,6 @@ pub fn build_emitted_topic(
     builder.line(&format!("{target_expr},"));
     builder.line("TOPIC_NAME,");
     builder.line("QOS,");
-    builder.dedent();
-    builder.line(")");
-    builder.dedent();
-    builder.blank_line();
-
-    // emit: one-shot publish convenience. Re-takes the central messenger lock on
-    // every call, so prefer declare_publisher for loops.
-    let mut emit_params = vec![String::from("node_runner: peppylib.NodeRunner")];
-    emit_params.extend(field_params.iter().cloned());
-    let emit_params_str = emit_params.join(", ");
-    builder.line(&format!("async def emit({emit_params_str}):"));
-    builder.indent();
-    builder.line("await peppylib.TopicMessenger.emit(");
-    builder.indent();
-    builder.line("node_runner.messenger(),");
-    builder.line("node_runner.bound_core_node(),");
-    builder.line("node_runner.bound_instance_id(),");
-    builder.line(&format!("{target_expr},"));
-    builder.line("TOPIC_NAME,");
-    builder.line("QOS,");
-    builder.line(&format!("build_message({field_names}),"));
     builder.dedent();
     builder.line(")");
     builder.dedent();

--- a/crates/generator-internal/src/generator/python/topics.rs
+++ b/crates/generator-internal/src/generator/python/topics.rs
@@ -83,23 +83,37 @@ pub fn build_emitted_topic(
     // Emit nested dataclasses (e.g., MessageHeader)
     emit_nested_classes(&mut builder, &nested_classes);
 
-    // Build parameter list for emit function
     builder.add_import("import peppylib");
-    let mut param_parts = vec![String::from("node_runner: peppylib.NodeRunner")];
-    for field in &fields {
-        param_parts.push(format!("{}: {}", field.name, field.type_str));
-    }
-    let params_str = param_parts.join(", ");
 
     let qos = qos_profile_python(&topic.qos_profile);
+    let target_expr =
+        sender_target_python_expr(origin, "node_runner.node_name()", "node_runner.node_tag()");
 
-    // Generate the emit function
-    builder.line(&format!("async def emit({params_str}):"));
-    builder.indent();
+    // Field params shared by build_message and emit (emit also takes node_runner).
+    let field_params: Vec<String> = fields
+        .iter()
+        .map(|field| format!("{}: {}", field.name, field.type_str))
+        .collect();
+    let field_params_str = field_params.join(", ");
+    let field_names = fields
+        .iter()
+        .map(|field| field.name.clone())
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    // Module-level topic constants, shared by build_message, declare_publisher,
+    // and emit.
     builder.line(&format!("TOPIC_NAME = \"{}\"", topic.name));
-    builder.line(&format!("qos = {qos}"));
+    builder.line(&format!("QOS = {qos}"));
+    builder.blank_line();
 
-    // Generate payload serialization
+    // build_message: serialize the message to wire bytes. Pure (no node_runner,
+    // no I/O), so a publish loop can build the payload off the asyncio event
+    // loop thread (for example on a decoder worker) and hand only the finished
+    // bytes to the loop, keeping per-message serialization off the loop's GIL
+    // time.
+    builder.line(&format!("def build_message({field_params_str}) -> bytes:"));
+    builder.indent();
     if let (Some(info), Some(fmt)) = (schema_info, topic.message_format.as_ref()) {
         let loader_fn_name = capnp_loader_fn_name(info);
         builder.line(&format!(
@@ -108,13 +122,41 @@ pub fn build_emitted_topic(
         ));
         let mut counter = 0u32;
         serialization::emit_capnp_assignments(&mut builder, "capnp_msg", fmt, "", &mut counter);
-        builder.line("payload = capnp_msg.to_bytes()");
+        builder.line("return capnp_msg.to_bytes()");
     } else {
-        builder.line("payload = b\"\"");
+        builder.line("return b\"\"");
     }
+    builder.dedent();
+    builder.blank_line();
 
-    let target_expr =
-        sender_target_python_expr(origin, "node_runner.node_name()", "node_runner.node_tag()");
+    // declare_publisher: take the central messenger lock ONCE and return a
+    // lock-free publisher whose publish(payload) never re-takes that lock. Use
+    // this for publish loops (a camera streaming frames, a sensor at rate),
+    // paired with build_message; use emit for one-shot publishes.
+    builder.line(
+        "async def declare_publisher(node_runner: peppylib.NodeRunner) -> peppylib.TopicPublisher:",
+    );
+    builder.indent();
+    builder.line("return await peppylib.TopicMessenger.declare_publisher(");
+    builder.indent();
+    builder.line("node_runner.messenger(),");
+    builder.line("node_runner.bound_core_node(),");
+    builder.line("node_runner.bound_instance_id(),");
+    builder.line(&format!("{target_expr},"));
+    builder.line("TOPIC_NAME,");
+    builder.line("QOS,");
+    builder.dedent();
+    builder.line(")");
+    builder.dedent();
+    builder.blank_line();
+
+    // emit: one-shot publish convenience. Re-takes the central messenger lock on
+    // every call, so prefer declare_publisher for loops.
+    let mut emit_params = vec![String::from("node_runner: peppylib.NodeRunner")];
+    emit_params.extend(field_params.iter().cloned());
+    let emit_params_str = emit_params.join(", ");
+    builder.line(&format!("async def emit({emit_params_str}):"));
+    builder.indent();
     builder.line("await peppylib.TopicMessenger.emit(");
     builder.indent();
     builder.line("node_runner.messenger(),");
@@ -122,8 +164,8 @@ pub fn build_emitted_topic(
     builder.line("node_runner.bound_instance_id(),");
     builder.line(&format!("{target_expr},"));
     builder.line("TOPIC_NAME,");
-    builder.line("qos,");
-    builder.line("payload,");
+    builder.line("QOS,");
+    builder.line(&format!("build_message({field_names}),"));
     builder.dedent();
     builder.line(")");
     builder.dedent();

--- a/crates/generator-internal/src/generator/rust.rs
+++ b/crates/generator-internal/src/generator/rust.rs
@@ -53,7 +53,7 @@ use services::{
     deserialize_fields_from_format,
 };
 use topics::{
-    ConsumedTopicCallbackSpec, build_consumed_topic_callback, build_topic_emit,
+    ConsumedTopicCallbackSpec, build_consumed_topic_callback, build_topic_publisher,
     consumed_to_target_expression,
 };
 use type_mapping::{render_tokens, unused_params_stmt};
@@ -663,15 +663,8 @@ impl LanguageGenerator for RustGenerator {
             &params,
         )?;
         let struct_tokens = context.into_tokens();
-        let method_ident = Ident::new("emit", Span::call_site());
-        let method_tokens = build_topic_emit(
-            &method_ident,
-            &params,
-            encoding.as_ref(),
-            topic,
-            &fn_name_str,
-            origin,
-        );
+        let method_tokens =
+            build_topic_publisher(&params, encoding.as_ref(), topic, &fn_name_str, origin);
 
         let tokens: TokenStream = quote! {
             #( #struct_tokens )*

--- a/crates/generator-internal/src/generator/rust/tests/topics.rs
+++ b/crates/generator-internal/src/generator/rust/tests/topics.rs
@@ -140,24 +140,35 @@ fn emit_topic() {
         ],
     );
 
-    // Generated structs and function signature
+    // Generated structs and function signatures
     assert_contains_all(
         &rendered,
         &[
             "pub struct MessageHeader",
             "frame: Vec<u8>",
-            "pub async fn emit(",
+            "pub fn build_message(",
+            "pub async fn declare_publisher(",
+            "-> crate::Result<peppylib::TopicPublisher>",
         ],
     );
 
-    // Topic metadata
+    // Topic metadata. declare_publisher is the only publish path; build_message
+    // serializes off the messenger lock, and emit() is no longer generated.
     assert_contains_all(
         &rendered,
         &[
             "let as_topic = \"video_stream\";",
             "let qos = peppylib::config::QoSProfile::SensorData;",
-            "peppylib::TopicMessenger::emit(",
+            "peppylib::TopicMessenger::declare_publisher(",
         ],
+    );
+    assert!(
+        !rendered.contains("pub async fn emit("),
+        "emit() should no longer be generated; declare_publisher is the only publish path; got: {rendered}"
+    );
+    assert!(
+        !rendered.contains("TopicMessenger::emit"),
+        "TopicMessenger::emit should no longer be generated; got: {rendered}"
     );
 }
 
@@ -206,7 +217,7 @@ fn emit_topic_escapes_rust_keyword_fields() {
     assert_contains_all(
         &rendered,
         &[
-            "pub async fn emit(",
+            "pub fn build_message(",
             "type_: u32",
             "match_: String",
             "root.set_type(type_);",

--- a/crates/generator-internal/src/generator/rust/topics.rs
+++ b/crates/generator-internal/src/generator/rust/topics.rs
@@ -19,7 +19,8 @@ pub struct ConsumedTopicCallbackSpec<'a> {
     pub dependency: &'a crate::generator::types::DependencyContext,
 }
 
-/// Specification for building an emit-style method (topic emit or action feedback emit).
+/// Specification for building an action-feedback emit-style method
+/// (publish_feedback / complete).
 pub struct EmitMethodSpec<'a> {
     pub method_name: &'a Ident,
     pub params: &'a [FunctionParam],
@@ -37,7 +38,7 @@ pub struct EmitMethodSpec<'a> {
 
 /// Builds an emit-style async method that serializes params and publishes.
 ///
-/// Shared logic for both `build_topic_emit` and `build_action_feedback_emit`:
+/// Shared logic for the action `publish_feedback` / `complete` methods:
 /// filters instance_id from params, branches on encoding presence, and either
 /// serializes + publishes or returns `MessageFormatUnavailable`.
 pub fn build_emit_method(spec: EmitMethodSpec<'_>) -> TokenStream {
@@ -105,8 +106,14 @@ pub fn build_emit_method(spec: EmitMethodSpec<'_>) -> TokenStream {
     }
 }
 
-pub fn build_topic_emit(
-    method_ident: &Ident,
+/// Generates the publish-side API for an emitted topic: a pure `build_message`
+/// that serializes the message fields to a wire `peppylib::Payload`, and an
+/// async `declare_publisher` that takes the central messenger lock once and
+/// returns a lock-free `peppylib::TopicPublisher`. A publish loop declares the
+/// publisher once and then calls `publisher.publish(build_message(...)?)`, so
+/// per-message serialization never re-takes the messenger lock. This is the
+/// only topic-publish path.
+pub fn build_topic_publisher(
     params: &[FunctionParam],
     encoding: Option<&MessageEncodingSpec>,
     topic: &EmittedTopic,
@@ -118,32 +125,98 @@ pub fn build_topic_emit(
     let label_literal = Literal::string(label);
     let target_expr = sender_target_expression(origin);
 
-    build_emit_method(EmitMethodSpec {
-        method_name: method_ident,
-        params,
-        encoding,
-        receiver: quote!(node_runner: &crate::NodeRunner),
-        publish_body: quote! {
+    let build_message = build_topic_build_message(params, encoding, &label_literal);
+
+    quote! {
+        #build_message
+
+        /// Declares the topic publisher: takes the central messenger lock once
+        /// and returns a lock-free `peppylib::TopicPublisher`. Declare once,
+        /// then call `publisher.publish(build_message(...)?)` per message.
+        pub async fn declare_publisher(
+            node_runner: &crate::NodeRunner,
+        ) -> crate::Result<peppylib::TopicPublisher> {
             let qos = #qos_tokens;
             let as_topic = #topic_literal;
             let as_instance_id = node_runner.processor().bound_instance_id();
             let with_core_node = node_runner.processor().bound_core_node();
             let as_target = #target_expr;
 
-            peppylib::TopicMessenger::emit(
+            let publisher = peppylib::TopicMessenger::declare_publisher(
                 node_runner.messenger(),
                 with_core_node,
                 as_instance_id,
                 as_target,
+                None,
                 as_topic,
                 qos,
-                payload,
             )
-                .await?;
-        },
-        error_context: quote!(String::from(#label_literal)),
-        suppress_unused: vec![quote!(let _ = node_runner;)],
-    })
+            .await?;
+            Ok(publisher)
+        }
+    }
+}
+
+/// `build_message(fields…)` for an emitted topic: serializes the message fields
+/// to a wire `peppylib::Payload` with no messenger access, so a publish loop can
+/// build the payload off any lock and hand the finished bytes to
+/// [`peppylib::TopicPublisher::publish`]. Filters the reserved `instance_id`
+/// from the params and returns `MessageFormatUnavailable` when the topic has no
+/// serializable message format.
+fn build_topic_build_message(
+    params: &[FunctionParam],
+    encoding: Option<&MessageEncodingSpec>,
+    label_literal: &Literal,
+) -> TokenStream {
+    let instance_id_ident = Ident::new("instance_id", proc_macro2::Span::call_site());
+    let kept_params: Vec<&FunctionParam> = params
+        .iter()
+        .filter(|param| param.ident != instance_id_ident)
+        .collect();
+    let method_param_tokens: Vec<TokenStream> = kept_params
+        .iter()
+        .map(|param| {
+            let ident = &param.ident;
+            let ty = &param.ty;
+            quote!(#ident: #ty)
+        })
+        .collect();
+
+    let error_context = quote!(String::from(#label_literal));
+
+    match encoding {
+        Some(spec) => {
+            let serialize_block =
+                build_serialize_payload(&spec.builder_type, &[], &spec.assignments, &error_context);
+
+            quote! {
+                #[allow(clippy::too_many_arguments)]
+                pub fn build_message(#(#method_param_tokens),*) -> crate::Result<peppylib::Payload> {
+                    let payload = #serialize_block;
+                    Ok(payload)
+                }
+            }
+        }
+        None => {
+            let ignore_params: Vec<TokenStream> = kept_params
+                .iter()
+                .map(|param| {
+                    let ident = &param.ident;
+                    quote!(let _ = #ident;)
+                })
+                .collect();
+
+            quote! {
+                #[allow(clippy::too_many_arguments)]
+                pub fn build_message(#(#method_param_tokens),*) -> crate::Result<peppylib::Payload> {
+                    #(#ignore_params)*
+                    Err(crate::Error::MessageFormatUnavailable {
+                        context: #error_context,
+                    })
+                }
+            }
+        }
+    }
 }
 
 /// Returns the `SenderTarget` constructor expression to splice into a

--- a/crates/generator-internal/tests/python/topics_communication.rs
+++ b/crates/generator-internal/tests/python/topics_communication.rs
@@ -228,16 +228,18 @@ async def setup(parameters, node_runner) -> list[asyncio.Task]:
     interval = 1.0 / frequency_hz
 
     async def emit_loop():
+        publisher = await video_stream.declare_publisher(node_runner)
         frame_id = 0
         print(f"emitter: starting emit loop with interval={interval}", flush=True)
         while True:
-            await video_stream.emit(
-                node_runner,
-                video_stream.MessageHeader(stamp=time.time(), frame_id=frame_id),
-                "rgb8",
-                640,
-                480,
-                bytes([1, 2, 3]),
+            await publisher.publish(
+                video_stream.build_message(
+                    video_stream.MessageHeader(stamp=time.time(), frame_id=frame_id),
+                    "rgb8",
+                    640,
+                    480,
+                    bytes([1, 2, 3]),
+                )
             )
             if frame_id == 0:
                 print("emitter: first emit succeeded", flush=True)

--- a/crates/generator-internal/tests/python/topics_conforms_to.rs
+++ b/crates/generator-internal/tests/python/topics_conforms_to.rs
@@ -2,7 +2,7 @@
 //! scenario, but verifying the Python generator emits the corresponding
 //! `peppygen/emitted_topics/{iface_name}/{iface_tag}/{topic}.py` files with
 //! the right `__init__.py` chains and the matching `iface_name` / `iface_tag`
-//! strings inside each emit call.
+//! strings inside each declare_publisher call.
 
 use crate::helpers::{prepare_directories, test_peppy_dirs};
 use config::node::{
@@ -63,15 +63,15 @@ const NODE_CONFIG: &str = r#"{
 "#;
 
 /// Realsense_d435 scenario for the Python generator: one native
-/// `video_stream` emit plus three resolved conformed interfaces
+/// `video_stream` publisher plus three resolved conformed interfaces
 /// (`depth_camera:v1`, `depth_camera:v2`, `uvc_camera:v1`) each shaped as
 /// `video_stream` with a distinguishing marker field. Verifies that:
 ///   1. Conformed artifacts nest under
 ///      `emitted_topics/{iface_name}/{iface_tag}/{topic}.py` while the native
 ///      artifact stays flat at `emitted_topics/{topic}.py`.
 ///   2. The `__init__.py` chain at each level imports its direct children.
-///   3. Each leaf's emit body passes the matching sender target to the
-///      messenger: `peppylib.SenderTarget.interface(...)` for conformed
+///   3. Each leaf's declare_publisher body passes the matching sender target to
+///      the messenger: `peppylib.SenderTarget.interface(...)` for conformed
 ///      leaves and `peppylib.SenderTarget.node(...)` for the native leaf.
 ///   4. The per-interface marker fields land in their own files — proof the
 ///      four artifacts weren't cross-wired during generation.
@@ -140,8 +140,8 @@ fn nests_conformed_topics_under_iface_name_and_tag() {
         "depth_camera/__init__.py should import v1 and v2:\n{depth_init}",
     );
 
-    // Each leaf's emit body passes a matching `peppylib.SenderTarget` expression
-    // to the messenger. Native gets `SenderTarget.node(...)`; conformed leaves
+    // Each leaf's declare_publisher body passes a matching `peppylib.SenderTarget`
+    // expression to the messenger. Native gets `SenderTarget.node(...)`; conformed leaves
     // pass `SenderTarget.interface("<name>", "<tag>")` with the producer's segments.
     let native_src = fs::read_to_string(&native_path).expect("read native");
     assert!(
@@ -180,7 +180,7 @@ fn nests_conformed_topics_under_iface_name_and_tag() {
     // for the flat native path but two levels short for nested conformed
     // artifacts at `peppygen/<category>/<iface>/<tag>/<leaf>.py`, which made
     // `capnp.load()` raise silently inside the asyncio loop and hung the
-    // consumer. All four files (native + three conformed) should now emit
+    // consumer. All four files (native + three conformed) should now produce
     // the same loader form.
     let expected_loader = "files(\"peppygen\") / \"capnp\" /";
     for (label, src) in [
@@ -204,8 +204,8 @@ fn nests_conformed_topics_under_iface_name_and_tag() {
 /// Exercises hyphen-to-underscore normalization in the `iface_tag` for the
 /// Python generator: a tag `v1-beta` becomes the directory `v1_beta` (Python
 /// identifiers can't carry hyphens) while the literal `"v1-beta"` is still
-/// embedded in the emit body — the messaging layer normalizes hyphens at the
-/// wire boundary, so the generator keeps the raw value.
+/// embedded in the declare_publisher body; the messaging layer normalizes hyphens
+/// at the wire boundary, so the generator keeps the raw value.
 #[test]
 fn hyphenated_tag_lands_in_underscore_directory() {
     let temp_dir = TempDir::new_in(crate::helpers::test_tmp_root()).expect("temp dir");

--- a/crates/generator-internal/tests/python/wire_compat.rs
+++ b/crates/generator-internal/tests/python/wire_compat.rs
@@ -958,13 +958,15 @@ from peppygen.emitted_topics import telemetry_feed
 
 async def setup(parameters, node_runner) -> list[asyncio.Task]:
     async def emit_loop():
+        publisher = await telemetry_feed.declare_publisher(node_runner)
         while True:
-            await telemetry_feed.emit(
-                node_runner,
-                sequence=1,
-                status="nominal",
-                readings=[1.0, 2.0, 3.0],
-                timestamp=12345.6,
+            await publisher.publish(
+                telemetry_feed.build_message(
+                    sequence=1,
+                    status="nominal",
+                    readings=[1.0, 2.0, 3.0],
+                    timestamp=12345.6,
+                )
             )
             await asyncio.sleep(0.1)
     return [asyncio.create_task(emit_loop())]

--- a/crates/generator-internal/tests/rust/topics_communication.rs
+++ b/crates/generator-internal/tests/rust/topics_communication.rs
@@ -210,7 +210,7 @@ fn main() -> Result<()> {
                 .expect("declare video_stream publisher");
             let mut frame_id = 0u32;
             loop {
-                if let Ok(payload) = video_stream::build_message(
+                let payload = video_stream::build_message(
                     video_stream::MessageHeader {
                         stamp: std::time::SystemTime::now(),
                         frame_id,
@@ -219,9 +219,12 @@ fn main() -> Result<()> {
                     640,
                     480,
                     vec![1, 2, 3],
-                ) {
-                    let _ = publisher.publish(payload).await;
-                }
+                )
+                .expect("build video_stream message");
+                publisher
+                    .publish(payload)
+                    .await
+                    .expect("publish video_stream message");
 
                 frame_id = frame_id.wrapping_add(1);
                 tokio::time::sleep(interval).await;

--- a/crates/generator-internal/tests/rust/topics_communication.rs
+++ b/crates/generator-internal/tests/rust/topics_communication.rs
@@ -205,10 +205,12 @@ fn main() -> Result<()> {
 
         let node_runner_clone = node_runner.clone();
         tokio::spawn(async move {
+            let publisher = video_stream::declare_publisher(&node_runner_clone)
+                .await
+                .expect("declare video_stream publisher");
             let mut frame_id = 0u32;
             loop {
-                let _ = video_stream::emit(
-                    &node_runner_clone,
+                if let Ok(payload) = video_stream::build_message(
                     video_stream::MessageHeader {
                         stamp: std::time::SystemTime::now(),
                         frame_id,
@@ -217,8 +219,9 @@ fn main() -> Result<()> {
                     640,
                     480,
                     vec![1, 2, 3],
-                )
-                .await;
+                ) {
+                    let _ = publisher.publish(payload).await;
+                }
 
                 frame_id = frame_id.wrapping_add(1);
                 tokio::time::sleep(interval).await;

--- a/crates/generator-internal/tests/rust/topics_conforms_to.rs
+++ b/crates/generator-internal/tests/rust/topics_conforms_to.rs
@@ -10,10 +10,10 @@
 //!      `emitted_topics/{iface_name}/{iface_tag}/{topic}.rs` while keeping the
 //!      native artifact at `emitted_topics/{topic}.rs`.
 //!   2. Each `mod.rs` declares the right children.
-//!   3. The rendered emit call inside each leaf passes the matching sender
-//!      target (`SenderTarget::interface("name", "tag")?` for conformed,
+//!   3. The rendered declare_publisher inside each leaf passes the matching
+//!      sender target (`SenderTarget::interface("name", "tag")?` for conformed,
 //!      `SenderTarget::node("name", "tag")?` for native) to
-//!      `peppylib::TopicMessenger::emit`.
+//!      `peppylib::TopicMessenger::declare_publisher`.
 
 use crate::helpers::{prepare_directories, test_peppy_dirs};
 use config::node::{
@@ -76,7 +76,7 @@ const NODE_CONFIG: &str = r#"{
 "#;
 
 /// Realsense_d435 scenario for the Rust generator: one native `video_stream`
-/// emit plus three resolved conformed interfaces (`depth_camera:v1`,
+/// publisher plus three resolved conformed interfaces (`depth_camera:v1`,
 /// `depth_camera:v2`, `uvc_camera:v1`) each shaped as `video_stream` with a
 /// distinguishing marker field. Verifies that:
 ///   1. Conformed artifacts nest under
@@ -85,9 +85,9 @@ const NODE_CONFIG: &str = r#"{
 ///   2. Each container `mod.rs` declares its direct child modules, and the
 ///      top-level `emitted_topics.rs` lists the native leaf plus one entry per
 ///      conforming interface directory.
-///   3. Each leaf calls `peppylib::TopicMessenger::emit` with the matching
-///      sender target: `SenderTarget::interface("name", "tag")?` for conformed
-///      leaves and `SenderTarget::node("name", "tag")?` for the native leaf.
+///   3. Each leaf calls `peppylib::TopicMessenger::declare_publisher` with the
+///      matching sender target: `SenderTarget::interface("name", "tag")?` for
+///      conformed leaves and `SenderTarget::node("name", "tag")?` for the native leaf.
 ///   4. The per-interface marker fields land in their own files — proof the
 ///      four artifacts weren't cross-wired during generation.
 #[test]
@@ -161,14 +161,14 @@ fn nests_conformed_topics_under_iface_name_and_tag() {
         );
     }
 
-    // Each leaf calls `peppylib::TopicMessenger::emit(...)` with the sender
-    // target threaded through. Conformed leaves splice in
+    // Each leaf calls `peppylib::TopicMessenger::declare_publisher(...)` with the
+    // sender target threaded through. Conformed leaves splice in
     // `SenderTarget::interface("name", "tag")?` while the native leaf passes
     // `SenderTarget::node("name", "tag")?`.
     let native_src = fs::read_to_string(&native_path).expect("read native");
     assert!(
-        native_src.contains("TopicMessenger::emit"),
-        "native source should call TopicMessenger::emit:\n{native_src}",
+        native_src.contains("TopicMessenger::declare_publisher"),
+        "native source should call TopicMessenger::declare_publisher:\n{native_src}",
     );
     assert!(
         native_src.contains("SenderTarget::node("),
@@ -221,7 +221,7 @@ fn nests_conformed_topics_under_iface_name_and_tag() {
 /// Exercises hyphen-to-underscore normalization in the `iface_tag` for the
 /// Rust generator: a tag `v1-beta` becomes the directory `v1_beta` (Rust
 /// module names can't carry hyphens) while the literal `"v1-beta"` is still
-/// embedded in the emit body — messaging.rs normalizes hyphens at the wire
+/// embedded in the declare_publisher body; messaging.rs normalizes hyphens at the wire
 /// boundary, so the generator keeps the raw value.
 #[test]
 fn hyphenated_tag_lands_in_underscore_directory() {

--- a/crates/node-stack-internal/src/node_stack/run_steps.rs
+++ b/crates/node-stack-internal/src/node_stack/run_steps.rs
@@ -370,7 +370,13 @@ pub(super) async fn build_container_command(
     // whole guest group via `kill_guest_process_group` (same key). A no-op on the
     // native backend (Linux), where the host group kill already reaches the
     // shared-namespace container directly.
-    let mut apptainer_cmd = apptainer.run(sif_str).cancel_pgid(instance_id);
+    // `clean_env`: the node must not inherit the daemon's process environment.
+    // Its parameters arrive via the explicit `--env` vars below (chiefly
+    // PEPPY_RUNTIME_CONFIG); inheriting the daemon env leaks secrets into the
+    // node and, worse, a host var with a shell-invalid name silently breaks
+    // apptainer's env-injection script and drops PEPPY_RUNTIME_CONFIG, making
+    // the node fall back to standalone defaults. See `ApptainerCommand::clean_env`.
+    let mut apptainer_cmd = apptainer.run(sif_str).cancel_pgid(instance_id).clean_env();
     for arg in apptainer_run_extra_args {
         apptainer_cmd = apptainer_cmd.raw_flag(arg);
     }

--- a/crates/peppy/src/commands/node/env.rs
+++ b/crates/peppy/src/commands/node/env.rs
@@ -4,15 +4,135 @@ use core_node::FORBIDDEN_ENV_KEYS;
 /// because the node runs in a different working directory (the instance dir).
 const CALLER_ONLY_ENV_KEYS: [&str; 2] = ["PWD", "OLDPWD"];
 
+/// Whether `name` is a valid POSIX shell identifier (`[A-Za-z_][A-Za-z0-9_]*`).
+///
+/// Only such names can be forwarded to a containerized node. A node runs under
+/// apptainer, which writes every forwarded `--env NAME=value` into a generated
+/// `/.inject-apptainer-env.sh` that the container sources at startup. A name
+/// that is not a shell identifier makes that `source` abort with "invalid var
+/// name", and because the abort happens mid-script every later var is dropped,
+/// including `PEPPY_RUNTIME_CONFIG`. The node then silently falls back to its
+/// standalone defaults instead of the daemon-provided parameters.
+///
+/// The caller's environment routinely contains such names: bash exports shell
+/// functions under keys like `BASH_FUNC_foo%%`, and other tooling uses keys
+/// with `%`, `(`, or `.`. None of these are meaningful to a node, so dropping
+/// them is both safe and necessary.
+fn is_valid_env_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    match chars.next() {
+        Some(first) if first == '_' || first.is_ascii_alphabetic() => {}
+        _ => return false,
+    }
+    chars.all(|c| c == '_' || c.is_ascii_alphanumeric())
+}
+
+/// Whether `value` is safe to forward to a containerized node.
+///
+/// Same root cause as [`is_valid_env_name`]: apptainer writes each forwarded
+/// `--env NAME=value` UNQUOTED into the `/.inject-apptainer-env.sh` the
+/// container sources, effectively `export NAME=value`. A value with whitespace
+/// makes the shell read trailing words as further export targets (`export X=a b`
+/// tries to export `b`), which aborts the script with "invalid var name" and
+/// drops every later var, including `PEPPY_RUNTIME_CONFIG`. Worse, a value with
+/// shell metacharacters is a command-injection vector (`X=a;cmd` would run
+/// `cmd` inside the container). Neither shape is meaningful for a node's
+/// environment, so we forward only values built from characters that survive an
+/// unquoted assignment unchanged.
+fn is_safe_env_value(value: &str) -> bool {
+    value.chars().all(|c| {
+        c.is_ascii_alphanumeric()
+            || matches!(c, '_' | '-' | '.' | '/' | ':' | ',' | '=' | '@' | '+' | '%')
+    })
+}
+
+/// Whether a caller env var should be forwarded to a spawned node: it must have
+/// a valid shell-identifier name (see [`is_valid_env_name`]) and a value safe to
+/// inject unquoted (see [`is_safe_env_value`]), not be a code injection vector,
+/// and not be a caller-only var that is wrong in the node's working directory.
+fn should_forward_env(key: &str, value: &str) -> bool {
+    let normalized = key.trim().to_ascii_uppercase();
+    is_valid_env_name(key)
+        && is_safe_env_value(value)
+        && !FORBIDDEN_ENV_KEYS.contains(&normalized.as_str())
+        && !CALLER_ONLY_ENV_KEYS.contains(&normalized.as_str())
+}
+
 /// Collects environment variables from the caller's environment to pass to the daemon.
-/// Filters out forbidden env vars that could be used for code injection, and
-/// caller-only vars that would be incorrect in the node's working directory.
+/// Filters out forbidden env vars that could be used for code injection,
+/// caller-only vars that would be incorrect in the node's working directory,
+/// vars whose names are not valid shell identifiers (see [`is_valid_env_name`]),
+/// and vars whose values are not safe to inject unquoted (see [`is_safe_env_value`]).
 pub fn caller_env_overrides() -> Vec<(String, String)> {
     std::env::vars()
-        .filter(|(key, _)| {
-            let normalized = key.trim().to_ascii_uppercase();
-            !FORBIDDEN_ENV_KEYS.contains(&normalized.as_str())
-                && !CALLER_ONLY_ENV_KEYS.contains(&normalized.as_str())
-        })
+        .filter(|(key, value)| should_forward_env(key, value))
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_non_identifier_env_names() {
+        // Bash exports functions under names like this; they break the
+        // container's env-injection script if forwarded.
+        assert!(!is_valid_env_name("BASH_FUNC_foo%%"));
+        assert!(!is_valid_env_name("foo bar"));
+        assert!(!is_valid_env_name("foo.bar"));
+        assert!(!is_valid_env_name("foo("));
+        assert!(!is_valid_env_name("1foo"));
+        assert!(!is_valid_env_name(""));
+    }
+
+    #[test]
+    fn accepts_valid_identifier_env_names() {
+        assert!(is_valid_env_name("PATH"));
+        assert!(is_valid_env_name("PEPPY_RUNTIME_CONFIG"));
+        assert!(is_valid_env_name("_underscore"));
+        assert!(is_valid_env_name("ROS_DOMAIN_ID"));
+        assert!(is_valid_env_name("X1"));
+    }
+
+    #[test]
+    fn rejects_unsafe_env_values() {
+        // Whitespace splits an unquoted `export X=a b` and aborts the script.
+        assert!(!is_safe_env_value("user:inference user:file_upload"));
+        assert!(!is_safe_env_value("a\tb"));
+        assert!(!is_safe_env_value("line1\nline2"));
+        // Shell metacharacters are command-injection vectors.
+        assert!(!is_safe_env_value("a;rm -rf /"));
+        assert!(!is_safe_env_value("$(whoami)"));
+        assert!(!is_safe_env_value("`id`"));
+        assert!(!is_safe_env_value("a|b"));
+    }
+
+    #[test]
+    fn accepts_safe_env_values() {
+        // Real-world safe values: paths, lists, ids, urls, ratios.
+        assert!(is_safe_env_value("/opt/node/.venv/bin:/usr/bin"));
+        assert!(is_safe_env_value("42"));
+        assert!(is_safe_env_value("sentry-release=app%401.2,public_key=abc"));
+        assert!(is_safe_env_value("https://example.com/path"));
+        assert!(is_safe_env_value(""));
+    }
+
+    #[test]
+    fn should_forward_env_drops_junk_keeps_useful() {
+        // Bash-exported function: dropped because the name is not an identifier.
+        assert!(!should_forward_env("BASH_FUNC_demo%%", "() { :; }"));
+        // Space-valued var (e.g. OAuth scopes): dropped because it breaks the
+        // unquoted env injection and silently loses later vars.
+        assert!(!should_forward_env("OAUTH_SCOPES", "read write admin"));
+        // Code-injection vector: dropped by the forbidden list.
+        assert!(!should_forward_env("LD_PRELOAD", "/evil.so"));
+        // Caller-only: dropped because it is wrong in the node's working dir.
+        assert!(!should_forward_env("PWD", "/home/user"));
+        // Ordinary vars a node may legitimately want are forwarded.
+        assert!(should_forward_env("ROS_DOMAIN_ID", "42"));
+        assert!(should_forward_env(
+            "PEPPY_RUNTIME_CONFIG",
+            "/path/to/config.json5"
+        ));
+    }
 }

--- a/crates/peppylib-py/peppylib/__init__.py
+++ b/crates/peppylib-py/peppylib/__init__.py
@@ -37,7 +37,7 @@ sys.modules["peppylib._peppylib.core_node"] = _peppylib.core_node
 messaging = _peppylib.messaging
 
 # Re-export the Rust-implemented functions/types from the native module
-from ._peppylib.messaging import SenderTarget, ProducerRef, MessengerHandle, TopicMessenger, ZenohdInstance  # noqa: E402  # type: ignore[import-not-found]
+from ._peppylib.messaging import SenderTarget, ProducerRef, MessengerHandle, TopicMessenger, TopicPublisher, ZenohdInstance  # noqa: E402  # type: ignore[import-not-found]
 from ._peppylib.config import QoSProfile  # noqa: E402  # type: ignore[import-not-found]
 from ._peppylib.messaging.services import ServiceMessenger  # noqa: E402  # type: ignore[import-not-found]
 from ._peppylib.messaging.actions import (  # noqa: E402  # type: ignore[import-not-found]
@@ -71,6 +71,7 @@ __all__ = [
     "ProducerRef",
     "MessengerHandle",
     "TopicMessenger",
+    "TopicPublisher",
     "ZenohdInstance",
     "QoSProfile",
     "ServiceMessenger",

--- a/crates/peppylib-py/src/messaging.rs
+++ b/crates/peppylib-py/src/messaging.rs
@@ -14,7 +14,7 @@ use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::Mutex;
-pub(crate) use topics::{PySubscription, PyTopicMessage, PyTopicMessenger};
+pub(crate) use topics::{PySubscription, PyTopicMessage, PyTopicMessenger, PyTopicPublisher};
 
 /// Convert a `peppylib::error::Error` into an appropriate Python exception.
 ///
@@ -215,6 +215,7 @@ pub(crate) fn register(parent_module: &Bound<'_, PyModule>) -> PyResult<()> {
     messaging_module.add_class::<PyTopicMessage>()?;
     messaging_module.add_class::<PySubscription>()?;
     messaging_module.add_class::<PyTopicMessenger>()?;
+    messaging_module.add_class::<PyTopicPublisher>()?;
     messaging_module.add_class::<PySenderTarget>()?;
     messaging_module.add_class::<PyProducerRef>()?;
     services::register(&messaging_module)?;

--- a/crates/peppylib-py/src/messaging/topics.rs
+++ b/crates/peppylib-py/src/messaging/topics.rs
@@ -1,7 +1,7 @@
 use super::iface::{PyProducerRef, PySenderTarget};
 use super::{PyMessengerHandle, future_into_py_unit, to_py_err};
 use crate::config::PyQoSProfile;
-use peppylib::messaging::{Subscription, TopicMessenger};
+use peppylib::messaging::{Subscription, TopicMessenger, TopicPublisher};
 use peppylib::types::{Message, Payload};
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
@@ -162,6 +162,67 @@ impl PyTopicMessenger {
             .await
             .map_err(to_py_err)?;
 
+            Ok(())
+        })
+    }
+
+    /// Declare a reusable publisher for a topic and return a [`PyTopicPublisher`].
+    ///
+    /// The central messenger lock is taken ONCE here, at declaration. Every
+    /// subsequent `publisher.publish(...)` is lock-free, unlike [`Self::emit`]
+    /// which re-acquires that lock on every call. Use this for publish loops
+    /// (a camera streaming frames, a sensor at rate); use [`Self::emit`] only
+    /// for one-shot publishes. Mixing the two on the same topic is unsupported
+    /// (see `TopicMessenger::declare_publisher`), so a node should pick one path
+    /// per topic.
+    #[staticmethod]
+    #[pyo3(signature = (messenger, as_core_node, as_instance_id, as_target, as_topic_name, qos))]
+    fn declare_publisher<'py>(
+        py: Python<'py>,
+        messenger: &PyMessengerHandle,
+        as_core_node: String,
+        as_instance_id: String,
+        as_target: PySenderTarget,
+        as_topic_name: String,
+        qos: PyQoSProfile,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let handle = messenger.inner.clone();
+        let as_target = as_target.into_inner();
+        crate::py_future::future_into_py(py, async move {
+            let publisher = TopicMessenger::declare_publisher(
+                &handle,
+                &as_core_node,
+                &as_instance_id,
+                as_target,
+                None,
+                &as_topic_name,
+                qos.into(),
+            )
+            .await
+            .map_err(to_py_err)?;
+            Ok(PyTopicPublisher { inner: publisher })
+        })
+    }
+}
+
+/// Python wrapper for a lock-free per-topic publisher, vended by
+/// [`PyTopicMessenger::declare_publisher`]. Holds the topic binding so each
+/// `publish` skips the central messenger lock; clone-cheap (an `Arc` bump).
+#[pyclass(name = "TopicPublisher")]
+pub struct PyTopicPublisher {
+    inner: TopicPublisher,
+}
+
+#[pymethods]
+impl PyTopicPublisher {
+    /// Publish a payload on the declared topic. Lock-free on the hot path.
+    fn publish<'py>(&self, py: Python<'py>, payload: Vec<u8>) -> PyResult<Bound<'py, PyAny>> {
+        let publisher = self.inner.clone();
+        future_into_py_unit(py, async move {
+            publisher
+                .publish(Payload::from(payload))
+                .await
+                .map_err(to_py_err)?;
             Ok(())
         })
     }

--- a/crates/peppylib-py/src/messaging/topics.rs
+++ b/crates/peppylib-py/src/messaging/topics.rs
@@ -132,49 +132,12 @@ impl PyTopicMessenger {
         })
     }
 
-    /// Emit (publish) a message to a topic. Pass `SenderTarget.node(name, tag)`
-    /// or `SenderTarget.interface(name, tag)`.
-    #[staticmethod]
-    #[pyo3(signature = (messenger, as_core_node, as_instance_id, as_target, as_topic_name, qos, payload))]
-    #[allow(clippy::too_many_arguments)]
-    fn emit<'py>(
-        py: Python<'py>,
-        messenger: &PyMessengerHandle,
-        as_core_node: String,
-        as_instance_id: String,
-        as_target: PySenderTarget,
-        as_topic_name: String,
-        qos: PyQoSProfile,
-        payload: Vec<u8>,
-    ) -> PyResult<Bound<'py, PyAny>> {
-        let handle = messenger.inner.clone();
-        let as_target = as_target.into_inner();
-        future_into_py_unit(py, async move {
-            TopicMessenger::emit(
-                &handle,
-                &as_core_node,
-                &as_instance_id,
-                as_target,
-                &as_topic_name,
-                qos.into(),
-                Payload::from(payload),
-            )
-            .await
-            .map_err(to_py_err)?;
-
-            Ok(())
-        })
-    }
-
     /// Declare a reusable publisher for a topic and return a [`PyTopicPublisher`].
     ///
-    /// The central messenger lock is taken ONCE here, at declaration. Every
-    /// subsequent `publisher.publish(...)` is lock-free, unlike [`Self::emit`]
-    /// which re-acquires that lock on every call. Use this for publish loops
-    /// (a camera streaming frames, a sensor at rate); use [`Self::emit`] only
-    /// for one-shot publishes. Mixing the two on the same topic is unsupported
-    /// (see `TopicMessenger::declare_publisher`), so a node should pick one path
-    /// per topic.
+    /// This is the only topic-publish path. The central messenger lock is taken
+    /// ONCE here, at declaration; every subsequent `publisher.publish(...)` is
+    /// lock-free. Declare once, then publish per message (a camera streaming
+    /// frames, a sensor at rate).
     #[staticmethod]
     #[pyo3(signature = (messenger, as_core_node, as_instance_id, as_target, as_topic_name, qos))]
     fn declare_publisher<'py>(

--- a/crates/peppylib-py/tests/core_node/test_clock.py
+++ b/crates/peppylib-py/tests/core_node/test_clock.py
@@ -79,15 +79,15 @@ async def test_subscribe_clock_yields_typed_ticks(tmp_path):
         await asyncio.sleep(0.05)
 
         canned = clock.ClockTick(time=1_700_000_000_123_456_789)
-        await TopicMessenger.emit(
+        publisher = await TopicMessenger.declare_publisher(
             server_handle,
             CORE_NODE,
             SERVER_INSTANCE,
             SenderTarget.node(CORE_NODE, CORE_NODE_TAG),
             "clock",
             QoSProfile.SensorData,
-            canned.encode(),
         )
+        await publisher.publish(canned.encode())
 
         tick = await asyncio.wait_for(sub.on_next_tick(), timeout=2.0)
     finally:

--- a/crates/peppylib-py/tests/test_runner.py
+++ b/crates/peppylib-py/tests/test_runner.py
@@ -997,16 +997,16 @@ async def test_shutdown_joins_event_loop_thread(monkeypatch):
 
                             async def emit_loop():
                                 started_queue.put("started")
+                                publisher = await TopicMessenger.declare_publisher(
+                                    messenger,
+                                    core_node,
+                                    instance_id,
+                                    SenderTarget.node(node_name, node_tag),
+                                    "regression_topic",
+                                    QoSProfile.Reliable,
+                                )
                                 while not token.is_cancelled():
-                                    await TopicMessenger.emit(
-                                        messenger,
-                                        core_node,
-                                        instance_id,
-                                        SenderTarget.node(node_name, node_tag),
-                                        "regression_topic",
-                                        QoSProfile.Reliable,
-                                        b"frame",
-                                    )
+                                    await publisher.publish(b"frame")
                                     await asyncio.sleep(0.001)
 
                             return [asyncio.create_task(emit_loop())]

--- a/crates/peppylib-py/tests/test_topics.py
+++ b/crates/peppylib-py/tests/test_topics.py
@@ -73,18 +73,19 @@ async def test_messenger_communication():
         # Allow subscription to propagate
         await asyncio.sleep(0.05)
 
-        # Emit a message. Void async bindings resolve to `None` (not the empty
-        # tuple a bare `Ok(())` would yield under PyO3 0.28).
-        emit_result = await TopicMessenger.emit(
+        # Declare the publisher (the only topic-publish path) and publish a
+        # message. Void async bindings resolve to `None` (not the empty tuple a
+        # bare `Ok(())` would yield under PyO3 0.28).
+        publisher = await TopicMessenger.declare_publisher(
             sender_handle,
             core_node,
             instance_id,
             SenderTarget.node(node_name, NODE_TAG),
             topic_name,
             qos,
-            payload,
         )
-        assert emit_result is None
+        publish_result = await publisher.publish(payload)
+        assert publish_result is None
 
         # Receive the message with a timeout
         message = await asyncio.wait_for(

--- a/crates/peppylib/src/lib.rs
+++ b/crates/peppylib/src/lib.rs
@@ -12,7 +12,9 @@ pub mod messaging;
 pub mod runtime;
 pub mod services;
 pub use error::{Error as PeppyError, ParameterDeserializationError, Result as PeppyResult};
-pub use messaging::{ActionMessenger, MessengerHandle, ServiceMessenger, TopicMessenger};
+pub use messaging::{
+    ActionMessenger, MessengerHandle, ServiceMessenger, TopicMessenger, TopicPublisher,
+};
 pub mod config;
 pub mod types;
 

--- a/crates/peppylib/src/messaging.rs
+++ b/crates/peppylib/src/messaging.rs
@@ -324,20 +324,6 @@ impl MessengerHandle {
             .map_err(Error::PeppyMessagingInterface)
     }
 
-    async fn emit_topic_message(
-        &self,
-        sender: &TopicWireSender,
-        qos: QoSProfile,
-        payload: Payload,
-        is_primary: bool,
-    ) -> Result<()> {
-        let mut messenger = self.messenger.lock().await;
-        messenger
-            .publish_topic(sender, payload.into_inner().into(), qos.into(), is_primary)
-            .await
-            .map_err(Error::PeppyMessagingInterface)
-    }
-
     /// Waits (deterministically, via Zenoh matching status) until a subscriber
     /// for `sender`'s topic is known to this session, or `timeout` elapses;
     /// returns whether a match was observed. A freshly-connected peer learns

--- a/crates/peppylib/src/messaging/tests.rs
+++ b/crates/peppylib/src/messaging/tests.rs
@@ -29,6 +29,32 @@ fn test_node_target(name: &str) -> SenderTarget {
     SenderTarget::node(name, "v1").expect("test node target")
 }
 
+/// Declares a publisher and publishes a single payload. The publisher is the
+/// only topic-publish path, so a test that publishes once just declares then
+/// publishes; the arguments mirror the old one-shot emit.
+#[allow(clippy::too_many_arguments)]
+async fn publish_once(
+    messenger: &MessengerHandle,
+    as_core_node: &str,
+    as_instance_id: &str,
+    as_target: SenderTarget,
+    as_topic_name: &str,
+    qos: QoSProfile,
+    payload: Payload,
+) -> Result<(), Error> {
+    let publisher = TopicMessenger::declare_publisher(
+        messenger,
+        as_core_node,
+        as_instance_id,
+        as_target,
+        None,
+        as_topic_name,
+        qos,
+    )
+    .await?;
+    publisher.publish(payload).await
+}
+
 #[derive(Clone)]
 struct ActionClientCase {
     client_id: String,
@@ -237,7 +263,7 @@ async fn topic_publish_subscribe_no_from_instance_id() {
     )
     .await
     .expect("subscriber should become reachable");
-    TopicMessenger::emit(
+    publish_once(
         &emitter_handle,
         emitter_core_node,
         emitter_instance_id,
@@ -327,7 +353,7 @@ async fn topic_publish_subscribe_with_from_instance_id() {
     )
     .await
     .expect("subscriber should become reachable");
-    TopicMessenger::emit(
+    publish_once(
         &emitter_handle1,
         emitter_core_node,
         emitter_instance_id2,
@@ -427,7 +453,7 @@ async fn topic_publish_subscribe_with_from_core_node() {
     )
     .await
     .expect("subscriber should become reachable");
-    TopicMessenger::emit(
+    publish_once(
         &emitter_handle1,
         emitter_core_node2,
         emitter_instance_id,
@@ -520,7 +546,7 @@ async fn consumer_filter_only_from_set_admits_listed_producers_and_drops_others(
         (p3, b"from-p3"),
         (p2, b"from-p2"),
     ] {
-        TopicMessenger::emit(
+        publish_once(
             &emitter_handle,
             core,
             producer,
@@ -622,7 +648,7 @@ async fn consumer_filter_any_except_drops_excluded_and_admits_rest() {
         (claimed, b"from-claimed".as_ref()),
         (unclaimed, b"from-unclaimed"),
     ] {
-        TopicMessenger::emit(
+        publish_once(
             &emitter_handle,
             core,
             producer,
@@ -711,7 +737,7 @@ async fn topic_publish_reliable_5000hz_messages() {
     let emitter = tokio::spawn(async move {
         for &message_id in &emit_ids {
             let payload = Payload::from(message_id.to_le_bytes().to_vec());
-            TopicMessenger::emit(
+            publish_once(
                 &sender_handle,
                 emitter_core_node,
                 emitter_instance_id,
@@ -3155,7 +3181,7 @@ async fn topic_duplicate_from_any_subscription_is_rejected() {
     )
     .await
     .expect("subscriber should become reachable");
-    TopicMessenger::emit(
+    publish_once(
         &emitter_handle,
         "pub_core",
         "pub_inst",
@@ -4504,7 +4530,7 @@ async fn topic_pinned_and_filtered_subscriptions_compare_full_pairs() {
                     biased;
                     _ = stop_notified.as_mut() => break,
                     _ = ticker.tick() => {
-                        TopicMessenger::emit(
+                        publish_once(
                             &handle,
                             core,
                             shared_inst,

--- a/crates/peppylib/src/messaging/topics.rs
+++ b/crates/peppylib/src/messaging/topics.rs
@@ -180,33 +180,12 @@ impl TopicMessenger {
         Ok(subscription)
     }
 
-    /// Publishes a payload to a topic. The producer advertises under the
-    /// reserved default `_` segment; consumers pin a specific producer by
-    /// the `(core_node, instance_id)` pair derived from the consumer's
-    /// binding map.
-    pub async fn emit(
-        messenger: &MessengerHandle,
-        as_core_node: &str,
-        as_instance_id: &str,
-        as_target: SenderTarget,
-        as_topic_name: &str,
-        qos: QoSProfile,
-        payload: Payload,
-    ) -> Result<()> {
-        let sender =
-            TopicWireSender::new(as_core_node, as_instance_id, as_target, None, as_topic_name)?;
-        messenger
-            .emit_topic_message(&sender, qos, payload, true)
-            .await?;
-        Ok(())
-    }
-
     /// Waits until a subscriber for this topic is known to the publisher's
     /// session, or `timeout` elapses; returns whether a match was observed.
     ///
     /// In peer mode a freshly-connected publisher learns about existing
     /// subscribers through gossip, which is not instantaneous, so its first
-    /// [`emit`](Self::emit) can be dropped before discovery propagates. Call
+    /// publish can be dropped before discovery propagates. Call
     /// this first when the very first publish must reach an already-running
     /// subscriber; it returns as soon as a match is observed (no fixed sleep).
     /// A `false` return means no subscriber appeared within `timeout`.
@@ -225,17 +204,13 @@ impl TopicMessenger {
             .await
     }
 
-    /// Pre-binds a topic publisher under a single producer-side link_id,
+    /// Declares a topic publisher bound under a single producer-side link_id,
     /// bypassing the central `Messenger` mutex on every subsequent publish.
-    /// Use this in publish loops; use [`emit`] for one-shot publishes.
     /// `link_id` `None` falls back to the reserved default `_` segment.
     ///
-    /// A pre-bound publisher always tags its publishes as primary on the
-    /// wire (it can't know about a parallel multi-link `emit` loop), so
-    /// mixing this with [`emit`] on the *same* topic isn't supported — a
-    /// wildcard subscriber would observe the pre-bound publish and the
-    /// `emit`'s primary publish as two separate deliveries. Pick one
-    /// publication path per topic.
+    /// This is the only topic-publish path: declare a publisher once, then
+    /// call [`TopicPublisher::publish`] per message. The publisher always tags
+    /// its publishes as primary on the wire.
     #[allow(clippy::too_many_arguments)]
     pub async fn declare_publisher(
         messenger: &MessengerHandle,

--- a/crates/peppylib/tests/common.rs
+++ b/crates/peppylib/tests/common.rs
@@ -1,14 +1,16 @@
 #![allow(dead_code)]
 
+use config::node::QoSProfile;
 use peppylib::messaging::{MessengerHandle, SenderTarget, TopicMessenger};
+use peppylib::types::Payload;
 use pmi::{Messenger, MessengerAdapter, MessengerBackend, MockAdapter};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::Mutex;
 
 /// Deterministically wait until `publisher`'s session sees a subscriber for the
-/// topic it is about to emit on, replacing a fixed "settle for zenoh discovery"
-/// sleep. The arguments mirror the subsequent [`TopicMessenger::emit`] call.
+/// topic it is about to publish on, replacing a fixed "settle for zenoh
+/// discovery" sleep. The arguments mirror the subsequent publish.
 /// Panics if no subscriber routes within 2s.
 pub async fn wait_for_topic_subscriber(
     publisher: &MessengerHandle,
@@ -44,6 +46,32 @@ pub const TEST_NODE_TAG: &str = "v1";
 /// invalid names — tests use known-good values only.
 pub fn test_node_target(name: &str) -> SenderTarget {
     SenderTarget::node(name, TEST_NODE_TAG).expect("test node target")
+}
+
+/// Declares a publisher and publishes a single payload. The publisher is the
+/// only topic-publish path, so a test that publishes once just declares then
+/// publishes; the arguments mirror the old one-shot emit.
+#[allow(clippy::too_many_arguments)]
+pub async fn publish_once(
+    messenger: &MessengerHandle,
+    core_node: &str,
+    instance_id: &str,
+    target: SenderTarget,
+    topic_name: &str,
+    qos: QoSProfile,
+    payload: Payload,
+) -> Result<(), peppylib::PeppyError> {
+    let publisher = TopicMessenger::declare_publisher(
+        messenger,
+        core_node,
+        instance_id,
+        target,
+        None,
+        topic_name,
+        qos,
+    )
+    .await?;
+    publisher.publish(payload).await
 }
 
 /// Client for sending requests to a test node.

--- a/crates/peppylib/tests/core_node/clock.rs
+++ b/crates/peppylib/tests/core_node/clock.rs
@@ -4,12 +4,12 @@ use config::node::QoSProfile;
 use core_node_api::encoding::{ClockResponse, ClockTick};
 use core_node_api::names;
 use peppylib::clock;
-use peppylib::messaging::{MessengerHandle, ServiceMessenger, TopicMessenger};
+use peppylib::messaging::{MessengerHandle, ServiceMessenger};
 use pmi::ZenohdInstance;
 use tempfile::TempDir;
 
 use super::common::{
-    CORE_NODE, SERVER_INSTANCE, start_router_and_runner, test_node_target,
+    CORE_NODE, SERVER_INSTANCE, publish_once, start_router_and_runner, test_node_target,
     wait_for_topic_subscriber, wait_until_reachable,
 };
 
@@ -95,7 +95,7 @@ async fn subscribe_clock_yields_typed_ticks() {
     .await;
 
     let canned = ClockTick::new(1_700_000_000_123_456_789);
-    TopicMessenger::emit(
+    publish_once(
         &server,
         CORE_NODE,
         SERVER_INSTANCE,

--- a/crates/peppylib/tests/core_node/common.rs
+++ b/crates/peppylib/tests/core_node/common.rs
@@ -6,12 +6,14 @@
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
+use config::node::QoSProfile;
 use core_node_api::names;
 use peppylib::messaging::SenderTarget;
 use peppylib::messaging::{
     MessengerHandle, ProducerRef, ServiceMessenger, ServiceTarget, TopicMessenger,
 };
 use peppylib::runtime::{NodeRunner, Processor, StandaloneConfig};
+use peppylib::types::Payload;
 use pmi::{ZenohAdapter, ZenohdInstance};
 use tempfile::TempDir;
 
@@ -24,6 +26,32 @@ pub(crate) const SERVER_INSTANCE: &str = "test_server";
 /// these tests must mirror that tag to actually route through the wire.
 pub(crate) fn test_node_target(name: &str) -> SenderTarget {
     SenderTarget::node(name, names::CORE_NODE_TAG).expect("test node target")
+}
+
+/// Declares a publisher and publishes a single payload. The publisher is the
+/// only topic-publish path, so a test that publishes once just declares then
+/// publishes; the arguments mirror the old one-shot emit.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn publish_once(
+    messenger: &MessengerHandle,
+    core_node: &str,
+    instance_id: &str,
+    target: SenderTarget,
+    topic_name: &str,
+    qos: QoSProfile,
+    payload: Payload,
+) -> Result<(), peppylib::PeppyError> {
+    let publisher = TopicMessenger::declare_publisher(
+        messenger,
+        core_node,
+        instance_id,
+        target,
+        None,
+        topic_name,
+        qos,
+    )
+    .await?;
+    publisher.publish(payload).await
 }
 
 /// Writes a minimal `peppy.json5` into `dir` suitable for
@@ -69,11 +97,10 @@ pub(crate) async fn wait_until_reachable(client: &MessengerHandle, service_name:
 }
 
 /// Deterministically waits until `publisher`'s session sees a subscriber for
-/// `topic_name` before the test emits on it, replacing a fixed "settle for
-/// zenoh discovery" sleep. Peer-mode discovery is not instantaneous, so an emit
-/// sent before routing completes can be dropped. The arguments mirror the
-/// subsequent [`TopicMessenger::emit`] call. Panics if no subscriber routes
-/// within 2s.
+/// `topic_name` before the test publishes on it, replacing a fixed "settle for
+/// zenoh discovery" sleep. Peer-mode discovery is not instantaneous, so a
+/// publish sent before routing completes can be dropped. The arguments mirror
+/// the subsequent publish. Panics if no subscriber routes within 2s.
 pub(crate) async fn wait_for_topic_subscriber(
     publisher: &MessengerHandle,
     core_node: &str,

--- a/crates/peppylib/tests/topics.rs
+++ b/crates/peppylib/tests/topics.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use common::{test_node_target, wait_for_topic_subscriber};
+use common::{publish_once, test_node_target, wait_for_topic_subscriber};
 use config::node::QoSProfile;
 use peppylib::messaging::{ConsumerFilter, MessengerHandle, TopicMessenger};
 use peppylib::types::Payload;
@@ -52,7 +52,7 @@ async fn topic_messenger_communication() {
     .await;
 
     // Emit a message
-    TopicMessenger::emit(
+    publish_once(
         &sender_handle,
         core_node,
         instance_id,
@@ -122,7 +122,7 @@ async fn node_session_recovers_after_router_restart() {
             topic_name,
         )
         .await;
-        TopicMessenger::emit(
+        publish_once(
             &sender_handle,
             core_node,
             instance_id,
@@ -169,7 +169,7 @@ async fn node_session_recovers_after_router_restart() {
     let mut recovered = false;
     while std::time::Instant::now() < deadline {
         // Ignore emit errors: the publisher link may still be settling.
-        let _ = TopicMessenger::emit(
+        let _ = publish_once(
             &sender_handle,
             core_node,
             instance_id,
@@ -274,7 +274,7 @@ async fn bidirectional_from_any_topics_with_late_producer() {
 
     // Direction 1: robot_arm (arm_1) -> arm_controller.
     let state_payload = Payload::from_static(b"joint_states@arm_1");
-    TopicMessenger::emit(
+    publish_once(
         &arm_handle,
         core_node,
         "arm_1",
@@ -297,7 +297,7 @@ async fn bidirectional_from_any_topics_with_late_producer() {
     // Direction 2: arm_controller (ctrl_1) -> robot_arm. The reverse stream
     // flows independently; nothing bound the two nodes to each other.
     let command_payload = Payload::from_static(b"joint_commands@ctrl_1");
-    TopicMessenger::emit(
+    publish_once(
         &controller_handle,
         core_node,
         "ctrl_1",
@@ -333,7 +333,7 @@ async fn bidirectional_from_any_topics_with_late_producer() {
     .await;
 
     let late_payload = Payload::from_static(b"joint_states@arm_2");
-    TopicMessenger::emit(
+    publish_once(
         &late_arm_handle,
         core_node,
         "arm_2",

--- a/crates/pmi-internal/src/adapters/mock.rs
+++ b/crates/pmi-internal/src/adapters/mock.rs
@@ -854,8 +854,8 @@ mod tests {
 
     #[test]
     fn test_key_exprs_intersect_topic_publisher_vs_subscriber() {
-        // The exact wire shape that motivated bidirectional matching:
-        // `emit_topic_message` hard-codes `*` into caller-identity slots, while a
+        // The exact wire shape that motivated bidirectional matching: the topic
+        // publish path hard-codes `*` into caller-identity slots, while a
         // subscriber identifies itself with concrete core/instance values. Both
         // sides must intersect or topic delivery against the mock breaks.
         let publisher = "*/core_node/*/responder_inst/topic/clock/clock";

--- a/docs/src/content/docs/advanced_guides/topics.mdx
+++ b/docs/src/content/docs/advanced_guides/topics.mdx
@@ -64,7 +64,8 @@ The `qos_profile` controls delivery guarantees. Available profiles are:
 ### Publishing messages
 
 After running `peppy node sync`, the code generator creates a module for each emitted topic under `peppygen::emitted_topics`.
-Use `emit` to publish a message:
+Each module exposes `declare_publisher(node_runner)`, which returns a `TopicPublisher`, and `build_message(...)`, which serializes the message fields into a payload.
+Declare the publisher once, then publish each message on it:
 
 ```rust
 use peppygen::emitted_topics::video_stream;
@@ -75,10 +76,13 @@ fn main() -> Result<()> {
     NodeBuilder::new().run(|_args: Parameters, node_runner| async move {
         let node_runner_clone = node_runner.clone();
         tokio::spawn(async move {
+            // Declare the publisher once; every publish below is then lock-free.
+            let publisher = video_stream::declare_publisher(&node_runner_clone)
+                .await
+                .expect("failed to declare video_stream publisher");
             let mut frame_id = 0u32;
             loop {
-                let _ = video_stream::emit(
-                    &node_runner_clone,
+                if let Ok(payload) = video_stream::build_message(
                     video_stream::MessageHeader {
                         stamp: std::time::SystemTime::now(),
                         frame_id,
@@ -87,8 +91,9 @@ fn main() -> Result<()> {
                     640,
                     480,
                     vec![1, 2, 3],
-                )
-                .await;
+                ) {
+                    let _ = publisher.publish(payload).await;
+                }
 
                 frame_id = frame_id.wrapping_add(1);
                 tokio::time::sleep(Duration::from_secs_f64(0.1)).await;
@@ -100,7 +105,7 @@ fn main() -> Result<()> {
 }
 ```
 
-The `emit` function takes the `node_runner` reference followed by each field from the `message_format` in order.
+`build_message` takes each field from the `message_format` in order (no `node_runner` argument) and returns the payload that `publisher.publish` sends.
 Nested objects become generated structs (e.g. `video_stream::MessageHeader`) whose fields match the object definition.
 
 A producer publishes a **single stream** regardless of how many consumers are listening, and it never knows about the bindings consumers use to address it.
@@ -118,12 +123,15 @@ For a topic with a simple message format:
 }
 ```
 
-the `emit` call takes a single `String` argument:
+`build_message` takes a single `String` argument:
 
 ```rust
 use peppygen::emitted_topics::message_stream;
 
-message_stream::emit(&node_runner, "hello world".to_owned()).await?;
+let publisher = message_stream::declare_publisher(&node_runner).await?;
+publisher
+    .publish(message_stream::build_message("hello world".to_owned()))
+    .await?;
 ```
 
 ## Consuming a topic

--- a/docs/src/content/docs/advanced_guides/topics.mdx
+++ b/docs/src/content/docs/advanced_guides/topics.mdx
@@ -129,9 +129,8 @@ For a topic with a simple message format:
 use peppygen::emitted_topics::message_stream;
 
 let publisher = message_stream::declare_publisher(&node_runner).await?;
-publisher
-    .publish(message_stream::build_message("hello world".to_owned()))
-    .await?;
+let payload = message_stream::build_message("hello world".to_owned())?;
+publisher.publish(payload).await?;
 ```
 
 ## Consuming a topic

--- a/docs/src/content/docs/guides/snippets/python/arm_controller/src/arm_controller/__main__.py
+++ b/docs/src/content/docs/guides/snippets/python/arm_controller/src/arm_controller/__main__.py
@@ -14,7 +14,12 @@ def compute_next_target(current: list[float]) -> list[float]:
 
 async def control_loop(node_runner: NodeRunner):
     # Declare the publisher once, then publish each command on it.
-    publisher = await joint_commands.declare_publisher(node_runner)
+    try:
+        publisher = await joint_commands.declare_publisher(node_runner)
+    except Exception as e:
+        print(f"Failed to declare joint_commands publisher: {e}", file=sys.stderr)
+        return
+
     while True:
         try:
             producer, state = await arm_joint_states.on_next_message_received(
@@ -34,12 +39,15 @@ async def control_loop(node_runner: NodeRunner):
 
         # Compute the next target from the reported state, then command it.
         target = compute_next_target(state.positions)
-        await publisher.publish(
-            joint_commands.build_message(
-                target,
-                1.0,  # max_velocity
+        try:
+            await publisher.publish(
+                joint_commands.build_message(
+                    target,
+                    1.0,  # max_velocity
+                )
             )
-        )
+        except Exception as e:
+            print(f"Failed to publish joint command: {e}", file=sys.stderr)
 
 
 async def setup(_params: Parameters, node_runner: NodeRunner) -> list[asyncio.Task]:

--- a/docs/src/content/docs/guides/snippets/python/arm_controller/src/arm_controller/__main__.py
+++ b/docs/src/content/docs/guides/snippets/python/arm_controller/src/arm_controller/__main__.py
@@ -13,6 +13,8 @@ def compute_next_target(current: list[float]) -> list[float]:
 
 
 async def control_loop(node_runner: NodeRunner):
+    # Declare the publisher once, then publish each command on it.
+    publisher = await joint_commands.declare_publisher(node_runner)
     while True:
         try:
             producer, state = await arm_joint_states.on_next_message_received(
@@ -32,10 +34,11 @@ async def control_loop(node_runner: NodeRunner):
 
         # Compute the next target from the reported state, then command it.
         target = compute_next_target(state.positions)
-        await joint_commands.emit(
-            node_runner,
-            target,
-            1.0,  # max_velocity
+        await publisher.publish(
+            joint_commands.build_message(
+                target,
+                1.0,  # max_velocity
+            )
         )
 
 

--- a/docs/src/content/docs/guides/snippets/python/hello_world/src/hello_world/__main__.py
+++ b/docs/src/content/docs/guides/snippets/python/hello_world/src/hello_world/__main__.py
@@ -5,12 +5,14 @@ from peppygen.emitted_topics import message_stream
 
 
 async def emit_hello_world_loop(node_runner: NodeRunner):
+    # Declare the publisher once, then publish each message on it.
+    publisher = await message_stream.declare_publisher(node_runner)
     counter = 0
     while True:
         counter += 1
         message = f"hello world count {counter}"
         print(message, flush=True)
-        await message_stream.emit(node_runner, message)
+        await publisher.publish(message_stream.build_message(message))
         await asyncio.sleep(3)
 
 

--- a/docs/src/content/docs/guides/snippets/python/hello_world/src/hello_world/__main__.py
+++ b/docs/src/content/docs/guides/snippets/python/hello_world/src/hello_world/__main__.py
@@ -1,4 +1,6 @@
 import asyncio
+import sys
+
 from peppygen import NodeBuilder, NodeRunner
 from peppygen.parameters import Parameters
 from peppygen.emitted_topics import message_stream
@@ -6,13 +8,21 @@ from peppygen.emitted_topics import message_stream
 
 async def emit_hello_world_loop(node_runner: NodeRunner):
     # Declare the publisher once, then publish each message on it.
-    publisher = await message_stream.declare_publisher(node_runner)
+    try:
+        publisher = await message_stream.declare_publisher(node_runner)
+    except Exception as e:
+        print(f"Failed to declare message_stream publisher: {e}", file=sys.stderr)
+        return
+
     counter = 0
     while True:
         counter += 1
         message = f"hello world count {counter}"
         print(message, flush=True)
-        await publisher.publish(message_stream.build_message(message))
+        try:
+            await publisher.publish(message_stream.build_message(message))
+        except Exception as e:
+            print(f"Failed to publish hello world: {e}", file=sys.stderr)
         await asyncio.sleep(3)
 
 

--- a/docs/src/content/docs/guides/snippets/python/hello_world_param/src/hello_world_param/__main__.py
+++ b/docs/src/content/docs/guides/snippets/python/hello_world_param/src/hello_world_param/__main__.py
@@ -5,12 +5,14 @@ from peppygen.emitted_topics import message_stream
 
 
 async def emit_hello_world_loop(node_runner: NodeRunner, name: str):
+    # Declare the publisher once, then publish each message on it.
+    publisher = await message_stream.declare_publisher(node_runner)
     counter = 0
     while True:
         counter += 1
         message = f"hello {name} count {counter}"
         print(message, flush=True)
-        await message_stream.emit(node_runner, message)
+        await publisher.publish(message_stream.build_message(message))
         await asyncio.sleep(3)
 
 

--- a/docs/src/content/docs/guides/snippets/python/robot_arm/src/robot_arm/__main__.py
+++ b/docs/src/content/docs/guides/snippets/python/robot_arm/src/robot_arm/__main__.py
@@ -1,4 +1,5 @@
 import asyncio
+import sys
 import time
 
 from peppygen import NodeBuilder, NodeRunner
@@ -9,7 +10,12 @@ from peppygen.emitted_topics.joint_state_source.v1 import joint_states
 
 async def handle_commands(node_runner: NodeRunner):
     # Declare the publisher once, then publish each state on it.
-    publisher = await joint_states.declare_publisher(node_runner)
+    try:
+        publisher = await joint_states.declare_publisher(node_runner)
+    except Exception as e:
+        print(f"Failed to declare joint_states publisher: {e}", file=sys.stderr)
+        return
+
     while True:
         producer, command = await controller_joint_commands.on_next_message_received(
             node_runner,
@@ -21,13 +27,16 @@ async def handle_commands(node_runner: NodeRunner):
         )
 
         # Drive the joints, then report the resulting state.
-        await publisher.publish(
-            joint_states.build_message(
-                command.target_positions,
-                [0.0, 0.0, 0.0],
-                time.time(),
+        try:
+            await publisher.publish(
+                joint_states.build_message(
+                    command.target_positions,
+                    [0.0, 0.0, 0.0],
+                    time.time(),
+                )
             )
-        )
+        except Exception as e:
+            print(f"Failed to publish joint state: {e}", file=sys.stderr)
 
 
 async def setup(_params: Parameters, node_runner: NodeRunner) -> list[asyncio.Task]:

--- a/docs/src/content/docs/guides/snippets/python/robot_arm/src/robot_arm/__main__.py
+++ b/docs/src/content/docs/guides/snippets/python/robot_arm/src/robot_arm/__main__.py
@@ -8,6 +8,8 @@ from peppygen.emitted_topics.joint_state_source.v1 import joint_states
 
 
 async def handle_commands(node_runner: NodeRunner):
+    # Declare the publisher once, then publish each state on it.
+    publisher = await joint_states.declare_publisher(node_runner)
     while True:
         producer, command = await controller_joint_commands.on_next_message_received(
             node_runner,
@@ -19,11 +21,12 @@ async def handle_commands(node_runner: NodeRunner):
         )
 
         # Drive the joints, then report the resulting state.
-        await joint_states.emit(
-            node_runner,
-            command.target_positions,
-            [0.0, 0.0, 0.0],
-            time.time(),
+        await publisher.publish(
+            joint_states.build_message(
+                command.target_positions,
+                [0.0, 0.0, 0.0],
+                time.time(),
+            )
         )
 
 

--- a/docs/src/content/docs/guides/snippets/rust/arm_controller/src/main.rs
+++ b/docs/src/content/docs/guides/snippets/rust/arm_controller/src/main.rs
@@ -11,6 +11,14 @@ use peppygen::{NodeBuilder, Parameters, Result};
 fn main() -> Result<()> {
     NodeBuilder::new().run(|_args: Parameters, node_runner| async move {
         tokio::spawn(async move {
+            // Declare the publisher once; every publish below is then lock-free.
+            let publisher = match joint_commands::declare_publisher(&node_runner).await {
+                Ok(publisher) => publisher,
+                Err(e) => {
+                    eprintln!("Failed to declare joint_commands publisher: {e}");
+                    return;
+                }
+            };
             loop {
                 let (producer, state) =
                     match arm_joint_states::on_next_message_received(&node_runner).await {
@@ -28,7 +36,9 @@ fn main() -> Result<()> {
 
                 // Compute the next target from the reported state, then command it.
                 let target = compute_next_target(&state.positions);
-                let _ = joint_commands::emit(&node_runner, target, 1.0).await;
+                if let Ok(payload) = joint_commands::build_message(target, 1.0) {
+                    let _ = publisher.publish(payload).await;
+                }
             }
         });
 

--- a/docs/src/content/docs/guides/snippets/rust/arm_controller/src/main.rs
+++ b/docs/src/content/docs/guides/snippets/rust/arm_controller/src/main.rs
@@ -36,8 +36,13 @@ fn main() -> Result<()> {
 
                 // Compute the next target from the reported state, then command it.
                 let target = compute_next_target(&state.positions);
-                if let Ok(payload) = joint_commands::build_message(target, 1.0) {
-                    let _ = publisher.publish(payload).await;
+                match joint_commands::build_message(target, 1.0) {
+                    Ok(payload) => {
+                        if let Err(e) = publisher.publish(payload).await {
+                            eprintln!("Failed to publish joint command: {e}");
+                        }
+                    }
+                    Err(e) => eprintln!("Failed to build joint_commands message: {e}"),
                 }
             }
         });

--- a/docs/src/content/docs/guides/snippets/rust/hello_world/src/main.rs
+++ b/docs/src/content/docs/guides/snippets/rust/hello_world/src/main.rs
@@ -1,12 +1,21 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use peppygen::emitted_topics::message_stream;
 use peppygen::{NodeBuilder, NodeRunner, Parameters, Result};
 use peppylib::runtime::CancellationToken;
 
 /// Emits a "hello world count X" message every 3 seconds, starting immediately.
 /// The loop runs until the cancellation token is triggered.
 async fn emit_hello_world_loop(runner: Arc<NodeRunner>, token: CancellationToken) {
+    // Declare the publisher once; every publish below is then lock-free.
+    let publisher = match message_stream::declare_publisher(&runner).await {
+        Ok(publisher) => publisher,
+        Err(e) => {
+            eprintln!("Failed to declare message_stream publisher: {e}");
+            return;
+        }
+    };
     let mut counter: u64 = 0;
     let mut interval = tokio::time::interval(Duration::from_secs(3));
     loop {
@@ -16,8 +25,13 @@ async fn emit_hello_world_loop(runner: Arc<NodeRunner>, token: CancellationToken
                 counter += 1;
                 let message = format!("hello world count {counter}");
                 println!("{message}");
-                if let Err(e) = peppygen::emitted_topics::message_stream::emit(&runner, message).await {
-                    eprintln!("Failed to emit hello world: {e}");
+                match message_stream::build_message(message) {
+                    Ok(payload) => {
+                        if let Err(e) = publisher.publish(payload).await {
+                            eprintln!("Failed to publish hello world: {e}");
+                        }
+                    }
+                    Err(e) => eprintln!("Failed to build hello world message: {e}"),
                 }
             }
         }

--- a/docs/src/content/docs/guides/snippets/rust/hello_world_param/src/main.rs
+++ b/docs/src/content/docs/guides/snippets/rust/hello_world_param/src/main.rs
@@ -1,12 +1,21 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use peppygen::emitted_topics::message_stream;
 use peppygen::{NodeBuilder, NodeRunner, Parameters, Result};
 use peppylib::runtime::CancellationToken;
 
 /// Emits a "hello world count X" message every 3 seconds, starting immediately.
 /// The loop runs until the cancellation token is triggered.
 async fn emit_hello_world_loop(runner: Arc<NodeRunner>, token: CancellationToken, name: String) {
+    // Declare the publisher once; every publish below is then lock-free.
+    let publisher = match message_stream::declare_publisher(&runner).await {
+        Ok(publisher) => publisher,
+        Err(e) => {
+            eprintln!("Failed to declare message_stream publisher: {e}");
+            return;
+        }
+    };
     let mut counter: u64 = 0;
     let mut interval = tokio::time::interval(Duration::from_secs(3));
     loop {
@@ -16,8 +25,13 @@ async fn emit_hello_world_loop(runner: Arc<NodeRunner>, token: CancellationToken
                 counter += 1;
                 let message = format!("hello {name} count {counter}");
                 println!("{message}");
-                if let Err(e) = peppygen::emitted_topics::message_stream::emit(&runner, message).await {
-                    eprintln!("Failed to emit hello world: {e}");
+                match message_stream::build_message(message) {
+                    Ok(payload) => {
+                        if let Err(e) = publisher.publish(payload).await {
+                            eprintln!("Failed to publish hello world: {e}");
+                        }
+                    }
+                    Err(e) => eprintln!("Failed to build hello world message: {e}"),
                 }
             }
         }

--- a/docs/src/content/docs/guides/snippets/rust/robot_arm/src/main.rs
+++ b/docs/src/content/docs/guides/snippets/rust/robot_arm/src/main.rs
@@ -34,12 +34,17 @@ fn main() -> Result<()> {
                 );
 
                 // Drive the joints, then report the resulting state.
-                if let Ok(payload) = joint_states::build_message(
+                match joint_states::build_message(
                     command.target_positions,
                     [0.0, 0.0, 0.0],
                     std::time::SystemTime::now(),
                 ) {
-                    let _ = publisher.publish(payload).await;
+                    Ok(payload) => {
+                        if let Err(e) = publisher.publish(payload).await {
+                            eprintln!("Failed to publish joint state: {e}");
+                        }
+                    }
+                    Err(e) => eprintln!("Failed to build joint_states message: {e}"),
                 }
             }
         });

--- a/docs/src/content/docs/guides/snippets/rust/robot_arm/src/main.rs
+++ b/docs/src/content/docs/guides/snippets/rust/robot_arm/src/main.rs
@@ -11,6 +11,14 @@ use peppygen::{NodeBuilder, Parameters, Result};
 fn main() -> Result<()> {
     NodeBuilder::new().run(|_args: Parameters, node_runner| async move {
         tokio::spawn(async move {
+            // Declare the publisher once; every publish below is then lock-free.
+            let publisher = match joint_states::declare_publisher(&node_runner).await {
+                Ok(publisher) => publisher,
+                Err(e) => {
+                    eprintln!("Failed to declare joint_states publisher: {e}");
+                    return;
+                }
+            };
             loop {
                 let (producer, command) =
                     controller_joint_commands::on_next_message_received(&node_runner)
@@ -26,13 +34,13 @@ fn main() -> Result<()> {
                 );
 
                 // Drive the joints, then report the resulting state.
-                let _ = joint_states::emit(
-                    &node_runner,
+                if let Ok(payload) = joint_states::build_message(
                     command.target_positions,
                     [0.0, 0.0, 0.0],
                     std::time::SystemTime::now(),
-                )
-                .await;
+                ) {
+                    let _ = publisher.publish(payload).await;
+                }
             }
         });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Refactored topic publishing to a declare-once publisher workflow, separating `build_message` from `publish`.
  * Added `TopicPublisher` to public exports, including Python availability.
* **Bug Fixes**
  * Improved container startup to clean the environment inside Apptainer to prevent leaking daemon variables.
  * Hardened forwarded environment variables with stricter name/value validation to reduce injection risk.
* **Documentation & Tests**
  * Updated guides, snippets, and messaging/topic tests to use the new publisher-based flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->