### PR TITLE
Fix topics sub

### DIFF
--- a/crates/generator-internal/src/generator/python/tests/topics.rs
+++ b/crates/generator-internal/src/generator/python/tests/topics.rs
@@ -569,6 +569,20 @@ fn consumed_topic() {
             "return Subscription(inner)",
         ],
     );
+
+    // `__anext__` must terminate async iteration by raising `StopAsyncIteration`
+    // once `next()` reports the subscription has closed (returns None). Without
+    // this stop path, an `async for` over the subscription would hang or keep
+    // yielding past completion, so assert the full delegate-to-`next` body.
+    assert_contains_all(
+        &rendered,
+        &[
+            "result = await self.next()",
+            "if result is None:",
+            "raise StopAsyncIteration",
+            "return result",
+        ],
+    );
     assert!(
         !rendered.contains("on_next_message_received"),
         "the per-call on_next_message_received API must be gone; rendered:\n{rendered}"

--- a/crates/generator-internal/src/generator/python/tests/topics.rs
+++ b/crates/generator-internal/src/generator/python/tests/topics.rs
@@ -553,15 +553,25 @@ fn consumed_topic() {
         ],
     );
 
-    // Subscriber function signature — the producer identity is returned with
-    // every message as a structured `peppylib.ProducerRef` (its full
-    // `(core_node, instance_id)` pair); it never appears as a user-facing
-    // core_node (or instance_id) parameter.
+    // Held-subscription API — `subscribe()` returns a `Subscription` whose
+    // `next()` yields the producer identity as a structured
+    // `peppylib.ProducerRef` (its full `(core_node, instance_id)` pair); it
+    // never appears as a user-facing core_node (or instance_id) parameter. The
+    // class is also async-iterable via `__aiter__` / `__anext__`.
     assert_contains_all(
         &rendered,
         &[
-            "async def on_next_message_received(node_runner: peppylib.NodeRunner) -> Tuple[peppylib.ProducerRef, Message]:",
+            "class Subscription:",
+            "async def subscribe(node_runner: peppylib.NodeRunner) -> Subscription:",
+            "async def next(self) -> Optional[Tuple[peppylib.ProducerRef, Message]]:",
+            "def __aiter__(self) -> \"Subscription\":",
+            "async def __anext__(self) -> Tuple[peppylib.ProducerRef, Message]:",
+            "return Subscription(inner)",
         ],
+    );
+    assert!(
+        !rendered.contains("on_next_message_received"),
+        "the per-call on_next_message_received API must be gone; rendered:\n{rendered}"
     );
     assert!(
         !rendered.contains("from_core_node"),
@@ -586,16 +596,30 @@ fn consumed_topic() {
         ],
     );
 
-    // on_next_message_received body: receive, deserialize, return
+    // next() body: receive (None once closed), deserialize, return.
     assert_contains_all(
         &rendered,
         &[
-            "raw_message = await subscription.on_next_message()",
-            "payload = raw_message.payload",
+            "raw_message = await self._inner.on_next_message()",
+            "if raw_message is None:",
+            "return None",
             "producer = raw_message.producer",
-            "message = _deserialize_payload(payload)",
+            "message = _deserialize_payload(raw_message.payload)",
             "return producer, message",
         ],
+    );
+
+    // Regression guard for the dropped-message bug: the topic is subscribed
+    // exactly once (in `subscribe`), never per `next` call. The old
+    // `on_next_message_received` re-subscribed on every call, so anything
+    // published in the re-subscribe gap was silently lost; with a held
+    // subscription the buffer keeps every message between `next` calls.
+    assert_eq!(
+        rendered
+            .matches("peppylib.TopicMessenger.subscribe(")
+            .count(),
+        1,
+        "topic must be subscribed once, not per next() call; rendered:\n{rendered}"
     );
 }
 

