### PR TITLE
Propagate organization namespace through daemon and restart generation on login/logout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,7 +406,6 @@ dependencies = [
 [[package]]
 name = "build-helpers"
 version = "0.0.1"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#69dc57ea609dd4fc1beedfc17fbf009d9d94bc50"
 dependencies = [
  "sha2 0.11.0",
 ]
@@ -607,7 +606,6 @@ dependencies = [
 [[package]]
 name = "config-test-support"
 version = "0.0.1"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#69dc57ea609dd4fc1beedfc17fbf009d9d94bc50"
 dependencies = [
  "askama",
  "git2",
@@ -749,7 +747,6 @@ dependencies = [
 [[package]]
 name = "core-node-api"
 version = "0.0.1"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#69dc57ea609dd4fc1beedfc17fbf009d9d94bc50"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -2300,7 +2297,6 @@ dependencies = [
 [[package]]
 name = "json5-pretty"
 version = "0.0.1"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#69dc57ea609dd4fc1beedfc17fbf009d9d94bc50"
 dependencies = [
  "serde",
  "serde_json",
@@ -3156,7 +3152,6 @@ dependencies = [
 [[package]]
 name = "peppy-config-model"
 version = "0.0.1"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#69dc57ea609dd4fc1beedfc17fbf009d9d94bc50"
 dependencies = [
  "capnp",
  "clap",
@@ -3172,6 +3167,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "walkdir",
+ "zenoh-keyexpr",
 ]
 
 [[package]]
@@ -3181,7 +3177,6 @@ version = "0.0.1"
 [[package]]
 name = "peppylib-rs"
 version = "0.0.1"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#69dc57ea609dd4fc1beedfc17fbf009d9d94bc50"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -3357,7 +3352,6 @@ dependencies = [
 [[package]]
 name = "pmi"
 version = "0.0.1"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#69dc57ea609dd4fc1beedfc17fbf009d9d94bc50"
 dependencies = [
  "build-helpers",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,7 +407,7 @@ dependencies = [
 [[package]]
 name = "build-helpers"
 version = "0.0.1"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#0d41745ad1638802b0f3ebb66d0433f2c43ac6e0"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#ed46a7adcd06fe81b60eb3d2dd5b4be313dcb1e2"
 dependencies = [
  "sha2 0.11.0",
 ]
@@ -608,7 +608,7 @@ dependencies = [
 [[package]]
 name = "config-test-support"
 version = "0.0.1"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#0d41745ad1638802b0f3ebb66d0433f2c43ac6e0"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#ed46a7adcd06fe81b60eb3d2dd5b4be313dcb1e2"
 dependencies = [
  "askama",
  "git2",
@@ -750,7 +750,7 @@ dependencies = [
 [[package]]
 name = "core-node-api"
 version = "0.0.1"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#0d41745ad1638802b0f3ebb66d0433f2c43ac6e0"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#ed46a7adcd06fe81b60eb3d2dd5b4be313dcb1e2"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -2301,7 +2301,7 @@ dependencies = [
 [[package]]
 name = "json5-pretty"
 version = "0.0.1"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#0d41745ad1638802b0f3ebb66d0433f2c43ac6e0"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#ed46a7adcd06fe81b60eb3d2dd5b4be313dcb1e2"
 dependencies = [
  "serde",
  "serde_json",
@@ -3150,7 +3150,7 @@ dependencies = [
 [[package]]
 name = "peppy-config-model"
 version = "0.0.1"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#0d41745ad1638802b0f3ebb66d0433f2c43ac6e0"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#ed46a7adcd06fe81b60eb3d2dd5b4be313dcb1e2"
 dependencies = [
  "capnp",
  "clap",
@@ -3176,7 +3176,7 @@ version = "0.0.1"
 [[package]]
 name = "peppylib-rs"
 version = "0.0.1"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#0d41745ad1638802b0f3ebb66d0433f2c43ac6e0"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#ed46a7adcd06fe81b60eb3d2dd5b4be313dcb1e2"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -3352,7 +3352,7 @@ dependencies = [
 [[package]]
 name = "pmi"
 version = "0.0.1"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#0d41745ad1638802b0f3ebb66d0433f2c43ac6e0"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#ed46a7adcd06fe81b60eb3d2dd5b4be313dcb1e2"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -4024,9 +4024,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
  "web-time",
  "zeroize",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,9 +276,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -286,14 +286,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.41.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -406,6 +407,7 @@ dependencies = [
 [[package]]
 name = "build-helpers"
 version = "0.0.1"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#0d41745ad1638802b0f3ebb66d0433f2c43ac6e0"
 dependencies = [
  "sha2 0.11.0",
 ]
@@ -606,6 +608,7 @@ dependencies = [
 [[package]]
 name = "config-test-support"
 version = "0.0.1"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#0d41745ad1638802b0f3ebb66d0433f2c43ac6e0"
 dependencies = [
  "askama",
  "git2",
@@ -747,6 +750,7 @@ dependencies = [
 [[package]]
 name = "core-node-api"
 version = "0.0.1"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#0d41745ad1638802b0f3ebb66d0433f2c43ac6e0"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -2297,6 +2301,7 @@ dependencies = [
 [[package]]
 name = "json5-pretty"
 version = "0.0.1"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#0d41745ad1638802b0f3ebb66d0433f2c43ac6e0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2304,9 +2309,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.46.6"
+version = "0.46.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8374249b1bdce1c1773a09fa294347e19e4bfeb86d845c2d8ebaf8a8dbf11233"
+checksum = "185abd1edcef44ac028ec6588ad1360155fbd0a8baa20243a28f5b2a05537a48"
 dependencies = [
  "ahash",
  "bytecount",
@@ -3145,6 +3150,7 @@ dependencies = [
 [[package]]
 name = "peppy-config-model"
 version = "0.0.1"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#0d41745ad1638802b0f3ebb66d0433f2c43ac6e0"
 dependencies = [
  "capnp",
  "clap",
@@ -3170,6 +3176,7 @@ version = "0.0.1"
 [[package]]
 name = "peppylib-rs"
 version = "0.0.1"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#0d41745ad1638802b0f3ebb66d0433f2c43ac6e0"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -3345,6 +3352,7 @@ dependencies = [
 [[package]]
 name = "pmi"
 version = "0.0.1"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#0d41745ad1638802b0f3ebb66d0433f2c43ac6e0"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -3715,9 +3723,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.46.6"
+version = "0.46.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65a910f9d63351f9c9d7dc3053d02b214ea3a005917140c70087d7b59cbc5bb1"
+checksum = "c335a4796e6081e384712c269f29ed8d2f6613e7afdd54a8467bb7d48f99859f"
 dependencies = [
  "ahash",
  "fluent-uri",
@@ -4774,9 +4782,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.51"
+version = "0.3.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
+checksum = "0e48db7b415311b615f910b3dcaa4557bcd4bf1982379c95c223fd8c2a20e210"
 dependencies = [
  "deranged",
  "num-conv",
@@ -4794,9 +4802,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.30"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2113,9 +2113,9 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.18.4"
+version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
+checksum = "993f007684f2e9727160da8b960ec161264703bfd1af084fd2e34d040c9a0dd4"
 dependencies = [
  "console",
  "portable-atomic",
@@ -2975,13 +2975,12 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "open"
-version = "5.3.5"
+version = "5.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fbaa89d2ddc8473c78a3adf69eea8cffa28c483b8e02a971ef31527cd0fc92c"
+checksum = "cd8d3b65c44123a56e0133d2cd06ce4361bd3ca99d41198b2f25e3c3db9b8b4a"
 dependencies = [
  "is-wsl",
  "libc",
- "pathdiff",
 ]
 
 [[package]]
@@ -3073,12 +3072,6 @@ checksum = "c2a97453bc21a968f722df730bfe11bd08745cb50d1300b0df2bda131dece136"
 dependencies = [
  "smallvec",
 ]
-
-[[package]]
-name = "pathdiff"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "pem"

--- a/crates/core-node-internal/src/services.rs
+++ b/crates/core-node-internal/src/services.rs
@@ -118,6 +118,11 @@ pub struct CoreNodeConfig {
     /// Daemon-global messaging mode + peer buffer sizes, injected into every
     /// spawned node's runtime config (see `node::run`).
     pub peppy_config: config::peppy_config::PeppyConfig,
+    /// The daemon's organization namespace for this generation (`"local"` when
+    /// logged out, else the org id). Stamped onto every spawned node's
+    /// `discovery.organization_id` so the node opens its session under the same
+    /// namespace as the daemon.
+    pub organization_namespace: String,
     /// Cancelled at the start of daemon shutdown to stop the core node's own
     /// clock + heartbeat publishers before the messaging session is closed, so
     /// they do not spin against a closed session logging a failed publish on
@@ -142,6 +147,9 @@ pub struct CoreNode {
     /// Daemon-global messaging mode + peer buffer sizes, read once at startup.
     /// Injected into every spawned node's runtime config (see `node::run`).
     peppy_config: config::peppy_config::PeppyConfig,
+    /// The daemon's organization namespace for this generation, stamped onto
+    /// every spawned node so it opens its session under the daemon's namespace.
+    organization_namespace: String,
     /// Cancelled on shutdown to stop the clock + heartbeat publishers cleanly.
     /// Cloned into each publisher task in [`CoreNode::start_with_ready`].
     shutdown_token: CancellationToken,
@@ -211,6 +219,7 @@ impl CoreNode {
             root_dir,
             peppy_dirs,
             peppy_config,
+            organization_namespace,
             shutdown_token,
         } = config;
 
@@ -269,6 +278,7 @@ impl CoreNode {
             heartbeat_interval,
             daemon_use_sim_time,
             peppy_config,
+            organization_namespace,
             shutdown_token,
             started: AtomicBool::new(false),
         }
@@ -467,7 +477,10 @@ impl CoreNode {
                         health_monitor_timeout: self.health_monitor_timeout,
                     },
                     use_sim_time: self.daemon_use_sim_time,
-                    daemon_defaults: node::DaemonDefaults::from_peppy_config(&self.peppy_config),
+                    daemon_defaults: node::DaemonDefaults::from_peppy_config(
+                        &self.peppy_config,
+                        self.organization_namespace.clone(),
+                    ),
                     shutdown_token: self.shutdown_token.clone(),
                 },
             )
@@ -545,7 +558,10 @@ impl CoreNode {
                     peppy_dirs: self.peppy_dirs.clone(),
                     health_monitor_interval: self.health_monitor_interval,
                     health_monitor_timeout: self.health_monitor_timeout,
-                    daemon_defaults: node::DaemonDefaults::from_peppy_config(&self.peppy_config),
+                    daemon_defaults: node::DaemonDefaults::from_peppy_config(
+                        &self.peppy_config,
+                        self.organization_namespace.clone(),
+                    ),
                     shutdown_token: self.shutdown_token.clone(),
                 },
             )

--- a/crates/core-node-internal/src/services/node/run.rs
+++ b/crates/core-node-internal/src/services/node/run.rs
@@ -63,7 +63,7 @@ fn drain_quiet_window(is_container: bool) -> Duration {
 /// constructors through the run/launch context chains down to
 /// [`apply_daemon_defaults`], so the next daemon-global knob touches this
 /// struct and that function, not every context in between.
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct DaemonDefaults {
     /// Daemon-global messaging mode, injected into every spawned node.
     pub messaging_mode: Mode,
@@ -76,18 +76,27 @@ pub struct DaemonDefaults {
     /// node so its runtime bounds registered shutdown hooks by the same window
     /// the daemon waits before force-killing a stopping node.
     pub shutdown_grace_secs: u64,
+    /// The daemon's organization namespace (`"local"` when logged out, else the
+    /// org id), stamped onto every spawned node's `discovery.organization_id` so
+    /// the node opens its session under exactly the daemon's namespace and stays
+    /// routing-isolated across the federation. Resolved per daemon generation
+    /// from the cached credentials, not from `peppy_config`, so it is threaded in
+    /// rather than derived in `from_peppy_config`.
+    pub organization_namespace: String,
 }
 
 impl DaemonDefaults {
     /// Resolves the per-node defaults from the daemon's loaded `peppy_config`
     /// — the single place that knows which of its fields are shipped to
-    /// spawned nodes.
-    pub fn from_peppy_config(config: &PeppyConfig) -> Self {
+    /// spawned nodes — plus the daemon's resolved `organization_namespace`
+    /// (which comes from the credentials, not `peppy_config`).
+    pub fn from_peppy_config(config: &PeppyConfig, organization_namespace: String) -> Self {
         Self {
             messaging_mode: config.mode,
             peer_buffer: config.peer,
             daemon_grace_secs: config.lifecycle.daemon_grace_secs,
             shutdown_grace_secs: config.lifecycle.shutdown_grace_secs,
+            organization_namespace,
         }
     }
 }
@@ -138,6 +147,10 @@ fn apply_daemon_defaults(
     cfg.discovery.high_throughput_buffer_size = defaults.peer_buffer.high_throughput_buffer_size;
     cfg.lifecycle.daemon_grace_secs = defaults.daemon_grace_secs;
     cfg.lifecycle.shutdown_grace_secs = defaults.shutdown_grace_secs;
+    // Stamp the daemon's organization namespace so the spawned node opens its
+    // session under it (`peppylib` resolves `discovery.organization_id` through
+    // `resolve_session_namespace`). Always set: `"local"` when logged out.
+    cfg.discovery.organization_id = Some(defaults.organization_namespace.clone());
 }
 
 struct ProcessNodeRunContext {
@@ -1597,6 +1610,7 @@ mod tests {
             peer_buffer: peer,
             daemon_grace_secs: 123,
             shutdown_grace_secs: 17,
+            organization_namespace: "local".to_string(),
         }
     }
 
@@ -1643,8 +1657,8 @@ mod tests {
         );
     }
 
-    /// Buffer sizes and both grace periods are applied regardless of mode or
-    /// container placement.
+    /// Buffer sizes, both grace periods, and the organization namespace are
+    /// applied regardless of mode or container placement.
     #[test]
     fn apply_daemon_defaults_always_applies_buffers_and_grace() {
         let peer = PeerConfig {
@@ -1662,7 +1676,23 @@ mod tests {
             assert_eq!(cfg.discovery.high_throughput_buffer_size, 4096);
             assert_eq!(cfg.lifecycle.daemon_grace_secs, 123);
             assert_eq!(cfg.lifecycle.shutdown_grace_secs, 17);
+            // The node is stamped with the daemon's namespace, so it opens its
+            // session under the same routing-isolation prefix as the daemon.
+            assert_eq!(cfg.discovery.organization_id.as_deref(), Some("local"));
         }
+    }
+
+    /// A logged-in daemon stamps the org id (not `local`) onto every node.
+    #[test]
+    fn apply_daemon_defaults_stamps_the_org_namespace() {
+        let mut defaults = daemon_defaults(Mode::Peer, PeerConfig::default());
+        defaults.organization_namespace = "550e8400-e29b-41d4-a716-446655440000".to_string();
+        let mut cfg = runtime_config_for_test();
+        apply_daemon_defaults(&mut cfg, defaults, false);
+        assert_eq!(
+            cfg.discovery.organization_id.as_deref(),
+            Some("550e8400-e29b-41d4-a716-446655440000")
+        );
     }
 
     #[test]

--- a/crates/core-node-internal/src/services/stack/launch.rs
+++ b/crates/core-node-internal/src/services/stack/launch.rs
@@ -704,7 +704,7 @@ async fn start_node_directly(
         peppy_dirs: ctx.peppy_dirs.clone(),
         health_monitor_interval: ctx.timeouts.health_monitor_interval,
         health_monitor_timeout: ctx.timeouts.health_monitor_timeout,
-        daemon_defaults: ctx.daemon_defaults,
+        daemon_defaults: ctx.daemon_defaults.clone(),
         shutdown_token: ctx.shutdown_token.clone(),
     };
 

--- a/crates/core-node-internal/src/services/tests.rs
+++ b/crates/core-node-internal/src/services/tests.rs
@@ -40,6 +40,7 @@ fn test_core_node_config(
         root_dir: std::env::temp_dir(),
         peppy_dirs,
         peppy_config: config::peppy_config::PeppyConfig::default(),
+        organization_namespace: "local".to_string(),
         shutdown_token: tokio_util::sync::CancellationToken::new(),
     }
 }

--- a/crates/core-node-internal/tests/common.rs
+++ b/crates/core-node-internal/tests/common.rs
@@ -1790,6 +1790,7 @@ async fn start_core_node_with_messenger(
         root_dir,
         peppy_dirs: peppy_dirs.clone(),
         peppy_config,
+        organization_namespace: "local".to_string(),
         shutdown_token: shutdown_token.clone(),
     });
     let core_node_name = core_node.node_name().to_string();

--- a/crates/core-node-internal/tests/common.rs
+++ b/crates/core-node-internal/tests/common.rs
@@ -1693,6 +1693,12 @@ pub async fn start_core_node_with_real_messenger_in_mode(
         None,
         mode.gossip(),
         pmi::SubscriberBufferSizes::default(),
+        // The core node stamps the `local` org namespace onto every node it
+        // spawns (see `organization_namespace` below); its own session must open
+        // under the same namespace or it cannot reach a spawned node's
+        // node_ready/health services. Mirrors the daemon's
+        // `with_router(...).with_namespace(...)` pairing in production.
+        Some(config::org::OrgNamespace::local()),
     )
     .await
     .expect("failed to start zenoh router for test");

--- a/crates/core-node-internal/tests/latency/harness.rs
+++ b/crates/core-node-internal/tests/latency/harness.rs
@@ -452,13 +452,9 @@ pub async fn start_scenario(lang: Lang) -> Scenario {
     };
     let mut driver_child = spawn_rust_node_release(&driver_dir, &driver_env);
 
-    let control = MessengerHandle::from_host_port_with_namespace(
-        &host,
-        port,
-        Some(config::org::OrgNamespace::local()),
-    )
-    .await
-    .expect("control messenger");
+    let control = MessengerHandle::connect(&host, port)
+        .await
+        .expect("control messenger");
 
     {
         let ctx = WaitContext {

--- a/crates/core-node-internal/tests/latency/harness.rs
+++ b/crates/core-node-internal/tests/latency/harness.rs
@@ -452,9 +452,13 @@ pub async fn start_scenario(lang: Lang) -> Scenario {
     };
     let mut driver_child = spawn_rust_node_release(&driver_dir, &driver_env);
 
-    let control = MessengerHandle::from_host_port(&host, port)
-        .await
-        .expect("control messenger");
+    let control = MessengerHandle::from_host_port_with_namespace(
+        &host,
+        port,
+        Some(config::org::OrgNamespace::local()),
+    )
+    .await
+    .expect("control messenger");
 
     {
         let ctx = WaitContext {

--- a/crates/generator-internal/tests/python/actions_communication.rs
+++ b/crates/generator-internal/tests/python/actions_communication.rs
@@ -341,13 +341,9 @@ if __name__ == "__main__":
     let exposer_runtime_config_str = exposer_runtime_config_path.to_str().unwrap().to_owned();
     let consumer_runtime_config_str = consumer_runtime_config_path.to_str().unwrap().to_owned();
 
-    let messenger = peppylib::MessengerHandle::from_host_port_with_namespace(
-        &router_host,
-        router_port,
-        Some(config::org::OrgNamespace::local()),
-    )
-    .await
-    .expect("failed to create messenger for test control");
+    let messenger = peppylib::MessengerHandle::connect(&router_host, router_port)
+        .await
+        .expect("failed to create messenger for test control");
 
     // Spawn exposer first so it's ready to handle requests
     let mut exposer_child = spawn_python_run(
@@ -658,13 +654,9 @@ if __name__ == "__main__":
     let exposer_runtime_config_str = exposer_runtime_config_path.to_str().unwrap().to_owned();
     let consumer_runtime_config_str = consumer_runtime_config_path.to_str().unwrap().to_owned();
 
-    let messenger = peppylib::MessengerHandle::from_host_port_with_namespace(
-        &router_host,
-        router_port,
-        Some(config::org::OrgNamespace::local()),
-    )
-    .await
-    .expect("failed to create messenger for test control");
+    let messenger = peppylib::MessengerHandle::connect(&router_host, router_port)
+        .await
+        .expect("failed to create messenger for test control");
 
     // Spawn exposer first so it's ready to handle requests
     let mut exposer_child = spawn_python_run(
@@ -988,13 +980,9 @@ if __name__ == "__main__":
     let exposer_runtime_config_str = exposer_runtime_config_path.to_str().unwrap().to_owned();
     let consumer_runtime_config_str = consumer_runtime_config_path.to_str().unwrap().to_owned();
 
-    let messenger = peppylib::MessengerHandle::from_host_port_with_namespace(
-        &router_host,
-        router_port,
-        Some(config::org::OrgNamespace::local()),
-    )
-    .await
-    .expect("failed to create messenger for test control");
+    let messenger = peppylib::MessengerHandle::connect(&router_host, router_port)
+        .await
+        .expect("failed to create messenger for test control");
 
     let mut exposer_child = spawn_python_run(
         &user_node_exposer,
@@ -1332,13 +1320,9 @@ if __name__ == "__main__":
     let exposer_runtime_config_str = exposer_runtime_config_path.to_str().unwrap().to_owned();
     let consumer_runtime_config_str = consumer_runtime_config_path.to_str().unwrap().to_owned();
 
-    let messenger = peppylib::MessengerHandle::from_host_port_with_namespace(
-        &router_host,
-        router_port,
-        Some(config::org::OrgNamespace::local()),
-    )
-    .await
-    .expect("failed to create messenger for test control");
+    let messenger = peppylib::MessengerHandle::connect(&router_host, router_port)
+        .await
+        .expect("failed to create messenger for test control");
 
     let mut exposer_child = spawn_python_run(
         &user_node_exposer,
@@ -1705,13 +1689,9 @@ if __name__ == "__main__":
     let exposer_runtime_config_str = exposer_runtime_config_path.to_str().unwrap().to_owned();
     let consumer_runtime_config_str = consumer_runtime_config_path.to_str().unwrap().to_owned();
 
-    let messenger = peppylib::MessengerHandle::from_host_port_with_namespace(
-        &router_host,
-        router_port,
-        Some(config::org::OrgNamespace::local()),
-    )
-    .await
-    .expect("failed to create messenger for test control");
+    let messenger = peppylib::MessengerHandle::connect(&router_host, router_port)
+        .await
+        .expect("failed to create messenger for test control");
 
     let mut exposer_child = spawn_python_run(
         &user_node_exposer,
@@ -2076,13 +2056,9 @@ if __name__ == "__main__":
     let exposer_runtime_config_str = exposer_runtime_config_path.to_str().unwrap().to_owned();
     let consumer_runtime_config_str = consumer_runtime_config_path.to_str().unwrap().to_owned();
 
-    let messenger = peppylib::MessengerHandle::from_host_port_with_namespace(
-        &router_host,
-        router_port,
-        Some(config::org::OrgNamespace::local()),
-    )
-    .await
-    .expect("failed to create messenger for test control");
+    let messenger = peppylib::MessengerHandle::connect(&router_host, router_port)
+        .await
+        .expect("failed to create messenger for test control");
 
     let mut exposer_child = spawn_python_run(
         &user_node_exposer,
@@ -2424,13 +2400,9 @@ if __name__ == "__main__":
     let exposer_runtime_config_str = exposer_runtime_config_path.to_str().unwrap().to_owned();
     let consumer_runtime_config_str = consumer_runtime_config_path.to_str().unwrap().to_owned();
 
-    let messenger = peppylib::MessengerHandle::from_host_port_with_namespace(
-        &router_host,
-        router_port,
-        Some(config::org::OrgNamespace::local()),
-    )
-    .await
-    .expect("failed to create messenger for test control");
+    let messenger = peppylib::MessengerHandle::connect(&router_host, router_port)
+        .await
+        .expect("failed to create messenger for test control");
 
     let mut exposer_child = spawn_python_run(
         &user_node_exposer,

--- a/crates/generator-internal/tests/python/actions_communication.rs
+++ b/crates/generator-internal/tests/python/actions_communication.rs
@@ -341,9 +341,13 @@ if __name__ == "__main__":
     let exposer_runtime_config_str = exposer_runtime_config_path.to_str().unwrap().to_owned();
     let consumer_runtime_config_str = consumer_runtime_config_path.to_str().unwrap().to_owned();
 
-    let messenger = peppylib::MessengerHandle::from_host_port(&router_host, router_port)
-        .await
-        .expect("failed to create messenger for test control");
+    let messenger = peppylib::MessengerHandle::from_host_port_with_namespace(
+        &router_host,
+        router_port,
+        Some(config::org::OrgNamespace::local()),
+    )
+    .await
+    .expect("failed to create messenger for test control");
 
     // Spawn exposer first so it's ready to handle requests
     let mut exposer_child = spawn_python_run(
@@ -654,9 +658,13 @@ if __name__ == "__main__":
     let exposer_runtime_config_str = exposer_runtime_config_path.to_str().unwrap().to_owned();
     let consumer_runtime_config_str = consumer_runtime_config_path.to_str().unwrap().to_owned();
 
-    let messenger = peppylib::MessengerHandle::from_host_port(&router_host, router_port)
-        .await
-        .expect("failed to create messenger for test control");
+    let messenger = peppylib::MessengerHandle::from_host_port_with_namespace(
+        &router_host,
+        router_port,
+        Some(config::org::OrgNamespace::local()),
+    )
+    .await
+    .expect("failed to create messenger for test control");
 
     // Spawn exposer first so it's ready to handle requests
     let mut exposer_child = spawn_python_run(
@@ -980,9 +988,13 @@ if __name__ == "__main__":
     let exposer_runtime_config_str = exposer_runtime_config_path.to_str().unwrap().to_owned();
     let consumer_runtime_config_str = consumer_runtime_config_path.to_str().unwrap().to_owned();
 
-    let messenger = peppylib::MessengerHandle::from_host_port(&router_host, router_port)
-        .await
-        .expect("failed to create messenger for test control");
+    let messenger = peppylib::MessengerHandle::from_host_port_with_namespace(
+        &router_host,
+        router_port,
+        Some(config::org::OrgNamespace::local()),
+    )
+    .await
+    .expect("failed to create messenger for test control");
 
     let mut exposer_child = spawn_python_run(
         &user_node_exposer,
@@ -1320,9 +1332,13 @@ if __name__ == "__main__":
     let exposer_runtime_config_str = exposer_runtime_config_path.to_str().unwrap().to_owned();
     let consumer_runtime_config_str = consumer_runtime_config_path.to_str().unwrap().to_owned();
 
-    let messenger = peppylib::MessengerHandle::from_host_port(&router_host, router_port)
-        .await
-        .expect("failed to create messenger for test control");
+    let messenger = peppylib::MessengerHandle::from_host_port_with_namespace(
+        &router_host,
+        router_port,
+        Some(config::org::OrgNamespace::local()),
+    )
+    .await
+    .expect("failed to create messenger for test control");
 
     let mut exposer_child = spawn_python_run(
         &user_node_exposer,
@@ -1689,9 +1705,13 @@ if __name__ == "__main__":
     let exposer_runtime_config_str = exposer_runtime_config_path.to_str().unwrap().to_owned();
     let consumer_runtime_config_str = consumer_runtime_config_path.to_str().unwrap().to_owned();
 
-    let messenger = peppylib::MessengerHandle::from_host_port(&router_host, router_port)
-        .await
-        .expect("failed to create messenger for test control");
+    let messenger = peppylib::MessengerHandle::from_host_port_with_namespace(
+        &router_host,
+        router_port,
+        Some(config::org::OrgNamespace::local()),
+    )
+    .await
+    .expect("failed to create messenger for test control");
 
     let mut exposer_child = spawn_python_run(
         &user_node_exposer,
@@ -2056,9 +2076,13 @@ if __name__ == "__main__":
     let exposer_runtime_config_str = exposer_runtime_config_path.to_str().unwrap().to_owned();
     let consumer_runtime_config_str = consumer_runtime_config_path.to_str().unwrap().to_owned();
 
-    let messenger = peppylib::MessengerHandle::from_host_port(&router_host, router_port)
-        .await
-        .expect("failed to create messenger for test control");
+    let messenger = peppylib::MessengerHandle::from_host_port_with_namespace(
+        &router_host,
+        router_port,
+        Some(config::org::OrgNamespace::local()),
+    )
+    .await
+    .expect("failed to create messenger for test control");
 
     let mut exposer_child = spawn_python_run(
         &user_node_exposer,
@@ -2400,9 +2424,13 @@ if __name__ == "__main__":
     let exposer_runtime_config_str = exposer_runtime_config_path.to_str().unwrap().to_owned();
     let consumer_runtime_config_str = consumer_runtime_config_path.to_str().unwrap().to_owned();
 
-    let messenger = peppylib::MessengerHandle::from_host_port(&router_host, router_port)
-        .await
-        .expect("failed to create messenger for test control");
+    let messenger = peppylib::MessengerHandle::from_host_port_with_namespace(
+        &router_host,
+        router_port,
+        Some(config::org::OrgNamespace::local()),
+    )
+    .await
+    .expect("failed to create messenger for test control");
 
     let mut exposer_child = spawn_python_run(
         &user_node_exposer,

--- a/crates/generator-internal/tests/python/services_communication.rs
+++ b/crates/generator-internal/tests/python/services_communication.rs
@@ -252,9 +252,13 @@ if __name__ == "__main__":
         exposer_runtime_config_path.to_str().unwrap().to_owned();
     let user_node_consumer_config_str = consumer_runtime_config_path.to_str().unwrap().to_owned();
 
-    let messenger = peppylib::MessengerHandle::from_host_port(&router_host, router_port)
-        .await
-        .expect("failed to create messenger for test control");
+    let messenger = peppylib::MessengerHandle::from_host_port_with_namespace(
+        &router_host,
+        router_port,
+        Some(config::org::OrgNamespace::local()),
+    )
+    .await
+    .expect("failed to create messenger for test control");
     let ctx = WaitContext {
         messenger: &messenger,
         bound_core_node: TEST_CORE_NODE,
@@ -557,9 +561,13 @@ if __name__ == "__main__":
     let exposer_runtime_config_str = exposer_runtime_config_path.to_str().unwrap().to_owned();
     let consumer_runtime_config_str = consumer_runtime_config_path.to_str().unwrap().to_owned();
 
-    let messenger = peppylib::MessengerHandle::from_host_port(&router_host, router_port)
-        .await
-        .expect("failed to create messenger for test control");
+    let messenger = peppylib::MessengerHandle::from_host_port_with_namespace(
+        &router_host,
+        router_port,
+        Some(config::org::OrgNamespace::local()),
+    )
+    .await
+    .expect("failed to create messenger for test control");
     let ctx = WaitContext {
         messenger: &messenger,
         bound_core_node: TEST_CORE_NODE,
@@ -934,9 +942,13 @@ if __name__ == "__main__":
     let exposer2_runtime_config_str = exposer2_runtime_config_path.to_str().unwrap().to_owned();
     let consumer_runtime_config_str = consumer_runtime_config_path.to_str().unwrap().to_owned();
 
-    let messenger = peppylib::MessengerHandle::from_host_port(&router_host, router_port)
-        .await
-        .expect("failed to create messenger for test control");
+    let messenger = peppylib::MessengerHandle::from_host_port_with_namespace(
+        &router_host,
+        router_port,
+        Some(config::org::OrgNamespace::local()),
+    )
+    .await
+    .expect("failed to create messenger for test control");
     let ctx = WaitContext {
         messenger: &messenger,
         bound_core_node: TEST_CORE_NODE,

--- a/crates/generator-internal/tests/python/services_communication.rs
+++ b/crates/generator-internal/tests/python/services_communication.rs
@@ -252,13 +252,9 @@ if __name__ == "__main__":
         exposer_runtime_config_path.to_str().unwrap().to_owned();
     let user_node_consumer_config_str = consumer_runtime_config_path.to_str().unwrap().to_owned();
 
-    let messenger = peppylib::MessengerHandle::from_host_port_with_namespace(
-        &router_host,
-        router_port,
-        Some(config::org::OrgNamespace::local()),
-    )
-    .await
-    .expect("failed to create messenger for test control");
+    let messenger = peppylib::MessengerHandle::connect(&router_host, router_port)
+        .await
+        .expect("failed to create messenger for test control");
     let ctx = WaitContext {
         messenger: &messenger,
         bound_core_node: TEST_CORE_NODE,
@@ -561,13 +557,9 @@ if __name__ == "__main__":
     let exposer_runtime_config_str = exposer_runtime_config_path.to_str().unwrap().to_owned();
     let consumer_runtime_config_str = consumer_runtime_config_path.to_str().unwrap().to_owned();
 
-    let messenger = peppylib::MessengerHandle::from_host_port_with_namespace(
-        &router_host,
-        router_port,
-        Some(config::org::OrgNamespace::local()),
-    )
-    .await
-    .expect("failed to create messenger for test control");
+    let messenger = peppylib::MessengerHandle::connect(&router_host, router_port)
+        .await
+        .expect("failed to create messenger for test control");
     let ctx = WaitContext {
         messenger: &messenger,
         bound_core_node: TEST_CORE_NODE,
@@ -942,13 +934,9 @@ if __name__ == "__main__":
     let exposer2_runtime_config_str = exposer2_runtime_config_path.to_str().unwrap().to_owned();
     let consumer_runtime_config_str = consumer_runtime_config_path.to_str().unwrap().to_owned();
 
-    let messenger = peppylib::MessengerHandle::from_host_port_with_namespace(
-        &router_host,
-        router_port,
-        Some(config::org::OrgNamespace::local()),
-    )
-    .await
-    .expect("failed to create messenger for test control");
+    let messenger = peppylib::MessengerHandle::connect(&router_host, router_port)
+        .await
+        .expect("failed to create messenger for test control");
     let ctx = WaitContext {
         messenger: &messenger,
         bound_core_node: TEST_CORE_NODE,

--- a/crates/generator-internal/tests/python/topics_communication.rs
+++ b/crates/generator-internal/tests/python/topics_communication.rs
@@ -290,9 +290,13 @@ if __name__ == "__main__":
         )],
     );
 
-    let messenger = peppylib::MessengerHandle::from_host_port(&router_host, router_port)
-        .await
-        .expect("failed to create messenger for shutdown");
+    let messenger = peppylib::MessengerHandle::from_host_port_with_namespace(
+        &router_host,
+        router_port,
+        Some(config::org::OrgNamespace::local()),
+    )
+    .await
+    .expect("failed to create messenger for shutdown");
     let ctx = WaitContext {
         messenger: &messenger,
         bound_core_node: TEST_CORE_NODE,

--- a/crates/generator-internal/tests/python/topics_communication.rs
+++ b/crates/generator-internal/tests/python/topics_communication.rs
@@ -290,13 +290,9 @@ if __name__ == "__main__":
         )],
     );
 
-    let messenger = peppylib::MessengerHandle::from_host_port_with_namespace(
-        &router_host,
-        router_port,
-        Some(config::org::OrgNamespace::local()),
-    )
-    .await
-    .expect("failed to create messenger for shutdown");
+    let messenger = peppylib::MessengerHandle::connect(&router_host, router_port)
+        .await
+        .expect("failed to create messenger for shutdown");
     let ctx = WaitContext {
         messenger: &messenger,
         bound_core_node: TEST_CORE_NODE,

--- a/crates/generator-internal/tests/python/wire_compat.rs
+++ b/crates/generator-internal/tests/python/wire_compat.rs
@@ -365,13 +365,9 @@ if __name__ == "__main__":
     let producer_runtime_config_str = producer_runtime_config_path.to_str().unwrap().to_owned();
     let consumer_runtime_config_str = consumer_runtime_config_path.to_str().unwrap().to_owned();
 
-    let messenger = peppylib::MessengerHandle::from_host_port_with_namespace(
-        &router_host,
-        router_port,
-        Some(config::org::OrgNamespace::local()),
-    )
-    .await
-    .expect("failed to create messenger for test control");
+    let messenger = peppylib::MessengerHandle::connect(&router_host, router_port)
+        .await
+        .expect("failed to create messenger for test control");
 
     let mut producer_child = spawn_python_run(
         &producer_dir,
@@ -728,13 +724,9 @@ if __name__ == "__main__":
     let producer_runtime_config_str = producer_runtime_config_path.to_str().unwrap().to_owned();
     let consumer_runtime_config_str = consumer_runtime_config_path.to_str().unwrap().to_owned();
 
-    let messenger = peppylib::MessengerHandle::from_host_port_with_namespace(
-        &router_host,
-        router_port,
-        Some(config::org::OrgNamespace::local()),
-    )
-    .await
-    .expect("failed to create messenger for test control");
+    let messenger = peppylib::MessengerHandle::connect(&router_host, router_port)
+        .await
+        .expect("failed to create messenger for test control");
 
     let mut producer_child = spawn_python_run(
         &producer_dir,
@@ -1088,13 +1080,9 @@ if __name__ == "__main__":
     let producer_runtime_config_str = producer_runtime_config_path.to_str().unwrap().to_owned();
     let consumer_runtime_config_str = consumer_runtime_config_path.to_str().unwrap().to_owned();
 
-    let messenger = peppylib::MessengerHandle::from_host_port_with_namespace(
-        &router_host,
-        router_port,
-        Some(config::org::OrgNamespace::local()),
-    )
-    .await
-    .expect("failed to create messenger for test control");
+    let messenger = peppylib::MessengerHandle::connect(&router_host, router_port)
+        .await
+        .expect("failed to create messenger for test control");
 
     let mut producer_child = spawn_python_run(
         &producer_dir,

--- a/crates/generator-internal/tests/python/wire_compat.rs
+++ b/crates/generator-internal/tests/python/wire_compat.rs
@@ -365,9 +365,13 @@ if __name__ == "__main__":
     let producer_runtime_config_str = producer_runtime_config_path.to_str().unwrap().to_owned();
     let consumer_runtime_config_str = consumer_runtime_config_path.to_str().unwrap().to_owned();
 
-    let messenger = peppylib::MessengerHandle::from_host_port(&router_host, router_port)
-        .await
-        .expect("failed to create messenger for test control");
+    let messenger = peppylib::MessengerHandle::from_host_port_with_namespace(
+        &router_host,
+        router_port,
+        Some(config::org::OrgNamespace::local()),
+    )
+    .await
+    .expect("failed to create messenger for test control");
 
     let mut producer_child = spawn_python_run(
         &producer_dir,
@@ -724,9 +728,13 @@ if __name__ == "__main__":
     let producer_runtime_config_str = producer_runtime_config_path.to_str().unwrap().to_owned();
     let consumer_runtime_config_str = consumer_runtime_config_path.to_str().unwrap().to_owned();
 
-    let messenger = peppylib::MessengerHandle::from_host_port(&router_host, router_port)
-        .await
-        .expect("failed to create messenger for test control");
+    let messenger = peppylib::MessengerHandle::from_host_port_with_namespace(
+        &router_host,
+        router_port,
+        Some(config::org::OrgNamespace::local()),
+    )
+    .await
+    .expect("failed to create messenger for test control");
 
     let mut producer_child = spawn_python_run(
         &producer_dir,
@@ -1080,9 +1088,13 @@ if __name__ == "__main__":
     let producer_runtime_config_str = producer_runtime_config_path.to_str().unwrap().to_owned();
     let consumer_runtime_config_str = consumer_runtime_config_path.to_str().unwrap().to_owned();
 
-    let messenger = peppylib::MessengerHandle::from_host_port(&router_host, router_port)
-        .await
-        .expect("failed to create messenger for test control");
+    let messenger = peppylib::MessengerHandle::from_host_port_with_namespace(
+        &router_host,
+        router_port,
+        Some(config::org::OrgNamespace::local()),
+    )
+    .await
+    .expect("failed to create messenger for test control");
 
     let mut producer_child = spawn_python_run(
         &producer_dir,

--- a/crates/generator-internal/tests/rust/actions_communication.rs
+++ b/crates/generator-internal/tests/rust/actions_communication.rs
@@ -337,9 +337,13 @@ fn main() -> Result<()> {
     compile_project(&user_node_consumer);
     compile_project(&user_node_exposer);
 
-    let messenger = peppylib::MessengerHandle::from_host_port(&router_host, router_port)
-        .await
-        .expect("failed to create messenger for test control");
+    let messenger = peppylib::MessengerHandle::from_host_port_with_namespace(
+        &router_host,
+        router_port,
+        Some(config::org::OrgNamespace::local()),
+    )
+    .await
+    .expect("failed to create messenger for test control");
 
     // Spawn BOTH arms before the consumer, and wait for each to be
     // reachable so the "right arm never ran a goal" assertion can't pass
@@ -694,9 +698,13 @@ fn main() -> Result<()> {
     let exposer_runtime_config_str = exposer_runtime_config_path.to_str().unwrap().to_owned();
     let consumer_runtime_config_str = consumer_runtime_config_path.to_str().unwrap().to_owned();
 
-    let messenger = peppylib::MessengerHandle::from_host_port(&router_host, router_port)
-        .await
-        .expect("failed to create messenger for test control");
+    let messenger = peppylib::MessengerHandle::from_host_port_with_namespace(
+        &router_host,
+        router_port,
+        Some(config::org::OrgNamespace::local()),
+    )
+    .await
+    .expect("failed to create messenger for test control");
 
     // Spawn exposer first so it's ready to handle requests
     let mut exposer_child = spawn_cargo_run(
@@ -1008,9 +1016,13 @@ fn main() -> Result<()> {
     let exposer_runtime_config_str = exposer_runtime_config_path.to_str().unwrap().to_owned();
     let consumer_runtime_config_str = consumer_runtime_config_path.to_str().unwrap().to_owned();
 
-    let messenger = peppylib::MessengerHandle::from_host_port(&router_host, router_port)
-        .await
-        .expect("failed to create messenger for test control");
+    let messenger = peppylib::MessengerHandle::from_host_port_with_namespace(
+        &router_host,
+        router_port,
+        Some(config::org::OrgNamespace::local()),
+    )
+    .await
+    .expect("failed to create messenger for test control");
 
     // Spawn exposer first so it's ready to handle requests
     let mut exposer_child = spawn_cargo_run(
@@ -1372,9 +1384,13 @@ fn main() -> Result<()> {
     let exposer_runtime_config_str = exposer_runtime_config_path.to_str().unwrap().to_owned();
     let consumer_runtime_config_str = consumer_runtime_config_path.to_str().unwrap().to_owned();
 
-    let messenger = peppylib::MessengerHandle::from_host_port(&router_host, router_port)
-        .await
-        .expect("failed to create messenger for test control");
+    let messenger = peppylib::MessengerHandle::from_host_port_with_namespace(
+        &router_host,
+        router_port,
+        Some(config::org::OrgNamespace::local()),
+    )
+    .await
+    .expect("failed to create messenger for test control");
 
     let mut exposer_child = spawn_cargo_run(
         &user_node_exposer,
@@ -1742,9 +1758,13 @@ fn main() -> Result<()> {
     let exposer_runtime_config_str = exposer_runtime_config_path.to_str().unwrap().to_owned();
     let consumer_runtime_config_str = consumer_runtime_config_path.to_str().unwrap().to_owned();
 
-    let messenger = peppylib::MessengerHandle::from_host_port(&router_host, router_port)
-        .await
-        .expect("failed to create messenger for test control");
+    let messenger = peppylib::MessengerHandle::from_host_port_with_namespace(
+        &router_host,
+        router_port,
+        Some(config::org::OrgNamespace::local()),
+    )
+    .await
+    .expect("failed to create messenger for test control");
 
     let mut exposer_child = spawn_cargo_run(
         &user_node_exposer,
@@ -2123,9 +2143,13 @@ fn main() -> Result<()> {
     let exposer_runtime_config_str = exposer_runtime_config_path.to_str().unwrap().to_owned();
     let consumer_runtime_config_str = consumer_runtime_config_path.to_str().unwrap().to_owned();
 
-    let messenger = peppylib::MessengerHandle::from_host_port(&router_host, router_port)
-        .await
-        .expect("failed to create messenger for test control");
+    let messenger = peppylib::MessengerHandle::from_host_port_with_namespace(
+        &router_host,
+        router_port,
+        Some(config::org::OrgNamespace::local()),
+    )
+    .await
+    .expect("failed to create messenger for test control");
 
     let mut exposer_child = spawn_cargo_run(
         &user_node_exposer,
@@ -2505,9 +2529,13 @@ fn main() -> Result<()> {
     let exposer_runtime_config_str = exposer_runtime_config_path.to_str().unwrap().to_owned();
     let consumer_runtime_config_str = consumer_runtime_config_path.to_str().unwrap().to_owned();
 
-    let messenger = peppylib::MessengerHandle::from_host_port(&router_host, router_port)
-        .await
-        .expect("failed to create messenger for test control");
+    let messenger = peppylib::MessengerHandle::from_host_port_with_namespace(
+        &router_host,
+        router_port,
+        Some(config::org::OrgNamespace::local()),
+    )
+    .await
+    .expect("failed to create messenger for test control");
 
     let mut exposer_child = spawn_cargo_run(
         &user_node_exposer,

--- a/crates/generator-internal/tests/rust/actions_communication.rs
+++ b/crates/generator-internal/tests/rust/actions_communication.rs
@@ -337,13 +337,9 @@ fn main() -> Result<()> {
     compile_project(&user_node_consumer);
     compile_project(&user_node_exposer);
 
-    let messenger = peppylib::MessengerHandle::from_host_port_with_namespace(
-        &router_host,
-        router_port,
-        Some(config::org::OrgNamespace::local()),
-    )
-    .await
-    .expect("failed to create messenger for test control");
+    let messenger = peppylib::MessengerHandle::connect(&router_host, router_port)
+        .await
+        .expect("failed to create messenger for test control");
 
     // Spawn BOTH arms before the consumer, and wait for each to be
     // reachable so the "right arm never ran a goal" assertion can't pass
@@ -698,13 +694,9 @@ fn main() -> Result<()> {
     let exposer_runtime_config_str = exposer_runtime_config_path.to_str().unwrap().to_owned();
     let consumer_runtime_config_str = consumer_runtime_config_path.to_str().unwrap().to_owned();
 
-    let messenger = peppylib::MessengerHandle::from_host_port_with_namespace(
-        &router_host,
-        router_port,
-        Some(config::org::OrgNamespace::local()),
-    )
-    .await
-    .expect("failed to create messenger for test control");
+    let messenger = peppylib::MessengerHandle::connect(&router_host, router_port)
+        .await
+        .expect("failed to create messenger for test control");
 
     // Spawn exposer first so it's ready to handle requests
     let mut exposer_child = spawn_cargo_run(
@@ -1016,13 +1008,9 @@ fn main() -> Result<()> {
     let exposer_runtime_config_str = exposer_runtime_config_path.to_str().unwrap().to_owned();
     let consumer_runtime_config_str = consumer_runtime_config_path.to_str().unwrap().to_owned();
 
-    let messenger = peppylib::MessengerHandle::from_host_port_with_namespace(
-        &router_host,
-        router_port,
-        Some(config::org::OrgNamespace::local()),
-    )
-    .await
-    .expect("failed to create messenger for test control");
+    let messenger = peppylib::MessengerHandle::connect(&router_host, router_port)
+        .await
+        .expect("failed to create messenger for test control");
 
     // Spawn exposer first so it's ready to handle requests
     let mut exposer_child = spawn_cargo_run(
@@ -1384,13 +1372,9 @@ fn main() -> Result<()> {
     let exposer_runtime_config_str = exposer_runtime_config_path.to_str().unwrap().to_owned();
     let consumer_runtime_config_str = consumer_runtime_config_path.to_str().unwrap().to_owned();
 
-    let messenger = peppylib::MessengerHandle::from_host_port_with_namespace(
-        &router_host,
-        router_port,
-        Some(config::org::OrgNamespace::local()),
-    )
-    .await
-    .expect("failed to create messenger for test control");
+    let messenger = peppylib::MessengerHandle::connect(&router_host, router_port)
+        .await
+        .expect("failed to create messenger for test control");
 
     let mut exposer_child = spawn_cargo_run(
         &user_node_exposer,
@@ -1758,13 +1742,9 @@ fn main() -> Result<()> {
     let exposer_runtime_config_str = exposer_runtime_config_path.to_str().unwrap().to_owned();
     let consumer_runtime_config_str = consumer_runtime_config_path.to_str().unwrap().to_owned();
 
-    let messenger = peppylib::MessengerHandle::from_host_port_with_namespace(
-        &router_host,
-        router_port,
-        Some(config::org::OrgNamespace::local()),
-    )
-    .await
-    .expect("failed to create messenger for test control");
+    let messenger = peppylib::MessengerHandle::connect(&router_host, router_port)
+        .await
+        .expect("failed to create messenger for test control");
 
     let mut exposer_child = spawn_cargo_run(
         &user_node_exposer,
@@ -2143,13 +2123,9 @@ fn main() -> Result<()> {
     let exposer_runtime_config_str = exposer_runtime_config_path.to_str().unwrap().to_owned();
     let consumer_runtime_config_str = consumer_runtime_config_path.to_str().unwrap().to_owned();
 
-    let messenger = peppylib::MessengerHandle::from_host_port_with_namespace(
-        &router_host,
-        router_port,
-        Some(config::org::OrgNamespace::local()),
-    )
-    .await
-    .expect("failed to create messenger for test control");
+    let messenger = peppylib::MessengerHandle::connect(&router_host, router_port)
+        .await
+        .expect("failed to create messenger for test control");
 
     let mut exposer_child = spawn_cargo_run(
         &user_node_exposer,
@@ -2529,13 +2505,9 @@ fn main() -> Result<()> {
     let exposer_runtime_config_str = exposer_runtime_config_path.to_str().unwrap().to_owned();
     let consumer_runtime_config_str = consumer_runtime_config_path.to_str().unwrap().to_owned();
 
-    let messenger = peppylib::MessengerHandle::from_host_port_with_namespace(
-        &router_host,
-        router_port,
-        Some(config::org::OrgNamespace::local()),
-    )
-    .await
-    .expect("failed to create messenger for test control");
+    let messenger = peppylib::MessengerHandle::connect(&router_host, router_port)
+        .await
+        .expect("failed to create messenger for test control");
 
     let mut exposer_child = spawn_cargo_run(
         &user_node_exposer,

--- a/crates/generator-internal/tests/rust/services_communication.rs
+++ b/crates/generator-internal/tests/rust/services_communication.rs
@@ -238,13 +238,9 @@ fn main() -> Result<()> {
         exposer_runtime_config_path.to_str().unwrap().to_owned();
     let user_node_consumer_config_str = consumer_runtime_config_path.to_str().unwrap().to_owned();
 
-    let messenger = peppylib::MessengerHandle::from_host_port_with_namespace(
-        &router_host,
-        router_port,
-        Some(config::org::OrgNamespace::local()),
-    )
-    .await
-    .expect("failed to create messenger for test control");
+    let messenger = peppylib::MessengerHandle::connect(&router_host, router_port)
+        .await
+        .expect("failed to create messenger for test control");
     let ctx = WaitContext {
         messenger: &messenger,
         bound_core_node: TEST_CORE_NODE,
@@ -536,13 +532,9 @@ fn main() -> Result<()> {
     let exposer_runtime_config_str = exposer_runtime_config_path.to_str().unwrap().to_owned();
     let consumer_runtime_config_str = consumer_runtime_config_path.to_str().unwrap().to_owned();
 
-    let messenger = peppylib::MessengerHandle::from_host_port_with_namespace(
-        &router_host,
-        router_port,
-        Some(config::org::OrgNamespace::local()),
-    )
-    .await
-    .expect("failed to create messenger for test control");
+    let messenger = peppylib::MessengerHandle::connect(&router_host, router_port)
+        .await
+        .expect("failed to create messenger for test control");
     let ctx = WaitContext {
         messenger: &messenger,
         bound_core_node: TEST_CORE_NODE,
@@ -901,13 +893,9 @@ fn main() -> Result<()> {
     let exposer2_runtime_config_str = exposer2_runtime_config_path.to_str().unwrap().to_owned();
     let consumer_runtime_config_str = consumer_runtime_config_path.to_str().unwrap().to_owned();
 
-    let messenger = peppylib::MessengerHandle::from_host_port_with_namespace(
-        &router_host,
-        router_port,
-        Some(config::org::OrgNamespace::local()),
-    )
-    .await
-    .expect("failed to create messenger for test control");
+    let messenger = peppylib::MessengerHandle::connect(&router_host, router_port)
+        .await
+        .expect("failed to create messenger for test control");
     let ctx = WaitContext {
         messenger: &messenger,
         bound_core_node: TEST_CORE_NODE,

--- a/crates/generator-internal/tests/rust/services_communication.rs
+++ b/crates/generator-internal/tests/rust/services_communication.rs
@@ -238,9 +238,13 @@ fn main() -> Result<()> {
         exposer_runtime_config_path.to_str().unwrap().to_owned();
     let user_node_consumer_config_str = consumer_runtime_config_path.to_str().unwrap().to_owned();
 
-    let messenger = peppylib::MessengerHandle::from_host_port(&router_host, router_port)
-        .await
-        .expect("failed to create messenger for test control");
+    let messenger = peppylib::MessengerHandle::from_host_port_with_namespace(
+        &router_host,
+        router_port,
+        Some(config::org::OrgNamespace::local()),
+    )
+    .await
+    .expect("failed to create messenger for test control");
     let ctx = WaitContext {
         messenger: &messenger,
         bound_core_node: TEST_CORE_NODE,
@@ -532,9 +536,13 @@ fn main() -> Result<()> {
     let exposer_runtime_config_str = exposer_runtime_config_path.to_str().unwrap().to_owned();
     let consumer_runtime_config_str = consumer_runtime_config_path.to_str().unwrap().to_owned();
 
-    let messenger = peppylib::MessengerHandle::from_host_port(&router_host, router_port)
-        .await
-        .expect("failed to create messenger for test control");
+    let messenger = peppylib::MessengerHandle::from_host_port_with_namespace(
+        &router_host,
+        router_port,
+        Some(config::org::OrgNamespace::local()),
+    )
+    .await
+    .expect("failed to create messenger for test control");
     let ctx = WaitContext {
         messenger: &messenger,
         bound_core_node: TEST_CORE_NODE,
@@ -893,9 +901,13 @@ fn main() -> Result<()> {
     let exposer2_runtime_config_str = exposer2_runtime_config_path.to_str().unwrap().to_owned();
     let consumer_runtime_config_str = consumer_runtime_config_path.to_str().unwrap().to_owned();
 
-    let messenger = peppylib::MessengerHandle::from_host_port(&router_host, router_port)
-        .await
-        .expect("failed to create messenger for test control");
+    let messenger = peppylib::MessengerHandle::from_host_port_with_namespace(
+        &router_host,
+        router_port,
+        Some(config::org::OrgNamespace::local()),
+    )
+    .await
+    .expect("failed to create messenger for test control");
     let ctx = WaitContext {
         messenger: &messenger,
         bound_core_node: TEST_CORE_NODE,

--- a/crates/generator-internal/tests/rust/topics_communication.rs
+++ b/crates/generator-internal/tests/rust/topics_communication.rs
@@ -261,13 +261,9 @@ fn main() -> Result<()> {
 
     // Wait until both nodes have completed their setup_fn (node_health is reachable).
     // (The receiver reaches this point only after it receives a frame.)
-    let messenger = peppylib::MessengerHandle::from_host_port_with_namespace(
-        &router_host,
-        router_port,
-        Some(config::org::OrgNamespace::local()),
-    )
-    .await
-    .expect("failed to create messenger for shutdown");
+    let messenger = peppylib::MessengerHandle::connect(&router_host, router_port)
+        .await
+        .expect("failed to create messenger for shutdown");
     let ctx = WaitContext {
         messenger: &messenger,
         bound_core_node: TEST_CORE_NODE,

--- a/crates/generator-internal/tests/rust/topics_communication.rs
+++ b/crates/generator-internal/tests/rust/topics_communication.rs
@@ -261,9 +261,13 @@ fn main() -> Result<()> {
 
     // Wait until both nodes have completed their setup_fn (node_health is reachable).
     // (The receiver reaches this point only after it receives a frame.)
-    let messenger = peppylib::MessengerHandle::from_host_port(&router_host, router_port)
-        .await
-        .expect("failed to create messenger for shutdown");
+    let messenger = peppylib::MessengerHandle::from_host_port_with_namespace(
+        &router_host,
+        router_port,
+        Some(config::org::OrgNamespace::local()),
+    )
+    .await
+    .expect("failed to create messenger for shutdown");
     let ctx = WaitContext {
         messenger: &messenger,
         bound_core_node: TEST_CORE_NODE,

--- a/crates/peppy/src/auth/client.rs
+++ b/crates/peppy/src/auth/client.rs
@@ -67,6 +67,12 @@ pub struct ZenohRouterConfig {
     /// still-fresh config (rather than re-pulling) never risks the router being torn
     /// down.
     pub reconnect_after_secs: u64,
+    /// The caller's organization id (the platform's stable per-user `Uuid`, as a
+    /// string). Becomes the daemon's session namespace so robots of the same org
+    /// interoperate across the federation while different orgs stay routing-isolated.
+    /// Required: a backend that predates this field fails to parse, which is the
+    /// intended clean break (re-run `peppy auth login`).
+    pub organization_id: String,
 }
 
 impl ZenohRouterConfig {
@@ -271,6 +277,7 @@ mod tests {
             endpoint: endpoint.to_string(),
             protocol: "tls".to_string(),
             reconnect_after_secs: 3000,
+            organization_id: "550e8400-e29b-41d4-a716-446655440000".to_string(),
         }
     }
 
@@ -315,11 +322,13 @@ mod tests {
             "protocol": "tls",
             "mode": "client",
             "reconnect_after_secs": 3000,
+            "organization_id": "550e8400-e29b-41d4-a716-446655440000",
             "some_future_field": "ignored"
         }"#;
         let cfg: ZenohRouterConfig = serde_json::from_str(json).expect("tolerant parse");
         assert_eq!(cfg.protocol, "tls");
         assert_eq!(cfg.reconnect_after_secs, 3000);
+        assert_eq!(cfg.organization_id, "550e8400-e29b-41d4-a716-446655440000");
         assert_eq!(
             cfg.host_port().unwrap(),
             ("abc.zenoh.localhost".to_string(), 7443)

--- a/crates/peppy/src/auth/router.rs
+++ b/crates/peppy/src/auth/router.rs
@@ -69,6 +69,10 @@ pub struct RouterEndpoint {
     pub host: String,
     pub port: u16,
     pub tls: pmi::TlsConfig,
+    /// The organization id this endpoint was resolved for, carried out of the
+    /// same pull so the caller derives the federation gate and the session
+    /// namespace from one source.
+    pub organization_id: String,
 }
 
 /// The router trust anchor, resolved CLI-side with zero configuration. In a debug
@@ -167,19 +171,26 @@ pub fn resolve_router_endpoint(
     client_identity: Option<(PathBuf, PathBuf)>,
 ) -> Result<RouterEndpoint> {
     let now = storage::now_unix();
-    let cached = storage::load(creds_path)?.router;
-    // The cache is identity-bound: `login`/`logout` clear it with the session
-    // (`storage::Credentials` doc). The fresh-cache branch reuses the endpoint
-    // without re-resolving a credential, which is fine for the daemon's
-    // federation poll (`resolve_federation_target`): a fresh cache means the
-    // upstream is unchanged, so no re-pull (and no last_seen refresh) is needed
-    // until it goes stale. FOLLOW-UP: tag the cached `RouterSession` with the
-    // identity it was pulled for and verify it on reuse, so a cache that survives
-    // an identity change is re-pulled rather than reused. A blanket "require a
-    // session" guard is wrong here — it would disable caching for a
-    // `PEPPY_API_KEY` PAT, which has no session.
-    let endpoint = match cached {
-        Some(rs) if !rs.is_stale(now, REPULL_SKEW_SECS) => rs.endpoint,
+    // Load once: the cached router config and the active session's subject come
+    // from the same snapshot, so the identity check below sees a consistent view.
+    let creds = storage::load(creds_path)?;
+    let active_subject = creds
+        .session
+        .as_ref()
+        .map(|s| s.subject.clone())
+        .unwrap_or_default();
+    // The cache is identity-bound two ways: `login`/`logout` clear it with the
+    // session, AND `RouterSession.subject` tags it with the identity it was pulled
+    // for. The fresh-cache branch reuses the endpoint (and its `organization_id`)
+    // only while the cache is fresh AND its subject still matches the active
+    // session, so a cache that somehow survived an identity change is re-pulled
+    // rather than reused under the wrong org. A PAT pull has no session, so both
+    // subjects are empty and still match (the PAT path keeps caching, which a
+    // blanket "require a session" guard would wrongly disable).
+    let (endpoint, organization_id) = match creds.router {
+        Some(rs) if !rs.is_stale(now, REPULL_SKEW_SECS) && rs.subject == active_subject => {
+            (rs.endpoint, rs.organization_id)
+        }
         _ => pull_and_cache(creds_path, http, api_url, pat, now)?,
     };
 
@@ -188,6 +199,7 @@ pub fn resolve_router_endpoint(
         host,
         port,
         tls: client_tls(ca_certificate, client_identity),
+        organization_id,
     })
 }
 
@@ -202,7 +214,7 @@ fn pull_and_cache(
     api_url: &str,
     pat: Option<String>,
     now: i64,
-) -> Result<String> {
+) -> Result<(String, String)> {
     let mut cred = resolver::resolve(creds_path, http, pat)?;
     let cfg = client::establish_messaging_federation(http, api_url, &mut cred)?;
 
@@ -226,13 +238,23 @@ fn pull_and_cache(
     // Reload before caching so we don't clobber a concurrent refresh's rotation
     // (the same load-before-write discipline the token refresh uses).
     let mut creds = storage::load(creds_path)?;
+    // Tag the cache with the identity it was pulled for so a stale cache that
+    // outlives an identity change is re-pulled (see `resolve_router_endpoint`).
+    // A PAT pull has no session, so the subject is empty.
+    let subject = creds
+        .session
+        .as_ref()
+        .map(|s| s.subject.clone())
+        .unwrap_or_default();
     creds.router = Some(RouterSession {
         endpoint: cfg.endpoint.clone(),
         protocol: cfg.protocol.clone(),
         repull_after: now.saturating_add(saturating_secs_to_i64(cfg.reconnect_after_secs)),
+        organization_id: cfg.organization_id.clone(),
+        subject,
     });
     storage::save(creds_path, &creds)?;
-    Ok(cfg.endpoint)
+    Ok((cfg.endpoint, cfg.organization_id))
 }
 
 /// Best-effort federation target for the daemon's *local* router: the upstream
@@ -303,7 +325,22 @@ pub fn resolve_federation_target_at(
         ca_certificate,
         client_identity,
     ) {
-        Ok(ep) => Some((format!("tls/{}:{}", ep.host, ep.port), ep.tls)),
+        // Fail-closed gate, single source: federate only when the resolved org id
+        // is a valid namespace. The daemon's session namespace is resolved from
+        // the same cached `organization_id`, so a config that cannot federate also
+        // cannot carry a federating namespace -- an unprefixed/`local` session can
+        // never reach the shared multi-tenant router.
+        Ok(ep) if config::org::should_federate(Some(&ep.organization_id)) => {
+            Some((format!("tls/{}:{}", ep.host, ep.port), ep.tls))
+        }
+        Ok(ep) => {
+            tracing::warn!(
+                organization_id = %ep.organization_id,
+                "router federation: resolved organization id is not a valid namespace; \
+                 local router stays standalone (fail closed)"
+            );
+            None
+        }
         Err(e) => {
             tracing::warn!(
                 error = %e,
@@ -312,6 +349,24 @@ pub fn resolve_federation_target_at(
             None
         }
     }
+}
+
+/// The cached organization id the daemon resolves its session namespace from, or
+/// `None` when there is no fresh router cache (logged out, or not yet pulled). An
+/// empty cached value is treated as absent. Pairs with
+/// [`config::org::resolve_session_namespace`] (absent -> `local`) and
+/// [`config::org::should_federate`] (absent -> standalone).
+pub fn cached_organization_id(creds_path: &Path) -> Option<String> {
+    storage::load(creds_path)
+        .ok()?
+        .router
+        .map(|r| r.organization_id)
+        .filter(|s| !s.is_empty())
+}
+
+/// [`cached_organization_id`] against the process-global credentials path.
+pub fn cached_organization_id_default() -> Option<String> {
+    cached_organization_id(&storage::default_path())
 }
 
 /// Client TLS material for dialing the shared router: validate it against the

--- a/crates/peppy/src/auth/router.rs
+++ b/crates/peppy/src/auth/router.rs
@@ -180,15 +180,22 @@ pub fn resolve_router_endpoint(
         .map(|s| s.subject.clone())
         .unwrap_or_default();
     // The cache is identity-bound two ways: `login`/`logout` clear it with the
-    // session, AND `RouterSession.subject` tags it with the identity it was pulled
-    // for. The fresh-cache branch reuses the endpoint (and its `organization_id`)
-    // only while the cache is fresh AND its subject still matches the active
-    // session, so a cache that somehow survived an identity change is re-pulled
-    // rather than reused under the wrong org. A PAT pull has no session, so both
-    // subjects are empty and still match (the PAT path keeps caching, which a
-    // blanket "require a session" guard would wrongly disable).
+    // session, AND `RouterSession.subject` tags it with the backend identity it was
+    // pulled for. Reuse the cached endpoint (and its `organization_id`) only for a
+    // *session* resolve (no active PAT) whose non-empty subject still matches the
+    // cache, so a config pulled under one identity is never replayed under another
+    // (e.g. a PAT-pulled org leaking onto the on-disk session once the PAT is gone).
+    // An active PAT always re-pulls: a PAT is bound to its own backend subject at
+    // pull time (see `pull_and_cache`), which the session-derived `active_subject`
+    // cannot match on this fast path, and re-pulling is cheap (federation resolves
+    // only at startup and on a login/logout poke).
+    let reuse_cache = pat.is_none() && !active_subject.is_empty();
     let (endpoint, organization_id) = match creds.router {
-        Some(rs) if !rs.is_stale(now, REPULL_SKEW_SECS) && rs.subject == active_subject => {
+        Some(rs)
+            if reuse_cache
+                && !rs.is_stale(now, REPULL_SKEW_SECS)
+                && rs.subject == active_subject =>
+        {
             (rs.endpoint, rs.organization_id)
         }
         _ => pull_and_cache(creds_path, http, api_url, pat, now)?,
@@ -216,6 +223,11 @@ fn pull_and_cache(
     now: i64,
 ) -> Result<(String, String)> {
     let mut cred = resolver::resolve(creds_path, http, pat)?;
+    // The identity this pull is actually authenticated as drives the cache tag
+    // below. A PAT is not the on-disk session, so it must not be tagged with the
+    // session subject — doing so would let the session reuse the PAT's org once the
+    // PAT is gone (a cross-identity leak).
+    let is_pat = matches!(cred.kind, resolver::CredentialKind::Pat);
     let cfg = client::establish_messaging_federation(http, api_url, &mut cred)?;
 
     // Validate the config *before* it is written to `creds.router`: a malformed
@@ -238,14 +250,21 @@ fn pull_and_cache(
     // Reload before caching so we don't clobber a concurrent refresh's rotation
     // (the same load-before-write discipline the token refresh uses).
     let mut creds = storage::load(creds_path)?;
-    // Tag the cache with the identity it was pulled for so a stale cache that
-    // outlives an identity change is re-pulled (see `resolve_router_endpoint`).
-    // A PAT pull has no session, so the subject is empty.
-    let subject = creds
-        .session
-        .as_ref()
-        .map(|s| s.subject.clone())
-        .unwrap_or_default();
+    // Tag the cache with the backend identity the config was pulled for so a stale
+    // cache that outlives an identity change is re-pulled (see
+    // `resolve_router_endpoint`). For a session that is the session subject; for a
+    // PAT it is the PAT owner's stable, non-secret subject from the backend (`/me`)
+    // — never the session subject (which is a different identity) or an empty
+    // string (which an empty active subject would spuriously match).
+    let subject = if is_pat {
+        client::get_me(http, api_url, &mut cred)?.sub
+    } else {
+        creds
+            .session
+            .as_ref()
+            .map(|s| s.subject.clone())
+            .unwrap_or_default()
+    };
     creds.router = Some(RouterSession {
         endpoint: cfg.endpoint.clone(),
         protocol: cfg.protocol.clone(),

--- a/crates/peppy/src/auth/storage.rs
+++ b/crates/peppy/src/auth/storage.rs
@@ -70,6 +70,18 @@ pub struct RouterSession {
     /// next poke instead of reusing this cached config. A cache-freshness deadline
     /// only; derived at pull time from the server's `reconnect_after_secs`.
     pub repull_after: i64,
+    /// The organization id this config was pulled for (the platform's stable
+    /// per-user `Uuid`, as a string). Drives the daemon's session namespace, so
+    /// it is cached alongside the endpoint. Required: a pre-`organization_id`
+    /// file fails to parse with [`Error::Auth`], the intended clean break (the
+    /// load-resilient `auth login`/`logout` then start fresh).
+    pub organization_id: String,
+    /// The OAuth subject the config was pulled for, tagging the cache to one
+    /// identity. On reuse the daemon re-pulls when this no longer matches the
+    /// active session, so a cache that survives an identity change can never be
+    /// reused under the wrong org. Empty for a PAT pull (no session). Required
+    /// for the same clean-break reason as `organization_id`.
+    pub subject: String,
 }
 
 impl RouterSession {
@@ -309,6 +321,8 @@ mod tests {
                 endpoint: "tls/cap.zenoh.localhost:7443".into(),
                 protocol: "tls".into(),
                 repull_after: 1_700_000_000,
+                organization_id: "550e8400-e29b-41d4-a716-446655440000".into(),
+                subject: "auth0|alice".into(),
             }),
             ..Default::default()
         };
@@ -319,6 +333,8 @@ mod tests {
         assert_eq!(rs.endpoint, "tls/cap.zenoh.localhost:7443");
         assert_eq!(rs.protocol, "tls");
         assert_eq!(rs.repull_after, 1_700_000_000);
+        assert_eq!(rs.organization_id, "550e8400-e29b-41d4-a716-446655440000");
+        assert_eq!(rs.subject, "auth0|alice");
     }
 
     #[test]
@@ -354,6 +370,8 @@ mod tests {
             endpoint: "tls/cap:7443".into(),
             protocol: "tls".into(),
             repull_after: 1_000,
+            organization_id: "550e8400-e29b-41d4-a716-446655440000".into(),
+            subject: "auth0|alice".into(),
         };
         assert!(!rs.is_stale(900, 30));
         assert!(rs.is_stale(980, 30)); // 980 + 30 >= 1000

--- a/crates/peppy/src/commands/auth.rs
+++ b/crates/peppy/src/commands/auth.rs
@@ -8,13 +8,14 @@ pub mod logout;
 pub mod whoami;
 
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use clap::Subcommand;
 use config::consts::PeppyDirs;
 
 use super::Command;
 use crate::daemon_control::{self, PokeOutcome};
+use crate::daemon_state::DaemonState;
 use crate::error::Error;
 use crate::{context::AppContext, error::Result};
 
@@ -24,6 +25,23 @@ use crate::{context::AppContext, error::Result};
 const PINNED_NOTE: &str = "Note: this daemon's router config is operator-pinned (ZENOH_CONFIG); \
      federation is not auto-managed.";
 
+/// Re-poke cadence and overall deadline while waiting for the daemon to restart
+/// under the new namespace. The deadline covers zenohd's readiness ceiling (30s)
+/// plus the federation connect timeout and slack.
+const RESTART_POLL_INTERVAL: Duration = Duration::from_millis(250);
+const RESTART_POLL_DEADLINE: Duration = Duration::from_secs(60);
+
+/// The namespace the current on-disk credentials resolve to (`local` when logged
+/// out, else the org id). The same resolution the daemon does at startup, so the
+/// CLI can confirm the daemon came back under exactly what it just wrote.
+fn current_creds_namespace() -> String {
+    config::org::resolve_session_namespace(
+        crate::auth::router::cached_organization_id_default().as_deref(),
+    )
+    .as_str()
+    .to_string()
+}
+
 /// Whether a federation poke follows a login (federate) or a logout
 /// (de-federate). Affects the user-facing wording and, crucially, whether a
 /// federation failure is fatal: a login that cannot establish federation fails
@@ -31,6 +49,40 @@ const PINNED_NOTE: &str = "Note: this daemon's router config is operator-pinned 
 pub(crate) enum FederationPokeAction {
     Login,
     Logout,
+}
+
+/// Confirms (before authentication begins) a login/logout that may restart the
+/// daemon and wipe the running node stack, unless `--yes` was passed. Returns
+/// `Ok(true)` to proceed. Only prompts when a daemon is actually running (else
+/// there is nothing to restart) and stdin is a TTY (so a script is never blocked
+/// on a prompt).
+pub(crate) fn confirm_restart(yes: bool, action: &FederationPokeAction) -> Result<bool> {
+    use std::io::{IsTerminal, Write};
+
+    if yes {
+        return Ok(true);
+    }
+    // Nothing to restart if no daemon is running; and never block a non-interactive
+    // invocation (a script / CI) on a prompt.
+    if DaemonState::read().is_err() || !std::io::stdin().is_terminal() {
+        return Ok(true);
+    }
+    let verb = match action {
+        FederationPokeAction::Login => "Logging in",
+        FederationPokeAction::Logout => "Logging out",
+    };
+    eprintln!(
+        "{verb} changes this machine's organization namespace, which restarts the messaging \
+         daemon and wipes the running node stack."
+    );
+    eprint!("Continue? [y/N] ");
+    std::io::stderr().flush().ok();
+    let mut line = String::new();
+    std::io::stdin().read_line(&mut line).map_err(Error::Io)?;
+    Ok(matches!(
+        line.trim().to_ascii_lowercase().as_str(),
+        "y" | "yes"
+    ))
 }
 
 /// After credentials change, poke the running daemon over its control socket so
@@ -71,6 +123,12 @@ pub(crate) fn poke_federation_and_report(
     if let Some(pb) = spinner {
         pb.finish_and_clear();
     }
+    // A namespace change makes the daemon restart its whole generation. The first
+    // ack is `Restarting`; poll the (path-stable) control socket until the daemon
+    // is back under the namespace we just wrote, then report the settled outcome.
+    if matches!(outcome, PokeOutcome::Restarting) {
+        return await_restart(&socket, read_timeout, &action);
+    }
     match action {
         FederationPokeAction::Login => report_login(outcome),
         FederationPokeAction::Logout => {
@@ -78,6 +136,67 @@ pub(crate) fn poke_federation_and_report(
             Ok(())
         }
     }
+}
+
+/// Polls until the daemon is back under the namespace the credentials now resolve
+/// to, then reports the settled federation outcome. Detects a concurrent
+/// credentials change (a second login/logout mid-restart) and a never-recovers
+/// timeout. Bounded by [`RESTART_POLL_DEADLINE`].
+fn await_restart(
+    socket: &std::path::Path,
+    read_timeout: Duration,
+    action: &FederationPokeAction,
+) -> Result<()> {
+    // The namespace the daemon must come back under (what we just wrote).
+    let expected = current_creds_namespace();
+    let spinner =
+        crate::terminal::spinner("Waiting for the daemon to restart under the new namespace");
+    let deadline = Instant::now() + RESTART_POLL_DEADLINE;
+    let result = loop {
+        if Instant::now() >= deadline {
+            break Err(Error::Auth(format!(
+                "the daemon did not come back under namespace `{expected}` within the timeout; \
+                 check the `peppy service serve` logs and re-run `peppy auth login`"
+            )));
+        }
+        std::thread::sleep(RESTART_POLL_INTERVAL);
+
+        // A concurrent login/logout rewrote the credentials mid-restart, so the
+        // daemon will not come back under what we wrote.
+        if current_creds_namespace() != expected {
+            break Err(Error::Auth(
+                "credentials changed during restart; re-run `peppy auth login`".to_string(),
+            ));
+        }
+
+        // The (path-stable) daemon state records the live generation's namespace,
+        // written before the control socket binds. While the daemon is down or the
+        // old generation is still up, this is unreadable or carries the old value.
+        let back_under_expected =
+            matches!(DaemonState::read(), Ok(state) if state.organization_namespace == expected);
+        if !back_under_expected {
+            continue;
+        }
+
+        // Back under the expected namespace. Confirm the settled federation state
+        // with a fresh poke (which now resolves "unchanged" and federates live).
+        match daemon_control::poke_refederate(socket, read_timeout) {
+            PokeOutcome::Restarting => continue, // still settling (rare)
+            other => {
+                break match action {
+                    FederationPokeAction::Login => report_login(other),
+                    FederationPokeAction::Logout => {
+                        report_logout(other);
+                        Ok(())
+                    }
+                };
+            }
+        }
+    };
+    if let Some(pb) = spinner {
+        pb.finish_and_clear();
+    }
+    result
 }
 
 /// Strict reporting for a login poke: success and the operator-pinned case print
@@ -121,6 +240,13 @@ fn report_login(outcome: PokeOutcome) -> Result<()> {
              reachable and your account is provisioned, then run `peppy auth login` again."
                 .to_string(),
         )),
+        // `Restarting` is intercepted by `poke_federation_and_report` (it drives
+        // the restart poll), so it should not reach here; treat defensively.
+        PokeOutcome::Restarting => Err(Error::Auth(
+            "the daemon is restarting to apply the new namespace; re-run `peppy auth login` \
+             once it is back."
+                .to_string(),
+        )),
     }
 }
 
@@ -140,6 +266,10 @@ fn report_logout(outcome: PokeOutcome) {
         PokeOutcome::TimedOut => {
             println!("Federation poke timed out; the daemon will retry shortly.")
         }
+        // Intercepted by `poke_federation_and_report`; defensive only.
+        PokeOutcome::Restarting => {
+            println!("The daemon is restarting to apply the cleared namespace.")
+        }
     }
 }
 
@@ -153,11 +283,17 @@ pub enum AuthCommands {
         /// Print the verification URL/code instead of opening a browser.
         #[arg(long = "no-browser")]
         no_browser: bool,
+        /// Skip the "this restarts the daemon and wipes the node stack" prompt.
+        #[arg(long = "yes", short = 'y')]
+        yes: bool,
     },
     /// Log out: revoke the access token on the backend and clear local credentials
     Logout {
         #[arg(long = "api-url")]
         api_url: Option<String>,
+        /// Skip the "this restarts the daemon and wipes the node stack" prompt.
+        #[arg(long = "yes", short = 'y')]
+        yes: bool,
     },
     /// Show the current Peppy identity, backend, and token status
     #[command(visible_alias = "status")]
@@ -180,14 +316,17 @@ impl Command for AuthCommand {
             AuthCommands::Login {
                 api_url,
                 no_browser,
+                yes,
             } => login::LoginCommand {
                 api_url,
                 no_browser,
+                yes,
                 peppy_dirs: None,
             }
             .execute(app_ctx),
-            AuthCommands::Logout { api_url } => logout::LogoutCommand {
+            AuthCommands::Logout { api_url, yes } => logout::LogoutCommand {
                 api_url,
+                yes,
                 peppy_dirs: None,
             }
             .execute(app_ctx),

--- a/crates/peppy/src/commands/auth.rs
+++ b/crates/peppy/src/commands/auth.rs
@@ -12,8 +12,12 @@ use std::time::{Duration, Instant};
 
 use clap::Subcommand;
 use config::consts::PeppyDirs;
+use core_node_api::encoding::StackListRequest;
+use core_node_api::{NodeStage, SerializedNodeGraph};
+use peppylib::core_node::transport::poll_stack_list;
 
 use super::Command;
+use crate::commands::CALLER_INSTANCE_ID;
 use crate::daemon_control::{self, PokeOutcome};
 use crate::daemon_state::DaemonState;
 use crate::error::Error;
@@ -30,6 +34,12 @@ const PINNED_NOTE: &str = "Note: this daemon's router config is operator-pinned 
 /// plus the federation connect timeout and slack.
 const RESTART_POLL_INTERVAL: Duration = Duration::from_millis(250);
 const RESTART_POLL_DEADLINE: Duration = Duration::from_secs(60);
+
+/// Upper bound on the pre-prompt probe that asks the running daemon whether its
+/// node stack holds any user nodes. Kept short so a sluggish or half-up daemon
+/// (pid alive but its messaging router not yet reachable) delays the
+/// login/logout prompt only briefly before we fall back to showing the warning.
+const STACK_PROBE_TIMEOUT: Duration = Duration::from_secs(3);
 
 /// The namespace the current on-disk credentials resolve to (`local` when logged
 /// out, else the org id). The same resolution the daemon does at startup, so the
@@ -54,9 +64,14 @@ pub(crate) enum FederationPokeAction {
 /// Confirms (before authentication begins) a login/logout that may restart the
 /// daemon and wipe the running node stack, unless `--yes` was passed. Returns
 /// `Ok(true)` to proceed. Only prompts when a daemon is actually running (else
-/// there is nothing to restart) and stdin is a TTY (so a script is never blocked
-/// on a prompt).
-pub(crate) fn confirm_restart(yes: bool, action: &FederationPokeAction) -> Result<bool> {
+/// there is nothing to restart), stdin is a TTY (so a script is never blocked on
+/// a prompt), and the daemon is running at least one user node (else the restart
+/// wipes nothing worth warning about).
+pub(crate) fn confirm_restart(
+    ctx: &Arc<AppContext>,
+    yes: bool,
+    action: &FederationPokeAction,
+) -> Result<bool> {
     use std::io::{IsTerminal, Write};
 
     if yes {
@@ -68,6 +83,12 @@ pub(crate) fn confirm_restart(yes: bool, action: &FederationPokeAction) -> Resul
     // treating state-file readability as "a daemon is up".
     let daemon_running = DaemonState::read().is_ok_and(|s| s.is_running());
     if !daemon_running || !std::io::stdin().is_terminal() {
+        return Ok(true);
+    }
+    // The restart only wipes a node stack worth warning about when the daemon is
+    // actually running user nodes. A stack that holds nothing but the synthetic
+    // core-node root loses nothing on restart, so the warning would be noise.
+    if !daemon_has_user_nodes(ctx) {
         return Ok(true);
     }
     let verb = match action {
@@ -86,6 +107,57 @@ pub(crate) fn confirm_restart(yes: bool, action: &FederationPokeAction) -> Resul
         line.trim().to_ascii_lowercase().as_str(),
         "y" | "yes"
     ))
+}
+
+/// Whether the running daemon's node stack holds any user node, by querying its
+/// live stack over the messaging session (the same query `peppy stack list`
+/// uses). Drives the login/logout restart prompt: an empty stack means the
+/// restart wipes nothing the user staged, so the warning is skipped.
+///
+/// Best effort: connecting to the daemon and reading its stack can fail or stall
+/// (it is mid-restart, its messaging router is not up yet, the query times out).
+/// Any such outcome returns `true` so the caller still shows the warning rather
+/// than silently dropping it. The whole probe is bounded by
+/// [`STACK_PROBE_TIMEOUT`] because opening the session can itself stall when the
+/// router is unreachable, which the per-query timeout alone would not cover.
+fn daemon_has_user_nodes(ctx: &Arc<AppContext>) -> bool {
+    let probe = async {
+        let conn = ctx.connect_to_daemon().await?;
+        let response = poll_stack_list(
+            &StackListRequest::new(false),
+            conn.messenger,
+            &conn.core_node_name,
+            CALLER_INSTANCE_ID,
+            &conn.core_node_name,
+            STACK_PROBE_TIMEOUT,
+        )
+        .await?;
+        let graph = crate::commands::parse_stack_graph(&response.graph_json)?;
+        Ok::<bool, Error>(stack_has_user_nodes(&graph))
+    };
+
+    crate::commands::block_on(async move {
+        Ok(
+            match tokio::time::timeout(STACK_PROBE_TIMEOUT, probe).await {
+                Ok(Ok(has_user_nodes)) => has_user_nodes,
+                Ok(Err(_)) | Err(_) => true,
+            },
+        )
+    })
+    .unwrap_or(true)
+}
+
+/// Whether a serialized stack graph contains a user node, i.e. any node other
+/// than the synthetic [`NodeStage::Root`] entity the daemon always carries for
+/// itself. A node entity counts as present regardless of its instances' states,
+/// since a node whose only instances have finished is still in the stack and
+/// would be wiped by a restart. Pure over the graph so the decision is
+/// unit-testable without a live daemon.
+fn stack_has_user_nodes(graph: &SerializedNodeGraph) -> bool {
+    graph
+        .nodes
+        .iter()
+        .any(|node| node.stage != Some(NodeStage::Root))
 }
 
 /// After credentials change, poke the running daemon over its control socket so
@@ -358,8 +430,71 @@ impl Command for AuthCommand {
 
 #[cfg(test)]
 mod tests {
-    use super::{report_login, report_logout};
+    use super::{report_login, report_logout, stack_has_user_nodes};
     use crate::daemon_control::PokeOutcome;
+    use core_node_api::{
+        InstanceState, NodeStage, SerializedInstance, SerializedNode, SerializedNodeGraph,
+    };
+    use std::collections::BTreeMap;
+
+    /// Builds an instance-less node fixed at `stage`. The bindings/instances are
+    /// irrelevant to the user-node predicate, which keys only on `stage`.
+    fn node_with_stage(name: &str, stage: NodeStage) -> SerializedNode {
+        SerializedNode {
+            name: name.to_string(),
+            tag: "v1".to_string(),
+            config_path: format!("/tmp/{name}.json5"),
+            artifact_path: None,
+            stage: Some(stage),
+            instances: Vec::new(),
+        }
+    }
+
+    fn graph_of(nodes: Vec<SerializedNode>) -> SerializedNodeGraph {
+        SerializedNodeGraph {
+            nodes,
+            edges: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn a_stack_with_only_the_core_root_has_no_user_nodes() {
+        let graph = graph_of(vec![node_with_stage("core", NodeStage::Root)]);
+        assert!(
+            !stack_has_user_nodes(&graph),
+            "a daemon carrying only its synthetic root is an empty stack"
+        );
+    }
+
+    #[test]
+    fn a_stack_with_a_user_node_alongside_the_root_has_user_nodes() {
+        let graph = graph_of(vec![
+            node_with_stage("core", NodeStage::Root),
+            node_with_stage("sensor", NodeStage::Added),
+        ]);
+        assert!(stack_has_user_nodes(&graph));
+    }
+
+    #[test]
+    fn an_empty_graph_has_no_user_nodes() {
+        assert!(!stack_has_user_nodes(&graph_of(Vec::new())));
+    }
+
+    #[test]
+    fn a_user_node_with_only_terminal_instances_still_counts() {
+        // "Empty" is about node entities present in the stack, not running
+        // instances: a node whose only instance has finished is still in the
+        // stack and would be wiped by a restart, so it must keep the warning.
+        let mut recorder = node_with_stage("recorder", NodeStage::Ready);
+        recorder.instances = vec![SerializedInstance {
+            instance_id: "rec-1".to_string(),
+            state: InstanceState::Finished,
+            healthy: true,
+            slot_bindings: BTreeMap::new(),
+        }];
+        let graph = graph_of(vec![node_with_stage("core", NodeStage::Root), recorder]);
+        assert!(stack_has_user_nodes(&graph));
+    }
 
     #[test]
     fn login_is_ok_for_applied_some_and_pinned() {

--- a/crates/peppy/src/commands/auth.rs
+++ b/crates/peppy/src/commands/auth.rs
@@ -63,8 +63,11 @@ pub(crate) fn confirm_restart(yes: bool, action: &FederationPokeAction) -> Resul
         return Ok(true);
     }
     // Nothing to restart if no daemon is running; and never block a non-interactive
-    // invocation (a script / CI) on a prompt.
-    if DaemonState::read().is_err() || !std::io::stdin().is_terminal() {
+    // invocation (a script / CI) on a prompt. A readable state file can outlive a
+    // crashed daemon, so probe the recorded pid for *real* liveness rather than
+    // treating state-file readability as "a daemon is up".
+    let daemon_running = DaemonState::read().is_ok_and(|s| s.is_running());
+    if !daemon_running || !std::io::stdin().is_terminal() {
         return Ok(true);
     }
     let verb = match action {
@@ -149,6 +152,12 @@ fn await_restart(
 ) -> Result<()> {
     // The namespace the daemon must come back under (what we just wrote).
     let expected = current_creds_namespace();
+    // This helper is shared by both flows, so the recovery guidance must name the
+    // caller's own subcommand rather than always saying `login`.
+    let subcommand = match action {
+        FederationPokeAction::Login => "login",
+        FederationPokeAction::Logout => "logout",
+    };
     let spinner =
         crate::terminal::spinner("Waiting for the daemon to restart under the new namespace");
     let deadline = Instant::now() + RESTART_POLL_DEADLINE;
@@ -156,7 +165,7 @@ fn await_restart(
         if Instant::now() >= deadline {
             break Err(Error::Auth(format!(
                 "the daemon did not come back under namespace `{expected}` within the timeout; \
-                 check the `peppy service serve` logs and re-run `peppy auth login`"
+                 check the `peppy service serve` logs and re-run `peppy auth {subcommand}`"
             )));
         }
         std::thread::sleep(RESTART_POLL_INTERVAL);
@@ -164,9 +173,9 @@ fn await_restart(
         // A concurrent login/logout rewrote the credentials mid-restart, so the
         // daemon will not come back under what we wrote.
         if current_creds_namespace() != expected {
-            break Err(Error::Auth(
-                "credentials changed during restart; re-run `peppy auth login`".to_string(),
-            ));
+            break Err(Error::Auth(format!(
+                "credentials changed during restart; re-run `peppy auth {subcommand}`"
+            )));
         }
 
         // The (path-stable) daemon state records the live generation's namespace,
@@ -181,7 +190,14 @@ fn await_restart(
         // Back under the expected namespace. Confirm the settled federation state
         // with a fresh poke (which now resolves "unchanged" and federates live).
         match daemon_control::poke_refederate(socket, read_timeout) {
-            PokeOutcome::Restarting => continue, // still settling (rare)
+            // Still settling: the new generation wrote its state (so we got here)
+            // but its control socket may not have bound yet, so a poke can
+            // transiently find no socket or time out. Keep polling until it
+            // actually answers (or the deadline above fires) rather than reporting
+            // one of these in-flight outcomes as the settled state.
+            PokeOutcome::Restarting | PokeOutcome::DaemonNotRunning | PokeOutcome::TimedOut => {
+                continue;
+            }
             other => {
                 break match action {
                     FederationPokeAction::Login => report_login(other),

--- a/crates/peppy/src/commands/auth/login.rs
+++ b/crates/peppy/src/commands/auth/login.rs
@@ -22,6 +22,8 @@ pub struct LoginCommand {
     pub api_url: Option<String>,
     /// Suppress the automatic browser launch.
     pub no_browser: bool,
+    /// Skip the daemon-restart confirmation prompt.
+    pub yes: bool,
     /// Test seam: override the peppy data dirs (defaults to the global root).
     /// Both the credentials file and `peppy_config.json5` derive from it, so a
     /// test isolates all auth state under one tempdir without touching
@@ -40,6 +42,14 @@ impl Command for LoginCommand {
         let creds_path = storage::credentials_path(&dirs);
         let http = HttpClient::new();
 
+        // Warn (before authentication begins) that a login changing the
+        // organization namespace restarts the daemon and wipes the running node
+        // stack. Bypassed by `--yes`, and skipped when no daemon is running.
+        if !super::confirm_restart(self.yes, &super::FederationPokeAction::Login)? {
+            println!("Login aborted.");
+            return Ok(());
+        }
+
         let cfg = cli_config::fetch(&http, &api_url)?;
         let endpoints = discovery::discover(&http, &cfg.issuer)?;
         let tokens = device::run(
@@ -53,7 +63,14 @@ impl Command for LoginCommand {
         )?;
 
         // Persist immediately so a transient `/me` failure can't lose a good login.
-        let mut creds = storage::load(&creds_path)?;
+        // Load-resilient: a malformed / pre-`organization_id` / version-mismatched
+        // file fails to parse with `Error::Auth`; start fresh rather than wedge
+        // login on it (the stale file self-heals on this save).
+        let mut creds = match storage::load(&creds_path) {
+            Ok(creds) => creds,
+            Err(Error::Auth(_)) => storage::Credentials::default(),
+            Err(e) => return Err(e),
+        };
         let pc = client::creds_from_login(&cfg, &api_url, &tokens);
         creds.session = Some(pc.clone());
         // Drop any cached router config: it is identity-bound, and this login may

--- a/crates/peppy/src/commands/auth/login.rs
+++ b/crates/peppy/src/commands/auth/login.rs
@@ -32,7 +32,7 @@ pub struct LoginCommand {
 }
 
 impl Command for LoginCommand {
-    fn execute(self, _ctx: &Arc<AppContext>) -> Result<()> {
+    fn execute(self, ctx: &Arc<AppContext>) -> Result<()> {
         let dirs = self.peppy_dirs.unwrap_or_default();
         // Loads (and seeds/completes) peppy_config.json5 with the same strict,
         // fail-loud semantics the daemon uses; resource_servers supplies the
@@ -44,8 +44,9 @@ impl Command for LoginCommand {
 
         // Warn (before authentication begins) that a login changing the
         // organization namespace restarts the daemon and wipes the running node
-        // stack. Bypassed by `--yes`, and skipped when no daemon is running.
-        if !super::confirm_restart(self.yes, &super::FederationPokeAction::Login)? {
+        // stack. Bypassed by `--yes`, and skipped when no daemon is running or
+        // its node stack holds no user nodes (so the restart wipes nothing).
+        if !super::confirm_restart(ctx, self.yes, &super::FederationPokeAction::Login)? {
             println!("Login aborted.");
             return Ok(());
         }

--- a/crates/peppy/src/commands/auth/logout.rs
+++ b/crates/peppy/src/commands/auth/logout.rs
@@ -16,6 +16,8 @@ use crate::error::{Error, Result};
 
 pub struct LogoutCommand {
     pub api_url: Option<String>,
+    /// Skip the daemon-restart confirmation prompt.
+    pub yes: bool,
     /// Test seam: override the peppy data dirs (the credentials file and
     /// `peppy_config.json5` both derive from it).
     pub peppy_dirs: Option<PeppyDirs>,
@@ -29,11 +31,26 @@ impl Command for LogoutCommand {
         let creds_path = storage::credentials_path(&dirs);
         let http = HttpClient::new();
 
-        let mut creds = storage::load(&creds_path)?;
+        // Load-resilient: a malformed / pre-`organization_id` file fails to parse
+        // with `Error::Auth`; treat it as "already effectively logged out" rather
+        // than wedging logout (the clear below self-heals the file).
+        let mut creds = match storage::load(&creds_path) {
+            Ok(creds) => creds,
+            Err(Error::Auth(_)) => storage::Credentials::default(),
+            Err(e) => return Err(e),
+        };
         let Some(pc) = creds.session.as_ref() else {
             println!("Not logged in ({}).", profile::build_env_name());
             return Ok(());
         };
+
+        // Warn (before revoking) that logging out clears the namespace, which
+        // restarts the daemon and wipes the running node stack. Bypassed by
+        // `--yes`, skipped when no daemon is running.
+        if !super::confirm_restart(self.yes, &super::FederationPokeAction::Logout)? {
+            println!("Logout aborted.");
+            return Ok(());
+        }
 
         let access_token = pc.access_token.expose_secret().to_string();
         match client::logout(&http, &api_url, &access_token) {

--- a/crates/peppy/src/commands/auth/logout.rs
+++ b/crates/peppy/src/commands/auth/logout.rs
@@ -24,7 +24,7 @@ pub struct LogoutCommand {
 }
 
 impl Command for LogoutCommand {
-    fn execute(self, _ctx: &Arc<AppContext>) -> Result<()> {
+    fn execute(self, ctx: &Arc<AppContext>) -> Result<()> {
         let dirs = self.peppy_dirs.unwrap_or_default();
         let config = config::peppy_config::load_or_create(&dirs).map_err(Error::PeppyConfig)?;
         let api_url = profile::resolve_api_url(self.api_url.as_deref(), &config.resource_servers)?;
@@ -52,8 +52,9 @@ impl Command for LogoutCommand {
 
         // Warn (before revoking) that logging out clears the namespace, which
         // restarts the daemon and wipes the running node stack. Bypassed by
-        // `--yes`, skipped when no daemon is running.
-        if !super::confirm_restart(self.yes, &super::FederationPokeAction::Logout)? {
+        // `--yes`, skipped when no daemon is running or its node stack holds no
+        // user nodes (so the restart wipes nothing).
+        if !super::confirm_restart(ctx, self.yes, &super::FederationPokeAction::Logout)? {
             println!("Logout aborted.");
             return Ok(());
         }

--- a/crates/peppy/src/commands/auth/logout.rs
+++ b/crates/peppy/src/commands/auth/logout.rs
@@ -33,10 +33,16 @@ impl Command for LogoutCommand {
 
         // Load-resilient: a malformed / pre-`organization_id` file fails to parse
         // with `Error::Auth`; treat it as "already effectively logged out" rather
-        // than wedging logout (the clear below self-heals the file).
+        // than wedging logout. A default has no session, so the early return below
+        // would otherwise leave the bad file on disk — overwrite it with a clean
+        // default here so logout actually heals it.
         let mut creds = match storage::load(&creds_path) {
             Ok(creds) => creds,
-            Err(Error::Auth(_)) => storage::Credentials::default(),
+            Err(Error::Auth(_)) => {
+                let cleaned = storage::Credentials::default();
+                storage::save(&creds_path, &cleaned)?;
+                cleaned
+            }
             Err(e) => return Err(e),
         };
         let Some(pc) = creds.session.as_ref() else {

--- a/crates/peppy/src/commands/node/runtime_config.rs
+++ b/crates/peppy/src/commands/node/runtime_config.rs
@@ -116,10 +116,12 @@ async fn print_runtime_config_async(
 
     // Reflect the daemon's organization namespace, exactly as `apply_daemon_defaults`
     // stamps it onto a launched node, so this inspection output matches the session
-    // namespace a real node would open under.
+    // namespace a real node would open under. Reuse the namespace captured when the
+    // connection was established (above) rather than reading the state again, which
+    // could race a restart and pair this generation's stack lookup with another
+    // generation's namespace.
     let mut runtime_config = runtime_config;
-    runtime_config.discovery.organization_id =
-        Some(ctx.read_daemon_state()?.organization_namespace);
+    runtime_config.discovery.organization_id = Some(conn.organization_namespace);
 
     let runtime_config_json = serde_json::to_string(&runtime_config).map_err(|e| {
         Error::ExecutionFailed(format!("Failed to serialize runtime config: {}", e))

--- a/crates/peppy/src/commands/node/runtime_config.rs
+++ b/crates/peppy/src/commands/node/runtime_config.rs
@@ -114,6 +114,13 @@ async fn print_runtime_config_async(
     )
     .map_err(Error::PeppyConfig)?;
 
+    // Reflect the daemon's organization namespace, exactly as `apply_daemon_defaults`
+    // stamps it onto a launched node, so this inspection output matches the session
+    // namespace a real node would open under.
+    let mut runtime_config = runtime_config;
+    runtime_config.discovery.organization_id =
+        Some(ctx.read_daemon_state()?.organization_namespace);
+
     let runtime_config_json = serde_json::to_string(&runtime_config).map_err(|e| {
         Error::ExecutionFailed(format!("Failed to serialize runtime config: {}", e))
     })?;

--- a/crates/peppy/src/commands/service/builder.rs
+++ b/crates/peppy/src/commands/service/builder.rs
@@ -299,6 +299,10 @@ impl ServeCommandBuilder {
                         // the namespace it re-resolves from fresh creds against this
                         // to decide live re-federate (unchanged) vs restart (changed).
                         self.organization_namespace.clone(),
+                        // The startup poll raises this if it resolves a namespace
+                        // that differs from this generation's (the steady-state
+                        // poke path leaves the restart to the control handler).
+                        restart_tx.clone(),
                         self.teardown_token.clone(),
                     )));
 

--- a/crates/peppy/src/commands/service/builder.rs
+++ b/crates/peppy/src/commands/service/builder.rs
@@ -52,6 +52,18 @@ pub struct ServeCommandBuilder {
     /// moved into the core node, and shared by [`RouterFederation`] and
     /// [`FederationControl`].
     federation_connect_timeout: Duration,
+    /// The organization namespace resolved once for this daemon generation
+    /// (`"local"` when logged out, else the org id). Resolved in
+    /// [`with_messaging_router`](Self::with_messaging_router) from the cached
+    /// credentials and applied to the daemon's own session there; also threaded
+    /// into [`DaemonState`], the core node (and thus every spawned node), and the
+    /// [`RouterFederation`] task (which compares against it to decide restart vs
+    /// live re-federate). A single source for the whole generation.
+    organization_namespace: String,
+    /// The shared coordinator token for this generation: cloned into every serve
+    /// task (so a restart/stop unparks them for graceful teardown) and handed to
+    /// [`Serve`] (which cancels it on its way out). Created per generation.
+    teardown_token: CancellationToken,
 }
 
 impl ServeCommandBuilder {
@@ -71,6 +83,10 @@ impl ServeCommandBuilder {
             federation_connect_timeout: Duration::from_secs(
                 config::peppy_config::DEFAULT_FEDERATION_CONNECT_TIMEOUT_SECS,
             ),
+            // Default for the mock/other engines that never resolve a namespace;
+            // the zenoh path overwrites this in `with_messaging_router`.
+            organization_namespace: config::org::LOCAL_NAMESPACE.to_string(),
+            teardown_token: CancellationToken::new(),
         })
     }
 
@@ -124,6 +140,17 @@ impl ServeCommandBuilder {
                 self.federation_connect_timeout =
                     Duration::from_secs(self.peppy_config.federation.connect_timeout_secs);
 
+                // Resolve this generation's organization namespace once, from the
+                // cached credentials: `"local"` when logged out, else the org id.
+                // It is the single source threaded into the daemon's own session
+                // (here), `DaemonState`, every spawned node, and the federation
+                // task. The router itself is never namespaced (it only forwards),
+                // so the namespace rides only on application sessions.
+                let namespace = config::org::resolve_session_namespace(
+                    crate::auth::router::cached_organization_id_default().as_deref(),
+                );
+                self.organization_namespace = namespace.as_str().to_string();
+
                 let adapter = ZenohAdapter::with_router(
                     ZenohNetProtocol::Tcp,
                     "0.0.0.0",
@@ -135,7 +162,8 @@ impl ServeCommandBuilder {
                     Vec::new(),
                     None,
                 )?
-                .with_session_reconnect();
+                .with_session_reconnect()
+                .with_namespace(Some(namespace));
                 MessengerAdapter::Zenoh(adapter)
             }
             "mock" => MessengerAdapter::Mock(MockAdapter::default()),
@@ -163,6 +191,7 @@ impl ServeCommandBuilder {
                     messaging_ready_tx,
                     Some(core_node_done_rx),
                     teardown_budget,
+                    self.teardown_token.clone(),
                 )));
         Ok(self)
     }
@@ -200,16 +229,22 @@ impl ServeCommandBuilder {
                     self.messaging_ready.clone(),
                     self.clock_source,
                     self.peppy_config,
+                    self.organization_namespace.clone(),
+                    self.teardown_token.clone(),
                     core_node_done_tx,
                 );
 
-                // Write the daemon state file with the core node name
+                // Write the daemon state file with the core node name. The
+                // organization namespace is recorded here, before the control
+                // socket binds (below), so a CLI control session that reads it
+                // never sees a half-set generation.
                 let core_node_name = core_node.node_name().to_string();
                 let daemon_state = DaemonState::new(
                     &core_node_name,
                     messenger.blocking_lock().messaging_port(),
                     GIT_HASH,
                     shutdown_grace_secs,
+                    &self.organization_namespace,
                 );
                 let state_path = daemon_state.write().map_err(|e| {
                     Error::ExecutionFailed(format!("Failed to write daemon state: {}", e))
@@ -236,6 +271,9 @@ impl ServeCommandBuilder {
         // login/logout — immediately when poked over the control socket, else on
         // the next poll. It waits on `messaging_ready` before touching the router,
         // so it can't race MessagingRouter's initial `start_router`.
+        // In-process restart channel. `None` for the mock engine (no federation
+        // control), so a mock daemon never restarts; armed for the zenoh engine.
+        let mut restart_rx: Option<watch::Receiver<bool>> = None;
         if let Some(api_url) = self.federation_api_url.take()
             && let Some(messenger) = self.messenger.clone()
             && let Some(messaging_ready) = self.messaging_ready.clone()
@@ -245,6 +283,10 @@ impl ServeCommandBuilder {
             // the control socket so a login is federated immediately, not on the
             // next poll. Bounded + tiny: pokes are rare and serviced one at a time.
             let (trigger_tx, trigger_rx) = tokio::sync::mpsc::channel(8);
+            // Restart signal: the control handler raises it after flushing the
+            // `Restarting` ack; the serve coordinator observes it.
+            let (restart_tx, restart_signal_rx) = watch::channel(false);
+            restart_rx = Some(restart_signal_rx);
             self.composite_command =
                 self.composite_command
                     .add_async_command(Box::new(RouterFederation::new(
@@ -253,6 +295,11 @@ impl ServeCommandBuilder {
                         messaging_ready,
                         trigger_rx,
                         connect_timeout,
+                        // This generation's namespace: the federation loop compares
+                        // the namespace it re-resolves from fresh creds against this
+                        // to decide live re-federate (unchanged) vs restart (changed).
+                        self.organization_namespace.clone(),
+                        self.teardown_token.clone(),
                     )));
 
             // Control socket the CLI pokes. Derived from the same `PeppyDirs` the
@@ -266,10 +313,15 @@ impl ServeCommandBuilder {
                         socket_path,
                         trigger_tx,
                         connect_timeout,
+                        restart_tx,
+                        self.teardown_token.clone(),
                     )));
         }
 
-        let serve = Serve::new(self.composite_command);
+        let mut serve = Serve::new(self.composite_command).with_teardown_token(self.teardown_token);
+        if let Some(rx) = restart_rx {
+            serve = serve.with_restart_rx(rx);
+        }
         let serve = match self.shutdown_token {
             Some(token) => serve.with_shutdown_token(token),
             None => serve,
@@ -279,7 +331,7 @@ impl ServeCommandBuilder {
 }
 
 /// Extracts the messaging port from the environment variable, falling back to the default port.
-fn extract_messaging_port() -> u16 {
+pub(super) fn extract_messaging_port() -> u16 {
     std::env::var(config::consts::PEPPY_MESSAGING_PORT_VAR_NAME)
         .ok()
         .and_then(|s| s.parse().ok())

--- a/crates/peppy/src/commands/service/core_node.rs
+++ b/crates/peppy/src/commands/service/core_node.rs
@@ -34,8 +34,14 @@ pub struct CoreNodeRunner {
     core_node: CoreNode,
     messaging_ready: Option<watch::Receiver<bool>>,
     /// Cancelled at the start of shutdown to stop the core node's clock +
-    /// heartbeat publishers before the messaging session is closed.
+    /// heartbeat publishers before the messaging session is closed. This is the
+    /// core node's OWN internal token (publisher-stop), distinct from the shared
+    /// serve coordinator token below.
     shutdown_token: CancellationToken,
+    /// Shared serve coordinator token: the runner observes it to begin teardown
+    /// on either a real OS shutdown signal or an in-process restart. Distinct
+    /// from `shutdown_token`, which only stops the publishers.
+    serve_teardown_token: CancellationToken,
     /// Signaled (`true`) once node teardown has finished, releasing the
     /// messaging router to close the session. The startup `messaging_ready`
     /// watch's shutdown-side counterpart.
@@ -53,6 +59,8 @@ impl CoreNodeRunner {
         messaging_ready: Option<watch::Receiver<bool>>,
         clock_source: super::ClockSource,
         peppy_config: config::peppy_config::PeppyConfig,
+        organization_namespace: String,
+        serve_teardown_token: CancellationToken,
         core_node_done: watch::Sender<bool>,
     ) -> Self {
         let node_arguments = CoreNodeArguments {
@@ -84,12 +92,14 @@ impl CoreNodeRunner {
             root_dir,
             peppy_dirs,
             peppy_config,
+            organization_namespace,
             shutdown_token: shutdown_token.clone(),
         });
         Self {
             core_node,
             messaging_ready,
             shutdown_token,
+            serve_teardown_token,
             core_node_done,
         }
     }
@@ -105,10 +115,13 @@ impl ServeAsyncCommand for CoreNodeRunner {
         let core_node = self.core_node;
         let mut messaging_ready = self.messaging_ready;
         let shutdown_token = self.shutdown_token;
+        let serve_teardown_token = self.serve_teardown_token;
         let core_node_done = self.core_node_done;
         let future = Box::pin(async move {
-            let shutdown_signal = super::shutdown_signal::shutdown_signal();
-            tokio::pin!(shutdown_signal);
+            // Tear down on a real OS shutdown signal OR an in-process restart
+            // (the shared serve coordinator token).
+            let teardown = super::shutdown_signal::shutdown_or_token(&serve_teardown_token);
+            tokio::pin!(teardown);
 
             if let Some(mut ready_rx) = messaging_ready.take() {
                 if !*ready_rx.borrow() {
@@ -135,15 +148,9 @@ impl ServeAsyncCommand for CoreNodeRunner {
                         ))
                     })
                 }
-                ctrl_c_result = &mut shutdown_signal => {
+                _ = &mut teardown => {
                     shutdown_triggered = true;
-                    match ctrl_c_result {
-                        Ok(()) => Ok(()),
-                        Err(err) => Err(Error::ExecutionFailed(format!(
-                            "Failed to listen for shutdown signal: {}",
-                            err
-                        ))),
-                    }
+                    Ok(())
                 }
             };
 

--- a/crates/peppy/src/commands/service/federation_control.rs
+++ b/crates/peppy/src/commands/service/federation_control.rs
@@ -19,13 +19,13 @@ use std::time::Duration;
 
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{UnixListener, UnixStream};
-use tokio::sync::oneshot;
+use tokio::sync::{oneshot, watch};
+use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
 use super::router_federation::{FederationOutcome, RefederateRequest, TriggerSender};
 use super::serve::{ServeAsyncCommand, ServeAsyncHandle};
 use crate::daemon_control::{ControlResponse, REFEDERATE_VERB};
-use crate::error::Error;
 
 /// Bound on reading a request line, so a client that connects but never writes
 /// cannot hold a handler task open.
@@ -47,6 +47,7 @@ impl From<FederationOutcome> for ControlResponse {
             FederationOutcome::Pinned => ControlResponse::Pinned,
             FederationOutcome::Failed(message) => ControlResponse::Error { message },
             FederationOutcome::Unreachable(message) => ControlResponse::Unreachable { message },
+            FederationOutcome::Restart => ControlResponse::Restarting,
         }
     }
 }
@@ -58,6 +59,13 @@ pub(crate) struct FederationControl {
     /// Bound on how long to wait for a poked poll to apply before replying with a
     /// timeout (so a wedged apply can't hold a connection open forever).
     connect_timeout: Duration,
+    /// In-process restart signal. The control handler raises it *after* it has
+    /// flushed a `Restarting` ack (a real happens-before edge), so the CLI always
+    /// reads the ack before teardown can affect the connection.
+    restart_tx: watch::Sender<bool>,
+    /// Shared coordinator token: the task tears down when it is cancelled (an
+    /// in-process restart) or on a real OS shutdown signal.
+    teardown_token: CancellationToken,
 }
 
 impl FederationControl {
@@ -65,11 +73,15 @@ impl FederationControl {
         socket_path: PathBuf,
         trigger_tx: TriggerSender,
         connect_timeout: Duration,
+        restart_tx: watch::Sender<bool>,
+        teardown_token: CancellationToken,
     ) -> Self {
         Self {
             socket_path,
             trigger_tx,
             connect_timeout,
+            restart_tx,
+            teardown_token,
         }
     }
 }
@@ -80,17 +92,16 @@ impl ServeAsyncCommand for FederationControl {
             socket_path,
             trigger_tx,
             connect_timeout,
+            restart_tx,
+            teardown_token,
         } = *self;
         let future = Box::pin(async move {
-            // Race the accept loop against shutdown so the daemon can exit
-            // promptly (the loop is otherwise infinite).
+            // Race the accept loop against shutdown (a real signal or an in-process
+            // restart via the shared token) so the daemon can exit promptly (the
+            // loop is otherwise infinite).
             tokio::select! {
-                _ = serve_control(&socket_path, trigger_tx, connect_timeout) => {}
-                res = super::shutdown_signal::shutdown_signal() => {
-                    res.map_err(|e| Error::ExecutionFailed(
-                        format!("federation control: failed to listen for shutdown: {e}")
-                    ))?;
-                }
+                _ = serve_control(&socket_path, trigger_tx, connect_timeout, restart_tx) => {}
+                _ = super::shutdown_signal::shutdown_or_token(&teardown_token) => {}
             }
             // Best-effort cleanup so a stale socket does not linger (the next start
             // unlinks unconditionally anyway).
@@ -105,7 +116,12 @@ impl ServeAsyncCommand for FederationControl {
 
 /// Binds the socket and accepts poke connections until cancelled. A bind failure
 /// is non-fatal: log it and idle until shutdown rather than aborting the daemon.
-async fn serve_control(socket_path: &Path, trigger_tx: TriggerSender, connect_timeout: Duration) {
+async fn serve_control(
+    socket_path: &Path,
+    trigger_tx: TriggerSender,
+    connect_timeout: Duration,
+    restart_tx: watch::Sender<bool>,
+) {
     let listener = match bind_listener(socket_path) {
         Ok(listener) => listener,
         Err(e) => {
@@ -115,9 +131,11 @@ async fn serve_control(socket_path: &Path, trigger_tx: TriggerSender, connect_ti
                 "federation control: could not bind control socket; login/logout pokes \
                  will not be applied immediately (federation still updates on its own poll)"
             );
-            // Hold `trigger_tx` alive (so the federation loop's channel stays
-            // open) and wait for the shutdown race above to cancel us.
+            // Hold `trigger_tx`/`restart_tx` alive (so the federation loop's
+            // channel and the restart watch stay open) and wait for the shutdown
+            // race above to cancel us.
             let _keep_sender_alive = trigger_tx;
+            let _keep_restart_alive = restart_tx;
             std::future::pending::<()>().await;
             return;
         }
@@ -139,8 +157,11 @@ async fn serve_control(socket_path: &Path, trigger_tx: TriggerSender, connect_ti
             Ok((stream, _addr)) => {
                 accept_backoff = ACCEPT_BACKOFF_INIT;
                 let trigger_tx = trigger_tx.clone();
+                let restart_tx = restart_tx.clone();
                 tokio::spawn(async move {
-                    if let Err(e) = handle_conn(stream, trigger_tx, connect_timeout).await {
+                    if let Err(e) =
+                        handle_conn(stream, trigger_tx, connect_timeout, restart_tx).await
+                    {
                         warn!(error = %e, "federation control: error handling a poke");
                     }
                 });
@@ -180,6 +201,7 @@ async fn handle_conn(
     stream: UnixStream,
     trigger_tx: TriggerSender,
     connect_timeout: Duration,
+    restart_tx: watch::Sender<bool>,
 ) -> std::io::Result<()> {
     let (read_half, mut write_half) = stream.into_split();
     let mut reader = BufReader::new(read_half);
@@ -215,7 +237,18 @@ async fn handle_conn(
         Ok(Err(_)) => ControlResponse::error("federation task dropped the request"),
         Err(_elapsed) => ControlResponse::error("timed out applying federation"),
     };
-    write_response(&mut write_half, response).await
+
+    // The namespace changed: write+flush the `Restarting` ack FIRST, and only
+    // after the flush returns `Ok` (the bytes are in the kernel socket buffer)
+    // raise the in-process restart signal. This is a real happens-before edge:
+    // the CLI always reads the ack before teardown can affect the connection, and
+    // there is no self-SIGTERM and no fire-and-forget oneshot race.
+    let trigger_restart = matches!(response, ControlResponse::Restarting);
+    write_response(&mut write_half, response).await?;
+    if trigger_restart {
+        let _ = restart_tx.send(true);
+    }
+    Ok(())
 }
 
 /// Writes one JSON response line and flushes.
@@ -290,8 +323,15 @@ mod tests {
 
         // The control listener, bound on the temp socket.
         let socket_for_listener = socket.clone();
+        let (restart_tx, _restart_rx) = watch::channel(false);
         let control = tokio::spawn(async move {
-            serve_control(&socket_for_listener, trigger_tx, Duration::from_secs(5)).await;
+            serve_control(
+                &socket_for_listener,
+                trigger_tx,
+                Duration::from_secs(5),
+                restart_tx,
+            )
+            .await;
         });
 
         // Drive the blocking client off the async workers; it retries connect
@@ -326,8 +366,15 @@ mod tests {
         let (trigger_tx, mut trigger_rx) = mpsc::channel::<RefederateRequest>(8);
 
         let socket_for_listener = socket.clone();
+        let (restart_tx, _restart_rx) = watch::channel(false);
         let control = tokio::spawn(async move {
-            serve_control(&socket_for_listener, trigger_tx, Duration::from_secs(5)).await;
+            serve_control(
+                &socket_for_listener,
+                trigger_tx,
+                Duration::from_secs(5),
+                restart_tx,
+            )
+            .await;
         });
 
         let socket_for_client = socket.clone();

--- a/crates/peppy/src/commands/service/install.rs
+++ b/crates/peppy/src/commands/service/install.rs
@@ -112,6 +112,22 @@ fn make_install_context(
             std::env::var_os(config::consts::PEPPY_HOME_ENV),
         )),
         autostart,
+        // Crash-only supervision: the daemon supervises its own NORMAL restarts
+        // in-process (a namespace change rebuilds the generation under the same
+        // PID), so the OS supervisor must recover ONLY a genuine crash or the
+        // `exit(RESTART_EXIT_CODE)` fallback (port-stuck / flap-cap), never a
+        // clean `service stop` (exit 0). `RestartPolicy::OnFailure` gives exactly
+        // that on both platforms via the `service_manager` crate (verified against
+        // 0.11): systemd `Restart=on-failure`, launchd `KeepAlive { SuccessfulExit
+        // = false }`. A clean stop therefore stays stopped.
+        //
+        // FOLLOW-UP: systemd's default `StartLimitBurst` could give up after a few
+        // rapid `exit(RESTART_EXIT_CODE)` fallbacks; the in-process flap backstop
+        // already caps that, but `StartLimitIntervalSec=0` would also disable the
+        // unit-side limit. The `service_manager` 0.11 generic API does not expose
+        // it (its own TODO maps `reset_after_secs` -> `StartLimitIntervalSec`), so
+        // it would require overriding `ServiceInstallCtx.contents` with a fully
+        // rendered unit; deferred until flapping is actually observed.
         restart_policy: RestartPolicy::OnFailure {
             delay_secs: Some(5),
             max_retries: None,

--- a/crates/peppy/src/commands/service/messaging_router.rs
+++ b/crates/peppy/src/commands/service/messaging_router.rs
@@ -4,6 +4,7 @@ use pmi::{Messenger, MessengerBackend, RouterHealthChecker};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{Mutex, oneshot, watch};
+use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 
 /// How often the watchdog probes the router while it appears healthy.
@@ -56,6 +57,9 @@ pub struct MessagingRouter {
     /// duration: `force_kill_deadline(grace)` (hook grace + event-loop join +
     /// interpreter finalize) plus the reap budget and a small margin.
     teardown_budget: Duration,
+    /// Shared coordinator token: the task tears down when it is cancelled (an
+    /// in-process restart) or on a real OS shutdown signal.
+    teardown_token: CancellationToken,
 }
 
 impl MessagingRouter {
@@ -64,12 +68,14 @@ impl MessagingRouter {
         messaging_ready: watch::Sender<bool>,
         core_node_done: Option<watch::Receiver<bool>>,
         teardown_budget: Duration,
+        teardown_token: CancellationToken,
     ) -> Self {
         Self {
             messenger,
             messaging_ready,
             core_node_done,
             teardown_budget,
+            teardown_token,
         }
     }
 }
@@ -81,6 +87,7 @@ impl ServeAsyncCommand for MessagingRouter {
         let messaging_ready = self.messaging_ready;
         let core_node_done = self.core_node_done;
         let teardown_budget = self.teardown_budget;
+        let teardown_token = self.teardown_token;
 
         let future = Box::pin(async move {
             {
@@ -109,24 +116,14 @@ impl ServeAsyncCommand for MessagingRouter {
                 Some(checker) => {
                     tokio::select! {
                         // The watchdog loops for the daemon's lifetime; in
-                        // practice only a shutdown signal resolves this select.
+                        // practice only shutdown (a real signal or an in-process
+                        // restart via the shared token) resolves this select.
                         _ = run_router_watchdog(&messenger, &checker) => {}
-                        res = super::shutdown_signal::shutdown_signal() => {
-                            res.map_err(|e| {
-                                Error::ExecutionFailed(format!("Failed to listen for shutdown signal: {}", e))
-                            })?;
-                        }
+                        _ = super::shutdown_signal::shutdown_or_token(&teardown_token) => {}
                     }
                 }
                 None => {
-                    super::shutdown_signal::shutdown_signal()
-                        .await
-                        .map_err(|e| {
-                            Error::ExecutionFailed(format!(
-                                "Failed to listen for shutdown signal: {}",
-                                e
-                            ))
-                        })?;
+                    super::shutdown_signal::shutdown_or_token(&teardown_token).await;
                 }
             }
 

--- a/crates/peppy/src/commands/service/router_federation.rs
+++ b/crates/peppy/src/commands/service/router_federation.rs
@@ -180,6 +180,13 @@ pub(crate) struct RouterFederation {
     /// Resolves the current namespace from the credentials (post-pull), compared
     /// against `startup_namespace` to detect a namespace change.
     namespace_resolver: NamespaceResolver,
+    /// In-process restart signal (the serve coordinator's). The *startup*
+    /// federation poll raises it when it discovers the credentials already resolve
+    /// to a different namespace than this generation started under, so the live
+    /// session (which can't be re-namespaced) is rebuilt rather than left running
+    /// un-federated. The steady-state poke path instead acks `Restart` and the
+    /// control handler raises this same signal after flushing the ack.
+    restart_tx: watch::Sender<bool>,
     /// Shared coordinator token: the task tears down when it is cancelled (an
     /// in-process restart) or on a real OS shutdown signal.
     teardown_token: CancellationToken,
@@ -194,6 +201,7 @@ impl RouterFederation {
         trigger_rx: TriggerReceiver,
         connect_timeout: Duration,
         startup_namespace: String,
+        restart_tx: watch::Sender<bool>,
         teardown_token: CancellationToken,
     ) -> Self {
         let resolver: Resolver = Arc::new(move || {
@@ -208,6 +216,7 @@ impl RouterFederation {
             connect_timeout,
             startup_namespace,
             namespace_resolver: real_namespace_resolver(),
+            restart_tx,
             teardown_token,
         }
     }
@@ -224,6 +233,7 @@ impl ServeAsyncCommand for RouterFederation {
             connect_timeout,
             startup_namespace,
             namespace_resolver,
+            restart_tx,
             teardown_token,
         } = *self;
         // Readiness gate: fired by `manage_federation` once the first federation
@@ -239,7 +249,7 @@ impl ServeAsyncCommand for RouterFederation {
             tokio::select! {
                 _ = manage_federation(
                     federator, resolver, prober, messaging_ready, trigger_rx, ready_tx,
-                    connect_timeout, startup_namespace, namespace_resolver,
+                    connect_timeout, startup_namespace, namespace_resolver, restart_tx,
                 ) => {}
                 _ = super::shutdown_signal::shutdown_or_token(&teardown_token) => {}
             }
@@ -291,6 +301,7 @@ async fn manage_federation(
     connect_timeout: Duration,
     startup_namespace: String,
     namespace_resolver: NamespaceResolver,
+    restart_tx: watch::Sender<bool>,
 ) {
     let mut ready_tx = Some(ready_tx);
 
@@ -329,7 +340,7 @@ async fn manage_federation(
     // initial poll does not verify (`verify = false`): startup must not block on a
     // TLS handshake, and the verifying check belongs to the login poke.
     let mut applied = AppliedState::default();
-    poll_and_apply(
+    let initial_outcome = poll_and_apply(
         &federator,
         &resolver,
         &prober,
@@ -341,6 +352,26 @@ async fn manage_federation(
     )
     .await;
     fire_gate(&mut ready_tx);
+
+    // The initial poll re-pulled the federation config, so the credentials now
+    // reflect the current org. If that resolves to a *different* namespace than
+    // this generation started under (e.g. the daemon started logged-in but with a
+    // cleared/stale router cache, so `startup_namespace` was `local` before the
+    // pull discovered the real org), the live session can't be re-namespaced.
+    // Request a generation restart now — otherwise the daemon would run
+    // un-federated under the wrong namespace until the next login/logout poke. The
+    // steady-state poke path leaves the actual restart to the control handler
+    // (which flushes its ack first); the startup poll has no ack to flush, so it
+    // raises the signal directly. The rebuilt generation resolves the namespace
+    // afresh and federates normally.
+    if matches!(initial_outcome, FederationOutcome::Restart) {
+        info!(
+            "router federation: startup resolved a namespace that differs from this generation's; \
+             requesting a daemon restart instead of federating under the wrong namespace"
+        );
+        let _ = restart_tx.send(true);
+        return;
+    }
 
     // Phase 3 — steady state: react to immediate login/logout pokes from `auth
     // login`/`logout`. There is no periodic keepalive: the local router keeps its
@@ -660,6 +691,23 @@ mod tests {
         (resolver, calls)
     }
 
+    /// A namespace resolver that returns `first` on its first call and `rest`
+    /// after, so the *startup* poll sees the unchanged namespace (no startup
+    /// restart) and a later *poke* sees the change — exercising the steady-state
+    /// `Restart` ack distinctly from the startup restart path.
+    fn switching_ns_resolver(first: &str, rest: &str) -> NamespaceResolver {
+        let calls = AtomicUsize::new(0);
+        let first = first.to_string();
+        let rest = rest.to_string();
+        Arc::new(move || {
+            if calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                first.clone()
+            } else {
+                rest.clone()
+            }
+        })
+    }
+
     /// A login/logout poke runs a federation poll *immediately*, verifies the
     /// link, and acks the applied outcome — the whole point of the control
     /// channel. The initial (non-poke) poll does NOT probe; only the verifying
@@ -683,6 +731,7 @@ mod tests {
             Duration::from_secs(5),
             "local".to_string(),
             local_ns_resolver(),
+            watch::channel(false).0,
         ));
 
         // Startup gate fires after the first (initial) poll; that poll resolved
@@ -756,6 +805,7 @@ mod tests {
             Duration::from_secs(45),
             "local".to_string(),
             local_ns_resolver(),
+            watch::channel(false).0,
         ));
         tokio::time::timeout(Duration::from_secs(1), ready_rx)
             .await
@@ -804,6 +854,7 @@ mod tests {
             Duration::from_secs(5),
             "local".to_string(),
             local_ns_resolver(),
+            watch::channel(false).0,
         ));
 
         tokio::time::timeout(Duration::from_secs(1), ready_rx)
@@ -859,6 +910,7 @@ mod tests {
             Duration::from_secs(5),
             "local".to_string(),
             local_ns_resolver(),
+            watch::channel(false).0,
         ));
 
         tokio::time::timeout(Duration::from_secs(1), ready_rx)
@@ -918,6 +970,7 @@ mod tests {
             Duration::from_millis(100),
             "local".to_string(),
             local_ns_resolver(),
+            watch::channel(false).0,
         ));
 
         // Gate fires close to the 100ms bound, well before the 400ms resolve.
@@ -950,6 +1003,7 @@ mod tests {
             Duration::from_secs(5),
             "local".to_string(),
             local_ns_resolver(),
+            watch::channel(false).0,
         ));
 
         tokio::time::timeout(Duration::from_secs(1), ready_rx)
@@ -969,16 +1023,21 @@ mod tests {
 
     /// A poke after the credentials change the daemon's namespace acks `Restart`
     /// (the control handler then triggers a generation restart). The loop must NOT
-    /// federate or probe on a namespace change — a restart is fail-closed.
+    /// federate or probe on a namespace change — a restart is fail-closed. The
+    /// change appears only at the poke (the startup poll still sees `local`), so the
+    /// startup-restart path stays dormant and the steady-state ack is exercised.
     #[tokio::test]
     async fn poke_acks_restart_on_a_namespace_change() {
         let (resolver, _calls) = counting_resolver(upstream());
         let (prober, probe_calls) = counting_prober(Ok(()));
-        // The re-resolved namespace differs from the `local` startup namespace.
-        let (ns_resolver, ns_calls) = counting_ns_resolver("550e8400-e29b-41d4-a716-446655440000");
+        // Startup resolves `local` (matches the startup namespace ⇒ no startup
+        // restart); the poke resolves the changed org id ⇒ a steady-state Restart.
+        let ns_resolver = switching_ns_resolver("local", "550e8400-e29b-41d4-a716-446655440000");
         let (messaging_tx, messaging_rx) = watch::channel(true);
         let (trigger_tx, trigger_rx) = mpsc::channel(8);
         let (ready_tx, ready_rx) = oneshot::channel();
+        // The startup poll must NOT raise the restart signal in this scenario.
+        let (restart_tx, restart_rx) = watch::channel(false);
 
         let task = tokio::spawn(manage_federation(
             applying_federator(),
@@ -990,12 +1049,17 @@ mod tests {
             Duration::from_secs(5),
             "local".to_string(),
             ns_resolver,
+            restart_tx,
         ));
 
         tokio::time::timeout(Duration::from_secs(1), ready_rx)
             .await
             .expect("startup gate fires")
             .expect("gate sender not dropped");
+        assert!(
+            !*restart_rx.borrow(),
+            "the startup poll saw an unchanged namespace ⇒ no startup restart"
+        );
 
         let (ack_tx, ack_rx) = oneshot::channel();
         trigger_tx
@@ -1017,9 +1081,61 @@ mod tests {
             0,
             "a restart never probes the link"
         );
+
+        drop(messaging_tx);
+        task.abort();
+    }
+
+    /// The *startup* federation poll, on resolving a namespace that differs from
+    /// the one this generation started under (e.g. logged in but the router cache
+    /// was empty at build time so the startup namespace was `local`), must raise
+    /// the in-process restart signal itself — there is no poke to ack — rather than
+    /// run on un-federated under the wrong namespace. It also must not federate or
+    /// probe on that drift (a restart is fail-closed).
+    #[tokio::test]
+    async fn startup_poll_requests_restart_on_namespace_drift() {
+        let (resolver, _calls) = counting_resolver(upstream());
+        let (prober, probe_calls) = counting_prober(Ok(()));
+        // Every resolve returns an org id that differs from the `local` startup
+        // namespace, so the very first (startup) poll detects the drift.
+        let (ns_resolver, ns_calls) = counting_ns_resolver("550e8400-e29b-41d4-a716-446655440000");
+        let (messaging_tx, messaging_rx) = watch::channel(true);
+        let (_trigger_tx, trigger_rx) = mpsc::channel(8);
+        let (ready_tx, ready_rx) = oneshot::channel();
+        let (restart_tx, mut restart_rx) = watch::channel(false);
+
+        let task = tokio::spawn(manage_federation(
+            applying_federator(),
+            resolver,
+            prober,
+            messaging_rx,
+            trigger_rx,
+            ready_tx,
+            Duration::from_secs(5),
+            "local".to_string(),
+            ns_resolver,
+            restart_tx,
+        ));
+
+        // Startup still unblocks `serve` (the gate fires) ...
+        tokio::time::timeout(Duration::from_secs(1), ready_rx)
+            .await
+            .expect("startup gate fires even when a restart is requested")
+            .expect("gate sender not dropped");
+        // ... and then the startup poll raises the restart signal on its own.
+        tokio::time::timeout(Duration::from_secs(1), restart_rx.changed())
+            .await
+            .expect("the startup poll raises the restart signal")
+            .expect("restart sender not dropped");
+        assert!(*restart_rx.borrow(), "the restart signal is set");
+        assert_eq!(
+            probe_calls.load(Ordering::SeqCst),
+            0,
+            "a startup restart never probes the link"
+        );
         assert!(
             ns_calls.load(Ordering::SeqCst) >= 1,
-            "the namespace was re-resolved to detect the change"
+            "the namespace was re-resolved to detect the drift"
         );
 
         drop(messaging_tx);

--- a/crates/peppy/src/commands/service/router_federation.rs
+++ b/crates/peppy/src/commands/service/router_federation.rs
@@ -41,6 +41,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{Mutex, mpsc, oneshot, watch};
+use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
 /// How long a *verifying* login/logout poke waits for the federation link's TLS
@@ -116,6 +117,34 @@ pub(crate) enum FederationOutcome {
     /// federation with platform-backend is NOT actually in effect (e.g. an
     /// UnknownCA handshake loop). Only a verifying poke produces this.
     Unreachable(String),
+    /// The credentials changed the daemon's *organization namespace*. A session's
+    /// namespace is immutable after open and the core node holds long-lived
+    /// declarations, so the change cannot be applied to the live session by a
+    /// zenohd bounce; it needs a full daemon-generation restart. This poll does
+    /// NOT (de)federate (federating under a namespace that differs from the live
+    /// session's would leak across tenants); it just signals the restart. The
+    /// control handler owns triggering it (after flushing the ack); the federation
+    /// loop only reports it.
+    Restart,
+}
+
+/// Resolves the daemon's *current* organization namespace from the credentials
+/// (after a federation pull has warmed the cache), so the federation loop can
+/// compare it to the generation's startup namespace. A boxed closure so tests can
+/// inject a deterministic value in place of the real credentials read.
+type NamespaceResolver = Arc<dyn Fn() -> String + Send + Sync>;
+
+/// The real namespace resolver: read the cached organization id and resolve it to
+/// a namespace (absent -> `local`), matching exactly how the daemon generation
+/// resolved its own namespace at startup.
+fn real_namespace_resolver() -> NamespaceResolver {
+    Arc::new(|| {
+        config::org::resolve_session_namespace(
+            crate::auth::router::cached_organization_id_default().as_deref(),
+        )
+        .as_str()
+        .to_string()
+    })
 }
 
 /// A "refederate now" request from the control socket: run a poll immediately and
@@ -144,15 +173,28 @@ pub(crate) struct RouterFederation {
     /// Bound on the initial federation (the startup gate) and on each resolve, so
     /// a slow/unreachable backend can't stall startup or a poll past it.
     connect_timeout: Duration,
+    /// This generation's organization namespace, resolved once at startup. A poll
+    /// that re-resolves a *different* namespace from fresh creds requests a
+    /// restart instead of a live re-federation.
+    startup_namespace: String,
+    /// Resolves the current namespace from the credentials (post-pull), compared
+    /// against `startup_namespace` to detect a namespace change.
+    namespace_resolver: NamespaceResolver,
+    /// Shared coordinator token: the task tears down when it is cancelled (an
+    /// in-process restart) or on a real OS shutdown signal.
+    teardown_token: CancellationToken,
 }
 
 impl RouterFederation {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         messenger: Arc<Mutex<Messenger>>,
         api_url: String,
         messaging_ready: watch::Receiver<bool>,
         trigger_rx: TriggerReceiver,
         connect_timeout: Duration,
+        startup_namespace: String,
+        teardown_token: CancellationToken,
     ) -> Self {
         let resolver: Resolver = Arc::new(move || {
             crate::auth::router::resolve_federation_target(&api_url, connect_timeout)
@@ -164,6 +206,9 @@ impl RouterFederation {
             messaging_ready,
             trigger_rx,
             connect_timeout,
+            startup_namespace,
+            namespace_resolver: real_namespace_resolver(),
+            teardown_token,
         }
     }
 }
@@ -177,6 +222,9 @@ impl ServeAsyncCommand for RouterFederation {
             messaging_ready,
             trigger_rx,
             connect_timeout,
+            startup_namespace,
+            namespace_resolver,
+            teardown_token,
         } = *self;
         // Readiness gate: fired by `manage_federation` once the first federation
         // poll completes (or the timeout elapses), so `serve` blocks on federation
@@ -185,18 +233,15 @@ impl ServeAsyncCommand for RouterFederation {
         // below before it fires) degrades to "proceed standalone", never a crash.
         let (ready_tx, ready_rx) = oneshot::channel();
         let future = Box::pin(async move {
-            // Race the maintenance loop against shutdown so the daemon can exit
+            // Race the maintenance loop against shutdown (a real signal or an
+            // in-process restart via the shared token) so the daemon can exit
             // promptly (the loop is otherwise infinite).
             tokio::select! {
                 _ = manage_federation(
                     federator, resolver, prober, messaging_ready, trigger_rx, ready_tx,
-                    connect_timeout,
+                    connect_timeout, startup_namespace, namespace_resolver,
                 ) => {}
-                res = super::shutdown_signal::shutdown_signal() => {
-                    res.map_err(|e| Error::ExecutionFailed(
-                        format!("router federation: failed to listen for shutdown: {e}")
-                    ))?;
-                }
+                _ = super::shutdown_signal::shutdown_or_token(&teardown_token) => {}
             }
             Ok(())
         });
@@ -235,6 +280,7 @@ struct AppliedState {
 /// against the shutdown signal). There is no periodic keepalive: once federated,
 /// the local router holds its upstream link open on its own and the backend
 /// actively health-checks this daemon.
+#[allow(clippy::too_many_arguments)]
 async fn manage_federation(
     federator: Federator,
     resolver: Resolver,
@@ -243,6 +289,8 @@ async fn manage_federation(
     mut trigger_rx: TriggerReceiver,
     ready_tx: oneshot::Sender<()>,
     connect_timeout: Duration,
+    startup_namespace: String,
+    namespace_resolver: NamespaceResolver,
 ) {
     let mut ready_tx = Some(ready_tx);
 
@@ -288,6 +336,8 @@ async fn manage_federation(
         connect_timeout,
         &mut applied,
         false,
+        &startup_namespace,
+        &namespace_resolver,
     )
     .await;
     fire_gate(&mut ready_tx);
@@ -309,9 +359,14 @@ async fn manage_federation(
             connect_timeout,
             &mut applied,
             true,
+            &startup_namespace,
+            &namespace_resolver,
         )
         .await;
-        // The CLI may have already given up (read timeout); ignore.
+        // The CLI may have already given up (read timeout); ignore. On a namespace
+        // change this acks `Restart`; the control handler (`handle_conn`) flushes
+        // that ack and only then raises the in-process restart signal, so the
+        // restart is never triggered from this loop.
         let _ = req.ack.send(outcome);
     }
 }
@@ -325,6 +380,7 @@ async fn manage_federation(
 /// actually validates; a failed handshake is reported as
 /// [`FederationOutcome::Unreachable`] (and logged loudly) instead of a false
 /// `Applied`.
+#[allow(clippy::too_many_arguments)]
 async fn poll_and_apply(
     federator: &Federator,
     resolver: &Resolver,
@@ -332,6 +388,8 @@ async fn poll_and_apply(
     connect_timeout: Duration,
     applied: &mut AppliedState,
     verify: bool,
+    startup_namespace: &str,
+    namespace_resolver: &NamespaceResolver,
 ) -> FederationOutcome {
     // The resolver is blocking (HTTP + file I/O); keep it off the async worker. It
     // also re-pulls the cloud router's config when the cached copy has gone stale
@@ -356,6 +414,26 @@ async fn poll_and_apply(
             return FederationOutcome::Failed("resolve timed out".to_string());
         }
     };
+
+    // Namespace-change gate. The resolve above re-pulled (and re-cached) the
+    // federation config, so the credentials now reflect the current org id. A
+    // session's namespace is immutable after open, so if the re-resolved namespace
+    // differs from this generation's startup namespace the change cannot be applied
+    // by a live zenodh bounce: request a full restart instead, WITHOUT federating
+    // (federating under a namespace that differs from the live session's would leak
+    // across tenants). The control handler flushes the ack before triggering the
+    // restart; the initial (non-poke) poll discards this outcome but, crucially,
+    // also does not federate, so it stays fail-closed until the next generation.
+    let current_namespace = namespace_resolver();
+    if current_namespace != startup_namespace {
+        info!(
+            from = %startup_namespace,
+            to = %current_namespace,
+            "router federation: organization namespace changed; requesting a daemon restart \
+             (a namespace change cannot be applied to a live session)"
+        );
+        return FederationOutcome::Restart;
+    }
 
     let desired = resolved.as_ref().map(|(ep, _)| ep.clone());
 
@@ -562,6 +640,26 @@ mod tests {
         Some((ENDPOINT.to_string(), pmi::TlsConfig::default()))
     }
 
+    /// A namespace resolver that always returns `local`, matching the `local`
+    /// startup namespace these tests pass, so no namespace change is detected and
+    /// the existing federation behavior (Applied/Pinned/...) is exercised.
+    fn local_ns_resolver() -> NamespaceResolver {
+        Arc::new(|| "local".to_string())
+    }
+
+    /// A namespace resolver returning a fixed value and counting its calls, for a
+    /// test that exercises the namespace-change restart path.
+    fn counting_ns_resolver(value: &str) -> (NamespaceResolver, Arc<AtomicUsize>) {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let counter = calls.clone();
+        let value = value.to_string();
+        let resolver: NamespaceResolver = Arc::new(move || {
+            counter.fetch_add(1, Ordering::SeqCst);
+            value.clone()
+        });
+        (resolver, calls)
+    }
+
     /// A login/logout poke runs a federation poll *immediately*, verifies the
     /// link, and acks the applied outcome — the whole point of the control
     /// channel. The initial (non-poke) poll does NOT probe; only the verifying
@@ -583,6 +681,8 @@ mod tests {
             trigger_rx,
             ready_tx,
             Duration::from_secs(5),
+            "local".to_string(),
+            local_ns_resolver(),
         ));
 
         // Startup gate fires after the first (initial) poll; that poll resolved
@@ -654,6 +754,8 @@ mod tests {
             ready_tx,
             // A deliberately large connect_timeout: the probe must NOT inherit it.
             Duration::from_secs(45),
+            "local".to_string(),
+            local_ns_resolver(),
         ));
         tokio::time::timeout(Duration::from_secs(1), ready_rx)
             .await
@@ -700,6 +802,8 @@ mod tests {
             trigger_rx,
             ready_tx,
             Duration::from_secs(5),
+            "local".to_string(),
+            local_ns_resolver(),
         ));
 
         tokio::time::timeout(Duration::from_secs(1), ready_rx)
@@ -753,6 +857,8 @@ mod tests {
             trigger_rx,
             ready_tx,
             Duration::from_secs(5),
+            "local".to_string(),
+            local_ns_resolver(),
         ));
 
         tokio::time::timeout(Duration::from_secs(1), ready_rx)
@@ -810,6 +916,8 @@ mod tests {
             trigger_rx,
             ready_tx,
             Duration::from_millis(100),
+            "local".to_string(),
+            local_ns_resolver(),
         ));
 
         // Gate fires close to the 100ms bound, well before the 400ms resolve.
@@ -840,6 +948,8 @@ mod tests {
             trigger_rx,
             ready_tx,
             Duration::from_secs(5),
+            "local".to_string(),
+            local_ns_resolver(),
         ));
 
         tokio::time::timeout(Duration::from_secs(1), ready_rx)
@@ -851,6 +961,65 @@ mod tests {
             probe_calls.load(Ordering::SeqCst),
             0,
             "no upstream ⇒ nothing to probe"
+        );
+
+        drop(messaging_tx);
+        task.abort();
+    }
+
+    /// A poke after the credentials change the daemon's namespace acks `Restart`
+    /// (the control handler then triggers a generation restart). The loop must NOT
+    /// federate or probe on a namespace change — a restart is fail-closed.
+    #[tokio::test]
+    async fn poke_acks_restart_on_a_namespace_change() {
+        let (resolver, _calls) = counting_resolver(upstream());
+        let (prober, probe_calls) = counting_prober(Ok(()));
+        // The re-resolved namespace differs from the `local` startup namespace.
+        let (ns_resolver, ns_calls) = counting_ns_resolver("550e8400-e29b-41d4-a716-446655440000");
+        let (messaging_tx, messaging_rx) = watch::channel(true);
+        let (trigger_tx, trigger_rx) = mpsc::channel(8);
+        let (ready_tx, ready_rx) = oneshot::channel();
+
+        let task = tokio::spawn(manage_federation(
+            applying_federator(),
+            resolver,
+            prober,
+            messaging_rx,
+            trigger_rx,
+            ready_tx,
+            Duration::from_secs(5),
+            "local".to_string(),
+            ns_resolver,
+        ));
+
+        tokio::time::timeout(Duration::from_secs(1), ready_rx)
+            .await
+            .expect("startup gate fires")
+            .expect("gate sender not dropped");
+
+        let (ack_tx, ack_rx) = oneshot::channel();
+        trigger_tx
+            .send(RefederateRequest { ack: ack_tx })
+            .await
+            .expect("trigger accepted");
+        let outcome = tokio::time::timeout(Duration::from_secs(1), ack_rx)
+            .await
+            .expect("poke serviced immediately")
+            .expect("ack sender not dropped");
+
+        assert_eq!(
+            outcome,
+            FederationOutcome::Restart,
+            "a namespace change must ack Restart, not Applied"
+        );
+        assert_eq!(
+            probe_calls.load(Ordering::SeqCst),
+            0,
+            "a restart never probes the link"
+        );
+        assert!(
+            ns_calls.load(Ordering::SeqCst) >= 1,
+            "the namespace was re-resolved to detect the change"
         );
 
         drop(messaging_tx);

--- a/crates/peppy/src/commands/service/serve.rs
+++ b/crates/peppy/src/commands/service/serve.rs
@@ -1,8 +1,9 @@
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
-use tokio::sync::oneshot;
+use tokio::sync::{oneshot, watch};
 use tokio::task::{JoinError, JoinSet};
 use tracing::{error, info, warn};
 
@@ -12,6 +13,30 @@ use crate::error::{Error, Result};
 
 use super::builder::ServeCommandBuilder;
 pub use tokio_util::sync::CancellationToken;
+
+/// Why a serve generation stopped running, threaded up to the in-process
+/// supervisor loop.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ServeOutcome {
+    /// A real stop (SIGINT/SIGTERM, `peppy service stop`, or all tasks done):
+    /// the daemon exits 0 and the supervisor (systemd/launchd) leaves it stopped.
+    Stop,
+    /// A namespace change requested an in-process restart: tear the generation
+    /// down and rebuild a fresh one under the same PID.
+    Restart,
+}
+
+/// Non-zero exit code used ONLY for the port-stuck / flap-cap fallback, so a
+/// crash-only supervisor (systemd `Restart=on-failure`, launchd `KeepAlive`
+/// scoped to `SuccessfulExit=false`) recovers a daemon the in-process loop could
+/// not. Distinct from a clean stop's `0` and the generic `exit(1)`.
+pub(crate) const RESTART_EXIT_CODE: i32 = 75;
+
+/// Wall-clock window and cap for the in-process flap backstop: more than
+/// [`FLAP_CAP`] restarts within [`FLAP_WINDOW`] converts a same-PID busy loop
+/// (otherwise invisible to systemd) into a visible `exit(RESTART_EXIT_CODE)`.
+const FLAP_WINDOW: Duration = Duration::from_secs(60);
+const FLAP_CAP: usize = 5;
 
 pub(crate) type ServeFuture = Pin<Box<dyn Future<Output = Result<()>> + Send + 'static>>;
 
@@ -81,7 +106,22 @@ impl CompositeCommand {
 
 pub(crate) struct Serve {
     composite_command: CompositeCommand,
+    /// External shutdown injection (tests / embedders): when `Some` and
+    /// cancelled, the coordinator records [`ServeOutcome::Stop`]. `None` in
+    /// production (the CLI path).
     shutdown_token: Option<CancellationToken>,
+    /// The shared token every serve task observes for teardown. The coordinator
+    /// cancels it on its way out so each task runs its real graceful teardown
+    /// (close session, stop_router, SIGKILL nodes, unlink the socket) rather than
+    /// being aborted. For a generation built by [`ServeCommandBuilder`] this is
+    /// the token cloned into the tasks; a bare [`Serve::new`] (tests) creates a
+    /// fresh one its tasks do not observe.
+    teardown_token: CancellationToken,
+    /// In-process restart channel: a `true` from [`super::federation_control`]'s
+    /// `handle_conn` (after it flushed the `Restarting` ack) makes the
+    /// coordinator record [`ServeOutcome::Restart`]. `None` when no federation
+    /// control task exists (mock engine).
+    restart_rx: Option<watch::Receiver<bool>>,
 }
 
 /// The serve command is the command that runs as a daemon in systemd and maintains a "node stack" (a graph representation of nodes)
@@ -103,6 +143,8 @@ impl Serve {
         Self {
             composite_command,
             shutdown_token: None,
+            teardown_token: CancellationToken::new(),
+            restart_rx: None,
         }
     }
 
@@ -111,16 +153,31 @@ impl Serve {
         self
     }
 
-    pub(crate) fn execute(self) -> Result<()> {
+    /// Sets the shared token the generation's tasks observe (so the coordinator
+    /// can cancel it to unpark them for graceful teardown).
+    pub(crate) fn with_teardown_token(mut self, token: CancellationToken) -> Self {
+        self.teardown_token = token;
+        self
+    }
+
+    /// Arms the in-process restart channel the federation control handler signals.
+    pub(crate) fn with_restart_rx(mut self, rx: watch::Receiver<bool>) -> Self {
+        self.restart_rx = Some(rx);
+        self
+    }
+
+    pub(crate) fn execute(self) -> Result<ServeOutcome> {
         let runtime = tokio::runtime::Builder::new_multi_thread()
             .enable_all()
             .build()?;
 
         let handles = self.composite_command.execute()?;
-        let shutdown_token = self.shutdown_token;
+        let external_shutdown = self.shutdown_token;
+        let teardown_token = self.teardown_token;
+        let mut restart_rx = self.restart_rx;
 
         info!("Running serve command...");
-        runtime.block_on(async move {
+        let outcome = runtime.block_on(async move {
             let mut join_set = JoinSet::new();
             let mut readiness = Vec::new();
             for handle in handles {
@@ -162,55 +219,68 @@ impl Serve {
             }
 
             info!("Serve command initialized!");
-            loop {
+            // The coordinator: the SOLE observer of the OS shutdown signal, the
+            // external injection, and the in-process restart channel. On any of
+            // them it records the reason and breaks; tasks observe only the shared
+            // `teardown_token`, which the coordinator cancels below so each runs
+            // its real graceful teardown (no force-abort).
+            let reason = loop {
                 tokio::select! {
                     result = join_set.join_next() => {
                         match result {
                             Some(result) => Self::log_task_result(result),
                             None => {
                                 info!("All serve handlers completed. Exiting...");
-                                break;
+                                break ServeOutcome::Stop;
                             }
                         }
                     }
                     _ = async {
-                        if let Some(token) = &shutdown_token {
-                            token.cancelled().await
-                        } else {
-                            std::future::pending::<()>().await
+                        match &external_shutdown {
+                            Some(token) => token.cancelled().await,
+                            None => std::future::pending::<()>().await,
                         }
                     } => {
-                        info!("Shutdown signal received");
-                        info!("Waiting for serve handlers to finish...");
-                        break;
+                        info!("External shutdown requested");
+                        break ServeOutcome::Stop;
                     }
                     signal = super::shutdown_signal::shutdown_signal() => {
                         match signal {
                             Ok(_) => {
                                 info!("Shutdown signal received");
-                                info!("Waiting for serve handlers to finish...");
+                                break ServeOutcome::Stop;
                             }
                             Err(e) => {
-                                return Err(Error::ExecutionFailed(format!("Failed to listen for shutdown signal: {}", e)));
+                                return Err(Error::ExecutionFailed(format!(
+                                    "Failed to listen for shutdown signal: {}", e
+                                )));
                             }
                         }
-                        break;
+                    }
+                    _ = async {
+                        match &mut restart_rx {
+                            Some(rx) => { let _ = rx.changed().await; }
+                            None => std::future::pending::<()>().await,
+                        }
+                    } => {
+                        info!("In-process restart signal received (namespace change)");
+                        break ServeOutcome::Restart;
                     }
                 }
-            }
+            };
 
-            // If shutdown was triggered by the cancellation token, abort remaining tasks
-            // since they may also be waiting on ctrl_c which won't arrive
-            if shutdown_token.is_some() {
-                join_set.abort_all();
-            }
+            info!("Tearing down serve handlers (reason: {reason:?})...");
+            // Unpark every task that observes the shared token so they run their
+            // real graceful teardown rather than waiting on a signal that (for a
+            // restart) will never arrive. Idempotent if already cancelled.
+            teardown_token.cancel();
             while let Some(result) = join_set.join_next().await {
                 Self::log_task_result(result);
             }
 
-            Ok::<(), Error>(())
+            Ok::<ServeOutcome, Error>(reason)
         })?;
-        Ok(())
+        Ok(outcome)
     }
 }
 
@@ -223,10 +293,43 @@ pub struct ServeCommand {
 
 impl Command for ServeCommand {
     fn execute(self, ctx: &Arc<AppContext>) -> Result<()> {
-        // Read the daemon-global config once at startup, creating it with
-        // defaults if missing. Resolved from `PeppyDirs::default()` (the same
-        // ~/.peppy the core node uses), and applied to the daemon's own session
-        // and every spawned node. Fails loud on a malformed config.
+        // In-process supervised restart loop: a namespace change (login/logout)
+        // tears down the current generation and rebuilds a fresh one under the
+        // SAME PID, with no execv and no external supervisor, so the switch is
+        // uniform across a systemd install, a launchd install, and a bare
+        // `peppy service serve` terminal. A real stop (SIGTERM / `service stop`)
+        // returns `Stop` and this loop exits 0; the crash-only supervisor never
+        // restarts a clean exit.
+        let mut flap = FlapWindow::new();
+        loop {
+            match self.run_one_generation(ctx)? {
+                ServeOutcome::Stop => return Ok(()),
+                ServeOutcome::Restart => {
+                    finalize_before_restart();
+                    if flap.record_and_is_flapping() {
+                        error!(
+                            "daemon restarted more than {FLAP_CAP} times within {:?}; \
+                             exiting ({RESTART_EXIT_CODE}) for the supervisor to recover",
+                            FLAP_WINDOW
+                        );
+                        std::process::exit(RESTART_EXIT_CODE);
+                    }
+                    info!("Rebuilding the daemon generation under the new namespace...");
+                }
+            }
+        }
+    }
+}
+
+impl ServeCommand {
+    /// Builds and runs one daemon generation, returning why it stopped. Each call
+    /// is a clean generation: fresh sessions, a fresh `CoreNode` (so its
+    /// declaration guard re-runs), and the namespace + federation gate re-resolved
+    /// from the credentials at the top of the build.
+    fn run_one_generation(&self, ctx: &Arc<AppContext>) -> Result<ServeOutcome> {
+        // Read the daemon-global config, creating it with defaults if missing.
+        // Resolved from `PeppyDirs::default()` (the same ~/.peppy the core node
+        // uses), applied to the daemon's own session and every spawned node.
         let peppy_dirs = config::consts::PeppyDirs::default();
         let peppy_config = config::peppy_config::load_or_create(&peppy_dirs).map_err(|e| {
             Error::ExecutionFailed(format!("Failed to load peppy_config.json5: {e}"))
@@ -234,22 +337,107 @@ impl Command for ServeCommand {
 
         let mut builder = ServeCommandBuilder::new(&ctx.root_dir)?
             .with_peppy_config(peppy_config)
-            .with_messaging_router(self.messaging_engine)?
-            .with_core_node(self.core_node_name, self.clock_source)?;
+            .with_messaging_router(self.messaging_engine.clone())?
+            .with_core_node(self.core_node_name.clone(), self.clock_source)?;
 
-        if let Some(token) = self.shutdown_token {
-            builder = builder.with_shutdown_token(token);
+        if let Some(token) = &self.shutdown_token {
+            builder = builder.with_shutdown_token(token.clone());
         }
 
         let executor = builder.build()?;
+        executor
+            .execute()
+            .inspect_err(|e| error!("Serve command failed: {}", e))
+    }
+}
 
-        match executor.execute() {
-            Ok(()) => Ok(()),
-            Err(e) => {
-                error!("Serve command failed: {}", e);
-                Err(e)
-            }
+/// In-process flap backstop: more than [`FLAP_CAP`] restarts within
+/// [`FLAP_WINDOW`] is a flap, converted into a visible `exit(RESTART_EXIT_CODE)`
+/// so a same-PID busy loop is not invisible to systemd.
+struct FlapWindow {
+    restarts: Vec<Instant>,
+}
+
+impl FlapWindow {
+    fn new() -> Self {
+        Self {
+            restarts: Vec::new(),
         }
+    }
+
+    /// Records a restart and reports whether the recent rate exceeds the cap.
+    fn record_and_is_flapping(&mut self) -> bool {
+        let now = Instant::now();
+        self.restarts
+            .retain(|t| now.duration_since(*t) < FLAP_WINDOW);
+        self.restarts.push(now);
+        self.restarts.len() > FLAP_CAP
+    }
+}
+
+/// Between-generations finalizer for a restart: reap straggler children, then
+/// confirm the messaging port is free before the next `start_router`. A still-
+/// bound port the loop cannot recover from exits with [`RESTART_EXIT_CODE`].
+fn finalize_before_restart() {
+    // Node children were reaped only by detached exit-watcher tasks that died with
+    // the just-dropped runtime; because the process is long-lived (no execv/exit
+    // re-parenting to init) an un-reaped child becomes a persistent zombie. A
+    // single WNOHANG pass can miss a killed-but-not-yet-zombie child, so loop with
+    // a short sleep until no children remain or the deadline.
+    reap_stragglers(Duration::from_secs(2));
+
+    // Verify the messaging listen endpoint is free before the next generation's
+    // start_router. TCP-only today (the local router listens on tcp/); if the old
+    // zenohd has not released the port after a short bounded retry the in-process
+    // loop cannot recover, so exit for the supervisor rather than spin.
+    let port = super::builder::extract_messaging_port();
+    if !wait_port_free(port, Duration::from_secs(5)) {
+        error!(
+            port,
+            "messaging port still bound after the previous generation tore down; \
+             exiting ({RESTART_EXIT_CODE}) for the supervisor to recover"
+        );
+        std::process::exit(RESTART_EXIT_CODE);
+    }
+}
+
+/// Reaps zombie children with a bounded blocking `waitpid(-1, WNOHANG)` loop
+/// until no children remain (`ECHILD`) or `deadline` elapses.
+fn reap_stragglers(deadline: Duration) {
+    use rustix::process::{WaitOptions, wait};
+    let start = Instant::now();
+    loop {
+        match wait(WaitOptions::NOHANG) {
+            // Reaped one; keep draining the rest immediately.
+            Ok(Some(_)) => {}
+            // Children exist but none is a zombie yet: wait briefly and retry.
+            Ok(None) => {
+                if start.elapsed() >= deadline {
+                    break;
+                }
+                std::thread::sleep(Duration::from_millis(20));
+            }
+            // ECHILD (no children left) or any other error: nothing to reap.
+            Err(_) => break,
+        }
+    }
+}
+
+/// Whether the local messaging port has been released by the old router. Probes
+/// by connecting to loopback: a refused connect means nothing is listening.
+/// Retries until free or `deadline`. TCP-only (documented assumption).
+fn wait_port_free(port: u16, deadline: Duration) -> bool {
+    use std::net::{Ipv4Addr, SocketAddr, TcpStream};
+    let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, port));
+    let start = Instant::now();
+    loop {
+        if TcpStream::connect_timeout(&addr, Duration::from_millis(200)).is_err() {
+            return true;
+        }
+        if start.elapsed() >= deadline {
+            return false;
+        }
+        std::thread::sleep(Duration::from_millis(100));
     }
 }
 

--- a/crates/peppy/src/commands/service/shutdown_signal.rs
+++ b/crates/peppy/src/commands/service/shutdown_signal.rs
@@ -24,3 +24,17 @@ pub async fn shutdown_signal() -> std::io::Result<()> {
         tokio::signal::ctrl_c().await
     }
 }
+
+/// Resolves when this serve generation should tear down: either an OS shutdown
+/// signal (SIGINT/SIGTERM) OR the shared coordinator token being cancelled (an
+/// in-process restart). Every serve task awaits this so a namespace-change
+/// restart triggers the *same* graceful teardown as a real stop, without a
+/// self-SIGTERM. The OS-signal error is swallowed here: the serve coordinator is
+/// the authoritative signal observer and records the stop/restart reason; a task
+/// only needs the unpark, not the cause.
+pub(crate) async fn shutdown_or_token(token: &tokio_util::sync::CancellationToken) {
+    tokio::select! {
+        _ = shutdown_signal() => {}
+        _ = token.cancelled() => {}
+    }
+}

--- a/crates/peppy/src/context.rs
+++ b/crates/peppy/src/context.rs
@@ -85,12 +85,9 @@ impl AppContext {
         let namespace = config::org::resolve_session_namespace(Some(organization_namespace));
         self.messenger_handle
             .get_or_try_init(|| async {
-                MessengerHandle::from_host_port_with_namespace(
-                    config::consts::DEFAULT_MESSAGING_HOST,
-                    messaging_port,
-                    Some(namespace),
-                )
-                .await
+                MessengerHandle::connect(config::consts::DEFAULT_MESSAGING_HOST, messaging_port)
+                    .namespace(namespace)
+                    .await
             })
             .await?;
         Ok(())

--- a/crates/peppy/src/context.rs
+++ b/crates/peppy/src/context.rs
@@ -1,6 +1,6 @@
 use crate::daemon_state::DaemonState;
 use crate::error::Error;
-use peppylib::MessengerHandle;
+use peppylib::{MessengerHandle, SessionScope};
 use pmi::Messenger;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -86,7 +86,7 @@ impl AppContext {
         self.messenger_handle
             .get_or_try_init(|| async {
                 MessengerHandle::connect(config::consts::DEFAULT_MESSAGING_HOST, messaging_port)
-                    .namespace(namespace)
+                    .scope(SessionScope::Namespace(namespace))
                     .await
             })
             .await?;

--- a/crates/peppy/src/context.rs
+++ b/crates/peppy/src/context.rs
@@ -73,12 +73,22 @@ impl AppContext {
         }
     }
 
-    async fn connect_with_port(&self, messaging_port: u16) -> crate::error::Result<()> {
+    async fn connect_with_port(
+        &self,
+        messaging_port: u16,
+        organization_namespace: &str,
+    ) -> crate::error::Result<()> {
+        // Open the control session under the daemon's namespace so the CLI reaches
+        // the daemon/node services that run under it. The daemon recorded the
+        // namespace in `DaemonState` before binding the control socket, so it is a
+        // valid value; resolve defensively (a bad value falls back to `local`).
+        let namespace = config::org::resolve_session_namespace(Some(organization_namespace));
         self.messenger_handle
             .get_or_try_init(|| async {
-                MessengerHandle::from_host_port(
+                MessengerHandle::from_host_port_with_namespace(
                     config::consts::DEFAULT_MESSAGING_HOST,
                     messaging_port,
+                    Some(namespace),
                 )
                 .await
             })
@@ -104,7 +114,11 @@ pub(crate) struct DaemonConnection<'a> {
 impl AppContext {
     pub(crate) async fn connect_to_daemon(&self) -> crate::error::Result<DaemonConnection<'_>> {
         let daemon_state = self.read_daemon_state()?;
-        self.connect_with_port(daemon_state.messaging_port).await?;
+        self.connect_with_port(
+            daemon_state.messaging_port,
+            &daemon_state.organization_namespace,
+        )
+        .await?;
         let messenger = self
             .messenger_handle()
             .ok_or_else(|| Error::ExecutionFailed("Failed to connect to daemon".to_string()))?;

--- a/crates/peppy/src/context.rs
+++ b/crates/peppy/src/context.rs
@@ -109,6 +109,12 @@ pub(crate) struct DaemonConnection<'a> {
     /// node, from its `peppy_config`. Lets `node stop` size its request timeout
     /// to outlast the daemon's grace + reap window.
     pub shutdown_grace_secs: u64,
+    /// The organization namespace recorded by the generation this connection was
+    /// established against, captured from the *same* `DaemonState` read the
+    /// connection used. Callers reuse this instead of reading the state again,
+    /// which could race a restart and pair this connection's data with a different
+    /// generation's namespace.
+    pub organization_namespace: String,
 }
 
 impl AppContext {
@@ -127,6 +133,7 @@ impl AppContext {
             core_node_name: daemon_state.core_node_name,
             git_hash: daemon_state.git_hash,
             shutdown_grace_secs: daemon_state.shutdown_grace_secs,
+            organization_namespace: daemon_state.organization_namespace,
         })
     }
 }

--- a/crates/peppy/src/daemon_control.rs
+++ b/crates/peppy/src/daemon_control.rs
@@ -69,6 +69,12 @@ pub(crate) enum ControlResponse {
     /// The daemon attempted the apply and it failed (e.g. backend unreachable
     /// within the federation timeout).
     Error { message: String },
+    /// The credentials changed the daemon's *organization namespace*, which is
+    /// immutable for a live session, so the daemon is restarting its whole
+    /// generation to re-open every session under the new namespace. The daemon
+    /// flushes this ack and only then tears down; the CLI polls the (path-stable)
+    /// control socket until the daemon is back under the expected namespace.
+    Restarting,
 }
 
 impl ControlResponse {
@@ -97,6 +103,10 @@ pub(crate) enum PokeOutcome {
     DaemonNotRunning,
     /// Connected, but the daemon did not ack within the read deadline.
     TimedOut,
+    /// The credentials changed the daemon's organization namespace, so the daemon
+    /// acked and is restarting its whole generation. The caller then polls until
+    /// the daemon is back under the expected namespace.
+    Restarting,
 }
 
 /// Pokes the running daemon over `socket_path` to re-resolve and (re)apply
@@ -140,6 +150,7 @@ fn poke_inner(socket_path: &Path, read_timeout: Duration) -> std::io::Result<Pok
         ControlResponse::Pinned => PokeOutcome::Pinned,
         ControlResponse::Unreachable { message } => PokeOutcome::Unreachable(message),
         ControlResponse::Error { message } => PokeOutcome::DaemonError(message),
+        ControlResponse::Restarting => PokeOutcome::Restarting,
     })
 }
 

--- a/crates/peppy/src/daemon_state.rs
+++ b/crates/peppy/src/daemon_state.rs
@@ -188,6 +188,14 @@ impl DaemonState {
         Self::rank_states(states, Self::pid_looks_alive)
     }
 
+    /// Whether the daemon that wrote this state still appears to be running, by
+    /// probing its recorded pid. A state file outlives a crashed daemon (it is
+    /// left on disk), so a successful [`read`](Self::read) is not by itself proof
+    /// of liveness — a caller that needs "is a daemon actually up" must check this.
+    pub(crate) fn is_running(&self) -> bool {
+        self.daemon_pid.is_some_and(Self::pid_looks_alive)
+    }
+
     /// Picks the state file that best represents the live daemon, given a
     /// liveness predicate (injected so tests can stub it without spawning real
     /// processes):

--- a/crates/peppy/src/daemon_state.rs
+++ b/crates/peppy/src/daemon_state.rs
@@ -40,6 +40,18 @@ pub(crate) struct DaemonState {
     /// read so a state file written before this field still parses.
     #[serde(default)]
     pub written_at_ms: u64,
+    /// The organization namespace this daemon generation resolved at startup
+    /// (`"local"` when logged out, else the org id). A CLI control session reads
+    /// it so it opens its session under exactly the daemon's namespace; it is
+    /// written before the control socket binds, so a reader never sees a half-set
+    /// generation. Defaulted to `"local"` on read so a state file written before
+    /// this field still parses.
+    #[serde(default = "default_organization_namespace")]
+    pub organization_namespace: String,
+}
+
+fn default_organization_namespace() -> String {
+    config::org::LOCAL_NAMESPACE.to_string()
 }
 
 fn default_messaging_port() -> u16 {
@@ -65,6 +77,7 @@ impl DaemonState {
         messaging_port: u16,
         git_hash: impl Into<String>,
         shutdown_grace_secs: u64,
+        organization_namespace: impl Into<String>,
     ) -> Self {
         Self {
             core_node_name: core_node_name.into(),
@@ -73,6 +86,7 @@ impl DaemonState {
             git_hash: git_hash.into(),
             shutdown_grace_secs,
             written_at_ms: now_epoch_ms(),
+            organization_namespace: organization_namespace.into(),
         }
     }
 
@@ -256,6 +270,7 @@ mod tests {
             git_hash: "test".to_string(),
             shutdown_grace_secs: 5,
             written_at_ms,
+            organization_namespace: "local".to_string(),
         }
     }
 

--- a/crates/peppy/src/test_support.rs
+++ b/crates/peppy/src/test_support.rs
@@ -191,6 +191,7 @@ impl ServeCommandEmulation {
             root_dir: temp_dir.path().to_path_buf(),
             peppy_dirs,
             peppy_config: config::peppy_config::PeppyConfig::default(),
+            organization_namespace: "local".to_string(),
             shutdown_token: tokio_util::sync::CancellationToken::new(),
         });
         let core_node_name = core_node.node_name().to_string();
@@ -214,6 +215,7 @@ impl ServeCommandEmulation {
             port,
             "test-git-hash",
             config::peppy_config::DEFAULT_SHUTDOWN_GRACE_SECS,
+            "local",
         );
         DaemonState::write_to(&daemon_state_path, &daemon_state)
             .expect("failed to write daemon state");

--- a/crates/peppy/src/test_support.rs
+++ b/crates/peppy/src/test_support.rs
@@ -150,7 +150,22 @@ impl ServeCommandEmulation {
     }
 
     pub async fn with_zenoh() -> Result<Self, pmi::PeppyMessagingInterfaceError> {
-        let mut instance = ZenohAdapter::start_router_ephemeral("127.0.0.1", None).await?;
+        // Host the router session under the `local` namespace so the core node's
+        // service queryables are declared under the same namespace the spawned
+        // `peppy` CLI opens its control session under. The CLI resolves `local`
+        // from the daemon state we write below and connects with
+        // `SessionScope::Namespace(local)`; zenoh sessions interoperate only when
+        // their namespaces are equal, so a namespace-free router would leave
+        // `node_init` (and every other core-node service) unreachable from the
+        // CLI. The other arguments mirror `start_router_ephemeral`'s defaults.
+        let mut instance = ZenohAdapter::start_router_ephemeral_in_mode(
+            "127.0.0.1",
+            None,
+            true,
+            pmi::SubscriberBufferSizes::default(),
+            Some(pmi::OrgNamespace::local()),
+        )
+        .await?;
         instance.messenger().start_session().await?;
         let port = instance.port;
         let messenger = instance.take_messenger();

--- a/crates/peppy/tests/auth_flow.rs
+++ b/crates/peppy/tests/auth_flow.rs
@@ -274,6 +274,41 @@ fn logout_calls_backend_and_clears_local_credentials() {
 }
 
 #[test]
+fn logout_heals_a_malformed_credentials_file() {
+    // A malformed (e.g. pre-`organization_id`/unversioned) credentials file fails
+    // to parse with `Error::Auth`. Logout treats that as "already logged out", but
+    // it must still rewrite the file to a clean default so the bad file does not
+    // linger on disk (the early "Not logged in" return used to skip the save).
+    let dir = tempfile::tempdir().expect("temp dir");
+    let path = creds_path(&dir);
+    std::fs::create_dir_all(path.parent().unwrap()).expect("mkdir conf");
+    // Unversioned old shape ⇒ rejected by `storage::load` with `Error::Auth`.
+    std::fs::write(
+        &path,
+        r#"{ session: { api_url: "http://x", issuer: "http://y", client_id: "c",
+            access_token: "a", refresh_token: "r", expires_at: 1, token_type: "Bearer",
+            scope: "openid" } }"#,
+    )
+    .expect("write malformed creds");
+
+    LogoutCommand {
+        // Never contacted: the malformed path returns "Not logged in" before any
+        // backend call. A dummy keeps the test independent of build-default URLs.
+        api_url: Some("http://127.0.0.1:9".to_string()),
+        yes: true,
+        peppy_dirs: Some(PeppyDirs::new(dir.path())),
+    }
+    .execute(&ctx())
+    .expect("logout tolerates a malformed file");
+
+    // The file now parses cleanly (healed to a current-version default) and is
+    // logged out.
+    let after = storage::load(&path).expect("malformed file must be healed, not left on disk");
+    assert!(after.session.is_none(), "healed file is logged out");
+    assert!(after.router.is_none(), "healed file has no router cache");
+}
+
+#[test]
 fn resolver_prefers_pat_env_over_files() {
     let http = HttpClient::new();
 
@@ -770,6 +805,80 @@ fn resolve_router_endpoint_re_pulls_and_caches_when_stale() {
     let rs = after.router.as_ref().expect("router cached");
     assert_eq!(rs.endpoint, "tls/fresh.zenoh.localhost:7443");
     assert!(rs.repull_after > storage::now_unix(), "deadline pushed out");
+}
+
+#[test]
+fn router_cache_is_bound_to_the_pull_identity_not_the_on_disk_session() {
+    // A PAT-authenticated pull must tag the cache with the PAT owner's stable
+    // backend subject (`/me`), NOT the on-disk session subject. Otherwise, once the
+    // PAT is gone, a session resolve would reuse the PAT's org — a cross-identity
+    // (cross-tenant) leak.
+    let server = MockServer::start();
+    let pull = server.mock(|when, then| {
+        when.method(POST).path("/me/messaging-federation");
+        then.status(200).json_body(json!({
+            "endpoint": "tls/pat-org.zenoh.localhost:7443",
+            "protocol": "tls",
+            "reconnect_after_secs": 3000,
+            "organization_id": "550e8400-e29b-41d4-a716-446655440000",
+        }));
+    });
+    // Only a PAT pull resolves `/me` (to learn the PAT owner's stable subject).
+    let me = server.mock(|when, then| {
+        when.method(GET).path("/me");
+        then.status(200)
+            .json_body(json!({ "sub": "pat-owner-xyz" }));
+    });
+
+    let dir = tempfile::tempdir().expect("temp dir");
+    let path = creds_path(&dir);
+    // A session for a *different* identity is on disk at the same time as the PAT.
+    let creds = Credentials {
+        session: Some(seeded_creds(&server, 9_999_999_999)), // subject "user-123"
+        ..Default::default()
+    };
+    storage::save(&path, &creds).expect("seed creds");
+
+    let http = HttpClient::new();
+
+    // Pull as the PAT.
+    let ep = router::resolve_router_endpoint(
+        &path,
+        &http,
+        &server.base_url(),
+        Some("the-pat".to_string()),
+        None,
+        None,
+    )
+    .expect("PAT pull resolves");
+    assert_eq!(ep.host, "pat-org.zenoh.localhost");
+    assert_eq!(pull.calls(), 1, "the PAT pull hit the backend once");
+    assert_eq!(
+        me.calls(),
+        1,
+        "a PAT pull resolves /me to bind the cache to the PAT identity"
+    );
+
+    // The cache is tagged with the PAT owner's subject, not the session subject.
+    let cached = storage::load(&path)
+        .expect("reload")
+        .router
+        .expect("router cached");
+    assert_eq!(
+        cached.subject, "pat-owner-xyz",
+        "a PAT pull must bind the cache to the PAT identity, not the on-disk session"
+    );
+
+    // With the PAT gone, a session resolve must NOT reuse the PAT's cache: the
+    // subjects differ, so it re-pulls rather than leaking the PAT's org.
+    let _ = router::resolve_router_endpoint(&path, &http, &server.base_url(), None, None, None)
+        .expect("session resolve");
+    assert_eq!(
+        pull.calls(),
+        2,
+        "the session must re-pull, not reuse the PAT-identity cache"
+    );
+    assert_eq!(me.calls(), 1, "a session pull does not need /me");
 }
 
 /// A session credential pointing at `server` with the given absolute expiry.

--- a/crates/peppy/tests/auth_flow.rs
+++ b/crates/peppy/tests/auth_flow.rs
@@ -111,6 +111,7 @@ fn login_persists_credentials_and_resolves_identity() {
     let err = LoginCommand {
         api_url: Some(server.base_url()),
         no_browser: true,
+        yes: true,
         peppy_dirs: Some(PeppyDirs::new(dir.path())),
     }
     .execute(&ctx())
@@ -166,6 +167,7 @@ fn login_pokes_the_running_daemon_to_refederate() {
     LoginCommand {
         api_url: Some(server.base_url()),
         no_browser: true,
+        yes: true,
         peppy_dirs: Some(peppy_dirs),
     }
     .execute(&ctx())
@@ -191,6 +193,7 @@ fn login_seeds_peppy_config_with_resource_servers_block() {
     let _ = LoginCommand {
         api_url: Some(server.base_url()),
         no_browser: true,
+        yes: true,
         peppy_dirs: Some(PeppyDirs::new(dir.path())),
     }
     .execute(&ctx());
@@ -227,6 +230,7 @@ fn login_writes_credentials_file_0600() {
     let _ = LoginCommand {
         api_url: Some(server.base_url()),
         no_browser: true,
+        yes: true,
         peppy_dirs: Some(PeppyDirs::new(dir.path())),
     }
     .execute(&ctx());
@@ -255,6 +259,7 @@ fn logout_calls_backend_and_clears_local_credentials() {
 
     LogoutCommand {
         api_url: Some(server.base_url()),
+        yes: true,
         peppy_dirs: Some(PeppyDirs::new(dir.path())),
     }
     .execute(&ctx())
@@ -388,6 +393,7 @@ fn establish_messaging_federation_parses_the_contract() {
             "protocol": "tls",
             "mode": "client",
             "reconnect_after_secs": 3000,
+            "organization_id": "550e8400-e29b-41d4-a716-446655440000",
             "some_future_field": "ignored by a tolerant client",
         }));
     });
@@ -402,6 +408,7 @@ fn establish_messaging_federation_parses_the_contract() {
         .expect("fetch shared router config");
     assert_eq!(cfg.protocol, "tls");
     assert_eq!(cfg.reconnect_after_secs, 3000);
+    assert_eq!(cfg.organization_id, "550e8400-e29b-41d4-a716-446655440000");
     assert_eq!(
         cfg.host_port().expect("parse endpoint"),
         ("localhost".to_string(), 7447)
@@ -450,6 +457,7 @@ fn router_config_pull_refreshes_on_401_then_re_pulls() {
             "protocol": "tls",
             "mode": "client",
             "reconnect_after_secs": 3000,
+            "organization_id": "550e8400-e29b-41d4-a716-446655440000",
         }));
     });
 
@@ -518,6 +526,10 @@ fn resolve_router_endpoint_reuses_a_fresh_cache_without_pulling() {
             protocol: "tls".into(),
             // Far in the future ⇒ fresh ⇒ reuse.
             repull_after: storage::now_unix() + 100_000,
+            organization_id: "550e8400-e29b-41d4-a716-446655440000".into(),
+            // Matches `seeded_creds`'s subject so the identity tag agrees and the
+            // fresh cache is reused (a mismatch would force a re-pull).
+            subject: "user-123".into(),
         }),
         ..Default::default()
     };
@@ -546,6 +558,7 @@ fn resolve_federation_target_derives_the_upstream_tls_locator() {
             "endpoint": "tls/cap.zenoh.localhost:7443",
             "protocol": "tls",
             "reconnect_after_secs": 3000,
+            "organization_id": "550e8400-e29b-41d4-a716-446655440000",
         }));
     });
 
@@ -607,6 +620,44 @@ fn resolve_federation_target_is_none_when_not_logged_in() {
     assert_eq!(pull.calls(), 0, "not logged in ⇒ the backend is never hit");
 }
 
+#[test]
+fn resolve_federation_target_fails_closed_on_an_invalid_org_namespace() {
+    // Fail closed: a logged-in pull whose `organization_id` cannot be a zenoh
+    // namespace (here a wildcard) must NOT federate. The local router stays
+    // standalone rather than dialing the shared router under a bogus namespace.
+    // The daemon resolves its session namespace from the same org id, so a value
+    // that cannot federate also cannot carry a federating namespace.
+    let server = MockServer::start();
+    let pull = server.mock(|when, then| {
+        when.method(POST).path("/me/messaging-federation");
+        then.status(200).json_body(json!({
+            "endpoint": "tls/cap.zenoh.localhost:7443",
+            "protocol": "tls",
+            "reconnect_after_secs": 3000,
+            "organization_id": "**",
+        }));
+    });
+
+    let dir = tempfile::tempdir().expect("temp dir");
+    let path = creds_path(&dir);
+    let creds = Credentials {
+        session: Some(seeded_creds(&server, 9_999_999_999)),
+        ..Default::default()
+    };
+    storage::save(&path, &creds).expect("seed creds");
+
+    let target =
+        router::resolve_federation_target_at(&path, &server.base_url(), None, None, None, SECS_30);
+    assert!(
+        target.is_none(),
+        "an org id that is not a valid namespace must fail closed (no federation)"
+    );
+    assert!(
+        pull.calls() >= 1,
+        "the gate is applied after the pull, not before"
+    );
+}
+
 /// A generous federation timeout for tests that don't exercise the bound itself.
 const SECS_30: Duration = Duration::from_secs(30);
 
@@ -625,6 +676,7 @@ fn resolve_federation_target_honors_a_short_connect_timeout() {
                 "endpoint": "tls/cap.zenoh.localhost:7443",
                 "protocol": "tls",
                 "reconnect_after_secs": 3000,
+                "organization_id": "550e8400-e29b-41d4-a716-446655440000",
             }));
     });
 
@@ -673,6 +725,7 @@ fn resolve_router_endpoint_re_pulls_and_caches_when_stale() {
             "protocol": "tls",
             "mode": "client",
             "reconnect_after_secs": 3000,
+            "organization_id": "550e8400-e29b-41d4-a716-446655440000",
         }));
     });
 
@@ -684,6 +737,8 @@ fn resolve_router_endpoint_re_pulls_and_caches_when_stale() {
             endpoint: "tls/stale.zenoh.localhost:7443".into(),
             protocol: "tls".into(),
             repull_after: 1, // long past ⇒ stale ⇒ re-pull
+            organization_id: "550e8400-e29b-41d4-a716-446655440000".into(),
+            subject: "user-123".into(),
         }),
         ..Default::default()
     };

--- a/crates/peppy/tests/service_serve.rs
+++ b/crates/peppy/tests/service_serve.rs
@@ -64,9 +64,14 @@ fn serve_command() {
         "serve command should log initialization message. Logs:\n{}",
         logs
     );
+    // This test drives shutdown via the injected external cancellation token
+    // (not an OS signal), so the coordinator takes the external-shutdown arm.
+    // The OS-signal arm logs "Shutdown signal received" instead; asserting that
+    // here made the test pass only when a sibling test's process-wide SIGINT
+    // happened to race in first.
     assert!(
-        logs.contains("Shutdown signal received"),
-        "serve command should log shutdown signal reception. Logs:\n{}",
+        logs.contains("External shutdown requested"),
+        "serve command should log external shutdown reception. Logs:\n{}",
         logs
     );
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Organization-specific session namespaces are now applied consistently across daemon startup, messaging, and authentication flows.
  * Service federation/serve can trigger supervised restarts when organization-namespace drift is detected.
  * Added `--yes/-y` to login/logout to skip the daemon restart confirmation prompt.
* **Bug Fixes**
  * Federation now fails closed when the organization namespace is invalid.
  * Router cache reuse is now identity-bound to prevent cross-session reuse after auth changes.
  * Improved restart-aware authentication coordination and resilient logout that heals malformed credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->