### PR TITLE
Refactor resources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,7 +406,7 @@ dependencies = [
 [[package]]
 name = "build-helpers"
 version = "0.0.1"
-source = "git+https://github.com/Peppy-bot/nodes_shared_code#da823f2e20682a4370477e8b963c8c55e5603364"
+source = "git+https://github.com/Peppy-bot/nodes_shared_code#c42025204f95702dbdb87112842e33816f440381"
 dependencies = [
  "sha2 0.11.0",
 ]
@@ -607,7 +607,7 @@ dependencies = [
 [[package]]
 name = "config-test-support"
 version = "0.0.1"
-source = "git+https://github.com/Peppy-bot/nodes_shared_code#da823f2e20682a4370477e8b963c8c55e5603364"
+source = "git+https://github.com/Peppy-bot/nodes_shared_code#c42025204f95702dbdb87112842e33816f440381"
 dependencies = [
  "askama",
  "git2",
@@ -749,7 +749,7 @@ dependencies = [
 [[package]]
 name = "core-node-api"
 version = "0.0.1"
-source = "git+https://github.com/Peppy-bot/nodes_shared_code#da823f2e20682a4370477e8b963c8c55e5603364"
+source = "git+https://github.com/Peppy-bot/nodes_shared_code#c42025204f95702dbdb87112842e33816f440381"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -1050,7 +1050,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1198,7 +1198,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2300,7 +2300,7 @@ dependencies = [
 [[package]]
 name = "json5-pretty"
 version = "0.0.1"
-source = "git+https://github.com/Peppy-bot/nodes_shared_code#da823f2e20682a4370477e8b963c8c55e5603364"
+source = "git+https://github.com/Peppy-bot/nodes_shared_code#c42025204f95702dbdb87112842e33816f440381"
 dependencies = [
  "serde",
  "serde_json",
@@ -2735,7 +2735,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3156,7 +3156,7 @@ dependencies = [
 [[package]]
 name = "peppy-config-model"
 version = "0.0.1"
-source = "git+https://github.com/Peppy-bot/nodes_shared_code#da823f2e20682a4370477e8b963c8c55e5603364"
+source = "git+https://github.com/Peppy-bot/nodes_shared_code#c42025204f95702dbdb87112842e33816f440381"
 dependencies = [
  "capnp",
  "clap",
@@ -3181,7 +3181,7 @@ version = "0.0.1"
 [[package]]
 name = "peppylib-rs"
 version = "0.0.1"
-source = "git+https://github.com/Peppy-bot/nodes_shared_code#da823f2e20682a4370477e8b963c8c55e5603364"
+source = "git+https://github.com/Peppy-bot/nodes_shared_code#c42025204f95702dbdb87112842e33816f440381"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -3357,7 +3357,7 @@ dependencies = [
 [[package]]
 name = "pmi"
 version = "0.0.1"
-source = "git+https://github.com/Peppy-bot/nodes_shared_code#da823f2e20682a4370477e8b963c8c55e5603364"
+source = "git+https://github.com/Peppy-bot/nodes_shared_code#c42025204f95702dbdb87112842e33816f440381"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -3538,7 +3538,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.4",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3984,7 +3984,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4052,7 +4052,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4073,7 +4073,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4449,7 +4449,7 @@ version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
 dependencies = [
- "dirs 4.0.0",
+ "dirs 6.0.0",
 ]
 
 [[package]]
@@ -4730,7 +4730,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5529,7 +5529,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5679,6 +5679,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -5710,11 +5719,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -5739,6 +5765,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5749,6 +5781,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5763,10 +5801,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5781,6 +5831,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5791,6 +5847,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5805,6 +5867,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5815,6 +5883,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/crates/core-node-internal/src/services/node.rs
+++ b/crates/core-node-internal/src/services/node.rs
@@ -80,7 +80,7 @@ mod tests {
     use super::*;
 
     const TEST_NODE_CONFIG: &str = r#"{
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "standalone",
     tag: "v1",

--- a/crates/core-node-internal/src/services/node/info.rs
+++ b/crates/core-node-internal/src/services/node/info.rs
@@ -379,7 +379,7 @@ mod tests {
         let bundle_dir = tempfile::tempdir().expect("failed to create temp bundle dir");
         let config = format!(
             r#"{{
-                peppy_schema: "node_v1",
+                peppy_schema: "node/v1",
                 manifest: {{
                     name: "{name}",
                     tag: "{tag}",

--- a/crates/core-node-internal/src/services/node/sync.rs
+++ b/crates/core-node-internal/src/services/node/sync.rs
@@ -1469,7 +1469,7 @@ mod conforms_to_tests {
     }
 
     const DEPTH_V1_BODY: &str = r#"{
-        peppy_schema: "interface_v1",
+        peppy_schema: "interface/v1",
         manifest: { name: "depth_camera", tag: "v1" },
         interfaces: {
             topics: [
@@ -1608,7 +1608,7 @@ mod conforms_to_tests {
     }
 
     const ARM_V1_WITH_SERVICE_AND_ACTION: &str = r#"{
-        peppy_schema: "interface_v1",
+        peppy_schema: "interface/v1",
         manifest: { name: "arm", tag: "v1" },
         interfaces: {
             services: [
@@ -1842,7 +1842,7 @@ mod conforms_to_tests {
     #[test]
     fn consumed_service_with_response_only_format_resolves() {
         const UVC_V1_BODY: &str = r#"{
-            peppy_schema: "interface_v1",
+            peppy_schema: "interface/v1",
             manifest: { name: "uvc_camera", tag: "v1" },
             interfaces: {
                 services: [

--- a/crates/core-node-internal/src/services/repo/cache.rs
+++ b/crates/core-node-internal/src/services/repo/cache.rs
@@ -69,7 +69,7 @@ pub struct NodeCacheEntry {
 /// One entry as it appears in `launchers.json5`. Launchers live in the
 /// same kind of repositories as nodes (FS or Git), but they don't carry
 /// a tag — they're just the location of a launcher `.json5` file (any
-/// filename; identified by `peppy_schema: "launcher_v1"` and keyed by
+/// filename; identified by `peppy_schema: "launcher/v1"` and keyed by
 /// file stem).
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct LauncherCacheEntry {
@@ -97,7 +97,7 @@ pub struct LauncherCacheEntry {
 }
 
 /// One entry as it appears in `interfaces.json5`. Interfaces are
-/// stand-alone JSON5 documents (`peppy_schema: "interface_v1"`) that
+/// stand-alone JSON5 documents (`peppy_schema: "interface/v1"`) that
 /// describe a reusable contract of topics / services / actions. The
 /// `sha256` of the manifest bytes is the primary way to disambiguate
 /// entries that share `(name, tag)`.

--- a/crates/core-node-internal/src/services/repo/refresh.rs
+++ b/crates/core-node-internal/src/services/repo/refresh.rs
@@ -458,7 +458,7 @@ fn count_unique_by_name<'a>(it: impl Iterator<Item = &'a str>) -> u32 {
 }
 
 /// Walk a directory looking for `peppy.json5` (node) and any `.json5`
-/// file whose body declares `peppy_schema: "launcher_v1"` (launcher),
+/// file whose body declares `peppy_schema: "launcher/v1"` (launcher),
 /// collecting discovered nodes and launchers.
 ///
 /// Any directory whose path matches one of the `excluded_paths` entries is
@@ -549,7 +549,7 @@ pub(crate) fn walk_directory(
         };
         match schema {
             PeppySchema::NodeV1 => {
-                // A non-`peppy.json5` file declaring `node_v1` is unusual
+                // A non-`peppy.json5` file declaring `node/v1` is unusual
                 // but we still parse it strictly: matches the documented
                 // "schema dispatch" rule for any `.json5`.
                 try_collect_node_entry(&ctx, &mut nodes_seen, &mut nodes);
@@ -994,7 +994,7 @@ mod tests {
             dir.join(NODE_CONFIG_FILE),
             format!(
                 r#"{{
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {{ name: "{name}", tag: "{tag}" }},
   interfaces: {{}},
   execution: {{ language: "rust", build_cmd: ["true"], run_cmd: ["true"] }},
@@ -1218,7 +1218,7 @@ mod tests {
         std::fs::write(
             path,
             r#"{
-  peppy_schema: "launcher_v1",
+  peppy_schema: "launcher/v1",
   deployments: []
 }"#,
         )
@@ -1232,7 +1232,7 @@ mod tests {
         }
         let body = format!(
             r#"{{
-  peppy_schema: "interface_v1",
+  peppy_schema: "interface/v1",
   manifest: {{ name: "{name}", tag: "{tag}" }},
   interfaces: {{}}
 }}"#
@@ -1241,7 +1241,7 @@ mod tests {
         body.into_bytes()
     }
 
-    /// FS-side interface discovery: an `interface_v1` document is
+    /// FS-side interface discovery: an `interface/v1` document is
     /// recognized regardless of its filename, the cached `path` points
     /// at the manifest file itself, and `sha256` matches the raw bytes.
     #[test]
@@ -1351,7 +1351,7 @@ mod tests {
         std::fs::write(
             repo_a.join("uvc_camera/peppy.json5"),
             r#"{
-  peppy_schema: "interface_v1",
+  peppy_schema: "interface/v1",
   manifest: { name: "uvc_camera", tag: "v1" },
   interfaces: {}
 }"#,
@@ -1362,7 +1362,7 @@ mod tests {
             repo_b.join("uvc_camera/peppy.json5"),
             r#"{
   // Same identity, different content fingerprint via extra whitespace.
-  peppy_schema: "interface_v1",
+  peppy_schema: "interface/v1",
   manifest:    { name: "uvc_camera", tag: "v1" },
   interfaces:  {}
 }"#,
@@ -1445,7 +1445,7 @@ mod tests {
     }
 
     /// Process_refresh discovers launcher files (any `.json5` filename
-    /// with `peppy_schema: "launcher_v1"`) alongside node files in the
+    /// with `peppy_schema: "launcher/v1"`) alongside node files in the
     /// same FS walk, names them by basename, and dedupes across repos.
     #[test]
     fn process_refresh_discovers_launchers_from_fs_repo() {
@@ -1524,7 +1524,7 @@ mod tests {
         );
     }
 
-    /// `.json5` files that don't declare `peppy_schema: "launcher_v1"`
+    /// `.json5` files that don't declare `peppy_schema: "launcher/v1"`
     /// must be skipped silently — they're unrelated configuration, not
     /// launchers.
     #[test]
@@ -1547,7 +1547,7 @@ mod tests {
         // in the repo and must not be misclassified.
         std::fs::write(
             repo.join("manifest.json5"),
-            r#"{ peppy_schema: "node_v1", manifest: { name: "x", tag: "v1" }, interfaces: {}, execution: { language: "rust", build_cmd: ["true"], run_cmd: ["true"] } }"#,
+            r#"{ peppy_schema: "node/v1", manifest: { name: "x", tag: "v1" }, interfaces: {}, execution: { language: "rust", build_cmd: ["true"], run_cmd: ["true"] } }"#,
         )
         .unwrap();
 
@@ -1627,7 +1627,7 @@ mod tests {
         std::fs::write(
             src.join("openarm01").join("openarm01_teleop.json5"),
             r#"{
-                peppy_schema: "launcher_v1",
+                peppy_schema: "launcher/v1",
                 deployments: []
             }"#,
         )

--- a/crates/core-node-internal/src/services/stack/benchmark.rs
+++ b/crates/core-node-internal/src/services/stack/benchmark.rs
@@ -1087,7 +1087,7 @@ mod tests {
     fn consumer() -> NodeConfig {
         parse(
             r#"{
-                peppy_schema: "node_v1",
+                peppy_schema: "node/v1",
                 manifest: {
                     name: "brain", tag: "v1",
                     depends_on: {
@@ -1108,7 +1108,7 @@ mod tests {
     fn camera_mock() -> NodeConfig {
         parse(
             r#"{
-                peppy_schema: "node_v1",
+                peppy_schema: "node/v1",
                 manifest: { name: "uvc_camera_python_mock", tag: "v1" },
                 execution: { language: "rust", run_cmd: ["camera"] },
                 interfaces: { conforms_to: [ { name: "uvc_camera", tag: "v1" } ] }
@@ -1119,7 +1119,7 @@ mod tests {
     fn arm() -> NodeConfig {
         parse(
             r#"{
-                peppy_schema: "node_v1",
+                peppy_schema: "node/v1",
                 manifest: { name: "arm", tag: "v1" },
                 execution: { language: "rust", run_cmd: ["arm"] },
                 interfaces: { actions: { exposes: [ { name: "move_arm" } ] } }
@@ -1240,7 +1240,7 @@ mod tests {
     fn formats_from_node_sizes_topic_message_on_response_side() {
         let provider = parse(
             r#"{
-                peppy_schema: "node_v1",
+                peppy_schema: "node/v1",
                 manifest: { name: "camera", tag: "v1" },
                 execution: { language: "rust", run_cmd: ["camera"] },
                 interfaces: { topics: { emits: [ {
@@ -1269,7 +1269,7 @@ mod tests {
     fn formats_from_interface_sizes_topic_message_on_response_side() {
         let doc = config::interface::PeppyInterfaceParser::from_content(
             r#"{
-                peppy_schema: "interface_v1",
+                peppy_schema: "interface/v1",
                 manifest: { name: "uvc_camera", tag: "v1" },
                 interfaces: { topics: [ {
                     name: "video_stream",
@@ -1294,7 +1294,7 @@ mod tests {
     fn formats_from_node_resolves_service_request_response_sizes() {
         let provider = parse(
             r#"{
-                peppy_schema: "node_v1",
+                peppy_schema: "node/v1",
                 manifest: { name: "arm", tag: "v1" },
                 execution: { language: "rust", run_cmd: ["arm"] },
                 interfaces: { services: { exposes: [ {

--- a/crates/core-node-internal/templates/node_init/python/peppy.json5.j2
+++ b/crates/core-node-internal/templates/node_init/python/peppy.json5.j2
@@ -1,5 +1,5 @@
 {
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "{{ node_name }}",
     tag: "v1",

--- a/crates/core-node-internal/templates/node_init/rust/peppy.json5.j2
+++ b/crates/core-node-internal/templates/node_init/rust/peppy.json5.j2
@@ -1,5 +1,5 @@
 {
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "{{ node_name }}",
     tag: "v1",

--- a/crates/core-node-internal/tests/common.rs
+++ b/crates/core-node-internal/tests/common.rs
@@ -1309,7 +1309,7 @@ pub async fn add_and_build_forking_node(
 ) -> TempDir {
     let source_dir = tempfile::tempdir().expect("temp source dir");
     let peppy_json5 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: { name: "{NAME}", tag: "{TAG}" },
             execution: {
                 language: "rust",
@@ -1515,7 +1515,7 @@ fn main() -> Result<()> {
     std::fs::write(
         node_dir.join(NODE_CONFIG_FILE),
         r#"{
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "{crate_name}",
     tag: "{node_tag}",

--- a/crates/core-node-internal/tests/container_e2e.rs
+++ b/crates/core-node-internal/tests/container_e2e.rs
@@ -421,7 +421,7 @@ mod container_e2e_tests {
         write_peppy_json5(
             source_dir.path(),
             r#"{
-                peppy_schema: "node_v1",
+                peppy_schema: "node/v1",
                 manifest: { name: "zombie_e2e_node", tag: "v1" },
                 execution: { language: "rust", container: { def_file: "apptainer.def" } }
             }"#,

--- a/crates/core-node-internal/tests/launch_assets/fake_openarm01_controller/peppy.json5
+++ b/crates/core-node-internal/tests/launch_assets/fake_openarm01_controller/peppy.json5
@@ -1,5 +1,5 @@
 {
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "fake_openarm01_controller",
     tag: "v1",

--- a/crates/core-node-internal/tests/launch_assets/fake_robot_brain/peppy.json5
+++ b/crates/core-node-internal/tests/launch_assets/fake_robot_brain/peppy.json5
@@ -1,5 +1,5 @@
 {
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     // This is a brain that can plug to any controller
     name: "fake_robot_brain",

--- a/crates/core-node-internal/tests/launch_assets/fake_uvc_camera/peppy.json5
+++ b/crates/core-node-internal/tests/launch_assets/fake_uvc_camera/peppy.json5
@@ -1,5 +1,5 @@
 {
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "fake_uvc_camera",
     tag: "v1",

--- a/crates/core-node-internal/tests/launch_assets/peppy_launcher.json5
+++ b/crates/core-node-internal/tests/launch_assets/peppy_launcher.json5
@@ -1,5 +1,5 @@
 {
-  peppy_schema: "launcher_v1",
+  peppy_schema: "launcher/v1",
   deployments: [
     {
       source: {

--- a/crates/core-node-internal/tests/listen_for_launch.rs
+++ b/crates/core-node-internal/tests/listen_for_launch.rs
@@ -59,7 +59,7 @@ async fn seed_running_node(
     let source_dir = tempfile::tempdir().expect("temp source dir");
     let peppy_json5 = format!(
         r#"{{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {{ name: "{name}", tag: "{tag}" }},
             execution: {{ language: "rust", run_cmd: ["sleep", "60"] }}
         }}"#
@@ -92,7 +92,7 @@ async fn seed_running_node(
 
 const LAUNCHER_EXAMPLE1: &str = r#"
 {
-  peppy_schema: "launcher_v1",
+  peppy_schema: "launcher/v1",
   deployments: [
     {
       source: {
@@ -252,7 +252,7 @@ fn write_node_config_with_options(
     fs::write(
         &node_config_path,
         r#"{
-              peppy_schema: "node_v1",
+              peppy_schema: "node/v1",
               manifest: {
                 name: "{node_name}",
                 tag: "{node_tag}",
@@ -301,7 +301,7 @@ fn create_uvc_camera_repo(to_path: &Path, node_tag: &str) -> PathBuf {
     fs::write(
         repo_path.join(&rel_config_path),
         r#"{
-              peppy_schema: "node_v1",
+              peppy_schema: "node/v1",
               manifest: {
                 name: "uvc_camera",
                 tag: "{node_tag}",
@@ -959,7 +959,7 @@ async fn listen_for_launch_configuration_succeeds_with_repo_sources() {
     // `name:tag` shorthand.
     let launcher_json5 = format!(
         r#"{{
-  peppy_schema: "launcher_v1",
+  peppy_schema: "launcher/v1",
   deployments: [
     {{
       source: {{ name: "{BRAIN_NODE}", tag: "{NODE_TAG}" }},
@@ -1041,7 +1041,7 @@ async fn listen_for_launch_configuration_launch_config_invalid_json5_returns_err
         .push_config(existing_config, false, &existing_path)
         .expect("should seed stack");
 
-    let bad_launcher_json5 = r#"{ peppy_schema: "launcher_v1", deployments: [ }"#;
+    let bad_launcher_json5 = r#"{ peppy_schema: "launcher/v1", deployments: [ }"#;
     let launch_file_path = nodes_dir.path().join("peppy_launcher.json5");
     fs::write(&launch_file_path, bad_launcher_json5).expect("failed to write launch file");
 
@@ -1137,7 +1137,7 @@ async fn listen_for_launch_config_missing_required_deployment_does_not_apply_par
     // One deployment exists, the other is missing and required.
     let launcher_json5 = r#"
     {
-      peppy_schema: "launcher_v1",
+      peppy_schema: "launcher/v1",
       deployments: [
         { source: { local: "./existing_node" }, instances: [ { instance_id: "ok" } ] },
         { source: { local: "./missing_node" }, instances: [ { instance_id: "nope" } ] }
@@ -1215,7 +1215,7 @@ async fn listen_for_launch_configuration_launch_config_dependency_errors_are_rej
 
     let launcher_json5 = r#"
     {
-      peppy_schema: "launcher_v1",
+      peppy_schema: "launcher/v1",
       deployments: [
         { source: { local: "./uvc_camera" }, instances: [ { instance_id: "camera_front" } ] },
         { source: { local: "./robot_brain" }, instances: [ { instance_id: "main_robot_brain" } ] }
@@ -1317,7 +1317,7 @@ async fn listen_for_launch_configuration_launch_config_second_request_replaces_e
     tokio::time::sleep(Duration::from_millis(50)).await;
 
     let launch_a = r#"
-    { peppy_schema: "launcher_v1", deployments: [ { source: { local: "./node_a" }, instances: [ { instance_id: "a1" } ] } ] }
+    { peppy_schema: "launcher/v1", deployments: [ { source: { local: "./node_a" }, instances: [ { instance_id: "a1" } ] } ] }
     "#;
     let launch_file_path_a = nodes_dir.path().join("peppy_launcher.json5");
     fs::write(&launch_file_path_a, launch_a).expect("failed to write launch file");
@@ -1350,7 +1350,7 @@ async fn listen_for_launch_configuration_launch_config_second_request_replaces_e
     );
 
     let launch_b = r#"
-    { peppy_schema: "launcher_v1", deployments: [ { source: { local: "./node_b" }, instances: [ { instance_id: "b1" } ] } ] }
+    { peppy_schema: "launcher/v1", deployments: [ { source: { local: "./node_b" }, instances: [ { instance_id: "b1" } ] } ] }
     "#;
     let launch_file_path_b = nodes_dir.path().join("peppy_launcher.json5");
     fs::write(&launch_file_path_b, launch_b).expect("failed to write launch file");
@@ -1432,7 +1432,7 @@ async fn listen_for_launch_configuration_fails_when_one_node_never_becomes_healt
     );
 
     let launch_b = r#"
-    { peppy_schema: "launcher_v1", deployments: [ { source: { local: "./node_b" }, instances: [ { instance_id: "b1" } ] } ] }
+    { peppy_schema: "launcher/v1", deployments: [ { source: { local: "./node_b" }, instances: [ { instance_id: "b1" } ] } ] }
     "#;
     let launch_file_path = nodes_dir.path().join("peppy_launcher.json5");
     fs::write(&launch_file_path, launch_b).expect("failed to write launch file");
@@ -1543,7 +1543,7 @@ async fn listen_for_launch_configuration_fails_when_build_cmd_fails_and_clears_s
     );
 
     let launcher_json5 = r#"
-    { peppy_schema: "launcher_v1", deployments: [ { source: { local: "./failing_node" }, instances: [ { instance_id: "f1" } ] } ] }
+    { peppy_schema: "launcher/v1", deployments: [ { source: { local: "./failing_node" }, instances: [ { instance_id: "f1" } ] } ] }
     "#;
     let launch_file_path = nodes_dir.path().join("peppy_launcher.json5");
     fs::write(&launch_file_path, launcher_json5).expect("failed to write launch file");
@@ -1631,7 +1631,7 @@ async fn listen_for_launch_configuration_fails_when_run_cmd_exits_with_error() {
     );
 
     let launcher_json5 = format!(
-        r#"{{ peppy_schema: "launcher_v1", deployments: [ {{ source: {{ local: "./{NODE_NAME}" }}, instances: [ {{ instance_id: "{INSTANCE_ID}" }} ] }} ] }}"#
+        r#"{{ peppy_schema: "launcher/v1", deployments: [ {{ source: {{ local: "./{NODE_NAME}" }}, instances: [ {{ instance_id: "{INSTANCE_ID}" }} ] }} ] }}"#
     );
     let launch_file_path = nodes_dir.path().join("peppy_launcher.json5");
     fs::write(&launch_file_path, &launcher_json5).expect("failed to write launch file");
@@ -1761,7 +1761,7 @@ async fn listen_for_node_launch_uses_env_overrides_for_path() {
         false,
     );
     let launch_json5 = format!(
-        r#"{{ peppy_schema: "launcher_v1", deployments: [ {{ source: {{ local: "./{NODE_NAME}" }}, instances: [ {{ instance_id: "{INSTANCE_ID}" }} ] }} ] }}"#
+        r#"{{ peppy_schema: "launcher/v1", deployments: [ {{ source: {{ local: "./{NODE_NAME}" }}, instances: [ {{ instance_id: "{INSTANCE_ID}" }} ] }} ] }}"#
     );
     let launch_file_path = nodes_dir.path().join("peppy_launcher.json5");
     fs::write(&launch_file_path, &launch_json5).expect("failed to write launch file");
@@ -1910,7 +1910,7 @@ async fn listen_for_launch_resolves_launcher_from_repository_cache() {
     // resolved relative to the launcher file's parent dir.
     let launcher_json5 = format!(
         r#"{{
-  peppy_schema: "launcher_v1",
+  peppy_schema: "launcher/v1",
   deployments: [
     {{
       source: {{ local: "./{ROBOT_NODE_NAME}" }},

--- a/crates/core-node-internal/tests/listen_for_node_add.rs
+++ b/crates/core-node-internal/tests/listen_for_node_add.rs
@@ -69,7 +69,7 @@ fn minimal_node_config(name: &str, tag: &str, deps: &[(&str, &str)]) -> String {
     };
     format!(
         r#"{{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {{
                 name: "{name}",
                 tag: "{tag}",
@@ -91,7 +91,7 @@ fn minimal_node_config(name: &str, tag: &str, deps: &[(&str, &str)]) -> String {
 fn node_config_with_execution(name: &str, tag: &str, execution_body: &str) -> String {
     format!(
         r#"{{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {{
                 name: "{name}",
                 tag: "{tag}",
@@ -108,7 +108,7 @@ fn create_minimal_http_bundle(node_name: &str, node_tag: &str) -> (TempDir, Vec<
     let bundle_dir = tempfile::tempdir().expect("failed to create temp bundle dir");
     let peppy_json5 = format!(
         r#"{{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {{
                 name: "{node_name}",
                 tag: "{node_tag}",
@@ -220,7 +220,7 @@ fn create_versioned_nodes_git_repo(to_path: impl AsRef<Path>) -> PathBuf {
     std::fs::write(
         repo_path.join(&rel_config_path),
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "uvc_camera",
                 tag: "v1",
@@ -265,7 +265,7 @@ fn create_versioned_nodes_git_repo(to_path: impl AsRef<Path>) -> PathBuf {
     std::fs::write(
         repo_path.join(&rel_config_path),
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "uvc_camera",
                 tag: "v2",
@@ -327,7 +327,7 @@ fn create_git_repo_with_invalid_config(base_path: &Path) -> PathBuf {
     std::fs::write(
         repo_path.join(config_rel),
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "bad_node",
                 tag: "v1",

--- a/crates/core-node-internal/tests/listen_for_node_add/basic_sources.rs
+++ b/crates/core-node-internal/tests/listen_for_node_add/basic_sources.rs
@@ -10,7 +10,7 @@ async fn listen_for_node_fs_add_success() {
 
     let source_dir = tempfile::tempdir().expect("failed to create temp source dir");
     let peppy_json5 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "{TARGET_NODE_NAME}",
                 tag: "{TARGET_NODE_TAG}",
@@ -167,7 +167,7 @@ async fn listen_for_node_http_add_success() {
 
     let bundle_dir = tempfile::tempdir().expect("failed to create temp bundle dir");
     let peppy_json5 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "{TARGET_NODE_NAME}",
                 tag: "{TARGET_NODE_TAG}",

--- a/crates/core-node-internal/tests/listen_for_node_add/conforms_to.rs
+++ b/crates/core-node-internal/tests/listen_for_node_add/conforms_to.rs
@@ -19,7 +19,7 @@ use super::*;
 use common::TestPackagesCache;
 
 const INTERFACE_BODY: &str = r#"{
-    peppy_schema: "interface_v1",
+    peppy_schema: "interface/v1",
     manifest: { name: "uvc_camera", tag: "v1" },
     interfaces: {
         topics: [
@@ -32,7 +32,7 @@ const INTERFACE_BODY: &str = r#"{
 }"#;
 
 const NODE_BODY: &str = r#"{
-    peppy_schema: "node_v1",
+    peppy_schema: "node/v1",
     manifest: { name: "fake_uvc_camera", tag: "v1" },
     interfaces: {
         conforms_to: [

--- a/crates/core-node-internal/tests/listen_for_node_add/failures.rs
+++ b/crates/core-node-internal/tests/listen_for_node_add/failures.rs
@@ -351,7 +351,7 @@ async fn listen_for_node_add_dependency_not_resolved() {
 
     // Try to add a consumer node that depends on a non-existent provider
     let peppy_json5 = r#"{
-        peppy_schema: "node_v1",
+        peppy_schema: "node/v1",
         manifest: {
             name: "consumer_node",
             tag: "v1",
@@ -414,7 +414,7 @@ async fn listen_for_node_add_duplicate_link_id_fails() {
     // Two depends_on.nodes entries sharing the same link_id must be rejected
     // at parse time, before any dependency resolution runs.
     let peppy_json5 = r#"{
-        peppy_schema: "node_v1",
+        peppy_schema: "node/v1",
         manifest: {
             name: "dup_link_id_node",
             tag: "v1",
@@ -472,7 +472,7 @@ async fn listen_for_node_add_fails_runs_add_cmd_on_missing_node_dependency() {
 
     let source_dir = tempfile::tempdir().expect("failed to create temp source dir");
     let peppy_json5 = r#"{
-        peppy_schema: "node_v1",
+        peppy_schema: "node/v1",
         manifest: {
           name: "TARGET_NODE_NAME",
           tag: "TARGET_NODE_TAG",
@@ -582,7 +582,7 @@ async fn listen_for_node_add_fails_on_missing_interface_even_when_dependency_exi
     let target_source_dir = tempfile::tempdir().expect("failed to create temp target source dir");
 
     let target_peppy_json5 = r#"{
-        peppy_schema: "node_v1",
+        peppy_schema: "node/v1",
         manifest: {
           name: "TARGET_NODE_NAME",
           tag: "TARGET_NODE_TAG",

--- a/crates/core-node-internal/tests/listen_for_node_add/replacement_and_lifecycle.rs
+++ b/crates/core-node-internal/tests/listen_for_node_add/replacement_and_lifecycle.rs
@@ -13,7 +13,7 @@ async fn listen_for_node_add_same_node_same_tags_overwrites_when_no_dependents()
 
     // First add: no interfaces
     let peppy_json5_v1 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "{NODE_NAME}",
                 tag: "{NODE_TAG}",
@@ -54,7 +54,7 @@ async fn listen_for_node_add_same_node_same_tags_overwrites_when_no_dependents()
 
     // Second add: same name+tag but different interfaces -> should overwrite.
     let peppy_json5_v2 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "{NODE_NAME}",
                 tag: "{NODE_TAG}",
@@ -132,7 +132,7 @@ async fn listen_for_node_add_same_node_same_tags_fails_when_node_has_dependents(
     let dependent_source_dir = tempfile::tempdir().expect("failed to create temp source dir");
 
     let dependency_peppy_json5_v1 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "{DEPENDENCY_NODE_NAME}",
                 tag: "{DEPENDENCY_NODE_TAG}",
@@ -170,7 +170,7 @@ async fn listen_for_node_add_same_node_same_tags_fails_when_node_has_dependents(
     );
 
     let dependent_peppy_json5 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "{DEPENDENT_NODE_NAME}",
                 tag: "{DEPENDENT_NODE_TAG}",
@@ -221,7 +221,7 @@ async fn listen_for_node_add_same_node_same_tags_fails_when_node_has_dependents(
 
     // Overwrite attempt: same name+tag but different interfaces should fail due to dependent nodes.
     let dependency_peppy_json5_v2 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "{DEPENDENCY_NODE_NAME}",
                 tag: "{DEPENDENCY_NODE_TAG}",
@@ -316,7 +316,7 @@ async fn listen_for_node_add_same_node_different_tags_create_two_entities() {
     let source_dir_v2 = tempfile::tempdir().expect("failed to create temp source dir");
 
     let peppy_json5_v1 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "{NODE_NAME}",
                 tag: "v1",
@@ -354,7 +354,7 @@ async fn listen_for_node_add_same_node_different_tags_create_two_entities() {
     );
 
     let peppy_json5_v2 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "{NODE_NAME}",
                 tag: "v2",
@@ -406,7 +406,7 @@ async fn listen_for_node_add_fingerprint_mismatch() {
     let source_dir = tempfile::tempdir().expect("failed to create temp source dir");
 
     let peppy_json5 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "{TARGET_NODE_NAME}",
                 tag: "{TARGET_NODE_TAG}",
@@ -484,7 +484,7 @@ async fn listen_for_node_add_abandoned_action_does_not_block_next_goal() {
     // Create first node source directory
     let first_source_dir = tempfile::tempdir().expect("failed to create temp source dir");
     let first_peppy_json5 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "{FIRST_NODE_NAME}",
                 tag: "{FIRST_NODE_TAG}",
@@ -559,7 +559,7 @@ async fn listen_for_node_add_abandoned_action_does_not_block_next_goal() {
     // for the first action's result
     let second_source_dir = tempfile::tempdir().expect("failed to create temp source dir");
     let second_peppy_json5 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "{SECOND_NODE_NAME}",
                 tag: "{SECOND_NODE_TAG}",
@@ -618,7 +618,7 @@ async fn node_add_same_node_shutdown_existing_instances() {
 
     let source_dir_v1 = tempfile::tempdir().expect("failed to create temp source dir");
     let peppy_json5_v1 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "{NODE_NAME}",
                 tag: "{NODE_TAG}",
@@ -781,7 +781,7 @@ async fn node_add_same_node_shutdown_existing_instances() {
 
     let source_dir_v2 = tempfile::tempdir().expect("failed to create temp source dir");
     let peppy_json5_v2 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "{NODE_NAME}",
                 tag: "{NODE_TAG}",
@@ -916,7 +916,7 @@ async fn node_add_same_node_with_running_instance_and_dependents_succeeds() {
     let dependent_source_dir = tempfile::tempdir().expect("failed to create temp source dir");
 
     let dependency_peppy_json5 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "{DEPENDENCY_NODE_NAME}",
                 tag: "{DEPENDENCY_NODE_TAG}",
@@ -954,7 +954,7 @@ async fn node_add_same_node_with_running_instance_and_dependents_succeeds() {
     );
 
     let dependent_peppy_json5 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "{DEPENDENT_NODE_NAME}",
                 tag: "{DEPENDENT_NODE_TAG}",
@@ -1154,7 +1154,7 @@ async fn node_add_same_node_changing_interface_with_running_instance_and_depende
     let dependent_source_dir = tempfile::tempdir().expect("failed to create temp source dir");
 
     let dependency_peppy_json5_v1 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "{DEPENDENCY_NODE_NAME}",
                 tag: "{DEPENDENCY_NODE_TAG}",
@@ -1192,7 +1192,7 @@ async fn node_add_same_node_changing_interface_with_running_instance_and_depende
     );
 
     let dependent_peppy_json5 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "{DEPENDENT_NODE_NAME}",
                 tag: "{DEPENDENT_NODE_TAG}",
@@ -1298,7 +1298,7 @@ async fn node_add_same_node_changing_interface_with_running_instance_and_depende
 
     // Try to overwrite with a different interface (new_service instead of reset_sensor).
     let dependency_peppy_json5_v2 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "{DEPENDENCY_NODE_NAME}",
                 tag: "{DEPENDENCY_NODE_TAG}",
@@ -1407,7 +1407,7 @@ async fn node_add_same_node_with_running_instance_and_dependents_force_kills_stu
     let dependent_source_dir = tempfile::tempdir().expect("failed to create temp source dir");
 
     let dependency_peppy_json5 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "{DEPENDENCY_NODE_NAME}",
                 tag: "{DEPENDENCY_NODE_TAG}",
@@ -1438,7 +1438,7 @@ async fn node_add_same_node_with_running_instance_and_dependents_force_kills_stu
     );
 
     let dependent_peppy_json5 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "{DEPENDENT_NODE_NAME}",
                 tag: "{DEPENDENT_NODE_TAG}",
@@ -1625,7 +1625,7 @@ async fn node_add_overwrite_with_two_stuck_instances_shares_one_grace_budget() {
     // v2 with the same name/tag triggers the overwrite path.
     let source_dir_v2 = tempfile::tempdir().expect("failed to create temp source dir");
     let peppy_json5_v2 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: { name: "{NAME}", tag: "{TAG}" },
             execution: {
                 language: "rust",

--- a/crates/core-node-internal/tests/listen_for_node_build.rs
+++ b/crates/core-node-internal/tests/listen_for_node_build.rs
@@ -105,7 +105,7 @@ async fn listen_for_node_build_runs_build_cmd() {
     let source_dir = tempfile::tempdir().expect("failed to create temp source dir");
 
     let peppy_json5 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "{TARGET_NODE_NAME}",
                 tag: "{TARGET_NODE_TAG}",
@@ -239,7 +239,7 @@ async fn force_build_cancels_inflight_and_reuses_working_dir_then_succeeds() {
 
     let source_dir = tempfile::tempdir().expect("failed to create temp source dir");
     let peppy_json5 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "{TARGET_NODE_NAME}",
                 tag: "{TARGET_NODE_TAG}",
@@ -365,7 +365,7 @@ async fn listen_for_node_build_cmd_failure_fails_build() {
 
     let source_dir = tempfile::tempdir().expect("failed to create temp source dir");
     let peppy_json5 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "{TARGET_NODE_NAME}",
                 tag: "{TARGET_NODE_TAG}",
@@ -429,7 +429,7 @@ async fn listen_for_node_build_cmd_nonzero_exit_fails_build() {
 
     let source_dir = tempfile::tempdir().expect("failed to create temp source dir");
     let peppy_json5 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "{TARGET_NODE_NAME}",
                 tag: "{TARGET_NODE_TAG}",
@@ -495,7 +495,7 @@ async fn listen_for_node_build_cmd_streams_stdout_and_stderr() {
 
     let source_dir = tempfile::tempdir().expect("failed to create temp source dir");
     let peppy_json5 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "{TARGET_NODE_NAME}",
                 tag: "{TARGET_NODE_TAG}",
@@ -562,7 +562,7 @@ async fn listen_for_node_build_writes_log_file() {
 
     let source_dir = tempfile::tempdir().expect("failed to create temp source dir");
     let peppy_json5 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "{TARGET_NODE_NAME}",
                 tag: "{TARGET_NODE_TAG}",
@@ -671,7 +671,7 @@ async fn listen_for_node_build_copies_files_to_storage() {
         .expect("failed to write nested file");
 
     let peppy_json5 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "{TARGET_NODE_NAME}",
                 tag: "{TARGET_NODE_TAG}",
@@ -743,7 +743,7 @@ async fn listen_for_node_build_uses_env_overrides_for_path() {
 
     let source_dir = tempfile::tempdir().expect("failed to create temp source dir");
     let peppy_json5 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "{TARGET_NODE_NAME}",
                 tag: "{TARGET_NODE_TAG}",
@@ -849,7 +849,7 @@ async fn listen_for_node_build_injects_runtime_env_vars() {
     let started_core_node = start_core_node_with_mock_messenger().await;
     let source_dir = tempfile::tempdir().expect("failed to create temp source dir");
     let peppy_json5 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "{TARGET_NODE_NAME}",
                 tag: "{TARGET_NODE_TAG}",
@@ -901,7 +901,7 @@ async fn listen_for_node_build_with_container_success() {
 
     let source_dir = tempfile::tempdir().expect("failed to create temp source dir");
     let peppy_json5 = r#"{
-        peppy_schema: "node_v1",
+        peppy_schema: "node/v1",
         manifest: {
             name: "TARGET_NODE_NAME",
             tag: "TARGET_NODE_TAG",
@@ -1038,7 +1038,7 @@ async fn listen_for_node_build_container_build_failure_includes_stderr_in_error(
 
     let source_dir = tempfile::tempdir().expect("failed to create temp source dir");
     let peppy_json5 = r#"{
-        peppy_schema: "node_v1",
+        peppy_schema: "node/v1",
         manifest: {
             name: "TARGET_NODE_NAME",
             tag: "TARGET_NODE_TAG",
@@ -1139,7 +1139,7 @@ async fn listen_for_node_build_logs_error_on_spawn_failure() {
 
     let source_dir = tempfile::tempdir().expect("failed to create temp source dir");
     let peppy_json5 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "{TARGET_NODE_NAME}",
                 tag: "{TARGET_NODE_TAG}",

--- a/crates/core-node-internal/tests/listen_for_node_info.rs
+++ b/crates/core-node-internal/tests/listen_for_node_info.rs
@@ -66,7 +66,7 @@ async fn node_info_reports_stage_instances_and_logs_for_stack_resident_node() {
 
     let node_dir = tempfile::tempdir().expect("failed to create temp node dir");
     let peppy_json5 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "fs_node",
                 tag: "v1",
@@ -191,7 +191,7 @@ async fn node_info_has_instance_ids() {
 
     let source_dir = tempfile::tempdir().expect("failed to create temp source dir");
     let peppy_json5 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "instance_ids_node",
                 tag: "v1",
@@ -380,7 +380,7 @@ async fn node_info_reports_not_in_stack_and_recovers() {
     // is still alive.
     let node_dir = tempfile::tempdir().expect("failed to create temp node dir");
     let peppy_json5 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "fs_node",
                 tag: "v1",

--- a/crates/core-node-internal/tests/listen_for_node_list.rs
+++ b/crates/core-node-internal/tests/listen_for_node_list.rs
@@ -19,7 +19,7 @@ async fn listen_for_node_list_returns_succeeds() {
     let source_dir = tempfile::tempdir().expect("failed to create temp source dir");
 
     let peppy_json5 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "{TARGET_NODE_NAME}",
                 tag: "{TARGET_NODE_TAG}",
@@ -113,7 +113,7 @@ async fn listen_for_node_list_returns_dot_graph() {
     let source_dir = tempfile::tempdir().expect("failed to create temp source dir");
 
     let peppy_json5 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "{TARGET_NODE_NAME}",
                 tag: "{TARGET_NODE_TAG}",

--- a/crates/core-node-internal/tests/listen_for_node_remove.rs
+++ b/crates/core-node-internal/tests/listen_for_node_remove.rs
@@ -23,7 +23,7 @@ async fn listen_for_node_remove_success() {
     let source_dir = tempfile::tempdir().expect("failed to create temp source dir");
 
     let peppy_json5 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "{TARGET_NODE_NAME}",
                 tag: "{TARGET_NODE_TAG}",
@@ -145,7 +145,7 @@ async fn listen_for_node_remove_stop_running_instances_first() {
     let source_dir = tempfile::tempdir().expect("failed to create temp source dir");
 
     let peppy_json5 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "{TARGET_NODE_NAME}",
                 tag: "{TARGET_NODE_TAG}",
@@ -249,7 +249,7 @@ async fn listen_for_node_remove_clears_a_terminal_instance() {
 
     let source_dir = tempfile::tempdir().expect("failed to create temp source dir");
     let peppy_json5 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "{TARGET_NODE_NAME}",
                 tag: "{TARGET_NODE_TAG}",
@@ -359,7 +359,7 @@ async fn listen_for_node_fails_when_stop_instances_parameter_not_set_and_instanc
     let source_dir = tempfile::tempdir().expect("failed to create temp source dir");
 
     let peppy_json5 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "{TARGET_NODE_NAME}",
                 tag: "{TARGET_NODE_TAG}",

--- a/crates/core-node-internal/tests/listen_for_node_run.rs
+++ b/crates/core-node-internal/tests/listen_for_node_run.rs
@@ -137,7 +137,7 @@ async fn listen_for_node_run_timeout() {
     // Create a node config with a run_cmd that won't respond to health checks
     // Using "sleep 10" as a simple command that runs but doesn't respond
     let peppy_json5 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "{TARGET_NODE_NAME}",
                 tag: "v1",
@@ -314,7 +314,7 @@ async fn listen_for_node_run_streams_stdout_and_stderr() {
     // while the gated start waits on the delayed health responder. The sleep just
     // needs to outlast that wait; teardown kills the node well before it elapses.
     let peppy_json5 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "{TARGET_NODE_NAME}",
                 tag: "{TARGET_NODE_TAG}",
@@ -431,7 +431,7 @@ async fn listen_for_node_run_writes_log_file() {
 
     let source_dir = tempfile::tempdir().expect("failed to create temp source dir");
     let peppy_json5 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "{TARGET_NODE_NAME}",
                 tag: "{TARGET_NODE_TAG}",
@@ -570,7 +570,7 @@ async fn listen_for_node_run_reports_all_missing_parameters() {
     // Create a node config with multiple required parameters
     let source_dir = tempfile::tempdir().expect("failed to create temp source dir");
     let peppy_json5 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "{TARGET_NODE_NAME}",
                 tag: "{TARGET_NODE_TAG}",
@@ -693,7 +693,7 @@ async fn listen_for_node_run_reports_only_missing_parameters_when_some_provided(
     // Create a node config with multiple required parameters
     let source_dir = tempfile::tempdir().expect("failed to create temp source dir");
     let peppy_json5 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "{TARGET_NODE_NAME}",
                 tag: "{TARGET_NODE_TAG}",
@@ -845,7 +845,7 @@ async fn listen_for_node_run_abandoned_action_does_not_block_next_goal() {
     // Create and add first node
     let first_source_dir = tempfile::tempdir().expect("failed to create temp source dir");
     let first_peppy_json5 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "{FIRST_NODE_NAME}",
                 tag: "{FIRST_NODE_TAG}",
@@ -878,7 +878,7 @@ async fn listen_for_node_run_abandoned_action_does_not_block_next_goal() {
     // Create and add second node
     let second_source_dir = tempfile::tempdir().expect("failed to create temp source dir");
     let second_peppy_json5 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "{SECOND_NODE_NAME}",
                 tag: "{SECOND_NODE_TAG}",
@@ -1057,7 +1057,7 @@ async fn listen_for_node_run_uses_env_overrides_for_path() {
 
     let source_dir = tempfile::tempdir().expect("failed to create temp source dir");
     let peppy_json5 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "{TARGET_NODE_NAME}",
                 tag: "{TARGET_NODE_TAG}",
@@ -1206,7 +1206,7 @@ async fn listen_for_node_run_injects_runtime_env_vars() {
 
     let source_dir = tempfile::tempdir().expect("failed to create temp source dir");
     let peppy_json5 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "{TARGET_NODE_NAME}",
                 tag: "{TARGET_NODE_TAG}",
@@ -1311,7 +1311,7 @@ async fn listen_for_node_run_with_container_success() {
     // Create source directory with container config and apptainer definition
     let source_dir = tempfile::tempdir().expect("failed to create temp source dir");
     let peppy_json5 = r#"{
-        peppy_schema: "node_v1",
+        peppy_schema: "node/v1",
         manifest: {
             name: "TARGET_NODE_NAME",
             tag: "TARGET_NODE_TAG",
@@ -1527,7 +1527,7 @@ async fn listen_for_node_run_with_container_creates_missing_mount_dir_and_warns(
     // Create source directory with container config and apptainer definition
     let source_dir = tempfile::tempdir().expect("failed to create temp source dir");
     let peppy_json5 = r#"{
-        peppy_schema: "node_v1",
+        peppy_schema: "node/v1",
         manifest: {
             name: "TARGET_NODE_NAME",
             tag: "TARGET_NODE_TAG",
@@ -1687,7 +1687,7 @@ async fn listen_for_node_run_container_failure_includes_stderr_in_error() {
     // process dies, and the stderr output should be captured in the error.
     let source_dir = tempfile::tempdir().expect("failed to create temp source dir");
     let peppy_json5 = r#"{
-        peppy_schema: "node_v1",
+        peppy_schema: "node/v1",
         manifest: {
             name: "TARGET_NODE_NAME",
             tag: "TARGET_NODE_TAG",
@@ -1811,7 +1811,7 @@ async fn listen_for_node_run_logs_error_on_spawn_failure() {
     // This will cause command.spawn() to fail in start_node().
     let source_dir = tempfile::tempdir().expect("failed to create temp source dir");
     let peppy_json5 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "{TARGET_NODE_NAME}",
                 tag: "{TARGET_NODE_TAG}",
@@ -1927,7 +1927,7 @@ async fn listen_for_node_run_marks_node_unhealthy_on_failed_health_checks() {
 
     // Create a node with a simple long-running run_cmd
     let peppy_json5 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "{TARGET_NODE_NAME}",
                 tag: "{TARGET_NODE_TAG}",
@@ -2119,7 +2119,7 @@ async fn listen_for_node_run_marks_node_failed_when_its_process_exits() {
             .await;
 
     let peppy_json5 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "{TARGET_NODE_NAME}",
                 tag: "{TARGET_NODE_TAG}",
@@ -2296,7 +2296,7 @@ async fn listen_for_node_run_marks_node_finished_when_its_process_exits_cleanly(
     // trap, standing in for a one-shot node finishing its work. The short inner
     // sleep keeps any orphaned `sleep` child from outliving the test.
     let peppy_json5 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "{TARGET_NODE_NAME}",
                 tag: "{TARGET_NODE_TAG}",
@@ -2478,7 +2478,7 @@ async fn shutdown_token_suppresses_exit_relabel_and_health_warning() {
             .await;
 
     let peppy_json5 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "{TARGET_NODE_NAME}",
                 tag: "{TARGET_NODE_TAG}",

--- a/crates/core-node-internal/tests/listen_for_node_stop.rs
+++ b/crates/core-node-internal/tests/listen_for_node_stop.rs
@@ -34,7 +34,7 @@ async fn listen_for_node_stop_success() {
 
     // Add the node to the stack so it can be discovered by instance_id
     let peppy_json5 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "{TARGET_NODE_NAME}",
                 tag: "{TARGET_NODE_TAG}",
@@ -188,7 +188,7 @@ async fn node_stop_reports_graceful_for_node_that_exits_after_grace_but_within_d
 
     let source_dir = tempfile::tempdir().expect("failed to create temp source dir");
     let peppy_json5 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "{TARGET_NODE_NAME}",
                 tag: "{TARGET_NODE_TAG}",
@@ -698,7 +698,7 @@ async fn node_stop_with_live_exit_watcher_removes_without_recording_a_crash() {
     let started = start_core_node_with_mock_messenger().await;
 
     let peppy_json5 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "{TARGET_NODE_NAME}",
                 tag: "{TARGET_NODE_TAG}",

--- a/crates/core-node-internal/tests/listen_for_node_sync.rs
+++ b/crates/core-node-internal/tests/listen_for_node_sync.rs
@@ -24,7 +24,7 @@ async fn listen_for_node_sync_success() {
     write_node_config(
         node_dir.path(),
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "example_node",
                 tag: "v1",
@@ -282,7 +282,7 @@ async fn listen_for_node_sync_missing_dependency_fails() {
         node_dir.path(),
         r#"
         {
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "my_robot_brain",
                 tag: "v1",
@@ -363,7 +363,7 @@ async fn listen_for_node_sync_multiple_missing_dependencies_fails() {
         node_dir.path(),
         r#"
         {
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "my_robot_brain",
                 tag: "v1",
@@ -445,7 +445,7 @@ async fn listen_for_node_sync_generates_rust_interfaces() {
         uvc_camera_node_dir.path(),
         r#"
         {
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "uvc_camera",
                 tag: "v1",
@@ -538,7 +538,7 @@ async fn listen_for_node_sync_generates_rust_interfaces() {
         brain_node_dir.path(),
         r#"
         {
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "my_robot_brain",
                 tag: "v1",
@@ -658,7 +658,7 @@ async fn listen_for_node_sync_generates_rust_consumed_service_interfaces() {
         uvc_camera_node_dir.path(),
         r#"
         {
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "uvc_camera",
                 tag: "v1",
@@ -735,7 +735,7 @@ async fn listen_for_node_sync_generates_rust_consumed_service_interfaces() {
         brain_node_dir.path(),
         r#"
         {
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "my_robot_brain",
                 tag: "v1",
@@ -816,7 +816,7 @@ async fn listen_for_node_sync_generates_rust_consumed_topic_interfaces() {
         uvc_camera_node_dir.path(),
         r#"
         {
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "uvc_camera",
                 tag: "v1",
@@ -895,7 +895,7 @@ async fn listen_for_node_sync_generates_rust_consumed_topic_interfaces() {
         brain_node_dir.path(),
         r#"
         {
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "my_robot_brain",
                 tag: "v1",
@@ -976,7 +976,7 @@ async fn listen_for_node_sync_generates_rust_consumed_action_interfaces() {
         action_server_node_dir.path(),
         r#"
         {
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "brain",
                 tag: "v1",
@@ -1061,7 +1061,7 @@ async fn listen_for_node_sync_generates_rust_consumed_action_interfaces() {
         controller_node_dir.path(),
         r#"
         {
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "controller",
                 tag: "v1",
@@ -1142,7 +1142,7 @@ async fn listen_for_node_sync_generates_rust_parameters() {
         node_dir.path(),
         r#"
         {
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "uvc_camera",
                 tag: "v1",
@@ -1252,7 +1252,7 @@ async fn listen_for_node_sync_deletes_previous_peppy_folder() {
     write_node_config(
         node_dir.path(),
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "example_node",
                 tag: "v1",
@@ -1350,7 +1350,7 @@ async fn listen_for_node_sync_undeclared_link_id_fails() {
         node_dir.path(),
         r#"
         {
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "my_robot_brain",
                 tag: "v1",
@@ -1419,7 +1419,7 @@ async fn listen_for_node_sync_undeclared_link_id_fails() {
 fn camera_config() -> &'static str {
     r#"
     {
-        peppy_schema: "node_v1",
+        peppy_schema: "node/v1",
         manifest: {
             name: "uvc_camera",
             tag: "v1",
@@ -1452,7 +1452,7 @@ fn camera_config() -> &'static str {
 fn brain_consumes_camera_config() -> &'static str {
     r#"
     {
-        peppy_schema: "node_v1",
+        peppy_schema: "node/v1",
         manifest: {
             name: "my_robot_brain",
             tag: "v1",
@@ -1604,7 +1604,7 @@ async fn include_repositories_true_caches_git_checkout_across_deps() {
     std::fs::write(
         source_repo_dir.join("nodes/dep_a").join(NODE_CONFIG_FILE),
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: { name: "dep_a", tag: "v1" },
             interfaces: {
                 topics: {
@@ -1620,7 +1620,7 @@ async fn include_repositories_true_caches_git_checkout_across_deps() {
     std::fs::write(
         source_repo_dir.join("nodes/dep_b").join(NODE_CONFIG_FILE),
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: { name: "dep_b", tag: "v1" },
             interfaces: {
                 topics: {
@@ -1660,7 +1660,7 @@ async fn include_repositories_true_caches_git_checkout_across_deps() {
         brain_dir.path(),
         r#"
         {
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "my_robot_brain",
                 tag: "v1",
@@ -1721,7 +1721,7 @@ async fn include_repositories_true_stack_takes_priority_over_repository() {
         stack_camera_dir.path(),
         r#"
         {
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: { name: "uvc_camera", tag: "v1" },
             interfaces: {
                 topics: {
@@ -1758,7 +1758,7 @@ async fn include_repositories_true_stack_takes_priority_over_repository() {
         repo_camera_dir.path(),
         r#"
         {
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: { name: "uvc_camera", tag: "v1" },
             interfaces: {
                 topics: {
@@ -1782,7 +1782,7 @@ async fn include_repositories_true_stack_takes_priority_over_repository() {
         brain_dir.path(),
         r#"
         {
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "my_robot_brain",
                 tag: "v1",
@@ -1838,7 +1838,7 @@ async fn include_repositories_true_walks_transitive_dep() {
     write_node_config(
         c_dir.path(),
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: { name: "dep_c", tag: "v1" },
             interfaces: {
                 topics: {
@@ -1853,7 +1853,7 @@ async fn include_repositories_true_walks_transitive_dep() {
     write_node_config(
         b_dir.path(),
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "dep_b",
                 tag: "v1",
@@ -1872,7 +1872,7 @@ async fn include_repositories_true_walks_transitive_dep() {
     write_node_config(
         a_dir.path(),
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "dep_a",
                 tag: "v1",
@@ -1897,7 +1897,7 @@ async fn include_repositories_true_walks_transitive_dep() {
     write_node_config(
         brain_dir.path(),
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "my_robot_brain",
                 tag: "v1",
@@ -1981,7 +1981,7 @@ async fn node_sync_resolves_git_sourced_conforms_to_interface() {
     let branch = init_local_git_repo(&source_repo_dir);
 
     const INTERFACE_BODY: &str = r#"{
-        peppy_schema: "interface_v1",
+        peppy_schema: "interface/v1",
         manifest: { name: "depth_camera", tag: "v1" },
         interfaces: {
             topics: [
@@ -2033,7 +2033,7 @@ async fn node_sync_resolves_git_sourced_conforms_to_interface() {
     write_node_config(
         node_dir.path(),
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: { name: "depth_publisher", tag: "v1" },
             interfaces: {
                 topics: { emits: [], consumes: [] },

--- a/crates/core-node-internal/tests/listen_for_repo_list.rs
+++ b/crates/core-node-internal/tests/listen_for_repo_list.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 fn minimal_peppy_json5(name: &str, tag: &str) -> String {
     format!(
         r#"{{
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {{
     name: "{name}",
     tag: "{tag}",

--- a/crates/core-node-internal/tests/listen_for_repo_refresh.rs
+++ b/crates/core-node-internal/tests/listen_for_repo_refresh.rs
@@ -22,7 +22,7 @@ use std::time::Duration;
 fn minimal_peppy_json5(name: &str, tag: &str) -> String {
     format!(
         r#"{{
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {{
     name: "{name}",
     tag: "{tag}",
@@ -842,7 +842,7 @@ async fn refresh_discovers_interfaces() {
     let iface_dir = repo_dir.join("uvc_camera");
     std::fs::create_dir_all(&iface_dir).expect("create iface dir");
     let manifest_body = r#"{
-  peppy_schema: "interface_v1",
+  peppy_schema: "interface/v1",
   manifest: { name: "uvc_camera", tag: "v1", labels: ["uvc", "camera"] },
   interfaces: {}
 }"#;
@@ -991,7 +991,7 @@ async fn refresh_discovers_launchers() {
     let repo_dir = started.peppy_dirs.root().join("launcher_repo");
     std::fs::create_dir_all(&repo_dir).expect("create launcher repo dir");
     let manifest_body = r#"{
-  peppy_schema: "launcher_v1",
+  peppy_schema: "launcher/v1",
   deployments: []
 }"#;
     std::fs::write(repo_dir.join("openarm01_teleop.json5"), manifest_body)

--- a/crates/core-node-internal/tests/listen_for_repo_remove.rs
+++ b/crates/core-node-internal/tests/listen_for_repo_remove.rs
@@ -38,7 +38,7 @@ fn write_packages_cache(started: &StartedCoreNode, content: &str) {
 fn minimal_peppy_json5(name: &str, tag: &str) -> String {
     format!(
         r#"{{
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {{
     name: "{name}",
     tag: "{tag}",

--- a/crates/core-node-internal/tests/listen_for_reset.rs
+++ b/crates/core-node-internal/tests/listen_for_reset.rs
@@ -41,7 +41,7 @@ async fn listen_for_node_reset_clears_node_stack() {
     let source_dir_b = tempfile::tempdir().expect("failed to create temp source dir");
 
     let peppy_json5_a = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "{TARGET_NODE_A_NAME}",
                 tag: "{TARGET_NODE_A_TAG}",
@@ -73,7 +73,7 @@ async fn listen_for_node_reset_clears_node_stack() {
     );
 
     let peppy_json5_b = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "{TARGET_NODE_B_NAME}",
                 tag: "{TARGET_NODE_B_TAG}",
@@ -356,7 +356,7 @@ async fn node_reset_with_live_exit_watcher_clears_without_recording_a_crash() {
     let started = start_core_node_with_mock_messenger().await;
 
     let peppy_json5 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "{TARGET_NODE_NAME}",
                 tag: "{TARGET_NODE_TAG}",

--- a/crates/core-node-internal/tests/listen_for_stack_benchmark.rs
+++ b/crates/core-node-internal/tests/listen_for_stack_benchmark.rs
@@ -117,7 +117,7 @@ async fn stack_benchmark_runs_repeatedly() {
 
 fn provider_config() -> &'static str {
     r#"{
-        peppy_schema: "node_v1",
+        peppy_schema: "node/v1",
         manifest: { name: "bench_provider", tag: "v1" },
         interfaces: { services: { exposes: [{ name: "bench_svc" }] } },
         execution: { language: "rust", run_cmd: ["sleep", "10"] }
@@ -126,7 +126,7 @@ fn provider_config() -> &'static str {
 
 fn consumer_config() -> &'static str {
     r#"{
-        peppy_schema: "node_v1",
+        peppy_schema: "node/v1",
         manifest: {
             name: "bench_consumer",
             tag: "v1",
@@ -191,7 +191,7 @@ async fn stack_benchmark_enumerates_wired_service_edge() {
 /// duplicate, indistinguishable rows that prompted carrying `link_id` end-to-end.
 fn two_link_consumer_config() -> &'static str {
     r#"{
-        peppy_schema: "node_v1",
+        peppy_schema: "node/v1",
         manifest: {
             name: "bench_consumer",
             tag: "v1",

--- a/crates/generator-internal/build.rs
+++ b/crates/generator-internal/build.rs
@@ -718,7 +718,16 @@ mod peppylib_build {
         // crate from scratch: the guarantee the documented escape hatch provides
         // against any input the source hash does not cover.
         if force {
-            std::fs::remove_dir_all(&target_dir).ok();
+            match std::fs::remove_dir_all(&target_dir) {
+                Ok(()) => {}
+                // No cached target yet (e.g. first forced build): nothing to discard.
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => panic!(
+                    "failed to clear maturin target dir {:?} for a forced rebuild \
+                     ({REBUILD_ENV_VAR}): {e}",
+                    target_dir
+                ),
+            }
         }
 
         // Host extension: rebuilt whenever it is missing, its recorded

--- a/crates/generator-internal/build.rs
+++ b/crates/generator-internal/build.rs
@@ -356,6 +356,73 @@ mod peppylib_build {
             .is_ok_and(|s| s.success())
     }
 
+    /// Reads the cargo package name from a crate directory's `Cargo.toml`. The
+    /// dependency directory name and the package name diverge for some crates (the
+    /// `peppy-messaging-interface` directory builds the `pmi` package), and
+    /// `cargo clean -p` matches on the package name, not the directory. Reading it
+    /// from the manifest keeps a single source of truth rather than duplicating the
+    /// mapping in `SO_DEP_CRATES`. Falls back to the directory name if the manifest
+    /// cannot be read or has no `[package]` name.
+    fn crate_package_name(crate_dir: &Path) -> String {
+        let dir_name = crate_dir
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        let Ok(manifest) = std::fs::read_to_string(crate_dir.join("Cargo.toml")) else {
+            return dir_name;
+        };
+        let mut in_package = false;
+        for line in manifest.lines() {
+            let trimmed = line.trim();
+            if trimmed.starts_with('[') {
+                in_package = trimmed == "[package]";
+            } else if in_package
+                && let Some(value) = trimmed.strip_prefix("name").and_then(|r| {
+                    let v = r.trim_start().strip_prefix('=')?.trim().trim_matches('"');
+                    (!v.is_empty()).then_some(v)
+                })
+            {
+                return value.to_string();
+            }
+        }
+        dir_name
+    }
+
+    /// Force-cleans every `.so` dependency crate's artifacts from the shared
+    /// maturin target so the next build recompiles them from current sources.
+    /// `cargo clean -p` physically deletes the cached rlib, so the rebuild cannot
+    /// reuse a stale one that cargo's mtime fingerprint failed to invalidate.
+    /// Called only when the dependency sources changed, so iterating on
+    /// peppylib-py's own code keeps a warm cache. `target_triple` is `None` for the
+    /// host build and `Some(triple)` for a cross target so each artifact tree is
+    /// cleaned. Best-effort: a failed clean only risks the stale-rlib path the
+    /// build would already have taken, so it warns rather than aborting.
+    fn clean_dep_crates(peppylib_py_dir: &Path, target_dir: &Path, target_triple: Option<&str>) {
+        let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
+        let crates_root = build_helpers::peppyos_shared_dir();
+        for (crate_dir, _) in SO_DEP_CRATES {
+            let package = crate_package_name(&crates_root.join(crate_dir));
+            let mut cmd = Command::new(&cargo);
+            cmd.args(["clean", "-p", package.as_str()]);
+            if let Some(triple) = target_triple {
+                cmd.args(["--target", triple]);
+            }
+            let status = cmd
+                .current_dir(peppylib_py_dir)
+                .env("CARGO_TARGET_DIR", target_dir)
+                .stdin(std::process::Stdio::null())
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .status();
+            if !matches!(status, Ok(s) if s.success()) {
+                println!(
+                    "cargo:warning=`cargo clean -p {package}` did not succeed while busting the \
+                     peppylib-py dependency cache; a stale .so is possible if its sources changed."
+                );
+            }
+        }
+    }
+
     /// Builds the native `.so` via pixi and renames it to a platform-suffixed name.
     fn build_native_so(
         peppylib_py_dir: &Path,
@@ -363,11 +430,18 @@ mod peppylib_build {
         so_path: &Path,
         pixi_task: &str,
         target_dir: &Path,
+        clean_deps: bool,
     ) {
         // Serialize concurrent pixi invocations to avoid "Text file busy" races
         // when multiple build scripts run pixi on the same environment.
         let lock_path = peppylib_py_dir.join(".pixi/.build.lock");
         let _pixi_lock = build_helpers::acquire_file_lock(&lock_path);
+
+        // Drop stale dependency artifacts under the same lock as the build so a
+        // concurrent worktree never observes a half-cleaned target.
+        if clean_deps {
+            clean_dep_crates(peppylib_py_dir, target_dir, None);
+        }
 
         println!("cargo:warning=Building peppylib-py native extension via pixi ({pixi_task})…");
         run_pixi_task(peppylib_py_dir, pixi_task, target_dir);
@@ -414,6 +488,7 @@ mod peppylib_build {
         peppylib_py_dir: &Path,
         target_dir: &Path,
         peppylib_dir: &Path,
+        clean_deps: bool,
     ) {
         println!(
             "cargo:warning=Cross-compiling peppylib-py for {} via pixi ({})…",
@@ -421,6 +496,9 @@ mod peppylib_build {
         );
 
         ensure_linux_rust_target(target.target_triple);
+        if clean_deps {
+            clean_dep_crates(peppylib_py_dir, target_dir, Some(target.target_triple));
+        }
         run_pixi_task(peppylib_py_dir, target.pixi_task, target_dir);
 
         let wheels_dir = target_dir.join("wheels");
@@ -440,6 +518,16 @@ mod peppylib_build {
     /// and Linux `.so` files go stale independently: the host always rebuilds,
     /// while a stale Linux `.so` is left alone on debug builds.
     const BUILD_STATE_MARKER: &str = ".so-build-state";
+
+    /// Marker file recording the dependency-crate source hash the embedded `.so`
+    /// files were last built against. When the current dep hash differs, the
+    /// dependency artifacts in the shared maturin target are force-cleaned before
+    /// rebuilding: cargo's mtime-based fingerprint can miss a dependency source
+    /// change across a git-checkout swap and link a stale rlib, producing a `.so`
+    /// compiled against outdated types (for example an old `peppy_schema` enum).
+    /// A missing marker is treated as a dep change so a checkout whose `.so`
+    /// predates this guard self-heals on its next build.
+    const BUILD_DEP_HASH_MARKER: &str = ".so-dep-hash";
 
     /// Env var that forces a full rebuild (including the Linux cross-compile) on
     /// a debug build. Set by the release build path and available to developers
@@ -461,6 +549,21 @@ mod peppylib_build {
         ("core-node-api", false),
     ];
 
+    /// Every source file of the `.so` dependency crates. Resolved against
+    /// `peppyos-shared`, located via build-helpers so it works in the superproject
+    /// and from a cargo git checkout of nodes_shared_code alike.
+    fn dep_crate_source_files() -> Vec<PathBuf> {
+        let crates_root = build_helpers::peppyos_shared_dir();
+        let mut files = Vec::new();
+        for (crate_name, is_config) in SO_DEP_CRATES {
+            files.extend(super::collect_crate_source_files(
+                &crates_root.join(crate_name),
+                *is_config,
+            ));
+        }
+        files
+    }
+
     /// Every existing file whose contents are compiled into the `.so`: peppylib-py's
     /// own Rust bindings and build manifests, plus the source of every dependency
     /// crate. This is the single source of truth shared by the content hash and the
@@ -477,42 +580,52 @@ mod peppylib_build {
             }
         }
 
-        // Resolve the `.so` dependency crates against `peppyos-shared`, located
-        // via build-helpers so it works in the superproject and from a cargo git
-        // checkout of nodes_shared_code alike.
-        let crates_root = build_helpers::peppyos_shared_dir();
-        for (crate_name, is_config) in SO_DEP_CRATES {
-            files.extend(super::collect_crate_source_files(
-                &crates_root.join(crate_name),
-                *is_config,
-            ));
-        }
+        files.extend(dep_crate_source_files());
 
         files.sort();
         files
     }
 
-    /// Computes a SHA-256 hash over every `.so` input file, keyed by each file's
+    /// Computes a SHA-256 hash over the given input files, keyed by each file's
     /// path relative to the crates root so a move is detected and same-named files
     /// in different crates never collide.
-    fn compute_source_hash(peppylib_py_dir: &Path) -> String {
+    ///
+    /// Keys are relative to `peppyos-shared` (where every input, the dependency
+    /// crates and peppylib-py itself, lives). The marker files are per-checkout and
+    /// gitignored, so keys only need to be stable and collision-free within a
+    /// single checkout.
+    fn hash_files(files: &[PathBuf]) -> String {
         use sha2::{Digest, Sha256};
 
-        // Key each file by its path relative to `peppyos-shared` (where every
-        // input — the dependency crates and peppylib-py itself — lives). The
-        // `.so-build-state` marker is per-checkout and gitignored, so keys only
-        // need to be stable and collision-free within a single checkout.
         let crates_root = build_helpers::peppyos_shared_dir();
         let mut hasher = Sha256::new();
-        for file in so_rebuild_input_files(peppylib_py_dir) {
-            let rel = file.strip_prefix(&crates_root).unwrap_or(&file);
-            if let Ok(bytes) = std::fs::read(&file) {
+        for file in files {
+            let rel = file.strip_prefix(&crates_root).unwrap_or(file);
+            if let Ok(bytes) = std::fs::read(file) {
                 hasher.update(rel.to_string_lossy().as_bytes());
                 hasher.update(&bytes);
             }
         }
         let hash = hasher.finalize();
         hash.iter().map(|b| format!("{b:02x}")).collect()
+    }
+
+    /// Hash over every `.so` input file (peppylib-py plus its dependency crates).
+    /// Drives the per-platform rebuild decision: any change rebuilds the host `.so`.
+    fn compute_source_hash(peppylib_py_dir: &Path) -> String {
+        hash_files(&so_rebuild_input_files(peppylib_py_dir))
+    }
+
+    /// Hash over only the dependency crate sources, with peppylib-py's own code
+    /// excluded. Drives the dep-cache bust: when this changes, the shared maturin
+    /// target may hold a stale rlib that cargo's mtime fingerprint fails to
+    /// invalidate, so the dependency artifacts are force-cleaned before the build.
+    /// Keeping it separate from the full source hash means iterating on
+    /// peppylib-py's own bindings never busts the dependency cache.
+    fn compute_dep_hash() -> String {
+        let mut files = dep_crate_source_files();
+        files.sort();
+        hash_files(&files)
     }
 
     /// Reads the per-platform build state, mapping each platform suffix to the
@@ -662,12 +775,30 @@ mod peppylib_build {
         let mut state = read_build_state(&peppylib_dir);
         let force = std::env::var(REBUILD_ENV_VAR).is_ok_and(|v| !v.is_empty() && v != "0");
 
+        // A dependency-crate source change (rare) can leave a stale rlib in the
+        // shared maturin target that cargo's mtime fingerprint fails to
+        // invalidate, yielding a `.so` built against outdated types. Detect it
+        // with a deps-only hash and force-clean the dependency artifacts before
+        // building. peppylib-py's own edits do not change this hash, so iterating
+        // on the bindings keeps a warm cache. A forced rebuild also cleans, so the
+        // documented escape hatch reliably produces a fresh `.so`. A missing
+        // marker counts as changed, so a checkout whose `.so` predates this guard
+        // self-heals on its next build instead of needing a manual cache wipe.
+        let dep_hash = compute_dep_hash();
+        let dep_marker = peppylib_dir.join(BUILD_DEP_HASH_MARKER);
+        let deps_changed =
+            std::fs::read_to_string(&dep_marker).ok().as_deref() != Some(dep_hash.as_str());
+        let clean_deps = deps_changed || force;
+
         // Host extension: rebuilt whenever it is missing, its recorded
-        // (hash, profile) is stale, or a rebuild is forced. Built in both
-        // profiles so local host scaffolding always matches current sources.
+        // (hash, profile) is stale, a dependency changed, or a rebuild is forced.
+        // Built in both profiles so local host scaffolding always matches current
+        // sources. Folding `deps_changed` into the freshness check lets a build
+        // whose per-platform marker wrongly claims it is current (a `.so` poisoned
+        // before this guard existed) rebuild and self-heal.
         let host_so = peppylib_dir.join(format!("_peppylib.abi3.{host}.so"));
         let host_state = (current_hash.clone(), profile.tag().to_string());
-        let host_current = state.get(&host) == Some(&host_state);
+        let host_current = state.get(&host) == Some(&host_state) && !deps_changed;
         if peppylib_build_policy::should_build_host(host_so.exists(), host_current, force) {
             build_native_so(
                 &peppylib_py_dir,
@@ -675,6 +806,7 @@ mod peppylib_build {
                 &so_path,
                 profile.tag(),
                 &target_dir,
+                clean_deps,
             );
             state.insert(host.clone(), host_state);
         } else {
@@ -690,14 +822,20 @@ mod peppylib_build {
                 let suffix = target.platform_suffix;
                 let target_so = peppylib_dir.join(format!("_peppylib.abi3.{suffix}.so"));
                 let target_state = (current_hash.clone(), "release".to_string());
-                let stale = state.get(suffix) != Some(&target_state);
+                let stale = deps_changed || state.get(suffix) != Some(&target_state);
                 if peppylib_build_policy::should_cross_compile(
                     profile,
                     target_so.exists(),
                     stale,
                     force,
                 ) {
-                    cross_compile_linux_so(target, &peppylib_py_dir, &target_dir, &peppylib_dir);
+                    cross_compile_linux_so(
+                        target,
+                        &peppylib_py_dir,
+                        &target_dir,
+                        &peppylib_dir,
+                        clean_deps,
+                    );
                     state.insert(suffix.to_string(), target_state);
                 } else if stale {
                     println!(
@@ -711,6 +849,11 @@ mod peppylib_build {
 
         prune_orphan_so_files(&peppylib_dir, &mut state, &platforms);
         write_build_state(&peppylib_dir, &state);
+
+        // Record the dependency hash now that the host `.so` has been rebuilt from
+        // current dependency sources (a dep change always forces the host build
+        // above). The next build skips the cache bust until the deps change again.
+        build_helpers::write_if_changed(&dep_marker, dep_hash.as_bytes());
 
         // Guard against partial rebuilds leaving an unsuffixed .so behind.
         if so_path.exists() {

--- a/crates/generator-internal/build.rs
+++ b/crates/generator-internal/build.rs
@@ -356,73 +356,6 @@ mod peppylib_build {
             .is_ok_and(|s| s.success())
     }
 
-    /// Reads the cargo package name from a crate directory's `Cargo.toml`. The
-    /// dependency directory name and the package name diverge for some crates (the
-    /// `peppy-messaging-interface` directory builds the `pmi` package), and
-    /// `cargo clean -p` matches on the package name, not the directory. Reading it
-    /// from the manifest keeps a single source of truth rather than duplicating the
-    /// mapping in `SO_DEP_CRATES`. Falls back to the directory name if the manifest
-    /// cannot be read or has no `[package]` name.
-    fn crate_package_name(crate_dir: &Path) -> String {
-        let dir_name = crate_dir
-            .file_name()
-            .map(|n| n.to_string_lossy().into_owned())
-            .unwrap_or_default();
-        let Ok(manifest) = std::fs::read_to_string(crate_dir.join("Cargo.toml")) else {
-            return dir_name;
-        };
-        let mut in_package = false;
-        for line in manifest.lines() {
-            let trimmed = line.trim();
-            if trimmed.starts_with('[') {
-                in_package = trimmed == "[package]";
-            } else if in_package
-                && let Some(value) = trimmed.strip_prefix("name").and_then(|r| {
-                    let v = r.trim_start().strip_prefix('=')?.trim().trim_matches('"');
-                    (!v.is_empty()).then_some(v)
-                })
-            {
-                return value.to_string();
-            }
-        }
-        dir_name
-    }
-
-    /// Force-cleans every `.so` dependency crate's artifacts from the shared
-    /// maturin target so the next build recompiles them from current sources.
-    /// `cargo clean -p` physically deletes the cached rlib, so the rebuild cannot
-    /// reuse a stale one that cargo's mtime fingerprint failed to invalidate.
-    /// Called only when the dependency sources changed, so iterating on
-    /// peppylib-py's own code keeps a warm cache. `target_triple` is `None` for the
-    /// host build and `Some(triple)` for a cross target so each artifact tree is
-    /// cleaned. Best-effort: a failed clean only risks the stale-rlib path the
-    /// build would already have taken, so it warns rather than aborting.
-    fn clean_dep_crates(peppylib_py_dir: &Path, target_dir: &Path, target_triple: Option<&str>) {
-        let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
-        let crates_root = build_helpers::peppyos_shared_dir();
-        for (crate_dir, _) in SO_DEP_CRATES {
-            let package = crate_package_name(&crates_root.join(crate_dir));
-            let mut cmd = Command::new(&cargo);
-            cmd.args(["clean", "-p", package.as_str()]);
-            if let Some(triple) = target_triple {
-                cmd.args(["--target", triple]);
-            }
-            let status = cmd
-                .current_dir(peppylib_py_dir)
-                .env("CARGO_TARGET_DIR", target_dir)
-                .stdin(std::process::Stdio::null())
-                .stdout(std::process::Stdio::null())
-                .stderr(std::process::Stdio::null())
-                .status();
-            if !matches!(status, Ok(s) if s.success()) {
-                println!(
-                    "cargo:warning=`cargo clean -p {package}` did not succeed while busting the \
-                     peppylib-py dependency cache; a stale .so is possible if its sources changed."
-                );
-            }
-        }
-    }
-
     /// Builds the native `.so` via pixi and renames it to a platform-suffixed name.
     fn build_native_so(
         peppylib_py_dir: &Path,
@@ -430,18 +363,11 @@ mod peppylib_build {
         so_path: &Path,
         pixi_task: &str,
         target_dir: &Path,
-        clean_deps: bool,
     ) {
         // Serialize concurrent pixi invocations to avoid "Text file busy" races
         // when multiple build scripts run pixi on the same environment.
         let lock_path = peppylib_py_dir.join(".pixi/.build.lock");
         let _pixi_lock = build_helpers::acquire_file_lock(&lock_path);
-
-        // Drop stale dependency artifacts under the same lock as the build so a
-        // concurrent worktree never observes a half-cleaned target.
-        if clean_deps {
-            clean_dep_crates(peppylib_py_dir, target_dir, None);
-        }
 
         println!("cargo:warning=Building peppylib-py native extension via pixi ({pixi_task})…");
         run_pixi_task(peppylib_py_dir, pixi_task, target_dir);
@@ -488,7 +414,6 @@ mod peppylib_build {
         peppylib_py_dir: &Path,
         target_dir: &Path,
         peppylib_dir: &Path,
-        clean_deps: bool,
     ) {
         println!(
             "cargo:warning=Cross-compiling peppylib-py for {} via pixi ({})…",
@@ -496,9 +421,6 @@ mod peppylib_build {
         );
 
         ensure_linux_rust_target(target.target_triple);
-        if clean_deps {
-            clean_dep_crates(peppylib_py_dir, target_dir, Some(target.target_triple));
-        }
         run_pixi_task(peppylib_py_dir, target.pixi_task, target_dir);
 
         let wheels_dir = target_dir.join("wheels");
@@ -519,20 +441,20 @@ mod peppylib_build {
     /// while a stale Linux `.so` is left alone on debug builds.
     const BUILD_STATE_MARKER: &str = ".so-build-state";
 
-    /// Marker file recording the dependency-crate source hash the embedded `.so`
-    /// files were last built against. When the current dep hash differs, the
-    /// dependency artifacts in the shared maturin target are force-cleaned before
-    /// rebuilding: cargo's mtime-based fingerprint can miss a dependency source
-    /// change across a git-checkout swap and link a stale rlib, producing a `.so`
-    /// compiled against outdated types (for example an old `peppy_schema` enum).
-    /// A missing marker is treated as a dep change so a checkout whose `.so`
-    /// predates this guard self-heals on its next build.
-    const BUILD_DEP_HASH_MARKER: &str = ".so-dep-hash";
-
     /// Env var that forces a full rebuild (including the Linux cross-compile) on
     /// a debug build. Set by the release build path and available to developers
     /// iterating on container bindings.
     const REBUILD_ENV_VAR: &str = "PEPPYLIB_REBUILD";
+
+    /// This build script's own source, embedded so it can be mixed into every
+    /// `.so` hash. The build logic is itself an input to the compiled artifact:
+    /// a change to how the `.so` is built, or to how its staleness is judged, can
+    /// change the output, so it must invalidate the cached `.so` and its
+    /// `.so-build-state` marker. Folding the script's source into the hash does
+    /// that automatically on the next build, with no version constant for anyone
+    /// to remember to bump. `include_str!` resolves relative to this file, so it
+    /// always embeds `generator-internal/build.rs`.
+    const BUILD_SCRIPT_SOURCE: &str = include_str!("build.rs");
 
     /// Dependency crates compiled into the `.so`, paired with whether the crate
     /// is config (which embeds extra `tools/capnp_*` helpers). This list
@@ -586,9 +508,11 @@ mod peppylib_build {
         files
     }
 
-    /// Computes a SHA-256 hash over the given input files, keyed by each file's
-    /// path relative to the crates root so a move is detected and same-named files
-    /// in different crates never collide.
+    /// Computes a SHA-256 hash over this build script's source plus the given
+    /// input files, keyed by each file's path relative to the crates root so a
+    /// move is detected and same-named files in different crates never collide.
+    /// The build script's source is folded in first so a change to the build logic
+    /// invalidates the cached `.so` (see [`BUILD_SCRIPT_SOURCE`]).
     ///
     /// Keys are relative to `peppyos-shared` (where every input, the dependency
     /// crates and peppylib-py itself, lives). The marker files are per-checkout and
@@ -599,6 +523,7 @@ mod peppylib_build {
 
         let crates_root = build_helpers::peppyos_shared_dir();
         let mut hasher = Sha256::new();
+        hasher.update(BUILD_SCRIPT_SOURCE.as_bytes());
         for file in files {
             let rel = file.strip_prefix(&crates_root).unwrap_or(file);
             if let Ok(bytes) = std::fs::read(file) {
@@ -617,11 +542,11 @@ mod peppylib_build {
     }
 
     /// Hash over only the dependency crate sources, with peppylib-py's own code
-    /// excluded. Drives the dep-cache bust: when this changes, the shared maturin
-    /// target may hold a stale rlib that cargo's mtime fingerprint fails to
-    /// invalidate, so the dependency artifacts are force-cleaned before the build.
-    /// Keeping it separate from the full source hash means iterating on
-    /// peppylib-py's own bindings never busts the dependency cache.
+    /// excluded. Keys the isolated maturin target directory: when the dependency
+    /// crates change, the build moves to a fresh target tree so it can never link
+    /// a stale rlib that cargo's mtime fingerprint failed to invalidate across a
+    /// git-checkout swap. Keeping it separate from the full source hash means
+    /// iterating on peppylib-py's own bindings reuses the same warm target.
     fn compute_dep_hash() -> String {
         let mut files = dep_crate_source_files();
         files.sort();
@@ -769,36 +694,41 @@ mod peppylib_build {
             return;
         }
 
-        // Use a separate CARGO_TARGET_DIR so maturin's inner `cargo build`
-        // does not deadlock on the workspace build lock held by the outer cargo.
-        let target_dir = build_helpers::cache_dir("peppylib-py").join("target");
+        // Isolate the maturin target by dependency-source hash. A change to one of
+        // the `.so` dependency crates yields a different directory, so the build
+        // always starts from a tree with no artifacts from a previous version of
+        // those crates. This makes it impossible to link a stale dependency rlib
+        // that cargo's mtime fingerprint failed to invalidate across a checkout
+        // swap, the failure mode that produced a `.so` compiled against an
+        // outdated `peppy_schema` enum. peppylib-py's own edits do not change this
+        // hash, so iterating on the bindings reuses a warm target. A dedicated
+        // CARGO_TARGET_DIR also keeps maturin's inner `cargo build` from
+        // deadlocking on the workspace build lock held by the outer cargo. Old
+        // `target-<hash>` trees from prior dependency versions persist per the
+        // `cache_dir` convention (nothing auto-cleans it, and a sibling build in
+        // another checkout may still be using one); remove them by hand with
+        // `rm -rf ~/.peppy/tmp/peppylib-py/target-*` if disk use grows.
+        let dep_hash = compute_dep_hash();
+        let target_dir =
+            build_helpers::cache_dir("peppylib-py").join(format!("target-{}", &dep_hash[..16]));
         let mut state = read_build_state(&peppylib_dir);
         let force = std::env::var(REBUILD_ENV_VAR).is_ok_and(|v| !v.is_empty() && v != "0");
 
-        // A dependency-crate source change (rare) can leave a stale rlib in the
-        // shared maturin target that cargo's mtime fingerprint fails to
-        // invalidate, yielding a `.so` built against outdated types. Detect it
-        // with a deps-only hash and force-clean the dependency artifacts before
-        // building. peppylib-py's own edits do not change this hash, so iterating
-        // on the bindings keeps a warm cache. A forced rebuild also cleans, so the
-        // documented escape hatch reliably produces a fresh `.so`. A missing
-        // marker counts as changed, so a checkout whose `.so` predates this guard
-        // self-heals on its next build instead of needing a manual cache wipe.
-        let dep_hash = compute_dep_hash();
-        let dep_marker = peppylib_dir.join(BUILD_DEP_HASH_MARKER);
-        let deps_changed =
-            std::fs::read_to_string(&dep_marker).ok().as_deref() != Some(dep_hash.as_str());
-        let clean_deps = deps_changed || force;
+        // A forced rebuild discards the cached target so maturin recompiles every
+        // crate from scratch: the guarantee the documented escape hatch provides
+        // against any input the source hash does not cover.
+        if force {
+            std::fs::remove_dir_all(&target_dir).ok();
+        }
 
         // Host extension: rebuilt whenever it is missing, its recorded
-        // (hash, profile) is stale, a dependency changed, or a rebuild is forced.
-        // Built in both profiles so local host scaffolding always matches current
-        // sources. Folding `deps_changed` into the freshness check lets a build
-        // whose per-platform marker wrongly claims it is current (a `.so` poisoned
-        // before this guard existed) rebuild and self-heal.
+        // (hash, profile) is stale, or a rebuild is forced. Built in both profiles
+        // so local host scaffolding always matches current sources. The recorded
+        // source hash already covers the dependency crates, so a dependency change
+        // surfaces here as a stale hash and triggers a rebuild.
         let host_so = peppylib_dir.join(format!("_peppylib.abi3.{host}.so"));
         let host_state = (current_hash.clone(), profile.tag().to_string());
-        let host_current = state.get(&host) == Some(&host_state) && !deps_changed;
+        let host_current = state.get(&host) == Some(&host_state);
         if peppylib_build_policy::should_build_host(host_so.exists(), host_current, force) {
             build_native_so(
                 &peppylib_py_dir,
@@ -806,7 +736,6 @@ mod peppylib_build {
                 &so_path,
                 profile.tag(),
                 &target_dir,
-                clean_deps,
             );
             state.insert(host.clone(), host_state);
         } else {
@@ -822,20 +751,14 @@ mod peppylib_build {
                 let suffix = target.platform_suffix;
                 let target_so = peppylib_dir.join(format!("_peppylib.abi3.{suffix}.so"));
                 let target_state = (current_hash.clone(), "release".to_string());
-                let stale = deps_changed || state.get(suffix) != Some(&target_state);
+                let stale = state.get(suffix) != Some(&target_state);
                 if peppylib_build_policy::should_cross_compile(
                     profile,
                     target_so.exists(),
                     stale,
                     force,
                 ) {
-                    cross_compile_linux_so(
-                        target,
-                        &peppylib_py_dir,
-                        &target_dir,
-                        &peppylib_dir,
-                        clean_deps,
-                    );
+                    cross_compile_linux_so(target, &peppylib_py_dir, &target_dir, &peppylib_dir);
                     state.insert(suffix.to_string(), target_state);
                 } else if stale {
                     println!(
@@ -849,11 +772,6 @@ mod peppylib_build {
 
         prune_orphan_so_files(&peppylib_dir, &mut state, &platforms);
         write_build_state(&peppylib_dir, &state);
-
-        // Record the dependency hash now that the host `.so` has been rebuilt from
-        // current dependency sources (a dep change always forces the host build
-        // above). The next build skips the cache bust until the deps change again.
-        build_helpers::write_if_changed(&dep_marker, dep_hash.as_bytes());
 
         // Guard against partial rebuilds leaving an unsuffixed .so behind.
         if so_path.exists() {

--- a/crates/generator-internal/src/generator.rs
+++ b/crates/generator-internal/src/generator.rs
@@ -492,7 +492,7 @@ mod tests {
 
         // Write a canonical peppy.json5 at the default location
         let canonical_config = r#"{
-          peppy_schema: "node_v1",
+          peppy_schema: "node/v1",
           manifest: { name: "canonical_node", tag: "v1" },
           execution: { language: "rust", run_cmd: ["./target/release/canonical_node"] }
         }"#;
@@ -500,7 +500,7 @@ mod tests {
 
         // Write a different config at a custom path
         let custom_config = r#"{
-          peppy_schema: "node_v1",
+          peppy_schema: "node/v1",
           manifest: { name: "custom_node", tag: "v2" },
           execution: { language: "rust", run_cmd: ["./target/release/custom_node"] }
         }"#;

--- a/crates/generator-internal/src/generator/python/tests/parameters.rs
+++ b/crates/generator-internal/src/generator/python/tests/parameters.rs
@@ -5,7 +5,7 @@ use tempfile::TempDir;
 
 const NODE_EXAMPLE: &str = r#"
 {
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "uvc_camera",
     tag: "v1",
@@ -40,7 +40,7 @@ const NODE_EXAMPLE: &str = r#"
 
 const INVALID_PARAMETERS_NODE_EXAMPLE: &str = r#"
 {
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "uvc_camera",
     tag: "v1",
@@ -61,7 +61,7 @@ const INVALID_PARAMETERS_NODE_EXAMPLE: &str = r#"
 
 const NESTED_CLASS_COLLISION_NODE_EXAMPLE: &str = r#"
 {
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "uvc_camera",
     tag: "v1",
@@ -97,7 +97,7 @@ const NESTED_CLASS_COLLISION_NODE_EXAMPLE: &str = r#"
 
 const UNSUPPORTED_PARAMETERS_VARIANT_NODE_EXAMPLE: &str = r#"
 {
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "uvc_camera",
     tag: "v1",
@@ -126,7 +126,7 @@ const UNSUPPORTED_PARAMETERS_VARIANT_NODE_EXAMPLE: &str = r#"
 
 const UNKNOWN_PARAMETER_TYPE_NODE_EXAMPLE: &str = r#"
 {
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "uvc_camera",
     tag: "v1",
@@ -153,7 +153,7 @@ const UNKNOWN_PARAMETER_TYPE_NODE_EXAMPLE: &str = r#"
 
 const UNSUPPORTED_TOP_LEVEL_PARAMETER_VARIANT_NODE_EXAMPLE: &str = r#"
 {
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "uvc_camera",
     tag: "v1",

--- a/crates/generator-internal/src/generator/rust/tests/parameters.rs
+++ b/crates/generator-internal/src/generator/rust/tests/parameters.rs
@@ -5,7 +5,7 @@ use tempfile::TempDir;
 
 const NODE_EXAMPLE: &str = r#"
 {
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "uvc_camera",
     tag: "v1",
@@ -40,7 +40,7 @@ const NODE_EXAMPLE: &str = r#"
 
 const INVALID_PARAMETERS_NODE_EXAMPLE: &str = r#"
 {
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "uvc_camera",
     tag: "v1",
@@ -61,7 +61,7 @@ const INVALID_PARAMETERS_NODE_EXAMPLE: &str = r#"
 
 const NESTED_STRUCT_COLLISION_NODE_EXAMPLE: &str = r#"
 {
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "uvc_camera",
     tag: "v1",
@@ -99,7 +99,7 @@ const NESTED_STRUCT_COLLISION_NODE_EXAMPLE: &str = r#"
 
 const UNSUPPORTED_PARAMETERS_VARIANT_NODE_EXAMPLE: &str = r#"
 {
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "uvc_camera",
     tag: "v1",
@@ -128,7 +128,7 @@ const UNSUPPORTED_PARAMETERS_VARIANT_NODE_EXAMPLE: &str = r#"
 
 const UNKNOWN_PARAMETER_TYPE_NODE_EXAMPLE: &str = r#"
 {
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "uvc_camera",
     tag: "v1",
@@ -155,7 +155,7 @@ const UNKNOWN_PARAMETER_TYPE_NODE_EXAMPLE: &str = r#"
 
 const UNSUPPORTED_TOP_LEVEL_PARAMETER_VARIANT_NODE_EXAMPLE: &str = r#"
 {
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "uvc_camera",
     tag: "v1",

--- a/crates/generator-internal/src/generator/test_helpers.rs
+++ b/crates/generator-internal/src/generator/test_helpers.rs
@@ -18,7 +18,7 @@ use tempfile::TempDir;
 use super::types::InterfaceArtifact;
 
 pub const STUB_NODE_CONFIG: &str = r#"{
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "generated_node",
     tag: "v1",

--- a/crates/generator-internal/src/generator/test_helpers.rs
+++ b/crates/generator-internal/src/generator/test_helpers.rs
@@ -126,7 +126,8 @@ fn rename_peppygen_package(peppygen_dir: &Path) {
     }
     let renamed = contents.replacen("name = \"peppygen\"", &format!("name = \"{unique}\""), 1);
     assert_ne!(
-        renamed, contents,
+        renamed,
+        contents,
         "expected `name = \"peppygen\"` in generated peppygen Cargo.toml at {}",
         peppygen_cargo.display()
     );

--- a/crates/generator-internal/src/generator/test_helpers.rs
+++ b/crates/generator-internal/src/generator/test_helpers.rs
@@ -8,7 +8,9 @@ macro_rules! assert_rendered {
 }
 
 use config::consts::{NODE_CONFIG_FILE, PEPPYGEN_OUTPUT_PATH};
+use std::collections::hash_map::DefaultHasher;
 use std::fs;
+use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use tempfile::TempDir;
@@ -80,12 +82,72 @@ fn stable_test_target_dir() -> PathBuf {
     config_test_support::test_data_root().join("cache/rust/test-targets")
 }
 
-/// Runs `cargo clippy` on a generated crate, using a shared target directory
-/// and an exclusive file lock to prevent parallel cargo processes from
-/// exhausting file descriptors (sccache "Too many open files").
+/// Stable per-crate-dir hash used to derive a unique package name. Canonicalizes
+/// so the same directory always hashes identically regardless of how the path was
+/// spelled.
+///
+/// Deliberately duplicates `crate_identity_hash` in the integration-test helpers
+/// (`tests/helpers.rs`): that module is a separate compilation unit and this one is
+/// `#[cfg(test)]`-gated in the lib `src`, so they cannot share a private item
+/// without leaking test-only scaffolding into the non-test API.
+fn crate_identity_hash(crate_dir: &Path) -> u64 {
+    let stable_identity = crate_dir
+        .canonicalize()
+        .unwrap_or_else(|_| crate_dir.to_path_buf());
+    let mut hasher = DefaultHasher::new();
+    stable_identity.hash(&mut hasher);
+    hasher.finish()
+}
+
+/// Rewrites the generated `peppygen` crate's `Cargo.toml` `package.name` to a
+/// per-test-unique value before it is built.
+///
+/// The generator names every node's library `peppygen` (`peppygen v0.1.0`). These
+/// checks build that crate directly into the shared test target dir, so without a
+/// unique name cargo treats two structurally different `peppygen v0.1.0` crates as
+/// one interchangeable unit and may reuse (or clobber) a single cached rlib. A
+/// generated-code regression in one test could then be masked by another test's
+/// already-fresh artifact, defeating the point of these compile/clippy checks. A
+/// unique name per crate dir keeps each test's peppygen a distinct cargo unit; the
+/// heavy shared deps (peppylib, tokio, capnp, ...) keep their names and are still
+/// reused across builds.
+///
+/// The crate is built standalone here (nothing consumes it by name), so unlike the
+/// wrapper-consumed case in `tests/helpers.rs` no `package = "..."` consumer alias
+/// is needed. Idempotent; a no-op if the peppygen `Cargo.toml` is absent.
+fn rename_peppygen_package(peppygen_dir: &Path) {
+    let unique = format!("peppygen_{:016x}", crate_identity_hash(peppygen_dir));
+    let peppygen_cargo = peppygen_dir.join("Cargo.toml");
+    let Ok(contents) = fs::read_to_string(&peppygen_cargo) else {
+        return;
+    };
+    if contents.contains(&format!("name = \"{unique}\"")) {
+        return;
+    }
+    let renamed = contents.replacen("name = \"peppygen\"", &format!("name = \"{unique}\""), 1);
+    assert_ne!(
+        renamed, contents,
+        "expected `name = \"peppygen\"` in generated peppygen Cargo.toml at {}",
+        peppygen_cargo.display()
+    );
+    fs::write(&peppygen_cargo, renamed)
+        .expect("failed to rewrite peppygen Cargo.toml package name");
+}
+
+/// Runs `cargo clippy` on a generated crate.
+///
+/// Uses a shared target directory so heavy dependencies are compiled once and
+/// reused across all checks. Two protections cover its two distinct hazards:
+/// `rename_peppygen_package` gives this test's peppygen a distinct cargo unit so a
+/// neighbouring test's cached rlib cannot be reused in its place (correctness),
+/// and the exclusive file lock serializes the cargo invocations so parallel
+/// processes do not exhaust file descriptors (sccache "Too many open files"). The
+/// lock alone does not prevent the reuse: identity is decided in the target dir, so
+/// even serialized builds can pick up a stale same-named unit.
 pub fn run_clippy(output_dir: &Path) {
     let target_dir = stable_test_target_dir();
     fs::create_dir_all(&target_dir).expect("failed to create stable test target directory");
+    rename_peppygen_package(output_dir);
 
     let lock_file = fs::File::create(target_dir.join(".compile.lock"))
         .expect("failed to create compile lock file");
@@ -115,10 +177,11 @@ pub fn run_clippy(output_dir: &Path) {
 }
 
 /// Runs `cargo build` on a generated crate, using the same shared target
-/// directory and file lock as [`run_clippy`].
+/// directory, per-test peppygen rename, and file lock as [`run_clippy`].
 pub fn run_cargo_build(output_dir: &Path) {
     let target_dir = stable_test_target_dir();
     fs::create_dir_all(&target_dir).expect("failed to create stable test target directory");
+    rename_peppygen_package(output_dir);
 
     let lock_file = fs::File::create(target_dir.join(".compile.lock"))
         .expect("failed to create compile lock file");

--- a/crates/generator-internal/tests/helpers.rs
+++ b/crates/generator-internal/tests/helpers.rs
@@ -64,7 +64,7 @@ pub fn test_node_target(name: &str) -> SenderTarget {
 }
 
 pub const STUB_NODE_CONFIG: &str = r#"{
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "generated_node",
     tag: "v1"
@@ -882,7 +882,7 @@ pub async fn try_send_shutdown(
 // ---------------------------------------------------------------------------
 
 pub const STUB_PYTHON_NODE_CONFIG: &str = r#"{
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: { name: "generated_node",
     tag: "v1" },
   execution: { language: "python",

--- a/crates/generator-internal/tests/python/actions_conforms_to.rs
+++ b/crates/generator-internal/tests/python/actions_conforms_to.rs
@@ -40,7 +40,7 @@ fn conformed(name: &str, tag: &str, action: ExposedAction) -> DeploymentInterfac
 }
 
 const NODE_CONFIG: &str = r#"{
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "arm_driver",
     tag: "v1"

--- a/crates/generator-internal/tests/python/consumed_services_dedup.rs
+++ b/crates/generator-internal/tests/python/consumed_services_dedup.rs
@@ -17,7 +17,7 @@ use std::process::{Command, Stdio};
 use tempfile::TempDir;
 
 const NODE_CONFIG: &str = r#"{
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "test_consumer",
     tag: "v1",

--- a/crates/generator-internal/tests/python/consumed_topics_dedup.rs
+++ b/crates/generator-internal/tests/python/consumed_topics_dedup.rs
@@ -25,7 +25,7 @@ use std::process::{Command, Stdio};
 use tempfile::TempDir;
 
 const NODE_CONFIG: &str = r#"{
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "test_controller",
     tag: "v1",

--- a/crates/generator-internal/tests/python/generate_lib.rs
+++ b/crates/generator-internal/tests/python/generate_lib.rs
@@ -9,7 +9,7 @@ use std::fs;
 use tempfile::TempDir;
 
 const PEPPY_JSON5_CONFIG: &str = r#"{
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "test_node",
     tag: "v1"
@@ -281,7 +281,7 @@ fn generate_peppygen_lib_minimal_config() {
 
     // Minimal config with no interfaces
     let minimal_config = r#"{
-      peppy_schema: "node_v1",
+      peppy_schema: "node/v1",
       manifest: { name: "minimal_node",
         tag: "v1" },
       execution: { language: "python",
@@ -339,7 +339,7 @@ fn generate_peppygen_python_lib_emitted_and_consumed_topics() {
     let exposed_node_dir = exposed_dir.path();
 
     let exposed_config = r#"{
-          peppy_schema: "node_v1",
+          peppy_schema: "node/v1",
           manifest: {
             name: "{EXPOSED_NODE_NAME}",
             tag: "v1",
@@ -393,7 +393,7 @@ fn generate_peppygen_python_lib_emitted_and_consumed_topics() {
     let consumer_node_dir = consumer_dir.path();
 
     let consumer_config = r#"{
-          peppy_schema: "node_v1",
+          peppy_schema: "node/v1",
           manifest: {
             name: "{CONSUMER_NODE_NAME}",
             tag: "v1",
@@ -456,7 +456,7 @@ fn generate_peppygen_python_lib_exposed_and_consumed_services() {
     let exposed_node_dir = exposed_dir.path();
 
     let exposed_config = r#"{
-          peppy_schema: "node_v1",
+          peppy_schema: "node/v1",
           manifest: {
             name: "{EXPOSED_NODE_NAME}",
             tag: "v1",
@@ -513,7 +513,7 @@ fn generate_peppygen_python_lib_exposed_and_consumed_services() {
     let consumer_node_dir = consumer_dir.path();
 
     let consumer_config = r#"{
-          peppy_schema: "node_v1",
+          peppy_schema: "node/v1",
           manifest: {
             name: "{CONSUMER_NODE_NAME}",
             tag: "v1",
@@ -589,7 +589,7 @@ fn generate_peppygen_python_lib_exposed_and_consumed_actions() {
     let exposed_node_dir = exposed_dir.path();
 
     let exposed_config = r#"{
-          peppy_schema: "node_v1",
+          peppy_schema: "node/v1",
           manifest: {
             name: "{EXPOSED_NODE_NAME}",
             tag: "v1",
@@ -658,7 +658,7 @@ fn generate_peppygen_python_lib_exposed_and_consumed_actions() {
     let consumer_node_dir = consumer_dir.path();
 
     let consumer_config = r#"{
-          peppy_schema: "node_v1",
+          peppy_schema: "node/v1",
           manifest: {
             name: "{CONSUMER_NODE_NAME}",
             tag: "v1",

--- a/crates/generator-internal/tests/python/services_conforms_to.rs
+++ b/crates/generator-internal/tests/python/services_conforms_to.rs
@@ -37,7 +37,7 @@ fn conformed(name: &str, tag: &str, service: ExposedService) -> DeploymentInterf
 }
 
 const NODE_CONFIG: &str = r#"{
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "control_panel",
     tag: "v1"

--- a/crates/generator-internal/tests/python/topics_conforms_to.rs
+++ b/crates/generator-internal/tests/python/topics_conforms_to.rs
@@ -39,7 +39,7 @@ fn conformed(name: &str, tag: &str, topic: EmittedTopic) -> DeploymentInterface 
 }
 
 const NODE_CONFIG: &str = r#"{
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "realsense_d435",
     tag: "v1"

--- a/crates/generator-internal/tests/python/wire_compat.rs
+++ b/crates/generator-internal/tests/python/wire_compat.rs
@@ -102,7 +102,7 @@ const ACTION_RESULT_RECEIVED_SERVICE: &str = "result_received";
 // an order whose alphabetical sort swaps its two pointer-typed fields
 // (`status: Text`, `measurements: List(Float64)`); see module docstring.
 const ACTION_PRODUCER_CONFIG: &str = r#"{
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "producer",
     tag: "v1"
@@ -139,7 +139,7 @@ const ACTION_PRODUCER_CONFIG: &str = r#"{
 }"#;
 
 const ACTION_CONSUMER_CONFIG: &str = r#"{
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "consumer",
     tag: "v1",
@@ -508,7 +508,7 @@ const SERVICE_RESPONSE_RECEIVED_SERVICE: &str = "response_received";
 // alphabetical sort swaps its two pointer-typed fields (`status: Text`,
 // `measurements: List(Float64)`); see module docstring.
 const SERVICE_PRODUCER_CONFIG: &str = r#"{
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "producer",
     tag: "v1"
@@ -536,7 +536,7 @@ const SERVICE_PRODUCER_CONFIG: &str = r#"{
 }"#;
 
 const SERVICE_CONSUMER_CONFIG: &str = r#"{
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "consumer",
     tag: "v1",
@@ -859,7 +859,7 @@ const TOPIC_RECEIVED_SERVICE: &str = "received_ack";
 // alphabetical sort swaps its two pointer-typed fields (`status: Text`,
 // `readings: List(Float64)`); see module docstring.
 const TOPIC_PRODUCER_CONFIG: &str = r#"{
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "producer",
     tag: "v1"
@@ -887,7 +887,7 @@ const TOPIC_PRODUCER_CONFIG: &str = r#"{
 }"#;
 
 const TOPIC_CONSUMER_CONFIG: &str = r#"{
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "consumer",
     tag: "v1",

--- a/crates/generator-internal/tests/rust/actions_communication.rs
+++ b/crates/generator-internal/tests/rust/actions_communication.rs
@@ -116,7 +116,7 @@ const CONSUMED_ACTION_GOAL_FORMAT: &str = r#"
 /// resolve `slot_bindings["brain"]` into a `ConsumerFilter::Pin` that
 /// the generated `fire_goal` splices as its target.
 const BIMANUAL_CONSUMER_NODE_CONFIG: &str = r#"{
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "generated_node",
     tag: "v1",

--- a/crates/generator-internal/tests/rust/actions_conforms_to.rs
+++ b/crates/generator-internal/tests/rust/actions_conforms_to.rs
@@ -43,7 +43,7 @@ fn conformed(name: &str, tag: &str, action: ExposedAction) -> DeploymentInterfac
 }
 
 const NODE_CONFIG: &str = r#"{
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "arm_driver",
     tag: "v1"

--- a/crates/generator-internal/tests/rust/consumed_services_dedup.rs
+++ b/crates/generator-internal/tests/rust/consumed_services_dedup.rs
@@ -28,7 +28,7 @@ use tempfile::TempDir;
 use crate::helpers;
 
 const NODE_CONFIG: &str = r#"{
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "test_consumer",
     tag: "v1",

--- a/crates/generator-internal/tests/rust/consumed_topics_dedup.rs
+++ b/crates/generator-internal/tests/rust/consumed_topics_dedup.rs
@@ -23,7 +23,7 @@ use tempfile::TempDir;
 use crate::helpers;
 
 const NODE_CONFIG: &str = r#"{
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "test_controller",
     tag: "v1",

--- a/crates/generator-internal/tests/rust/generate_lib.rs
+++ b/crates/generator-internal/tests/rust/generate_lib.rs
@@ -10,7 +10,7 @@ use tempfile::TempDir;
 use crate::helpers;
 
 const PEPPY_JSON5_CONFIG: &str = r#"{
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "test_node",
     tag: "v1"
@@ -58,7 +58,7 @@ fn generate_peppygen_lib_minimal_config() {
 
     // Minimal config with no interfaces
     let minimal_config = r#"{
-      peppy_schema: "node_v1",
+      peppy_schema: "node/v1",
       manifest: {
         name: "minimal_node",
         tag: "v1"
@@ -101,7 +101,7 @@ fn generate_peppygen_lib_copy_mode_deploys_real_dirs() {
     let node_dir = temp_dir.path();
 
     let minimal_config = r#"{
-      peppy_schema: "node_v1",
+      peppy_schema: "node/v1",
       manifest: {
         name: "copy_node",
         tag: "v1"
@@ -331,7 +331,7 @@ fn generate_peppygen_rust_lib_emitted_and_consumed_topics() {
     let exposed_node_dir = exposed_dir.path();
 
     let exposed_config = r#"{
-          peppy_schema: "node_v1",
+          peppy_schema: "node/v1",
           manifest: {
             name: "{EXPOSED_NODE_NAME}",
             tag: "v1",
@@ -384,7 +384,7 @@ fn generate_peppygen_rust_lib_emitted_and_consumed_topics() {
     let consumer_node_dir = consumer_dir.path();
 
     let consumer_config = r#"{
-          peppy_schema: "node_v1",
+          peppy_schema: "node/v1",
           manifest: {
             name: "{CONSUMER_NODE_NAME}",
             tag: "v1",
@@ -446,7 +446,7 @@ fn generate_peppygen_rust_lib_exposed_and_consumed_services() {
     let exposed_node_dir = exposed_dir.path();
 
     let exposed_config = r#"{
-          peppy_schema: "node_v1",
+          peppy_schema: "node/v1",
           manifest: {
             name: "{EXPOSED_NODE_NAME}",
             tag: "v1",
@@ -502,7 +502,7 @@ fn generate_peppygen_rust_lib_exposed_and_consumed_services() {
     let consumer_node_dir = consumer_dir.path();
 
     let consumer_config = r#"{
-          peppy_schema: "node_v1",
+          peppy_schema: "node/v1",
           manifest: {
             name: "{CONSUMER_NODE_NAME}",
             tag: "v1",
@@ -577,7 +577,7 @@ fn generate_peppygen_rust_lib_exposed_and_consumed_actions() {
     let exposed_node_dir = exposed_dir.path();
 
     let exposed_config = r#"{
-          peppy_schema: "node_v1",
+          peppy_schema: "node/v1",
           manifest: {
             name: "{EXPOSED_NODE_NAME}",
             tag: "v1",
@@ -645,7 +645,7 @@ fn generate_peppygen_rust_lib_exposed_and_consumed_actions() {
     let consumer_node_dir = consumer_dir.path();
 
     let consumer_config = r#"{
-          peppy_schema: "node_v1",
+          peppy_schema: "node/v1",
           manifest: {
             name: "{CONSUMER_NODE_NAME}",
             tag: "v1",

--- a/crates/generator-internal/tests/rust/services_conforms_to.rs
+++ b/crates/generator-internal/tests/rust/services_conforms_to.rs
@@ -36,7 +36,7 @@ fn conformed(name: &str, tag: &str, service: ExposedService) -> DeploymentInterf
 }
 
 const NODE_CONFIG: &str = r#"{
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "control_panel",
     tag: "v1"

--- a/crates/generator-internal/tests/rust/topics_conforms_to.rs
+++ b/crates/generator-internal/tests/rust/topics_conforms_to.rs
@@ -52,7 +52,7 @@ fn conformed(name: &str, tag: &str, topic: EmittedTopic) -> DeploymentInterface 
 }
 
 const NODE_CONFIG: &str = r#"{
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "realsense_d435",
     tag: "v1"

--- a/crates/node-stack-internal/src/node_stack/entity.rs
+++ b/crates/node-stack-internal/src/node_stack/entity.rs
@@ -1386,7 +1386,7 @@ mod tests {
     fn sensor_config() -> NodeConfig {
         serde_json5::from_str::<NodeConfig>(
             r#"{
-                peppy_schema: "node_v1",
+                peppy_schema: "node/v1",
                 manifest: { name: "sensor", tag: "v1" },
                 interfaces: {},
                 execution: { language: "rust", run_cmd: ["sensor"] }

--- a/crates/node-stack-internal/src/service_action_cycle.rs
+++ b/crates/node-stack-internal/src/service_action_cycle.rs
@@ -318,7 +318,7 @@ mod tests {
             let name = &self.name;
             let json5 = format!(
                 r#"{{
-                    peppy_schema: "node_v1",
+                    peppy_schema: "node/v1",
                     manifest: {{
                         name: "{name}",
                         tag: "v1",

--- a/crates/node-stack-internal/src/virtual_deptree.rs
+++ b/crates/node-stack-internal/src/virtual_deptree.rs
@@ -179,7 +179,7 @@ mod tests {
         };
         let json5 = format!(
             r#"{{
-                peppy_schema: "node_v1",
+                peppy_schema: "node/v1",
                 manifest: {{
                     name: "{name}",
                     tag: "v1",
@@ -375,7 +375,7 @@ mod tests {
         );
         let json5 = format!(
             r#"{{
-                peppy_schema: "node_v1",
+                peppy_schema: "node/v1",
                 manifest: {{
                     name: "{name}",
                     tag: "v1",

--- a/crates/node-stack-internal/tests/helpers/config_common.rs
+++ b/crates/node-stack-internal/tests/helpers/config_common.rs
@@ -5,7 +5,7 @@ use config::node::{NodeConfig, NodeConfigParser};
 pub fn core_node_config() -> NodeConfig {
     NodeConfigParser::from_content(
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "core",
                 tag: "v1",

--- a/crates/node-stack-internal/tests/tests_modules/actions_runtime_resolution.rs
+++ b/crates/node-stack-internal/tests/tests_modules/actions_runtime_resolution.rs
@@ -10,7 +10,7 @@ use crate::helpers::graph_query;
 fn action_dependency_resolved_when_dependency_added_first() {
     let dependent: config::node::NodeConfig = serde_json5::from_str(
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
               name: "brain",
               tag: "v1",
@@ -40,7 +40,7 @@ fn action_dependency_resolved_when_dependency_added_first() {
 
     let dependency: config::node::NodeConfig = serde_json5::from_str(
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
               name: "controller",
               tag: "v1",
@@ -131,7 +131,7 @@ fn action_dependency_resolved_when_dependency_added_first() {
 fn action_dependency_fails_when_dependency_is_missing() {
     let dependent: config::node::NodeConfig = serde_json5::from_str(
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
               name: "brain",
               tag: "v1",
@@ -182,7 +182,7 @@ fn action_dependency_fails_when_action_not_exposed_by_dependency() {
     // but the target node exists without exposing the requested action
     let dependent: config::node::NodeConfig = serde_json5::from_str(
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
               name: "brain",
               tag: "v1",
@@ -213,7 +213,7 @@ fn action_dependency_fails_when_action_not_exposed_by_dependency() {
     // This node has the correct name but exposes a different action
     let dependency_wrong_action: config::node::NodeConfig = serde_json5::from_str(
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
               name: "controller",
               tag: "v1",
@@ -297,7 +297,7 @@ fn action_dependency_fails_when_action_not_exposed_by_dependency() {
 fn action_dependency_fails_when_link_id_is_undeclared() {
     let dependent: config::node::NodeConfig = serde_json5::from_str(
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
               name: "brain",
               tag: "v1",

--- a/crates/node-stack-internal/tests/tests_modules/lifecycle_transitions.rs
+++ b/crates/node-stack-internal/tests/tests_modules/lifecycle_transitions.rs
@@ -18,7 +18,7 @@ use crate::helpers::real_lifecycle;
 fn sensor_config() -> config::node::NodeConfig {
     serde_json5::from_str::<config::node::NodeConfig>(
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "sensor",
                 tag: "v1",
@@ -260,7 +260,7 @@ fn push_config_rewires_when_dependency_keys_change_with_unchanged_interfaces() {
 
     let producer_a: config::node::NodeConfig = serde_json5::from_str(
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: { name: "producer_a", tag: "v1" },
             interfaces: { services: { exposes: [ { name: "reset_sensor" } ] } },
             execution: { language: "rust", run_cmd: ["producer_a"] }
@@ -270,7 +270,7 @@ fn push_config_rewires_when_dependency_keys_change_with_unchanged_interfaces() {
 
     let producer_b: config::node::NodeConfig = serde_json5::from_str(
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: { name: "producer_b", tag: "v1" },
             interfaces: { services: { exposes: [ { name: "reset_sensor" } ] } },
             execution: { language: "rust", run_cmd: ["producer_b"] }
@@ -282,7 +282,7 @@ fn push_config_rewires_when_dependency_keys_change_with_unchanged_interfaces() {
         let link_id = format!("p_{}", producer_name);
         serde_json5::from_str(
             &r#"{
-                peppy_schema: "node_v1",
+                peppy_schema: "node/v1",
                 manifest: {
                     name: "consumer",
                     tag: "v1",
@@ -506,7 +506,7 @@ fn sensor_config_with_build_cmd(build_cmd_shell: &str) -> config::node::NodeConf
         .expect("snippet should be JSON-encodable");
     let json = format!(
         r#"{{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {{
                 name: "sensor",
                 tag: "v1",
@@ -629,7 +629,7 @@ async fn build_runs_add_cmd_for_process_node() {
 fn long_running_sensor_config() -> config::node::NodeConfig {
     serde_json5::from_str::<config::node::NodeConfig>(
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "sensor",
                 tag: "v1",

--- a/crates/node-stack-internal/tests/tests_modules/runtime_resolution.rs
+++ b/crates/node-stack-internal/tests/tests_modules/runtime_resolution.rs
@@ -13,7 +13,7 @@ use crate::helpers::real_lifecycle;
 async fn add_instance_creates_new_entity() {
     let config: config::node::NodeConfig = serde_json5::from_str(
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
               name: "sensor",
               tag: "v1",
@@ -104,7 +104,7 @@ async fn add_instance_creates_new_entity() {
 async fn add_instance_to_existing_entity() {
     let config: config::node::NodeConfig = serde_json5::from_str(
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
               name: "sensor",
               tag: "v1",
@@ -199,7 +199,7 @@ async fn add_instance_to_existing_entity() {
 async fn add_instance_with_specific_id() {
     let config: config::node::NodeConfig = serde_json5::from_str(
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
               name: "sensor",
               tag: "v1",
@@ -251,7 +251,7 @@ async fn add_instance_with_specific_id() {
 async fn remove_instance_from_entity_with_multiple_instances() {
     let config: config::node::NodeConfig = serde_json5::from_str(
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
               name: "sensor",
               tag: "v1",
@@ -327,7 +327,7 @@ async fn remove_instance_from_entity_with_multiple_instances() {
 async fn remove_last_instance_keeps_entity_in_graph() {
     let config: config::node::NodeConfig = serde_json5::from_str(
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
               name: "sensor",
               tag: "v1",
@@ -384,7 +384,7 @@ async fn remove_last_instance_keeps_entity_in_graph() {
 async fn remove_nonexistent_instance_returns_false() {
     let config: config::node::NodeConfig = serde_json5::from_str(
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
               name: "sensor",
               tag: "v1",
@@ -438,7 +438,7 @@ async fn remove_nonexistent_instance_returns_false() {
 fn reset_clears_all_except_core_node() {
     let config1: config::node::NodeConfig = serde_json5::from_str(
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
               name: "sensor1",
               tag: "v1",
@@ -462,7 +462,7 @@ fn reset_clears_all_except_core_node() {
 
     let config2: config::node::NodeConfig = serde_json5::from_str(
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
               name: "sensor2",
               tag: "v1",
@@ -524,7 +524,7 @@ fn reset_clears_all_except_core_node() {
 async fn spawning_multiple_instances_on_same_entity() {
     let config: config::node::NodeConfig = serde_json5::from_str(
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
               name: "sensor",
               tag: "v1",
@@ -607,7 +607,7 @@ fn adding_same_entity_with_different_interfaces_overwrites_when_no_dependents() 
     // First config: emits a topic
     let config_with_topic: config::node::NodeConfig = serde_json5::from_str(
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
               name: "sensor",
               tag: "v1",
@@ -633,7 +633,7 @@ fn adding_same_entity_with_different_interfaces_overwrites_when_no_dependents() 
     // Second config: same name and tag but emits a topic AND exposes a service
     let config_with_topic_and_service: config::node::NodeConfig = serde_json5::from_str(
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
               name: "sensor",
               tag: "v1",
@@ -713,7 +713,7 @@ fn adding_same_name_with_different_tag_and_different_interfaces_succeeds() {
     // First config: version 1.0.0 exposes a service
     let config_v1: config::node::NodeConfig = serde_json5::from_str(
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
               name: "sensor",
               tag: "v1",
@@ -738,7 +738,7 @@ fn adding_same_name_with_different_tag_and_different_interfaces_succeeds() {
     // Second config: version 2.0.0 emits a topic AND exposes a service (different interfaces are allowed with different tag)
     let config_v2: config::node::NodeConfig = serde_json5::from_str(
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
               name: "sensor",
               tag: "v2",
@@ -847,7 +847,7 @@ fn cannot_modify_root_node() {
 fn node_stack_wires_dependencies_for_dependants() {
     let dependency: config::node::NodeConfig = serde_json5::from_str(
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
               name: "lidar",
               tag: "v1",
@@ -869,7 +869,7 @@ fn node_stack_wires_dependencies_for_dependants() {
 
     let dependent: config::node::NodeConfig = serde_json5::from_str(
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
               name: "brain",
               tag: "v1",
@@ -917,7 +917,7 @@ fn dependency_fails_when_node_name_mismatches() {
     // Dependent expects "uvc_camera" but we add "lidar" instead
     let dependent: config::node::NodeConfig = serde_json5::from_str(
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
               name: "brain",
               tag: "v1",
@@ -944,7 +944,7 @@ fn dependency_fails_when_node_name_mismatches() {
 
     let wrong_dependency: config::node::NodeConfig = serde_json5::from_str(
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
               name: "lidar",
               tag: "v1",
@@ -989,7 +989,7 @@ fn dependency_fails_when_node_tag_mismatches() {
     // Dependent expects tag "v1" but we add tag "v2" instead
     let dependent: config::node::NodeConfig = serde_json5::from_str(
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
               name: "brain",
               tag: "v1",
@@ -1009,7 +1009,7 @@ fn dependency_fails_when_node_tag_mismatches() {
 
     let wrong_tag_dependency: config::node::NodeConfig = serde_json5::from_str(
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
               name: "lidar",
               tag: "v2",
@@ -1053,7 +1053,7 @@ fn dependency_fails_when_node_tag_mismatches() {
 fn overwriting_existing_node_fails_if_node_has_dependencies() {
     let dependency_v1: config::node::NodeConfig = serde_json5::from_str(
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
               name: "lidar",
               tag: "v1",
@@ -1075,7 +1075,7 @@ fn overwriting_existing_node_fails_if_node_has_dependencies() {
 
     let dependent: config::node::NodeConfig = serde_json5::from_str(
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
               name: "brain",
               tag: "v1",
@@ -1105,7 +1105,7 @@ fn overwriting_existing_node_fails_if_node_has_dependencies() {
 
     let dependency_v2: config::node::NodeConfig = serde_json5::from_str(
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
               name: "lidar",
               tag: "v1",
@@ -1172,7 +1172,7 @@ fn overwriting_existing_node_fails_if_node_has_dependencies() {
 fn updating_run_cmd_without_changing_interfaces_applies_new_config() {
     let original_config: config::node::NodeConfig = serde_json5::from_str(
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
               name: "sensor",
               tag: "v1",
@@ -1187,7 +1187,7 @@ fn updating_run_cmd_without_changing_interfaces_applies_new_config() {
 
     let updated_config: config::node::NodeConfig = serde_json5::from_str(
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
               name: "sensor",
               tag: "v1",
@@ -1238,7 +1238,7 @@ fn updating_run_cmd_without_changing_interfaces_applies_new_config() {
 fn updating_run_cmd_succeeds_even_when_node_has_dependents() {
     let dependency_v1: config::node::NodeConfig = serde_json5::from_str(
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
               name: "lidar",
               tag: "v1",
@@ -1253,7 +1253,7 @@ fn updating_run_cmd_succeeds_even_when_node_has_dependents() {
 
     let dependent: config::node::NodeConfig = serde_json5::from_str(
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
               name: "brain",
               tag: "v1",
@@ -1274,7 +1274,7 @@ fn updating_run_cmd_succeeds_even_when_node_has_dependents() {
     // Same interfaces as v1, but different run_cmd
     let dependency_v1_updated: config::node::NodeConfig = serde_json5::from_str(
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
               name: "lidar",
               tag: "v1",

--- a/crates/node-stack-internal/tests/tests_modules/service_action_cycle_resolution.rs
+++ b/crates/node-stack-internal/tests/tests_modules/service_action_cycle_resolution.rs
@@ -25,7 +25,7 @@ fn interface_node(
 ) -> config::node::NodeConfig {
     let json5 = format!(
         r#"{{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {{
                 name: "{name}",
                 tag: "v1",
@@ -196,7 +196,7 @@ fn one_directional_service_through_interface_allowed() {
     // Provider `b` conforms to `iface_b` and consumes nothing back.
     let provider = serde_json5::from_str::<config::node::NodeConfig>(
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: { name: "b", tag: "v1" },
             interfaces: {
                 conforms_to: [{ name: "iface_b", tag: "v1" }],

--- a/crates/node-stack-internal/tests/tests_modules/services_runtime_resolution.rs
+++ b/crates/node-stack-internal/tests/tests_modules/services_runtime_resolution.rs
@@ -10,7 +10,7 @@ use crate::helpers::graph_query;
 fn service_dependency_resolved_when_dependency_added_first() {
     let dependent: config::node::NodeConfig = serde_json5::from_str(
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
               name: "brain",
               tag: "v1",
@@ -40,7 +40,7 @@ fn service_dependency_resolved_when_dependency_added_first() {
 
     let dependency: config::node::NodeConfig = serde_json5::from_str(
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
               name: "lidar",
               tag: "v1",
@@ -109,7 +109,7 @@ fn service_dependency_resolved_when_dependency_added_first() {
 fn service_dependency_fails_when_dependency_is_missing() {
     let dependent: config::node::NodeConfig = serde_json5::from_str(
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
               name: "brain",
               tag: "v1",
@@ -160,7 +160,7 @@ fn service_dependency_fails_when_service_not_exposed_by_dependency() {
     // but the target node exists without exposing the requested service
     let dependent: config::node::NodeConfig = serde_json5::from_str(
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
               name: "brain",
               tag: "v1",
@@ -191,7 +191,7 @@ fn service_dependency_fails_when_service_not_exposed_by_dependency() {
     // This node has the correct name but exposes a different service
     let dependency_wrong_service: config::node::NodeConfig = serde_json5::from_str(
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
               name: "lidar",
               tag: "v1",
@@ -249,7 +249,7 @@ fn service_dependency_fails_when_service_not_exposed_by_dependency() {
 fn service_dependency_fails_when_link_id_is_undeclared() {
     let dependent: config::node::NodeConfig = serde_json5::from_str(
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
               name: "brain",
               tag: "v1",

--- a/crates/node-stack-internal/tests/tests_modules/topics_runtime_resolution.rs
+++ b/crates/node-stack-internal/tests/tests_modules/topics_runtime_resolution.rs
@@ -10,7 +10,7 @@ use crate::helpers::graph_query;
 fn topic_dependency_resolved_when_dependency_added_first() {
     let brain_dependent: config::node::NodeConfig = serde_json5::from_str(
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
               name: "brain",
               tag: "v1",
@@ -40,7 +40,7 @@ fn topic_dependency_resolved_when_dependency_added_first() {
 
     let lidar_dependency: config::node::NodeConfig = serde_json5::from_str(
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
               name: "lidar",
               tag: "v1",
@@ -113,7 +113,7 @@ fn topic_dependency_resolved_when_dependency_added_first() {
 fn topic_dependency_fails_when_dependency_is_missing() {
     let brain_dependent: config::node::NodeConfig = serde_json5::from_str(
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
               name: "brain",
               tag: "v1",
@@ -164,7 +164,7 @@ fn topic_dependency_fails_when_topic_not_exposed_by_dependency() {
     // but the target node exists without exposing the requested topic
     let dependent: config::node::NodeConfig = serde_json5::from_str(
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
               name: "brain",
               tag: "v1",
@@ -195,7 +195,7 @@ fn topic_dependency_fails_when_topic_not_exposed_by_dependency() {
     // This node has the correct name but emits a different topic
     let dependency_wrong_topic: config::node::NodeConfig = serde_json5::from_str(
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
               name: "lidar",
               tag: "v1",
@@ -252,7 +252,7 @@ fn topic_dependency_fails_when_topic_not_exposed_by_dependency() {
 fn topic_dependency_fails_when_link_id_is_undeclared() {
     let dependent: config::node::NodeConfig = serde_json5::from_str(
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
               name: "brain",
               tag: "v1",

--- a/crates/peppy/src/commands/node/info.rs
+++ b/crates/peppy/src/commands/node/info.rs
@@ -438,7 +438,7 @@ mod tests {
     fn sample_response_with_execution(execution_json5: &str) -> NodeInfo {
         let config_json5 = format!(
             r#"{{
-                peppy_schema: "node_v1",
+                peppy_schema: "node/v1",
                 manifest: {{
                     name: "sensor_node",
                     tag: "v1",

--- a/crates/peppy/tests/node_add.rs
+++ b/crates/peppy/tests/node_add.rs
@@ -1107,7 +1107,7 @@ fn write_consumer_with_pinned_depends_on(
         .join(",\n");
     let body = format!(
         r#"{{
-    peppy_schema: "node_v1",
+    peppy_schema: "node/v1",
     manifest: {{
         name: "{consumer_name}",
         tag: "v1",

--- a/crates/peppy/tests/node_info.rs
+++ b/crates/peppy/tests/node_info.rs
@@ -167,7 +167,7 @@ fn node_info_shows_dependencies_from_consumed_interfaces() {
     const NODE_TAG: &str = "v1";
 
     let peppy_json5 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "{NODE_NAME}",
                 tag: "{NODE_TAG}",
@@ -211,7 +211,7 @@ fn node_info_shows_dependencies_from_consumed_interfaces() {
     // up minimal publisher nodes that expose exactly the interfaces
     // `consumer_node` consumes, so the add resolves cleanly.
     let camera_node = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: { name: "camera_node", tag: "v1" },
             interfaces: {
                 topics: {
@@ -224,7 +224,7 @@ fn node_info_shows_dependencies_from_consumed_interfaces() {
             execution: { language: "rust", run_cmd: ["sleep", "10"] }
         }"#;
     let lidar_node = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: { name: "lidar_node", tag: "v1" },
             interfaces: {
                 topics: { emits: [{ name: "point_cloud" }] }
@@ -232,7 +232,7 @@ fn node_info_shows_dependencies_from_consumed_interfaces() {
             execution: { language: "rust", run_cmd: ["sleep", "10"] }
         }"#;
     let config_node = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: { name: "config_node", tag: "v1" },
             interfaces: {
                 services: { exposes: [{ name: "get_config" }] }
@@ -240,7 +240,7 @@ fn node_info_shows_dependencies_from_consumed_interfaces() {
             execution: { language: "rust", run_cmd: ["sleep", "10"] }
         }"#;
     let navigation_node = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: { name: "navigation_node", tag: "v1" },
             interfaces: {
                 actions: { exposes: [{ name: "go_to_pose" }] }
@@ -326,7 +326,7 @@ fn node_info_no_dependencies_when_no_consumes() {
     const NODE_TAG: &str = "v1";
 
     let peppy_json5 = r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "{NODE_NAME}",
                 tag: "{NODE_TAG}",

--- a/crates/peppy/tests/node_run.rs
+++ b/crates/peppy/tests/node_run.rs
@@ -262,7 +262,7 @@ async fn node_run_command_with_args_succeeds() {
 
     // Overwrite peppy.json5 with a config that includes parameters
     let peppy_config = r#"{
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: { name: "test_run_args_node",
     tag: "v1" },
   interfaces: {
@@ -996,7 +996,7 @@ fn write_consumer_with_depends_on(
         .join(",\n");
     let body = format!(
         r#"{{
-    peppy_schema: "node_v1",
+    peppy_schema: "node/v1",
     manifest: {{
         name: "{consumer_name}",
         tag: "v1",

--- a/crates/peppy/tests/node_sync.rs
+++ b/crates/peppy/tests/node_sync.rs
@@ -403,7 +403,7 @@ async fn node_sync_with_include_repositories_prints_provenance() {
     std::fs::write(
         camera_dir.path().join("peppy.json5"),
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: { name: "uvc_camera", tag: "v1" },
             interfaces: {
                 topics: {
@@ -447,7 +447,7 @@ async fn node_sync_with_include_repositories_prints_provenance() {
     std::fs::write(
         brain_dir.path().join("peppy.json5"),
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {
                 name: "my_robot_brain",
                 tag: "v1",

--- a/crates/peppy/tests/repo_list.rs
+++ b/crates/peppy/tests/repo_list.rs
@@ -8,7 +8,7 @@ use peppy::commands::repo::{RepoCommand, RepoCommands};
 fn minimal_peppy_json5(name: &str, tag: &str) -> String {
     format!(
         r#"{{
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {{
     name: "{name}",
     tag: "{tag}",

--- a/crates/peppy/tests/repo_refresh.rs
+++ b/crates/peppy/tests/repo_refresh.rs
@@ -28,7 +28,7 @@ fn repo_refresh_succeeds_after_adding_fs_repo() {
     std::fs::write(
         node_dir.path().join("peppy.json5"),
         r#"{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: { name: "test_node", tag: "v1" },
             execution: { language: "rust", run_cmd: ["sleep", "1"] }
         }"#,

--- a/crates/peppy/tests/service_reset.rs
+++ b/crates/peppy/tests/service_reset.rs
@@ -33,7 +33,7 @@ fn write_node_config(
     fs::write(
         &node_config_path,
         r#"{
-                peppy_schema: "node_v1",
+                peppy_schema: "node/v1",
                 manifest: {
                     name: "{node_name}",
                     tag: "{node_tag}",

--- a/crates/peppy/tests/stack_launch.rs
+++ b/crates/peppy/tests/stack_launch.rs
@@ -42,7 +42,7 @@ fn write_node_config(
     fs::write(
         &node_config_path,
         r#"{
-                peppy_schema: "node_v1",
+                peppy_schema: "node/v1",
                 manifest: {
                     name: "{node_name}",
                     tag: "{node_tag}",
@@ -210,7 +210,7 @@ async fn node_launch_command_succeed() {
     let node_b_path = nodes_dir.path().join(node_b_name);
     let launcher_json5 = format!(
         r#"{{
-            peppy_schema: "launcher_v1",
+            peppy_schema: "launcher/v1",
             deployments: [
                 {{
                     source: {{ local: "{}" }},
@@ -408,7 +408,7 @@ async fn node_launch_command_fails_when_node_never_becomes_healthy_and_clears_st
     let launcher_path = nodes_dir.path().join("peppy_launcher.json5");
     let launcher_json5 = format!(
         r#"{{
-            peppy_schema: "launcher_v1",
+            peppy_schema: "launcher/v1",
             deployments: [
                 {{
                     source: {{ local: "{}" }},
@@ -528,7 +528,7 @@ async fn setup_timeout_test(node_b_name: &'static str) -> TimeoutTestHarness {
     let launcher_path = nodes_dir_path.join("peppy_launcher.json5");
     let launcher_json5 = format!(
         r#"{{
-            peppy_schema: "launcher_v1",
+            peppy_schema: "launcher/v1",
             deployments: [
                 {{
                     source: {{ local: "{}" }},
@@ -700,7 +700,7 @@ fn write_node_config_for_helper(
         .unwrap_or_default();
     let body = format!(
         r#"{{
-            peppy_schema: "node_v1",
+            peppy_schema: "node/v1",
             manifest: {{
                 name: "{node_name}",
                 tag: "{node_tag}"{manifest_extra}
@@ -860,7 +860,7 @@ async fn stack_launch_populates_link_ids_from_launcher_bindings() {
     let launcher_path = nodes_dir.path().join("peppy_launcher.json5");
     let launcher_json5 = format!(
         r#"{{
-            peppy_schema: "launcher_v1",
+            peppy_schema: "launcher/v1",
             deployments: [
                 {{
                     source: {{ local: "{producer_path}" }},
@@ -1015,7 +1015,7 @@ async fn stack_launch_rejects_stack_wide_duplicate_instance_id() {
     let launcher_path = nodes_dir.path().join("peppy_launcher.json5");
     let launcher_json5 = format!(
         r#"{{
-            peppy_schema: "launcher_v1",
+            peppy_schema: "launcher/v1",
             deployments: [
                 {{
                     source: {{ local: "{camera}" }},
@@ -1081,7 +1081,7 @@ async fn stack_launch_rejects_stack_wide_duplicate_instance_id() {
     );
 }
 
-/// Writes a minimal `peppy_schema: "interface_v1"` document at `path` with
+/// Writes a minimal `peppy_schema: "interface/v1"` document at `path` with
 /// a single `video_stream` topic. Used by the conformance-binding
 /// integration tests to materialize the interface contract on disk
 /// alongside the producer/consumer node configs that reference it.
@@ -1116,7 +1116,7 @@ fn write_interface_v1_doc_with_topic(
     }
     let body = format!(
         r#"{{
-            peppy_schema: "interface_v1",
+            peppy_schema: "interface/v1",
             manifest: {{ name: "{name}", tag: "{tag}" }},
             interfaces: {{
                 topics: [
@@ -1129,13 +1129,13 @@ fn write_interface_v1_doc_with_topic(
             }}
         }}"#
     );
-    fs::write(path, body).expect("failed to write interface_v1 doc");
+    fs::write(path, body).expect("failed to write interface/v1 doc");
 }
 
 /// End-to-end check that a pinned interface binding resolves against
 /// the producer's `interfaces.conforms_to` declaration. Exercises a real
-/// `peppy_schema: "interface_v1"` document on disk alongside a `node_v1`
-/// producer declaring conformance and a `node_v1` consumer declaring
+/// `peppy_schema: "interface/v1"` document on disk alongside a `node/v1`
+/// producer declaring conformance and a `node/v1` consumer declaring
 /// the interface dep — pairs the unit-level binding validator tests
 /// with the full launch pipeline (cache resolution + daemon node-add).
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -1294,7 +1294,7 @@ async fn stack_launch_resolves_conforms_to_binding_with_real_interface_doc() {
     let launcher_path = nodes_dir.path().join("peppy_launcher.json5");
     let launcher_json5 = format!(
         r#"{{
-            peppy_schema: "launcher_v1",
+            peppy_schema: "launcher/v1",
             deployments: [
                 {{
                     source: {{ local: "{producer_path}" }},
@@ -1431,7 +1431,7 @@ async fn stack_launch_rejects_binding_when_producer_omits_conforms_to() {
     let launcher_path = nodes_dir.path().join("peppy_launcher.json5");
     let launcher_json5 = format!(
         r#"{{
-            peppy_schema: "launcher_v1",
+            peppy_schema: "launcher/v1",
             deployments: [
                 {{
                     source: {{ local: "{producer_path}" }},
@@ -1563,7 +1563,7 @@ async fn stack_launch_rejects_binding_with_wrong_tag_in_conforms_to() {
     let launcher_path = nodes_dir.path().join("peppy_launcher.json5");
     let launcher_json5 = format!(
         r#"{{
-            peppy_schema: "launcher_v1",
+            peppy_schema: "launcher/v1",
             deployments: [
                 {{
                     source: {{ local: "{producer_path}" }},
@@ -1819,7 +1819,7 @@ async fn stack_launch_bidirectional_from_any_needs_no_binds() {
     let launcher_path = nodes_dir.path().join("peppy_launcher.json5");
     let launcher_json5 = format!(
         r#"{{
-            peppy_schema: "launcher_v1",
+            peppy_schema: "launcher/v1",
             deployments: [
                 {{
                     source: {{ local: "{controller_path}" }},

--- a/docs/src/content/docs/advanced_guides/actions.mdx
+++ b/docs/src/content/docs/advanced_guides/actions.mdx
@@ -44,7 +44,7 @@ Each action defines a `goal_service`, a `feedback_topic`, and a `result_service`
 
 ```json5
 {
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "brain",
     tag: "v1",
@@ -355,7 +355,7 @@ Dependencies are declared in `manifest.depends_on` and referenced by `link_id` i
 
 ```json5
 {
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "controller",
     tag: "v1",

--- a/docs/src/content/docs/advanced_guides/bidirectional_communication.mdx
+++ b/docs/src/content/docs/advanced_guides/bidirectional_communication.mdx
@@ -58,7 +58,7 @@ Neither node lists the other in `depends_on.nodes`, so there is no cycle to brea
 
 ## Define the two interfaces
 
-Each interface is a standalone `interface_v1` document in a repository peppy scans (see [Repositories](/advanced_guides/repositories)). The `message_format` lives here once, and both the producer and the consumer inherit it by reference.
+Each interface is a standalone `interface/v1` document in a repository peppy scans (see [Repositories](/advanced_guides/repositories)). The `message_format` lives here once, and both the producer and the consumer inherit it by reference.
 
 <Code code={jointStateInterface} lang="json5" title="joint_state_source/peppy.json5" />
 
@@ -111,7 +111,7 @@ The order does not matter: running `arm_controller:v1` first works just as well,
 
 ```json5 title="peppy_launcher.json5"
 {
-  peppy_schema: "launcher_v1",
+  peppy_schema: "launcher/v1",
   deployments: [
     { source: { name: "robot_arm:v1" }, instances: [{ instance_id: "arm_1" }] },
     { source: { name: "arm_controller:v1" }, instances: [{ instance_id: "ctrl_1" }] },

--- a/docs/src/content/docs/advanced_guides/containers.mdx
+++ b/docs/src/content/docs/advanced_guides/containers.mdx
@@ -70,7 +70,7 @@ A container node includes a `container` block inside its `execution` section ins
   <TabItem label="Python">
     ```json5 title="peppy.json5"
     {
-      peppy_schema: "node_v1",
+      peppy_schema: "node/v1",
       manifest: {
         name: "my_node",
         tag: "v1",
@@ -88,7 +88,7 @@ A container node includes a `container` block inside its `execution` section ins
   <TabItem label="Rust">
     ```json5 title="peppy.json5"
     {
-      peppy_schema: "node_v1",
+      peppy_schema: "node/v1",
       manifest: {
         name: "my_node",
         tag: "v1",
@@ -113,7 +113,7 @@ Compare this with a standard process node, which defines `build_cmd` and `run_cm
   <TabItem label="Python">
     ```json5 title="peppy.json5 (process node)"
     {
-      peppy_schema: "node_v1",
+      peppy_schema: "node/v1",
       manifest: {
         name: "my_node",
         tag: "v1",
@@ -130,7 +130,7 @@ Compare this with a standard process node, which defines `build_cmd` and `run_cm
   <TabItem label="Rust">
     ```json5 title="peppy.json5 (process node)"
     {
-      peppy_schema: "node_v1",
+      peppy_schema: "node/v1",
       manifest: {
         name: "my_node",
         tag: "v1",
@@ -261,7 +261,7 @@ Add a `mount_paths` array to the `container` block inside `execution` in `peppy.
 
 ```json5 title="peppy.json5"
 {
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "my_node",
     tag: "v1",
@@ -304,7 +304,7 @@ Mount paths can reference runtime [parameters](/getting_started/parameters/) usi
 
 ```json5 title="peppy.json5"
 {
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "uvc_camera",
     tag: "v1",
@@ -365,7 +365,7 @@ You can pass additional command-line arguments directly to Apptainer or Lima usi
 
 ```json5 title="peppy.json5"
 {
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "my_node",
     tag: "v1",

--- a/docs/src/content/docs/advanced_guides/interface_conformance.mdx
+++ b/docs/src/content/docs/advanced_guides/interface_conformance.mdx
@@ -7,7 +7,7 @@ sidebar:
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
-A peppy node can either declare its `topics`, `services` and `actions` directly in its own `peppy.json5`, or it can claim conformance to a separately-defined **interface**. An interface is a standalone document with its own `peppy_schema: "interface_v1"` that names a set of topics, services and actions. Producers conform to the interface; consumers depend on the interface. Both sides cite the interface by `(name, tag)`, and the launcher binds a conforming producer to the consumer at launch time.
+A peppy node can either declare its `topics`, `services` and `actions` directly in its own `peppy.json5`, or it can claim conformance to a separately-defined **interface**. An interface is a standalone document with its own `peppy_schema: "interface/v1"` that names a set of topics, services and actions. Producers conform to the interface; consumers depend on the interface. Both sides cite the interface by `(name, tag)`, and the launcher binds a conforming producer to the consumer at launch time.
 
 Interface conformance is the abstraction you reach for when several nodes implement the same contract. A `realsense_d405` driver, a `zed_2i` driver, and a `mujoco_depth_camera_sim` all expose the same `video_stream` topic. Without conformance, every consumer would have to hard-code one of those producer names. With conformance, the consumer asks for the `depth_camera:v1` interface and the launcher decides which physical driver (or its sim equivalent) fills the slot.
 
@@ -15,12 +15,12 @@ Interface conformance is the abstraction you reach for when several nodes implem
 
 ### 1. The interface document
 
-An interface lives in its own file under a repository peppy scans (see [Repositories](/advanced_guides/repositories)). It uses `peppy_schema: "interface_v1"` and declares the same `topics` / `services` / `actions` shapes you would put on a node, except the `interfaces` block is the contract itself, with no `emits` / `consumes` split:
+An interface lives in its own file under a repository peppy scans (see [Repositories](/advanced_guides/repositories)). It uses `peppy_schema: "interface/v1"` and declares the same `topics` / `services` / `actions` shapes you would put on a node, except the `interfaces` block is the contract itself, with no `emits` / `consumes` split:
 
 ```json5
 // depth_camera/peppy.json5 (inside a registered repo)
 {
-  peppy_schema: "interface_v1",
+  peppy_schema: "interface/v1",
   manifest: {
     name: "depth_camera",
     tag: "v1",
@@ -54,7 +54,7 @@ An interface lives in its own file under a repository peppy scans (see [Reposito
 }
 ```
 
-After `peppy repo refresh`, the interface is cached and addressable by `(name, tag)`. Files use whatever filename you like; peppy identifies an `interface_v1` document by its `peppy_schema` field.
+After `peppy repo refresh`, the interface is cached and addressable by `(name, tag)`. Files use whatever filename you like; peppy identifies an `interface/v1` document by its `peppy_schema` field.
 
 ### 2. A producer that conforms
 
@@ -63,7 +63,7 @@ A producer node declares conformance with an `interfaces.conforms_to` list. Each
 ```json5
 // realsense_d405/peppy.json5
 {
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "realsense_d405",
     tag: "v1",
@@ -92,7 +92,7 @@ A consumer references an interface through `manifest.depends_on.interfaces` rath
 ```json5
 // video_reconstruction/peppy.json5
 {
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "video_reconstruction",
     tag: "v1",
@@ -133,7 +133,7 @@ A pinned interface dep (`from_any: false`, the default) requires an explicit `--
 ```json5
 // peppy_launcher.json5
 {
-  peppy_schema: "launcher_v1",
+  peppy_schema: "launcher/v1",
   deployments: [
     {
       source: { name: "realsense_d405:v1" },
@@ -188,7 +188,7 @@ First, the consumer declares a single `from_any: true` interface dep and consume
 ```json5
 // video_reconstruction/peppy.json5
 {
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "video_reconstruction",
     tag: "v1",
@@ -221,7 +221,7 @@ Then the launcher accepts one `--bind` per producer instance, each under a disti
 ```json5
 // peppy_launcher.json5
 {
-  peppy_schema: "launcher_v1",
+  peppy_schema: "launcher/v1",
   deployments: [
     {
       source: { name: "realsense_d405:v1" },
@@ -333,7 +333,7 @@ A launcher can wire the three slots to any mix of conforming producers:
 
 ```json5
 {
-  peppy_schema: "launcher_v1",
+  peppy_schema: "launcher/v1",
   deployments: [
     {
       source: { name: "realsense_d405:v1" },
@@ -384,7 +384,7 @@ Two service interfaces, one provided by each node:
 ```json5
 // pose_service/peppy.json5 (interface)
 {
-  peppy_schema: "interface_v1",
+  peppy_schema: "interface/v1",
   manifest: { name: "pose_service", tag: "v1" },
   interfaces: {
     services: [
@@ -398,7 +398,7 @@ Two service interfaces, one provided by each node:
 
 // obstacle_service/peppy.json5 (interface)
 {
-  peppy_schema: "interface_v1",
+  peppy_schema: "interface/v1",
   manifest: { name: "obstacle_service", tag: "v1" },
   interfaces: {
     services: [
@@ -417,7 +417,7 @@ Two service interfaces, one provided by each node:
 ```json5
 // localizer/peppy.json5
 {
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "localizer",
     tag: "v1",
@@ -444,7 +444,7 @@ Two service interfaces, one provided by each node:
 
 // mapper/peppy.json5
 {
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "mapper",
     tag: "v1",

--- a/docs/src/content/docs/advanced_guides/repositories.mdx
+++ b/docs/src/content/docs/advanced_guides/repositories.mdx
@@ -8,8 +8,8 @@ sidebar:
 Repositories tell peppy where to look for nodes, launchers, and interfaces. When you run `peppy repo refresh`, peppy walks every configured repository and indexes:
 
 - **Nodes**, identified by filename: every `peppy.json5` file is treated as a node config.
-- **Launchers**, identified by content: every `.json5` file whose body declares `peppy_schema: "launcher_v1"` is treated as a launcher, regardless of its filename. The launcher is keyed by the file stem (e.g. `openarm01_sim_teleop.json5` becomes the launcher named `openarm01_sim_teleop`).
-- **Interfaces**, identified by content: every `.json5` file whose body declares `peppy_schema: "interface_v1"` is treated as an interface, regardless of its filename. An interface is a reusable contract of topics, services, and actions, keyed by the `name:tag` declared in its manifest; nodes reference interfaces by `name:tag` to declare conformance.
+- **Launchers**, identified by content: every `.json5` file whose body declares `peppy_schema: "launcher/v1"` is treated as a launcher, regardless of its filename. The launcher is keyed by the file stem (e.g. `openarm01_sim_teleop.json5` becomes the launcher named `openarm01_sim_teleop`).
+- **Interfaces**, identified by content: every `.json5` file whose body declares `peppy_schema: "interface/v1"` is treated as an interface, regardless of its filename. An interface is a reusable contract of topics, services, and actions, keyed by the `name:tag` declared in its manifest; nodes reference interfaces by `name:tag` to declare conformance.
 
 Out of the box, four repositories are configured:
 
@@ -47,7 +47,7 @@ The two `conf/` files are JSON5 arrays. Each entry has an `id` (auto-assigned if
 
 | Type | Fields | Description |
 |------|--------|-------------|
-| `fs` | `path` | A local directory. Peppy recursively walks it, indexing every `peppy.json5` (node) and every `.json5` file whose body declares `peppy_schema: "launcher_v1"` (launcher) or `peppy_schema: "interface_v1"` (interface). |
+| `fs` | `path` | A local directory. Peppy recursively walks it, indexing every `peppy.json5` (node) and every `.json5` file whose body declares `peppy_schema: "launcher/v1"` (launcher) or `peppy_schema: "interface/v1"` (interface). |
 | `git` | `url`, `ref` (optional) | A git repository. Peppy shallow-clones it and scans it the same way as an `fs` source. Use `ref` to pin a branch, tag, or commit. |
 | `url` | `url` | An HTTP endpoint (not yet implemented). |
 
@@ -80,7 +80,7 @@ Re-scans all configured repositories and rebuilds the node, launcher, and interf
 - Reads `repositories.json5` (creates it with defaults on first run).
 - Skips any repository or path listed in `excluded_repositories.json5`.
 - Walks local directories and shallow-clones git repositories.
-- Records every `peppy.json5` as a node, every `.json5` file whose body declares `peppy_schema: "launcher_v1"` as a launcher (file stem becomes the launcher name), and every `.json5` file whose body declares `peppy_schema: "interface_v1"` as an interface (keyed by the `name:tag` in its manifest).
+- Records every `peppy.json5` as a node, every `.json5` file whose body declares `peppy_schema: "launcher/v1"` as a launcher (file stem becomes the launcher name), and every `.json5` file whose body declares `peppy_schema: "interface/v1"` as an interface (keyed by the `name:tag` in its manifest).
 - Reports each discovered node, launcher, interface, and excluded repository in real time.
 - Caches results in `~/.peppy/cache/nodes.json5`, `~/.peppy/cache/launchers.json5`, and `~/.peppy/cache/interfaces.json5`.
 

--- a/docs/src/content/docs/advanced_guides/services.mdx
+++ b/docs/src/content/docs/advanced_guides/services.mdx
@@ -17,7 +17,7 @@ Each service defines a `name`, an optional `request_message_format`, and an opti
 
 ```json5
 {
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "uvc_camera",
     tag: "v1",
@@ -143,7 +143,7 @@ Dependencies are declared in `manifest.depends_on` and referenced by `link_id` i
 
 ```json5
 {
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "robot_brain",
     tag: "v1",

--- a/docs/src/content/docs/advanced_guides/system_clock.mdx
+++ b/docs/src/content/docs/advanced_guides/system_clock.mdx
@@ -196,7 +196,7 @@ Subscribers see the same shape either way.
 
 ```json5 title="peppy_launcher.json5"
 {
-  peppy_schema: "launcher_v1",
+  peppy_schema: "launcher/v1",
   deployments: [
     {
       source: { local: "./uvc_camera" },

--- a/docs/src/content/docs/advanced_guides/topics.mdx
+++ b/docs/src/content/docs/advanced_guides/topics.mdx
@@ -18,7 +18,7 @@ Each topic defines a `name`, a `qos_profile`, and a `message_format`:
 
 ```json5
 {
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "uvc_camera",
     tag: "v1",
@@ -140,7 +140,7 @@ Dependencies are declared in `manifest.depends_on` and referenced by `link_id` i
 
 ```json5
 {
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "web_video_stream",
     tag: "v1",

--- a/docs/src/content/docs/guides/communication.mdx
+++ b/docs/src/content/docs/guides/communication.mdx
@@ -20,7 +20,7 @@ Each node is only aware of the interfaces it exposes and the ones it consumes, a
   <TabItem label="Python">
     ```json5
     {
-      peppy_schema: "node_v1",
+      peppy_schema: "node/v1",
       manifest: {
         name: "controller",
         tag: "v1",
@@ -50,7 +50,7 @@ Each node is only aware of the interfaces it exposes and the ones it consumes, a
   <TabItem label="Rust">
     ```json5
     {
-      peppy_schema: "node_v1",
+      peppy_schema: "node/v1",
       manifest: {
         name: "controller",
         tag: "v1",

--- a/docs/src/content/docs/guides/first_node.mdx
+++ b/docs/src/content/docs/guides/first_node.mdx
@@ -86,7 +86,7 @@ Let's open the `peppy.json5` file of the node we just created and explore it tog
   <TabItem label="Python">
     ```json5 title="peppy.json5"
     {
-      peppy_schema: "node_v1",
+      peppy_schema: "node/v1",
       manifest: {
         name: "hello_world",
         tag: "v1",
@@ -110,7 +110,7 @@ Let's open the `peppy.json5` file of the node we just created and explore it tog
   <TabItem label="Rust">
     ```json5 title="peppy.json5"
     {
-      peppy_schema: "node_v1",
+      peppy_schema: "node/v1",
       manifest: {
         name: "hello_world",
         tag: "v1",
@@ -133,7 +133,7 @@ Let's open the `peppy.json5` file of the node we just created and explore it tog
 </Tabs>
 
 Let's go through the different options:
- - `peppy_schema`: Identifies the structure of the configuration file. For node configs always set this to `"node_v1"`
+ - `peppy_schema`: Identifies the structure of the configuration file. For node configs always set this to `"node/v1"`
  - `manifest`: Contains information about the node. Each node is identified by its `name` and `tag`
  - `execution`: Contains the language and execution commands for the node
    - `language`: The programming language used by the node (e.g. `"python"`, `"rust"`)

--- a/docs/src/content/docs/guides/launch_files.mdx
+++ b/docs/src/content/docs/guides/launch_files.mdx
@@ -37,7 +37,7 @@ In the `examples/` directory, you'll find a launcher file for each language. Ope
   </TabItem>
 </Tabs>
 
- 1. The file is identified by `peppy_schema: "launcher_v1"` at the root: peppy uses this to distinguish launcher files from node `peppy.json5` files (which use `"node_v1"`)
+ 1. The file is identified by `peppy_schema: "launcher/v1"` at the root: peppy uses this to distinguish launcher files from node `peppy.json5` files (which use `"node/v1"`)
  2. All deployments are defined in the `deployments` array
  3. Each deployment requires a `source` and `instances` attribute
 

--- a/docs/src/content/docs/guides/snippets/interfaces/joint_command_source/peppy.json5
+++ b/docs/src/content/docs/guides/snippets/interfaces/joint_command_source/peppy.json5
@@ -1,5 +1,5 @@
 {
-  peppy_schema: "interface_v1",
+  peppy_schema: "interface/v1",
   manifest: {
     name: "joint_command_source",
     tag: "v1",

--- a/docs/src/content/docs/guides/snippets/interfaces/joint_state_source/peppy.json5
+++ b/docs/src/content/docs/guides/snippets/interfaces/joint_state_source/peppy.json5
@@ -1,5 +1,5 @@
 {
-  peppy_schema: "interface_v1",
+  peppy_schema: "interface/v1",
   manifest: {
     name: "joint_state_source",
     tag: "v1",

--- a/docs/src/content/docs/guides/snippets/python/arm_controller/peppy.json5
+++ b/docs/src/content/docs/guides/snippets/python/arm_controller/peppy.json5
@@ -1,5 +1,5 @@
 {
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "arm_controller",
     tag: "v1",

--- a/docs/src/content/docs/guides/snippets/python/hello_receiver/peppy.json5
+++ b/docs/src/content/docs/guides/snippets/python/hello_receiver/peppy.json5
@@ -1,5 +1,5 @@
 {
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "hello_receiver",
     tag: "v1",

--- a/docs/src/content/docs/guides/snippets/python/hello_world/peppy.json5
+++ b/docs/src/content/docs/guides/snippets/python/hello_world/peppy.json5
@@ -1,5 +1,5 @@
 {
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "hello_world",
     tag: "v1",

--- a/docs/src/content/docs/guides/snippets/python/hello_world_param/peppy.json5
+++ b/docs/src/content/docs/guides/snippets/python/hello_world_param/peppy.json5
@@ -1,5 +1,5 @@
 {
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "hello_world_param",
     tag: "v1",

--- a/docs/src/content/docs/guides/snippets/python/robot_arm/peppy.json5
+++ b/docs/src/content/docs/guides/snippets/python/robot_arm/peppy.json5
@@ -1,5 +1,5 @@
 {
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "robot_arm",
     tag: "v1",

--- a/docs/src/content/docs/guides/snippets/python/standalone/peppy.json5
+++ b/docs/src/content/docs/guides/snippets/python/standalone/peppy.json5
@@ -1,5 +1,5 @@
 {
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "standalone",
     tag: "v1",

--- a/docs/src/content/docs/guides/snippets/rust/arm_controller/peppy.json5
+++ b/docs/src/content/docs/guides/snippets/rust/arm_controller/peppy.json5
@@ -1,5 +1,5 @@
 {
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "arm_controller",
     tag: "v1",

--- a/docs/src/content/docs/guides/snippets/rust/first_node/peppy.json5
+++ b/docs/src/content/docs/guides/snippets/rust/first_node/peppy.json5
@@ -1,5 +1,5 @@
 {
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "hello_world",
     tag: "v1",

--- a/docs/src/content/docs/guides/snippets/rust/hello_receiver/peppy.json5
+++ b/docs/src/content/docs/guides/snippets/rust/hello_receiver/peppy.json5
@@ -1,5 +1,5 @@
 {
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "hello_receiver",
     tag: "v1",

--- a/docs/src/content/docs/guides/snippets/rust/hello_world/peppy.json5
+++ b/docs/src/content/docs/guides/snippets/rust/hello_world/peppy.json5
@@ -1,5 +1,5 @@
 {
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "hello_world",
     tag: "v1",

--- a/docs/src/content/docs/guides/snippets/rust/hello_world_param/peppy.json5
+++ b/docs/src/content/docs/guides/snippets/rust/hello_world_param/peppy.json5
@@ -1,5 +1,5 @@
 {
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "hello_world_param",
     tag: "v1",

--- a/docs/src/content/docs/guides/snippets/rust/robot_arm/peppy.json5
+++ b/docs/src/content/docs/guides/snippets/rust/robot_arm/peppy.json5
@@ -1,5 +1,5 @@
 {
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "robot_arm",
     tag: "v1",

--- a/docs/src/content/docs/guides/snippets/rust/standalone/peppy.json5
+++ b/docs/src/content/docs/guides/snippets/rust/standalone/peppy.json5
@@ -1,5 +1,5 @@
 {
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "standalone",
     tag: "v1",

--- a/docs/src/content/docs/reference/message_format.mdx
+++ b/docs/src/content/docs/reference/message_format.mdx
@@ -225,7 +225,7 @@ A full `peppy.json5` topic using multiple schema types:
 
 ```json5
 {
-  peppy_schema: "node_v1",
+  peppy_schema: "node/v1",
   manifest: {
     name: "arm_controller",
     tag: "v1"

--- a/docs/tests/integration/src/snippet_runner.rs
+++ b/docs/tests/integration/src/snippet_runner.rs
@@ -195,7 +195,7 @@ pub fn run_snippet_with_deps(
 /// Run a snippet whose `depends_on.interfaces` / `conforms_to` references are
 /// resolved from an interface repository rather than from other nodes in the
 /// stack. `interfaces_root` is a workspace-relative directory of
-/// `interface_v1` documents; it is registered as an fs repo and refreshed,
+/// `interface/v1` documents; it is registered as an fs repo and refreshed,
 /// then the snippet is synced with `-r`, added, built, and launched with NO
 /// `--bind`. This is the launch path for an optional, `from_any` interface
 /// consumer: it must come up with zero producers present.

--- a/docs/tests/integration/tests/snippet_configs.rs
+++ b/docs/tests/integration/tests/snippet_configs.rs
@@ -71,7 +71,7 @@ fn assert_parses_with_matching_schema(path: &Path) {
             );
         }
         PeppySchema::LauncherV1 => panic!(
-            "unexpected launcher_v1 among node/interface snippets: {}",
+            "unexpected launcher/v1 among node/interface snippets: {}",
             path.display()
         ),
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized Peppy schema identifiers across examples, templates, and test fixtures to use slash format (for example, `node/v1`, `launcher/v1`, `interface/v1`) for consistent creating, syncing, launching, and running.
  * Improved build reliability by more accurately detecting changes in dependency sources and triggering rebuilds when needed.
* **Documentation**
  * Updated guides and reference snippets to reflect the slash-form schema identifier format throughout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->