--- a/crates/generator-internal/src/generator/python/topics.rs
+++ b/crates/generator-internal/src/generator/python/topics.rs
@@ -161,9 +161,10 @@ pub fn build_consumed_topic(
     // Collect fields from the message format
     let fields = collect_fields_from_format(arguments, "Message", &mut nested_classes)?;
 
-    // Optional covers any Optional fields in the dataclasses; Tuple wraps the
-    // `(producer, message)` pair returned by on_next_message_received (the
-    // producer itself is a structured `peppylib.ProducerRef`).
+    // Optional covers any Optional fields in the dataclasses and the closed
+    // sentinel of `Subscription.next`; Tuple wraps the `(producer, message)`
+    // pair each message yields (the producer itself is a structured
+    // `peppylib.ProducerRef`).
     builder.add_import("from typing import Optional, Tuple");
 
     // Add capnp imports and a lazy, cached schema loader.
@@ -190,15 +191,58 @@ pub fn build_consumed_topic(
         "_deserialize_payload",
     );
 
-    // Generate on_next_message_received function
+    // Generate the held-subscription consumer API. `subscribe()` returns a
+    // `Subscription` whose buffer keeps every message in arrival order, so
+    // looping on `next()` (or `async for`) never drops a message published
+    // between calls.
     builder.add_import("import peppylib");
+
     builder.blank_line();
-    builder.line(
-        "async def on_next_message_received(node_runner: peppylib.NodeRunner) -> Tuple[peppylib.ProducerRef, Message]:",
-    );
+    builder.line("class Subscription:");
+    builder.indent();
+    builder
+        .line("\"\"\"A held subscription whose buffer keeps every message in arrival order.\"\"\"");
+    builder.blank_line();
+    builder.line("def __init__(self, inner) -> None:");
+    builder.indent();
+    builder.line("self._inner = inner");
+    builder.dedent();
+    builder.blank_line();
+    // `next()` mirrors the Rust `Subscription::next`: a message tuple, or
+    // `None` once the subscription has closed.
+    builder.line("async def next(self) -> Optional[Tuple[peppylib.ProducerRef, Message]]:");
+    builder.indent();
+    builder.line("raw_message = await self._inner.on_next_message()");
+    builder.line("if raw_message is None:");
+    builder.indent();
+    builder.line("return None");
+    builder.dedent();
+    builder.line("producer = raw_message.producer");
+    builder.line("message = _deserialize_payload(raw_message.payload)");
+    builder.line("return producer, message");
+    builder.dedent();
+    builder.blank_line();
+    builder.line("def __aiter__(self) -> \"Subscription\":");
+    builder.indent();
+    builder.line("return self");
+    builder.dedent();
+    builder.blank_line();
+    builder.line("async def __anext__(self) -> Tuple[peppylib.ProducerRef, Message]:");
+    builder.indent();
+    builder.line("result = await self.next()");
+    builder.line("if result is None:");
+    builder.indent();
+    builder.line("raise StopAsyncIteration");
+    builder.dedent();
+    builder.line("return result");
+    builder.dedent();
+    builder.dedent();
+
+    builder.blank_line();
+    builder.line("async def subscribe(node_runner: peppylib.NodeRunner) -> Subscription:");
     builder.indent();
     builder.line(&format!("topic_name = \"{}\"", topic_name));
-    builder.line("subscription = await peppylib.TopicMessenger.subscribe(");
+    builder.line("inner = await peppylib.TopicMessenger.subscribe(");
     builder.indent();
     builder.line("node_runner.messenger(),");
     builder.line("node_runner.bound_core_node(),");
@@ -227,12 +271,7 @@ pub fn build_consumed_topic(
     ));
     builder.dedent();
     builder.line(")");
-    builder.line("raw_message = await subscription.on_next_message()");
-    builder.line("payload = raw_message.payload");
-    builder.line("producer = raw_message.producer");
-    builder.line("message = _deserialize_payload(payload)");
-    builder.line("return producer, message");
-
+    builder.line("return Subscription(inner)");
     builder.dedent();
 
     Ok(builder.build())

--- a/crates/generator-internal/src/generator/rust.rs
+++ b/crates/generator-internal/src/generator/rust.rs
@@ -53,7 +53,7 @@ use services::{
     deserialize_fields_from_format,
 };
 use topics::{
-    ConsumedTopicCallbackSpec, build_consumed_topic_callback, build_topic_publisher,
+    ConsumedTopicSubscriptionSpec, build_consumed_topic_subscription, build_topic_publisher,
     consumed_to_target_expression,
 };
 use type_mapping::{render_tokens, unused_params_stmt};
@@ -1105,7 +1105,7 @@ impl LanguageGenerator for RustGenerator {
                 &encoding_params,
             )?
             .expect("message encoding spec should exist when message format is provided");
-        let method_tokens = build_consumed_topic_callback(ConsumedTopicCallbackSpec {
+        let method_tokens = build_consumed_topic_subscription(ConsumedTopicSubscriptionSpec {
             helper_fn_ident: &helper_fn_ident,
             args_struct_ident: &args_struct_ident,
             params: &params,

--- a/crates/generator-internal/src/generator/rust.rs
+++ b/crates/generator-internal/src/generator/rust.rs
@@ -1095,7 +1095,6 @@ impl LanguageGenerator for RustGenerator {
             .collect();
         context.add_struct(args_struct_ident.clone(), args_fields);
 
-        let callback_fn_ident = Ident::new("on_next_message_received", Span::call_site());
         let helper_fn_ident = Ident::new("deseralize_payload", Span::call_site());
 
         let encoding = self
@@ -1107,7 +1106,6 @@ impl LanguageGenerator for RustGenerator {
             )?
             .expect("message encoding spec should exist when message format is provided");
         let method_tokens = build_consumed_topic_callback(ConsumedTopicCallbackSpec {
-            fn_name: &callback_fn_ident,
             helper_fn_ident: &helper_fn_ident,
             args_struct_ident: &args_struct_ident,
             params: &params,

--- a/crates/generator-internal/src/generator/rust/tests/topics.rs
+++ b/crates/generator-internal/src/generator/rust/tests/topics.rs
@@ -427,18 +427,28 @@ fn consumed_topic() {
         ],
     );
 
-    // Subscriber function signature — the producer identity is returned with
-    // every message as the full `peppylib::messaging::ProducerRef`; it never
-    // appears as a user-facing core_node (or instance_id) parameter.
+    // Held-subscription API — `subscribe()` returns a `Subscription` and the
+    // per-message `next()` yields the producer identity as the full
+    // `peppylib::messaging::ProducerRef`; it never appears as a user-facing
+    // core_node (or instance_id) parameter. A closed subscription is `Ok(None)`.
     assert_contains_all(
         &rendered,
         &[
-            "pub async fn on_next_message_received(",
+            "pub struct Subscription",
+            "pub async fn subscribe(",
             "node_runner: &crate::NodeRunner",
-            "-> crate::Result<(peppylib::messaging::ProducerRef, Message)>",
+            "-> crate::Result<Subscription>",
+            "pub async fn next(",
+            "-> crate::Result<Option<(peppylib::messaging::ProducerRef, Message)>>",
+            "self.inner.on_next_message().await",
+            "return Ok(None);",
             "peppylib::messaging::ProducerRef::new(",
-            "Ok((producer, message))",
+            "Ok(Some((producer, message)))",
         ],
+    );
+    assert!(
+        !rendered.contains("on_next_message_received"),
+        "the per-call on_next_message_received API must be gone; got: {rendered}"
     );
     assert!(
         !rendered.contains("from_core_node"),
@@ -463,13 +473,25 @@ fn consumed_topic() {
         ],
     );
 
-    // Error variants
-    assert_contains_all(
-        &rendered,
-        &[
-            "crate::Error::TopicSubscribe",
-            "crate::Error::SubscriptionClosed",
-        ],
+    // Error variant — subscribing maps the failure to `TopicSubscribe`; a
+    // closed subscription is no longer an error (it surfaces as `Ok(None)`).
+    assert_contains_all(&rendered, &["crate::Error::TopicSubscribe"]);
+    assert!(
+        !rendered.contains("crate::Error::SubscriptionClosed"),
+        "closed subscriptions now return Ok(None), not SubscriptionClosed; got: {rendered}"
+    );
+
+    // Regression guard for the dropped-message bug: the topic is subscribed
+    // exactly once (in `subscribe`), never per `next` call. The old
+    // `on_next_message_received` re-subscribed on every call, so anything
+    // published in the re-subscribe gap was silently lost; with a held
+    // subscription the buffer keeps every message between `next` calls.
+    assert_eq!(
+        rendered
+            .matches("peppylib::TopicMessenger::subscribe(")
+            .count(),
+        1,
+        "topic must be subscribed once, not per next() call; got: {rendered}"
     );
 }
 

--- a/crates/generator-internal/src/generator/rust/topics.rs
+++ b/crates/generator-internal/src/generator/rust/topics.rs
@@ -8,7 +8,6 @@ use proc_macro2::{Ident, Literal, TokenStream};
 use quote::quote;
 
 pub struct ConsumedTopicCallbackSpec<'a> {
-    pub fn_name: &'a Ident,
     pub helper_fn_ident: &'a Ident,
     pub args_struct_ident: &'a Ident,
     pub params: &'a [FunctionParam],
@@ -243,7 +242,6 @@ pub fn sender_target_expression(
 
 pub fn build_consumed_topic_callback(spec: ConsumedTopicCallbackSpec) -> Result<TokenStream> {
     let ConsumedTopicCallbackSpec {
-        fn_name,
         helper_fn_ident,
         args_struct_ident,
         params,
@@ -269,46 +267,70 @@ pub fn build_consumed_topic_callback(spec: ConsumedTopicCallbackSpec) -> Result<
     let is_from_any_lit = is_from_any_literal(dependency);
 
     Ok(quote! {
-        pub async fn #fn_name(
+        /// A held subscription to this topic. Declared once via `subscribe`; its
+        /// buffer keeps every message in arrival order, so looping on `next` never
+        /// drops a message published between calls. Filter inside the loop on the
+        /// returned producer identity or the message fields.
+        pub struct Subscription {
+            inner: peppylib::messaging::Subscription,
+        }
+
+        impl Subscription {
+            /// Awaits the next message on this subscription.
+            ///
+            /// Returns `Ok(Some((producer, message)))` for each message in arrival
+            /// order, `Ok(None)` once the subscription has closed, and `Err(..)` if
+            /// a received payload fails to deserialize.
+            // An async `next` returning `Result<Option<_>>` is intentionally not
+            // `Iterator::next`; silence clippy's lookalike heuristic.
+            #[allow(clippy::should_implement_trait)]
+            pub async fn next(
+                &mut self,
+            ) -> crate::Result<Option<(peppylib::messaging::ProducerRef, #args_struct_ident)>> {
+                let Some(message) = self.inner.on_next_message().await else {
+                    return Ok(None);
+                };
+
+                let payload = message.payload();
+                let producer = peppylib::messaging::ProducerRef::new(
+                    message.core_node(),
+                    message.instance_id(),
+                );
+                let message = #helper_fn_ident(payload.as_ref())?;
+                Ok(Some((producer, message)))
+            }
+        }
+
+        /// Subscribes to this topic and returns a held `Subscription`.
+        ///
+        /// Call this once, then loop on `Subscription::next`; the subscription's
+        /// buffer retains messages published between calls, so nothing is lost to a
+        /// re-subscribe gap.
+        pub async fn subscribe(
             node_runner: &crate::NodeRunner,
-        ) -> crate::Result<(peppylib::messaging::ProducerRef, #args_struct_ident)> {
+        ) -> crate::Result<Subscription> {
             let topic_name = #topic_literal;
             let node_name = #node_name_literal;
             let qos = peppylib::config::QoSProfile::Standard;
 
-            let message = {
-                let subscription_future = peppylib::TopicMessenger::subscribe(
-                    node_runner.messenger(),
-                    node_runner.processor().bound_core_node(),
-                    node_runner.processor().bound_instance_id(),
-                    #from_target_expr,
-                    #is_from_any_lit,
-                    topic_name,
-                    #consumer_filter_expr,
-                    qos,
-                );
-                let mut subscription = subscription_future.await.map_err(|source| {
-                    crate::Error::TopicSubscribe {
-                        topic_name: topic_name.to_string(),
-                        node_name: node_name.to_string(),
-                        source_msg: source.to_string(),
-                    }
-                })?;
-                subscription
-                    .on_next_message()
-                    .await
-                    .ok_or_else(|| crate::Error::SubscriptionClosed {
-                        topic_name: topic_name.to_string(),
-                    })?
-            };
+            let inner = peppylib::TopicMessenger::subscribe(
+                node_runner.messenger(),
+                node_runner.processor().bound_core_node(),
+                node_runner.processor().bound_instance_id(),
+                #from_target_expr,
+                #is_from_any_lit,
+                topic_name,
+                #consumer_filter_expr,
+                qos,
+            )
+            .await
+            .map_err(|source| crate::Error::TopicSubscribe {
+                topic_name: topic_name.to_string(),
+                node_name: node_name.to_string(),
+                source_msg: source.to_string(),
+            })?;
 
-            let payload = message.payload();
-            let producer = peppylib::messaging::ProducerRef::new(
-                message.core_node(),
-                message.instance_id(),
-            );
-            let message = #helper_fn_ident(payload.as_ref())?;
-            Ok((producer, message))
+            Ok(Subscription { inner })
         }
 
         #helper_fn_tokens

--- a/crates/generator-internal/src/generator/rust/topics.rs
+++ b/crates/generator-internal/src/generator/rust/topics.rs
@@ -7,7 +7,7 @@ use encoding::{CapnpSchemaArtifacts, FunctionParam};
 use proc_macro2::{Ident, Literal, TokenStream};
 use quote::quote;
 
-pub struct ConsumedTopicCallbackSpec<'a> {
+pub struct ConsumedTopicSubscriptionSpec<'a> {
     pub helper_fn_ident: &'a Ident,
     pub args_struct_ident: &'a Ident,
     pub params: &'a [FunctionParam],
@@ -240,8 +240,10 @@ pub fn sender_target_expression(
     }
 }
 
-pub fn build_consumed_topic_callback(spec: ConsumedTopicCallbackSpec) -> Result<TokenStream> {
-    let ConsumedTopicCallbackSpec {
+pub fn build_consumed_topic_subscription(
+    spec: ConsumedTopicSubscriptionSpec,
+) -> Result<TokenStream> {
+    let ConsumedTopicSubscriptionSpec {
         helper_fn_ident,
         args_struct_ident,
         params,

--- a/crates/generator-internal/tests/python/topics_communication.rs
+++ b/crates/generator-internal/tests/python/topics_communication.rs
@@ -141,7 +141,8 @@ from peppygen.consumed_topics import uvc_camera_video_stream
 
 async def receive_frames(node_runner, frame_received):
     print("receiver: about to subscribe", flush=True)
-    producer, frame = await uvc_camera_video_stream.on_next_message_received(node_runner)
+    subscription = await uvc_camera_video_stream.subscribe(node_runner)
+    producer, frame = await subscription.next()
     print(
         f"got {frame.width}x{frame.height} frame encoded as {frame.encoding} from {producer.core_node}/{producer.instance_id}",
         flush=True,

--- a/crates/generator-internal/tests/python/topics_communication.rs
+++ b/crates/generator-internal/tests/python/topics_communication.rs
@@ -135,19 +135,35 @@ async fn topics_communication(#[case] mode: crate::helpers::Mode) {
     init_python_user_node(&user_node_receiver);
     let receiver_main = r#"
 import asyncio
+import os
+import sys
 from peppygen import NodeBuilder
 from peppygen.exposed_services import frame_received_ack
 from peppygen.consumed_topics import uvc_camera_video_stream
 
 async def receive_frames(node_runner, frame_received):
-    print("receiver: about to subscribe", flush=True)
-    subscription = await uvc_camera_video_stream.subscribe(node_runner)
-    producer, frame = await subscription.next()
-    print(
-        f"got {frame.width}x{frame.height} frame encoded as {frame.encoding} from {producer.core_node}/{producer.instance_id}",
-        flush=True,
-    )
-    frame_received.set()
+    # `next()` returns None once the subscription has closed; unpacking that
+    # directly would raise an opaque TypeError that asyncio swallows as an
+    # unhandled task exception, so the ack task would hang on the event until
+    # the test's wait timeout. Fail fast to stderr + os._exit(1) instead, so the
+    # harness sees the exit and panics with the captured stderr (matches the
+    # wire_compat.rs receiver).
+    try:
+        print("receiver: about to subscribe", flush=True)
+        subscription = await uvc_camera_video_stream.subscribe(node_runner)
+        received = await subscription.next()
+        if received is None:
+            print("receive failed: subscription closed before any frame", file=sys.stderr, flush=True)
+            os._exit(1)
+        producer, frame = received
+        print(
+            f"got {frame.width}x{frame.height} frame encoded as {frame.encoding} from {producer.core_node}/{producer.instance_id}",
+            flush=True,
+        )
+        frame_received.set()
+    except BaseException as e:
+        print(f"receive failed: {type(e).__name__}: {e}", file=sys.stderr, flush=True)
+        os._exit(1)
 
 async def expose_frame_received_ack(node_runner, frame_received):
     await frame_received.wait()

--- a/crates/generator-internal/tests/python/wire_compat.rs
+++ b/crates/generator-internal/tests/python/wire_compat.rs
@@ -1044,7 +1044,8 @@ from peppygen.consumed_topics import producer_telemetry_feed
 
 async def receive_one(node_runner, msg_received):
     try:
-        producer, msg = await producer_telemetry_feed.on_next_message_received(node_runner)
+        subscription = await producer_telemetry_feed.subscribe(node_runner)
+        producer, msg = await subscription.next()
         print(
             f"received message status={msg.status} readings={list(msg.readings)} "
             f"sequence={msg.sequence} timestamp={msg.timestamp} from {producer.core_node}/{producer.instance_id}",

--- a/crates/generator-internal/tests/rust/consumed_topics_dedup.rs
+++ b/crates/generator-internal/tests/rust/consumed_topics_dedup.rs
@@ -58,8 +58,8 @@ use peppygen::consumed_topics::{left_arm_joint_states, right_arm_joint_states};
 
 #[allow(dead_code)]
 fn _references_both_link_keyed_modules() {
-    let _left: fn(_) -> _ = left_arm_joint_states::on_next_message_received;
-    let _right: fn(_) -> _ = right_arm_joint_states::on_next_message_received;
+    let _left: fn(_) -> _ = left_arm_joint_states::subscribe;
+    let _right: fn(_) -> _ = right_arm_joint_states::subscribe;
 }
 
 fn main() {}

--- a/crates/generator-internal/tests/rust/topics_communication.rs
+++ b/crates/generator-internal/tests/rust/topics_communication.rs
@@ -125,16 +125,18 @@ async fn topics_communication(#[case] mode: crate::helpers::Mode) {
     // TODO: An exit signal should be sent to the receiver to terminate the process
     let receiver_main = r#"
 use peppygen::NodeBuilder;
-use peppygen::consumed_topics::uvc_camera_video_stream::on_next_message_received;
+use peppygen::consumed_topics::uvc_camera_video_stream::subscribe;
 use peppygen::Result;
 
 fn main() -> Result<()> {
     NodeBuilder::new().run(|_parameters: peppygen::Parameters, node_runner| async move {
-        let (producer, frame) = on_next_message_received(&node_runner).await?;
-        println!(
-            "got {}x{} frame encoded as {} from {}/{}",
-            frame.width, frame.height, frame.encoding, producer.core_node, producer.instance_id
-        );
+        let mut subscription = subscribe(&node_runner).await?;
+        if let Some((producer, frame)) = subscription.next().await? {
+            println!(
+                "got {}x{} frame encoded as {} from {}/{}",
+                frame.width, frame.height, frame.encoding, producer.core_node, producer.instance_id
+            );
+        }
         Ok(())
     })
 }

--- a/docs/src/content/docs/advanced_guides/bidirectional_communication.mdx
+++ b/docs/src/content/docs/advanced_guides/bidirectional_communication.mdx
@@ -122,7 +122,7 @@ The order does not matter: running `arm_controller:v1` first works just as well,
 Then `peppy stack launch ./peppy_launcher.json5`. There are no `bindings` to resolve, so the launcher brings both instances up regardless of order.
 
 :::caution[`from_any` makes the dependency optional, not the node's work]
-`from_any` makes a dependency optional *at the binding layer*: the node boots with zero producers and the launcher never rejects it for a missing bind. Whether the node then does useful work is up to its own code. The control loops below block on `await …on_next_message_received(...)`, so with no producer a node never receives, and therefore never emits either. Two such loops started together would each wait for the other's first message and neither would ever publish. If a node must run open-loop (emit before it has received anything), do not gate all of its output behind a never-arriving input: seed the first message from one side, drive emission from a timer, or use a receive timeout, so the loop can start on its own.
+`from_any` makes a dependency optional *at the binding layer*: the node boots with zero producers and the launcher never rejects it for a missing bind. Whether the node then does useful work is up to its own code. The control loops below block on `await subscription.next()`, so with no producer a node never receives, and therefore never emits either. Two such loops started together would each wait for the other's first message and neither would ever publish. If a node must run open-loop (emit before it has received anything), do not gate all of its output behind a never-arriving input: seed the first message from one side, drive emission from a timer, or use a receive timeout, so the loop can start on its own.
 :::
 
 :::note[Conformance is still enforced, just not up front]
@@ -155,7 +155,7 @@ On the other side, `arm_controller` consumes `joint_states` and emits `joint_com
   </TabItem>
 </Tabs>
 
-Both directions use the standard linked consumed-topic API. `on_next_message_received` returns the producer's full identity alongside the message (a `ProducerRef` carrying `core_node` and `instance_id`, in both Rust and Python), so a `from_any` consumer tells its producers apart by that identity: a single arm, several arms, or one that joins late all arrive through the same module, each distinguished by its full identity. There is no special call-site API for bidirectional topics: a node that both emits and consumes is simply a node that `conforms_to` one interface and `depends_on` another.
+Both directions use the standard linked consumed-topic API: `subscribe` returns a held `Subscription`, and each `next` returns the producer's full identity alongside the message (a `ProducerRef` carrying `core_node` and `instance_id`, in both Rust and Python), so a `from_any` consumer tells its producers apart by that identity: a single arm, several arms, or one that joins late all arrive through the same module, each distinguished by its full identity. There is no special call-site API for bidirectional topics: a node that both emits and consumes is simply a node that `conforms_to` one interface and `depends_on` another.
 
 ## Why topics only?
 

--- a/docs/src/content/docs/advanced_guides/interface_conformance.mdx
+++ b/docs/src/content/docs/advanced_guides/interface_conformance.mdx
@@ -260,8 +260,8 @@ Inside the consumer, every consumed-topic API returns the **producer's full `(co
 
     frames_by_producer: dict[ProducerRef, Frame] = {}
 
-    while True:
-        producer, frame = await extras_video_stream.on_next_message_received(node_runner)
+    subscription = await extras_video_stream.subscribe(node_runner)
+    async for producer, frame in subscription:
         # Key by the returned ProducerRef (its full core_node/instance_id
         # identity); do not compare against a hard-coded name.
         frames_by_producer[producer] = frame
@@ -276,9 +276,8 @@ Inside the consumer, every consumed-topic API returns the **producer's full `(co
 
     let mut frames_by_producer: HashMap<ProducerRef, Frame> = HashMap::new();
 
-    loop {
-        let (producer, frame) =
-            extras_video_stream::on_next_message_received(&node_runner).await?;
+    let mut subscription = extras_video_stream::subscribe(&node_runner).await?;
+    while let Some((producer, frame)) = subscription.next().await? {
         // Key by the returned producer identity; do not compare against a
         // hard-coded name.
         frames_by_producer.insert(producer, frame);

--- a/docs/src/content/docs/advanced_guides/topics.mdx
+++ b/docs/src/content/docs/advanced_guides/topics.mdx
@@ -185,7 +185,7 @@ To depend on a contract instead of a specific producer node, so any conforming n
 
 The code generator creates a module for each consumed topic under `peppygen::consumed_topics`.
 The module name is `<link_id>_<topic_name>` based on the `link_id` field; in this case `uvc_camera_video_stream`.
-Use `on_next_message_received` to wait for the next message:
+Call `subscribe` once to obtain a held `Subscription`, then await `next` for each message:
 
 ```rust
 use peppygen::consumed_topics::uvc_camera_video_stream;
@@ -193,32 +193,37 @@ use peppygen::{NodeBuilder, Parameters, Result};
 
 fn main() -> Result<()> {
     NodeBuilder::new().run(|_args: Parameters, node_runner| async move {
-        let (producer, frame) =
-            uvc_camera_video_stream::on_next_message_received(&node_runner).await?;
+        let mut subscription = uvc_camera_video_stream::subscribe(&node_runner).await?;
 
-        println!(
-            "got {}x{} frame encoded as {} from {}/{}",
-            frame.width, frame.height, frame.encoding, producer.core_node, producer.instance_id
-        );
+        if let Some((producer, frame)) = subscription.next().await? {
+            println!(
+                "got {}x{} frame encoded as {} from {}/{}",
+                frame.width, frame.height, frame.encoding, producer.core_node, producer.instance_id
+            );
+        }
 
         Ok(())
     })
 }
 ```
 
-The `on_next_message_received` function takes:
+`subscribe` takes:
 - `node_runner`: the node runner reference.
 
-It returns a tuple of:
-- `producer`: a `peppylib::messaging::ProducerRef` carrying the publisher's full `(core_node, instance_id)` wire identity, read straight from the message context.
-- `message`: the deserialized message, with fields matching the topic's `message_format`.
+and returns a `Subscription`. Awaiting `subscription.next()` yields:
+- `Ok(Some((producer, message)))` for each message, where `producer` is a `peppylib::messaging::ProducerRef` carrying the publisher's full `(core_node, instance_id)` wire identity (read straight from the message context), and `message` is the deserialized message, with fields matching the topic's `message_format`.
+- `Ok(None)` once the subscription has closed.
+- `Err(..)` if a received payload fails to deserialize.
 
-There are no call-site producer-targeting arguments at all. To pin a `from_any` slot to one specific producer, use a launcher binding (see [Bindings and routing](#bindings-and-routing) below); the resolved binding carries the producer's full `(core_node, instance_id)` wire address, so a pinned slot can never receive from a producer that merely shares the instance_id on another core node. The same full identity is what `on_next_message_received` returns with every message, so a consumer can pass it straight back into any producer-targeting slot.
+The subscription holds an in-order buffer, so a message published between `next` calls is kept, not dropped — loop on `next` and nothing is lost in the gap between iterations.
+
+There are no call-site producer-targeting arguments at all. To pin a `from_any` slot to one specific producer, use a launcher binding (see [Bindings and routing](#bindings-and-routing) below); the resolved binding carries the producer's full `(core_node, instance_id)` wire address, so a pinned slot can never receive from a producer that merely shares the instance_id on another core node. The same full identity is what `next` returns with every message, so a consumer can pass it straight back into any producer-targeting slot.
 
 ### Receiving messages continuously
 
-`on_next_message_received` processes a single message and returns.
-To receive messages continuously, call it in a loop.
+To receive messages continuously, subscribe once and loop on `next`.
+The held subscription keeps every message in arrival order, so the loop never
+misses a message published between iterations.
 Each message is processed in a separate task so that the receive loop is not blocked:
 
 ```rust
@@ -234,11 +239,17 @@ fn main() -> Result<()> {
 }
 
 async fn receive_frames(node_runner: Arc<NodeRunner>) {
-    loop {
-        let result = uvc_camera_video_stream::on_next_message_received(&node_runner).await;
+    let mut subscription = match uvc_camera_video_stream::subscribe(&node_runner).await {
+        Ok(subscription) => subscription,
+        Err(e) => {
+            eprintln!("Failed to subscribe: {e}");
+            return;
+        }
+    };
 
-        match result {
-            Ok((producer, frame)) => {
+    loop {
+        match subscription.next().await {
+            Ok(Some((producer, frame))) => {
                 tokio::spawn(async move {
                     println!(
                         "got {}x{} frame from {}/{}",
@@ -246,6 +257,7 @@ async fn receive_frames(node_runner: Arc<NodeRunner>) {
                     );
                 });
             }
+            Ok(None) => break,
             Err(e) => {
                 eprintln!("Error receiving frame: {e}");
                 break;

--- a/docs/src/content/docs/advanced_guides/topics.mdx
+++ b/docs/src/content/docs/advanced_guides/topics.mdx
@@ -217,7 +217,7 @@ and returns a `Subscription`. Awaiting `subscription.next()` yields:
 
 The subscription holds an in-order buffer, so a message published between `next` calls is kept, not dropped — loop on `next` and nothing is lost in the gap between iterations.
 
-There are no call-site producer-targeting arguments at all. To pin a `from_any` slot to one specific producer, use a launcher binding (see [Bindings and routing](#bindings-and-routing) below); the resolved binding carries the producer's full `(core_node, instance_id)` wire address, so a pinned slot can never receive from a producer that merely shares the instance_id on another core node. The same full identity is what `next` returns with every message, so a consumer can pass it straight back into any producer-targeting slot.
+There are no call-site producer-targeting arguments at all. To control which producers reach a `from_any` slot, use launcher bindings (see [Bindings and routing](#bindings-and-routing) below): a binding identifies or routes specific producers to the slot rather than turning it into a single-producer slot, and the resolved binding carries each producer's full `(core_node, instance_id)` wire address, so the slot can never match a producer that merely shares the instance_id on another core node. When you need a truly pinned, single-producer dependency, declare the slot with `from_any: false` instead. Either way, the same full identity is what `next` returns with every message, so a consumer can pass it straight back into any producer-targeting slot.
 
 ### Receiving messages continuously
 

--- a/docs/src/content/docs/guides/snippets/python/arm_controller/src/arm_controller/__main__.py
+++ b/docs/src/content/docs/guides/snippets/python/arm_controller/src/arm_controller/__main__.py
@@ -20,17 +20,22 @@ async def control_loop(node_runner: NodeRunner):
         print(f"Failed to declare joint_commands publisher: {e}", file=sys.stderr)
         return
 
+    # Subscribe once; the held subscription buffers state messages in order, so
+    # the loop never misses one published between iterations.
+    subscription = await arm_joint_states.subscribe(node_runner)
     while True:
         try:
-            producer, state = await arm_joint_states.on_next_message_received(
-                node_runner,
-            )
+            received = await subscription.next()
         except Exception as e:
             # Log the failure, then pause before retrying so a persistent
             # receive error does not spin the loop at full speed.
             print(f"Error receiving joint state: {e}", file=sys.stderr)
             await asyncio.sleep(1.0)
             continue
+
+        if received is None:
+            break  # subscription closed
+        producer, state = received
 
         print(
             f"state from {producer.core_node}/{producer.instance_id}: "

--- a/docs/src/content/docs/guides/snippets/python/arm_controller/src/arm_controller/__main__.py
+++ b/docs/src/content/docs/guides/snippets/python/arm_controller/src/arm_controller/__main__.py
@@ -22,7 +22,12 @@ async def control_loop(node_runner: NodeRunner):
 
     # Subscribe once; the held subscription buffers state messages in order, so
     # the loop never misses one published between iterations.
-    subscription = await arm_joint_states.subscribe(node_runner)
+    try:
+        subscription = await arm_joint_states.subscribe(node_runner)
+    except Exception as e:
+        print(f"Failed to subscribe to arm_joint_states: {e}", file=sys.stderr)
+        return
+
     while True:
         try:
             received = await subscription.next()

--- a/docs/src/content/docs/guides/snippets/python/hello_receiver/src/hello_receiver/__main__.py
+++ b/docs/src/content/docs/guides/snippets/python/hello_receiver/src/hello_receiver/__main__.py
@@ -10,10 +10,10 @@ async def setup(_params: Parameters, node_runner: NodeRunner) -> list[asyncio.Ta
 
 
 async def receive_messages(node_runner: NodeRunner):
-    while True:
-        producer, message = await hello_world_param_message_stream.on_next_message_received(
-            node_runner,
-        )
+    # Subscribe once; the held subscription buffers every message in order, so
+    # iterating never drops a message published between iterations.
+    subscription = await hello_world_param_message_stream.subscribe(node_runner)
+    async for producer, message in subscription:
         print(f"Received from {producer.instance_id}: {message.message}")
 
 

--- a/docs/src/content/docs/guides/snippets/python/robot_arm/src/robot_arm/__main__.py
+++ b/docs/src/content/docs/guides/snippets/python/robot_arm/src/robot_arm/__main__.py
@@ -16,11 +16,10 @@ async def handle_commands(node_runner: NodeRunner):
         print(f"Failed to declare joint_states publisher: {e}", file=sys.stderr)
         return
 
-    while True:
-        producer, command = await controller_joint_commands.on_next_message_received(
-            node_runner,
-        )
-
+    # Subscribe once; the held subscription buffers commands in order, so
+    # iterating never drops one published between iterations.
+    subscription = await controller_joint_commands.subscribe(node_runner)
+    async for producer, command in subscription:
         print(
             f"received from {producer.core_node}/{producer.instance_id}: "
             f"target={command.target_positions} max_vel={command.max_velocity}"

--- a/docs/src/content/docs/guides/snippets/python/robot_arm/src/robot_arm/__main__.py
+++ b/docs/src/content/docs/guides/snippets/python/robot_arm/src/robot_arm/__main__.py
@@ -18,7 +18,12 @@ async def handle_commands(node_runner: NodeRunner):
 
     # Subscribe once; the held subscription buffers commands in order, so
     # iterating never drops one published between iterations.
-    subscription = await controller_joint_commands.subscribe(node_runner)
+    try:
+        subscription = await controller_joint_commands.subscribe(node_runner)
+    except Exception as e:
+        print(f"Failed to subscribe to controller_joint_commands: {e}", file=sys.stderr)
+        return
+
     async for producer, command in subscription:
         print(
             f"received from {producer.core_node}/{producer.instance_id}: "

--- a/docs/src/content/docs/guides/snippets/rust/arm_controller/src/main.rs
+++ b/docs/src/content/docs/guides/snippets/rust/arm_controller/src/main.rs
@@ -19,15 +19,24 @@ fn main() -> Result<()> {
                     return;
                 }
             };
+            // Subscribe once; the held subscription buffers state messages in
+            // order, so the loop never misses one published between iterations.
+            let mut subscription = match arm_joint_states::subscribe(&node_runner).await {
+                Ok(subscription) => subscription,
+                Err(e) => {
+                    eprintln!("Failed to subscribe to joint_states: {e}");
+                    return;
+                }
+            };
             loop {
-                let (producer, state) =
-                    match arm_joint_states::on_next_message_received(&node_runner).await {
-                        Ok(received) => received,
-                        Err(e) => {
-                            eprintln!("Error receiving joint state: {e}");
-                            continue;
-                        }
-                    };
+                let (producer, state) = match subscription.next().await {
+                    Ok(Some(received)) => received,
+                    Ok(None) => break,
+                    Err(e) => {
+                        eprintln!("Error receiving joint state: {e}");
+                        continue;
+                    }
+                };
 
                 println!(
                     "state from {}/{}: positions={:?}",

--- a/docs/src/content/docs/guides/snippets/rust/hello_receiver/src/main.rs
+++ b/docs/src/content/docs/guides/snippets/rust/hello_receiver/src/main.rs
@@ -11,12 +11,22 @@ fn main() -> Result<()> {
 }
 
 async fn receive_messages(node_runner: Arc<NodeRunner>) {
-    loop {
-        let result = hello_world_param_message_stream::on_next_message_received(&node_runner)
-        .await;
+    // Subscribe once; the held subscription buffers every message in order, so
+    // looping on `next` never drops a message published between iterations.
+    let mut subscription = match hello_world_param_message_stream::subscribe(&node_runner).await {
+        Ok(subscription) => subscription,
+        Err(e) => {
+            eprintln!("Failed to subscribe: {e}");
+            return;
+        }
+    };
 
-        match result {
-            Ok((producer, message)) => println!("Received from {}: {}", producer.instance_id, message.message),
+    loop {
+        match subscription.next().await {
+            Ok(Some((producer, message))) => {
+                println!("Received from {}: {}", producer.instance_id, message.message)
+            }
+            Ok(None) => break,
             Err(e) => {
                 eprintln!("Error receiving message: {e}");
                 break;

--- a/docs/src/content/docs/guides/snippets/rust/robot_arm/src/main.rs
+++ b/docs/src/content/docs/guides/snippets/rust/robot_arm/src/main.rs
@@ -19,11 +19,20 @@ fn main() -> Result<()> {
                     return;
                 }
             };
+            // Subscribe once; the held subscription buffers commands in order,
+            // so the loop never misses one published between iterations.
+            let mut subscription = controller_joint_commands::subscribe(&node_runner)
+                .await
+                .expect("failed to subscribe to joint commands");
             loop {
-                let (producer, command) =
-                    controller_joint_commands::on_next_message_received(&node_runner)
-                        .await
-                        .expect("failed to receive joint command");
+                let (producer, command) = match subscription.next().await {
+                    Ok(Some(received)) => received,
+                    Ok(None) => break,
+                    Err(e) => {
+                        eprintln!("Error receiving joint command: {e}");
+                        continue;
+                    }
+                };
 
                 println!(
                     "received from {}/{}: target={:?} max_vel={}",

--- a/docs/src/content/docs/guides/snippets/rust/robot_arm/src/main.rs
+++ b/docs/src/content/docs/guides/snippets/rust/robot_arm/src/main.rs
@@ -21,9 +21,13 @@ fn main() -> Result<()> {
             };
             // Subscribe once; the held subscription buffers commands in order,
             // so the loop never misses one published between iterations.
-            let mut subscription = controller_joint_commands::subscribe(&node_runner)
-                .await
-                .expect("failed to subscribe to joint commands");
+            let mut subscription = match controller_joint_commands::subscribe(&node_runner).await {
+                Ok(subscription) => subscription,
+                Err(e) => {
+                    eprintln!("Failed to subscribe to controller_joint_commands: {e}");
+                    return;
+                }
+            };
             loop {
                 let (producer, command) = match subscription.next().await {
                     Ok(Some(received)) => received,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Topic consumers now use a held subscription that can be iterated over, instead of waiting for one message at a time.
  * Received messages now include the producing node identity alongside the message data.

* **Bug Fixes**
  * Improved subscription handling so messages are buffered in order and the subscription is created only once.
  * Closed subscriptions now end cleanly instead of surfacing as errors.

* **Documentation**
  * Updated guides and examples to show the new subscription-based receive flow in both Python and Rust.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->