### PR TITLE
Add daemon-config crate: extract daemon-side config models from peppy-config-model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,7 +407,7 @@ dependencies = [
 [[package]]
 name = "build-helpers"
 version = "0.0.1"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#a17a3ca523498797d4432bc412b67d93b3e85810"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#f3b3ea3635b511dc11a0734a56bbe0f6aa663b9d"
 dependencies = [
  "sha2 0.11.0",
 ]
@@ -608,7 +608,7 @@ dependencies = [
 [[package]]
 name = "config-test-support"
 version = "0.0.1"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#a17a3ca523498797d4432bc412b67d93b3e85810"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#f3b3ea3635b511dc11a0734a56bbe0f6aa663b9d"
 dependencies = [
  "askama",
  "git2",
@@ -750,7 +750,7 @@ dependencies = [
 [[package]]
 name = "core-node-api"
 version = "0.0.1"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#a17a3ca523498797d4432bc412b67d93b3e85810"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#f3b3ea3635b511dc11a0734a56bbe0f6aa663b9d"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -892,6 +892,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "daemon-config"
+version = "0.0.1"
+dependencies = [
+ "const_format",
+ "dirs 6.0.0",
+ "peppy-config-model",
+ "serde",
+ "serde_json",
+ "serde_json5",
+ "serde_path_to_error",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]
@@ -1051,7 +1067,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1199,7 +1215,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2301,7 +2317,7 @@ dependencies = [
 [[package]]
 name = "json5-pretty"
 version = "0.0.1"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#a17a3ca523498797d4432bc412b67d93b3e85810"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#f3b3ea3635b511dc11a0734a56bbe0f6aa663b9d"
 dependencies = [
  "serde",
  "serde_json",
@@ -2736,7 +2752,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3150,7 +3166,7 @@ dependencies = [
 [[package]]
 name = "peppy-config-model"
 version = "0.0.1"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#a17a3ca523498797d4432bc412b67d93b3e85810"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#f3b3ea3635b511dc11a0734a56bbe0f6aa663b9d"
 dependencies = [
  "capnp",
  "clap",
@@ -3176,7 +3192,7 @@ version = "0.0.1"
 [[package]]
 name = "peppylib-rs"
 version = "0.0.1"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#a17a3ca523498797d4432bc412b67d93b3e85810"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#f3b3ea3635b511dc11a0734a56bbe0f6aa663b9d"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -3352,7 +3368,7 @@ dependencies = [
 [[package]]
 name = "pmi"
 version = "0.0.1"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#a17a3ca523498797d4432bc412b67d93b3e85810"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#f3b3ea3635b511dc11a0734a56bbe0f6aa663b9d"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -3536,7 +3552,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.4",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3982,7 +3998,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4050,7 +4066,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4071,7 +4087,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4447,7 +4463,7 @@ version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
 dependencies = [
- "dirs 6.0.0",
+ "dirs 4.0.0",
 ]
 
 [[package]]
@@ -4728,7 +4744,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5527,7 +5543,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5677,15 +5693,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -5717,28 +5724,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -5763,12 +5753,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5779,12 +5763,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5799,22 +5777,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5829,12 +5795,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5845,12 +5805,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5865,12 +5819,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5881,12 +5829,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,7 +407,7 @@ dependencies = [
 [[package]]
 name = "build-helpers"
 version = "0.0.1"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#f3b3ea3635b511dc11a0734a56bbe0f6aa663b9d"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#fa10bc0461a712499c7571c0b1afd48c5d3e6bf6"
 dependencies = [
  "sha2 0.11.0",
 ]
@@ -608,7 +608,7 @@ dependencies = [
 [[package]]
 name = "config-test-support"
 version = "0.0.1"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#f3b3ea3635b511dc11a0734a56bbe0f6aa663b9d"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#fa10bc0461a712499c7571c0b1afd48c5d3e6bf6"
 dependencies = [
  "askama",
  "git2",
@@ -752,7 +752,7 @@ dependencies = [
 [[package]]
 name = "core-node-api"
 version = "0.0.1"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#f3b3ea3635b511dc11a0734a56bbe0f6aa663b9d"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#fa10bc0461a712499c7571c0b1afd48c5d3e6bf6"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -1069,7 +1069,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1219,7 +1219,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2322,7 +2322,7 @@ dependencies = [
 [[package]]
 name = "json5-pretty"
 version = "0.0.1"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#f3b3ea3635b511dc11a0734a56bbe0f6aa663b9d"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#fa10bc0461a712499c7571c0b1afd48c5d3e6bf6"
 dependencies = [
  "serde",
  "serde_json",
@@ -2758,7 +2758,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3173,7 +3173,7 @@ dependencies = [
 [[package]]
 name = "peppy-config-model"
 version = "0.0.1"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#f3b3ea3635b511dc11a0734a56bbe0f6aa663b9d"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#fa10bc0461a712499c7571c0b1afd48c5d3e6bf6"
 dependencies = [
  "capnp",
  "clap",
@@ -3199,7 +3199,7 @@ version = "0.0.1"
 [[package]]
 name = "peppylib-rs"
 version = "0.0.1"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#f3b3ea3635b511dc11a0734a56bbe0f6aa663b9d"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#fa10bc0461a712499c7571c0b1afd48c5d3e6bf6"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -3375,7 +3375,7 @@ dependencies = [
 [[package]]
 name = "pmi"
 version = "0.0.1"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#f3b3ea3635b511dc11a0734a56bbe0f6aa663b9d"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#fa10bc0461a712499c7571c0b1afd48c5d3e6bf6"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -3559,7 +3559,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.4",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4005,7 +4005,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4073,7 +4073,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4094,7 +4094,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4470,7 +4470,7 @@ version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
 dependencies = [
- "dirs 4.0.0",
+ "dirs 6.0.0",
 ]
 
 [[package]]
@@ -4751,7 +4751,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5550,7 +5550,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5700,6 +5700,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -5731,11 +5740,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -5760,6 +5786,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5770,6 +5802,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5784,10 +5822,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5802,6 +5852,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5812,6 +5868,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5826,6 +5888,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5836,6 +5904,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -666,6 +666,7 @@ version = "0.0.1"
 dependencies = [
  "build-helpers",
  "config-test-support",
+ "daemon-config",
  "peppy-config-model",
  "serde",
  "serde_yaml",
@@ -710,6 +711,7 @@ dependencies = [
  "config-test-support",
  "containers",
  "core-node-api",
+ "daemon-config",
  "dirs 6.0.0",
  "futures",
  "generator",
@@ -1108,6 +1110,7 @@ dependencies = [
 name = "docs-integration-tests"
 version = "0.1.0"
 dependencies = [
+ "daemon-config",
  "peppy",
  "peppy-config-model",
  "serde",
@@ -1175,6 +1178,7 @@ dependencies = [
  "build-helpers",
  "capnp",
  "capnpc",
+ "daemon-config",
  "indexmap 2.14.0",
  "peppy-config-model",
  "proc-macro2",
@@ -1484,6 +1488,7 @@ dependencies = [
  "build-helpers",
  "bytes",
  "config-test-support",
+ "daemon-config",
  "encoding",
  "indexmap 2.14.0",
  "json5-pretty",
@@ -2700,6 +2705,7 @@ dependencies = [
  "chrono",
  "containers",
  "core-node-api",
+ "daemon-config",
  "names-generator2",
  "parking_lot",
  "peppy-config-model",
@@ -3125,6 +3131,7 @@ dependencies = [
  "core-node",
  "core-node-api",
  "crossterm",
+ "daemon-config",
  "derive_more",
  "dirs 6.0.0",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ build-helpers = { git = "https://github.com/Peppy-bot/public-peppy-libs" }
 # features are still added at the use site with `{ workspace = true, features = [...] }`.
 containers = { path = "crates/containers-internal" }
 core-node = { path = "crates/core-node-internal" }
+daemon-config = { path = "crates/daemon-config-internal" }
 encoding = { path = "crates/encoding-internal" }
 generator = { path = "crates/generator-internal" }
 latency-report = { path = "crates/latency-report" }

--- a/crates/containers-internal/Cargo.toml
+++ b/crates/containers-internal/Cargo.toml
@@ -14,6 +14,8 @@ tracing = "0.1"
 [dev-dependencies]
 # Only `test_tmp_root` is needed (no git fixtures), so no `git_fixtures` feature.
 config-test-support = { workspace = true }
+# `DEFAULT_ALPINE_BASE_IMAGE` in tests/facade.rs.
+daemon-config = { workspace = true }
 tempfile = "3"
 
 [build-dependencies]

--- a/crates/containers-internal/tests/facade.rs
+++ b/crates/containers-internal/tests/facade.rs
@@ -1,4 +1,4 @@
-use config::consts::DEFAULT_ALPINE_BASE_IMAGE;
+use daemon_config::consts::DEFAULT_ALPINE_BASE_IMAGE;
 use containers::Apptainer;
 use std::fs;
 use std::path::PathBuf;

--- a/crates/core-node-internal/Cargo.toml
+++ b/crates/core-node-internal/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 [dependencies]
 pmi = { workspace = true, features = ["zenoh", "build_zenoh"] }
 config = { workspace = true }
+daemon-config = { workspace = true }
 node-stack = { workspace = true }
 peppylib = { workspace = true }
 core-node-api = { workspace = true }

--- a/crates/core-node-internal/src/services.rs
+++ b/crates/core-node-internal/src/services.rs
@@ -17,10 +17,10 @@ pub use node::{TEARDOWN_REAP_BUDGET, force_kill_deadline, teardown_all_instances
 use crate::Result;
 use config::{
     DefaultValue, ParameterSpec,
-    consts::PeppyDirs,
     node::{Execution, Manifest, Name, NodeConfig, PeppygenLanguage, TypeToken},
     schema::PeppySchema,
 };
+use daemon_config::consts::PeppyDirs;
 use futures::future::{BoxFuture, FutureExt, try_join_all};
 use names_generator2::get_random;
 use node_stack::NodeStack;
@@ -117,7 +117,7 @@ pub struct CoreNodeConfig {
     pub peppy_dirs: PeppyDirs,
     /// Daemon-global messaging mode + peer buffer sizes, injected into every
     /// spawned node's runtime config (see `node::run`).
-    pub peppy_config: config::peppy_config::PeppyConfig,
+    pub peppy_config: daemon_config::peppy_config::PeppyConfig,
     /// The daemon's organization namespace for this generation (`"local"` when
     /// logged out, else the org id). Stamped onto every spawned node's
     /// `discovery.organization_id` so the node opens its session under the same
@@ -146,7 +146,7 @@ pub struct CoreNode {
     daemon_use_sim_time: bool,
     /// Daemon-global messaging mode + peer buffer sizes, read once at startup.
     /// Injected into every spawned node's runtime config (see `node::run`).
-    peppy_config: config::peppy_config::PeppyConfig,
+    peppy_config: daemon_config::peppy_config::PeppyConfig,
     /// The daemon's organization namespace for this generation, stamped onto
     /// every spawned node so it opens its session under the daemon's namespace.
     organization_namespace: String,

--- a/crates/core-node-internal/src/services/node.rs
+++ b/crates/core-node-internal/src/services/node.rs
@@ -16,7 +16,7 @@ mod run;
 mod stop;
 mod sync;
 
-use config::consts::PeppyDirs;
+use daemon_config::consts::PeppyDirs;
 use config::node::NodeConfig;
 use core_node_api::encoding::NodeSource;
 

--- a/crates/core-node-internal/src/services/node/add.rs
+++ b/crates/core-node-internal/src/services/node/add.rs
@@ -13,7 +13,8 @@ use super::{
 use crate::Result;
 use crate::names;
 use chrono::Local;
-use config::consts::{NODE_CONFIG_FILE, PEPPYGEN_OUTPUT_PATH, PeppyDirs};
+use config::consts::{NODE_CONFIG_FILE, PEPPYGEN_OUTPUT_PATH};
+use daemon_config::consts::PeppyDirs;
 use config::node::validate_dependency_specs;
 use config::node::{NodeConfig, NodeConfigParser};
 use core_node_api::encoding::{

--- a/crates/core-node-internal/src/services/node/add_batch.rs
+++ b/crates/core-node-internal/src/services/node/add_batch.rs
@@ -13,7 +13,7 @@ use super::add::{NodeAddActionContext, run_node_add};
 use super::cache as node_cache;
 use super::{FeedbackLine, FeedbackStream, create_action_log_file};
 use chrono::Local;
-use config::consts::PeppyDirs;
+use daemon_config::consts::PeppyDirs;
 use config::node::NodeConfig;
 use core_node_api::encoding::{NodeAddGoal, NodeAddResult, NodeSource, RepoSourceKind};
 use futures::future::BoxFuture;

--- a/crates/core-node-internal/src/services/node/builder.rs
+++ b/crates/core-node-internal/src/services/node/builder.rs
@@ -5,7 +5,7 @@ use super::{FeedbackLine, FeedbackStream, create_action_log_file};
 use crate::Result;
 use crate::names;
 use chrono::Local;
-use config::consts::PeppyDirs;
+use daemon_config::consts::PeppyDirs;
 use core_node_api::encoding::{
     NodeBuildFeedback, NodeBuildGoal, NodeBuildGoalResponse, NodeBuildResult,
 };

--- a/crates/core-node-internal/src/services/node/cache.rs
+++ b/crates/core-node-internal/src/services/node/cache.rs
@@ -3,7 +3,7 @@
 //! `git` caches fully-cloned checkouts keyed by `(repo_url, ref)`;
 //! `bundle` caches extracted HTTP archives keyed by `(url, sha256)`.
 //! Both use `key` (slug + short hash) to produce deterministic directory
-//! names under [`config::consts::PeppyDirs`].
+//! names under [`daemon_config::consts::PeppyDirs`].
 
 pub(super) mod bundle;
 pub(crate) mod git;

--- a/crates/core-node-internal/src/services/node/cache/bundle.rs
+++ b/crates/core-node-internal/src/services/node/cache/bundle.rs
@@ -13,7 +13,7 @@
 use super::super::add::download_and_extract_http_source;
 use super::super::locate_node_root_dir;
 use super::key;
-use config::consts::PeppyDirs;
+use daemon_config::consts::PeppyDirs;
 use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};

--- a/crates/core-node-internal/src/services/node/cache/git.rs
+++ b/crates/core-node-internal/src/services/node/cache/git.rs
@@ -14,7 +14,7 @@
 use super::super::checkout_repo_ref;
 use super::super::git_utils::{clone_with_progress, fetch_with_progress};
 use super::key;
-use config::consts::PeppyDirs;
+use daemon_config::consts::PeppyDirs;
 use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};

--- a/crates/core-node-internal/src/services/node/cache/materialize.rs
+++ b/crates/core-node-internal/src/services/node/cache/materialize.rs
@@ -3,7 +3,7 @@
 //!
 //! Filesystem entries are resolved directly. Git and HTTP entries route
 //! through the persistent `git` / `bundle` caches under
-//! [`config::consts::PeppyDirs`], so the same repo or archive is fetched
+//! [`daemon_config::consts::PeppyDirs`], so the same repo or archive is fetched
 //! at most once per nodes-cache generation.
 //!
 //! Shared by `add_batch` (`run_repo_node_add`) and `sync`
@@ -13,7 +13,8 @@
 use super::super::sanitize_repo_path;
 use super::{ensure_bundle, ensure_checkout};
 use crate::services::repo::cache::NodeCacheEntry;
-use config::consts::{NODE_CONFIG_FILE, PeppyDirs};
+use config::consts::NODE_CONFIG_FILE;
+use daemon_config::consts::PeppyDirs;
 use config::node::{NodeConfig, NodeConfigParser};
 use core_node_api::encoding::RepoSourceKind;
 use std::path::{Path, PathBuf};

--- a/crates/core-node-internal/src/services/node/info.rs
+++ b/crates/core-node-internal/src/services/node/info.rs
@@ -4,7 +4,8 @@ use super::{
 use crate::Result;
 use crate::names;
 use crate::services::repo::cache as repo_cache;
-use config::consts::{NODE_CONFIG_FILE, PeppyDirs};
+use config::consts::NODE_CONFIG_FILE;
+use daemon_config::consts::PeppyDirs;
 use config::fingerprint::fingerprint_for_bytes;
 use config::node::{NodeConfig, NodeConfigParser};
 use core_node_api::encoding::{

--- a/crates/core-node-internal/src/services/node/init.rs
+++ b/crates/core-node-internal/src/services/node/init.rs
@@ -4,7 +4,7 @@ use self::templates::{apply_python_templates, apply_rust_templates};
 use crate::Result;
 use crate::names;
 use crate::services::response::into_service_response;
-use config::consts::PeppyDirs;
+use daemon_config::consts::PeppyDirs;
 use config::node::Toolchain;
 use core_node_api::encoding::{NodeInitRequest, NodeInitResponse};
 use peppylib::messaging::SenderTarget;

--- a/crates/core-node-internal/src/services/node/init/templates.rs
+++ b/crates/core-node-internal/src/services/node/init/templates.rs
@@ -103,7 +103,7 @@ pub fn apply_rust_templates(node_name: &str, node_dir: &Path, with_container: bo
     let cargo_toml = RustCargoToml {
         node_name,
         pepygen_path: config::consts::PEPPYGEN_OUTPUT_PATH,
-        pepylib_path: config::consts::PEPPYLIB_OUTPUT_PATH,
+        pepylib_path: daemon_config::consts::PEPPYLIB_OUTPUT_PATH,
     };
     std::fs::write(node_dir.join("Cargo.toml"), cargo_toml.render()?)?;
 
@@ -121,7 +121,7 @@ pub fn apply_rust_templates(node_name: &str, node_dir: &Path, with_container: bo
         let apptainer_def = ApptainerRustDef {
             node_name,
             tag: "v1",
-            base_image: config::consts::DEFAULT_RUST_BASE_IMAGE,
+            base_image: daemon_config::consts::DEFAULT_RUST_BASE_IMAGE,
         };
         std::fs::write(node_dir.join("apptainer.def"), apptainer_def.render()?)?;
     }
@@ -139,7 +139,7 @@ pub fn apply_python_templates(
     let pyproject_toml = PythonPyprojectToml {
         node_name,
         pepygen_path: config::consts::PEPPYGEN_OUTPUT_PATH,
-        pepylib_path: config::consts::PEPPYLIB_OUTPUT_PATH,
+        pepylib_path: daemon_config::consts::PEPPYLIB_OUTPUT_PATH,
         python_min_version: config::consts::PYTHON_MIN_VERSION,
         python_max_version: config::consts::PYTHON_MAX_VERSION,
     };
@@ -182,7 +182,7 @@ if __name__ == "__main__":
         let apptainer_def = ApptainerPythonDef {
             node_name,
             tag: "v1",
-            base_image: config::consts::DEFAULT_PYTHON_BASE_IMAGE,
+            base_image: daemon_config::consts::DEFAULT_PYTHON_BASE_IMAGE,
         };
         std::fs::write(node_dir.join("apptainer.def"), apptainer_def.render()?)?;
     }

--- a/crates/core-node-internal/src/services/node/logging.rs
+++ b/crates/core-node-internal/src/services/node/logging.rs
@@ -3,7 +3,7 @@
 //! the stack-operations append log.
 
 use chrono::Local;
-use config::consts::PeppyDirs;
+use daemon_config::consts::PeppyDirs;
 use parking_lot::Mutex as StdMutex;
 use std::fs::File;
 use std::io::Write;

--- a/crates/core-node-internal/src/services/node/run.rs
+++ b/crates/core-node-internal/src/services/node/run.rs
@@ -3,9 +3,10 @@ use super::gate::ConcurrencyGate;
 use super::{FeedbackLine, FeedbackStream, create_action_log_file, write_error_to_log};
 use crate::Result;
 use crate::names;
-use config::consts::PeppyDirs;
+use daemon_config::consts::PeppyDirs;
 use config::node::Name;
-use config::peppy_config::{Mode, PeerConfig, PeppyConfig};
+use config::peppy_config::PeerConfig;
+use daemon_config::peppy_config::{Mode, PeppyConfig};
 use config::runtime::RuntimeConfig;
 use config::{AnyType, apply_parameter_defaults, resolve_argument_path};
 use core_node_api::InstanceState;
@@ -1590,7 +1591,7 @@ mod tests {
     use super::*;
 
     fn runtime_config_for_test() -> RuntimeConfig {
-        let instance_id = config::launcher::Name::new("camera_front").unwrap();
+        let instance_id = config::runtime::Name::new("camera_front").unwrap();
         RuntimeConfig::new(
             "127.0.0.1",
             7448,

--- a/crates/core-node-internal/src/services/node/sync.rs
+++ b/crates/core-node-internal/src/services/node/sync.rs
@@ -4,7 +4,7 @@ use crate::services::node::cache as node_cache;
 use crate::services::repo::cache as repo_cache;
 use crate::services::response::into_service_response;
 use config::ParsingError;
-use config::consts::PeppyDirs;
+use daemon_config::consts::PeppyDirs;
 use config::node::{NodeConfigParser, validate_dependency_specs};
 use core_node_api::encoding::{NodeSyncRequest, NodeSyncResponse, RepoResolvedEntry};
 use generator::{ConsumedActionMessage, DeploymentInterface, InterfaceOrigin, InterfaceVariant};
@@ -66,14 +66,14 @@ pub async fn listen_for_node_sync(
 /// "No such file or directory" errors. Callers already run inside
 /// `tokio::task::spawn_blocking`, so the synchronous cost is acceptable.
 fn remove_previous_peppy_dir(node_root_dir: &std::path::Path) {
-    let peppy_output_dir = node_root_dir.join(config::consts::PEPPY_OUTPUT_DIR);
+    let peppy_output_dir = node_root_dir.join(daemon_config::consts::PEPPY_OUTPUT_DIR);
 
     // Path-string sanity check; pure CPU, no syscall.
-    if peppy_output_dir.file_name() != Some(std::ffi::OsStr::new(config::consts::PEPPY_OUTPUT_DIR))
+    if peppy_output_dir.file_name() != Some(std::ffi::OsStr::new(daemon_config::consts::PEPPY_OUTPUT_DIR))
     {
         debug!(
             "Unexpected directory name, expected {}: {}",
-            config::consts::PEPPY_OUTPUT_DIR,
+            daemon_config::consts::PEPPY_OUTPUT_DIR,
             peppy_output_dir.display()
         );
         return;
@@ -143,7 +143,7 @@ fn remove_previous_peppy_dir(node_root_dir: &std::path::Path) {
 /// - `git.hash` (non-empty)
 /// - `libs/peppygen/peppy.json5.sha256` (non-empty)
 fn needs_sync(node_root_dir: &std::path::Path) -> bool {
-    let peppy_dir = node_root_dir.join(config::consts::PEPPY_OUTPUT_DIR);
+    let peppy_dir = node_root_dir.join(daemon_config::consts::PEPPY_OUTPUT_DIR);
     if !peppy_dir.exists() {
         return true;
     }
@@ -676,7 +676,7 @@ pub fn collect_consumed_interfaces(
     // `(name, tag)` but different sha256 pin or `from_any` flag cache and
     // resolve separately. `resolve_interface_doc` handles SHA-pin matching
     // and on-disk drift detection per load.
-    let mut iface_dep_contracts: HashMap<String, config::interface::PeppyInterface> =
+    let mut iface_dep_contracts: HashMap<String, daemon_config::interface::PeppyInterface> =
         HashMap::new();
 
     for (link_id, entry) in dep_lookup.iter() {
@@ -839,14 +839,14 @@ pub fn collect_consumed_interfaces(
 fn resolve_consumed_offering<T>(
     dep_lookup: &HashMap<String, DependencyLookupEntry>,
     node_dep_offerings: &HashMap<(String, String), DependencyOfferings>,
-    iface_dep_contracts: &HashMap<String, config::interface::PeppyInterface>,
+    iface_dep_contracts: &HashMap<String, daemon_config::interface::PeppyInterface>,
     link_id: &str,
     lookup_name: &str,
     extract_from_node: impl FnOnce(
         &DependencyOfferings,
         &str,
     ) -> Option<(T, Option<generator::InterfaceOrigin>)>,
-    extract_from_interface: impl FnOnce(&config::interface::PeppyInterface, &str) -> Option<T>,
+    extract_from_interface: impl FnOnce(&daemon_config::interface::PeppyInterface, &str) -> Option<T>,
 ) -> Option<(T, generator::DependencyContext)> {
     let entry = dep_lookup.get(link_id)?;
     match entry.kind {
@@ -1065,7 +1065,7 @@ pub(crate) fn resolve_interface_doc(
     tag: &str,
     sha256_pin: Option<&str>,
     on_feedback: &dyn Fn(&str),
-) -> std::result::Result<config::interface::PeppyInterface, String> {
+) -> std::result::Result<daemon_config::interface::PeppyInterface, String> {
     let cache = repo_cache::load_interface_cache(peppy_dirs)
         .map_err(|e| format!("failed to load interface cache: {e}"))?;
 
@@ -1110,7 +1110,7 @@ pub(crate) fn resolve_interface_doc(
 
     let content = std::str::from_utf8(&bytes)
         .map_err(|e| format!("cached interface `{name}:{tag}` is not UTF-8: {e}"))?;
-    config::interface::PeppyInterfaceParser::from_content(content)
+    daemon_config::interface::PeppyInterfaceParser::from_content(content)
         .map_err(|e| format!("failed to parse cached interface `{name}:{tag}`: {e}"))
 }
 
@@ -1247,7 +1247,7 @@ pub fn auto_sync_if_missing(
     node_stack: &NodeStack,
     peppy_dirs: &PeppyDirs,
 ) -> crate::Result<()> {
-    let peppy_dir = params.node_dir.join(config::consts::PEPPY_OUTPUT_DIR);
+    let peppy_dir = params.node_dir.join(daemon_config::consts::PEPPY_OUTPUT_DIR);
     if needs_sync(params.node_dir) {
         // Back up existing .peppy so we can restore it on failure.
         let backup_dir = params.node_dir.join(format!(

--- a/crates/core-node-internal/src/services/repo/add.rs
+++ b/crates/core-node-internal/src/services/repo/add.rs
@@ -4,7 +4,7 @@ use crate::services::repo::cache::repositories_list_path;
 use crate::services::repo::refresh::read_or_create_repos;
 use crate::services::repo::{json_entry_identity, repo_source_to_json, source_identity};
 use crate::services::response::into_service_response;
-use config::consts::PeppyDirs;
+use daemon_config::consts::PeppyDirs;
 use core_node_api::encoding::{RepoAddRequest, RepoAddResponse};
 use peppylib::messaging::SenderTarget;
 use peppylib::messaging::ServiceRequestContext;

--- a/crates/core-node-internal/src/services/repo/cache.rs
+++ b/crates/core-node-internal/src/services/repo/cache.rs
@@ -17,7 +17,7 @@
 
 use crate::Result;
 use crate::services::repo::refresh::read_or_create_repos;
-use config::consts::PeppyDirs;
+use daemon_config::consts::PeppyDirs;
 use core_node_api::encoding::{NodeSource, RepoSourceKind};
 use parking_lot::Mutex;
 use std::collections::HashMap;
@@ -194,19 +194,19 @@ fn repositories_mtime(peppy_dirs: &PeppyDirs) -> SystemTime {
 }
 
 /// Write cached node information for git/url repositories. Atomic via
-/// [`config::atomic_write::publish_atomic`] so concurrent readers never
+/// [`daemon_config::atomic_write::publish_atomic`] so concurrent readers never
 /// observe a partial file.
 pub(crate) fn write_cache(peppy_dirs: &PeppyDirs, nodes: &[NodeCacheEntry]) -> Result<()> {
     let content = json5_pretty::to_string_pretty(nodes)
         .map_err(|e| core_node_api::Error::Encoding(format!("failed to serialize cache: {e}")))?;
-    config::atomic_write::publish_atomic(&nodes_repo_cache_path(peppy_dirs), |tmp| {
+    daemon_config::atomic_write::publish_atomic(&nodes_repo_cache_path(peppy_dirs), |tmp| {
         std::fs::write(tmp, &content)
     })?;
     Ok(())
 }
 
 /// Write cached launcher information for git/url/fs repositories. Atomic
-/// via [`config::atomic_write::publish_atomic`] so concurrent readers
+/// via [`daemon_config::atomic_write::publish_atomic`] so concurrent readers
 /// never observe a partial file.
 pub(crate) fn write_launcher_cache(
     peppy_dirs: &PeppyDirs,
@@ -215,14 +215,14 @@ pub(crate) fn write_launcher_cache(
     let content = json5_pretty::to_string_pretty(launchers).map_err(|e| {
         core_node_api::Error::Encoding(format!("failed to serialize launcher cache: {e}"))
     })?;
-    config::atomic_write::publish_atomic(&launchers_repo_cache_path(peppy_dirs), |tmp| {
+    daemon_config::atomic_write::publish_atomic(&launchers_repo_cache_path(peppy_dirs), |tmp| {
         std::fs::write(tmp, &content)
     })?;
     Ok(())
 }
 
 /// Write cached interface information. Atomic via
-/// [`config::atomic_write::publish_atomic`] so concurrent readers never
+/// [`daemon_config::atomic_write::publish_atomic`] so concurrent readers never
 /// observe a partial file.
 pub(crate) fn write_interface_cache(
     peppy_dirs: &PeppyDirs,
@@ -231,7 +231,7 @@ pub(crate) fn write_interface_cache(
     let content = json5_pretty::to_string_pretty(interfaces).map_err(|e| {
         core_node_api::Error::Encoding(format!("failed to serialize interface cache: {e}"))
     })?;
-    config::atomic_write::publish_atomic(&interfaces_repo_cache_path(peppy_dirs), |tmp| {
+    daemon_config::atomic_write::publish_atomic(&interfaces_repo_cache_path(peppy_dirs), |tmp| {
         std::fs::write(tmp, &content)
     })?;
     Ok(())

--- a/crates/core-node-internal/src/services/repo/exclude.rs
+++ b/crates/core-node-internal/src/services/repo/exclude.rs
@@ -7,7 +7,7 @@ use crate::services::repo::{
     json_entry_identity, normalize_repo_entries, repo_source_to_json, source_identity,
 };
 use crate::services::response::into_service_response;
-use config::consts::PeppyDirs;
+use daemon_config::consts::PeppyDirs;
 use core_node_api::encoding::{RepoExcludeRequest, RepoExcludeResponse, RepoSourceKind};
 use peppylib::messaging::SenderTarget;
 use peppylib::messaging::ServiceRequestContext;

--- a/crates/core-node-internal/src/services/repo/init.rs
+++ b/crates/core-node-internal/src/services/repo/init.rs
@@ -1,5 +1,5 @@
 use crate::Result;
-use config::consts::PeppyDirs;
+use daemon_config::consts::PeppyDirs;
 use serde_json::Value;
 use std::collections::HashSet;
 use tracing::info;

--- a/crates/core-node-internal/src/services/repo/list.rs
+++ b/crates/core-node-internal/src/services/repo/list.rs
@@ -5,7 +5,7 @@ use crate::services::repo::exclude::ExclusionSet;
 use crate::services::repo::refresh::{parse_repo_entry, read_or_create_repos, walk_directory};
 use crate::services::repo::source_identity;
 use crate::services::response::into_service_response;
-use config::consts::PeppyDirs;
+use daemon_config::consts::PeppyDirs;
 use core_node_api::encoding::{
     RepoListNodeEntry, RepoListRequest, RepoListResponse, RepoSource, RepoSourceKind,
 };

--- a/crates/core-node-internal/src/services/repo/refresh.rs
+++ b/crates/core-node-internal/src/services/repo/refresh.rs
@@ -6,10 +6,11 @@ use crate::services::node::gate::{Admission, ConcurrencyGate};
 use crate::services::repo::cache::{InterfaceCacheEntry, LauncherCacheEntry};
 use crate::services::repo::exclude::ExclusionSet;
 use crate::services::repo::{normalize_repo_entries, source_identity};
-use config::consts::{NODE_CONFIG_FILE, PeppyDirs};
+use config::consts::NODE_CONFIG_FILE;
+use daemon_config::consts::PeppyDirs;
 use config::fingerprint::fingerprint_for_bytes;
-use config::interface::PeppyInterfaceParser;
-use config::launcher::PeppyLauncherParser;
+use daemon_config::interface::PeppyInterfaceParser;
+use daemon_config::launcher::PeppyLauncherParser;
 use config::node::NodeConfigParser;
 use config::schema::PeppySchema;
 use core_node_api::encoding::{

--- a/crates/core-node-internal/src/services/repo/remove.rs
+++ b/crates/core-node-internal/src/services/repo/remove.rs
@@ -5,7 +5,7 @@ use crate::services::repo::refresh::{
     process_refresh, read_or_create_repos, write_cache, write_interface_cache, write_launcher_cache,
 };
 use crate::services::response::into_service_response;
-use config::consts::PeppyDirs;
+use daemon_config::consts::PeppyDirs;
 use core_node_api::encoding::{RepoRemoveRequest, RepoRemoveResponse};
 use peppylib::messaging::SenderTarget;
 use peppylib::messaging::ServiceRequestContext;

--- a/crates/core-node-internal/src/services/stack/benchmark.rs
+++ b/crates/core-node-internal/src/services/stack/benchmark.rs
@@ -22,7 +22,7 @@ use crate::names;
 use crate::services::action_loop::{GoalHandler, accept_goal, reject_goal, run_action_loop};
 use crate::services::node::gate::{Admission, ConcurrencyGate};
 use crate::services::node::resolve_interface_doc;
-use config::consts::PeppyDirs;
+use daemon_config::consts::PeppyDirs;
 use config::node::{
     DependsOn, MessageSizeEstimate, NodeConfig, QoSProfile, estimate_serialized_size,
     node_conforms_to,
@@ -399,7 +399,7 @@ fn resolve_conformed_topic_qos(
     peppy_dirs: &PeppyDirs,
     tx: &UnboundedSender<StackBenchmarkFeedback>,
 ) {
-    let mut cache: HashMap<(String, String), Option<config::interface::PeppyInterface>> =
+    let mut cache: HashMap<(String, String), Option<daemon_config::interface::PeppyInterface>> =
         HashMap::new();
     for edge in edges.iter_mut() {
         if edge.kind != InterfaceKind::Topic {
@@ -451,7 +451,7 @@ fn resolve_probe_sizes(edges: &mut [Edge], configs: &[NodeConfig], peppy_dirs: &
         .iter()
         .map(|c| ((c.manifest.name.as_str(), c.manifest.tag.as_str()), c))
         .collect();
-    let mut iface_cache: HashMap<(String, String), Option<config::interface::PeppyInterface>> =
+    let mut iface_cache: HashMap<(String, String), Option<daemon_config::interface::PeppyInterface>> =
         HashMap::new();
 
     for edge in edges.iter_mut() {
@@ -543,7 +543,7 @@ fn formats_from_node(
 /// Request/response size estimates for an interface declared in an interface
 /// contract. Same response-side convention for topics as [`formats_from_node`].
 fn formats_from_interface(
-    doc: Option<&config::interface::PeppyInterface>,
+    doc: Option<&daemon_config::interface::PeppyInterface>,
     kind: InterfaceKind,
     name: &str,
 ) -> (Option<MessageSizeEstimate>, Option<MessageSizeEstimate>) {
@@ -1267,7 +1267,7 @@ mod tests {
 
     #[test]
     fn formats_from_interface_sizes_topic_message_on_response_side() {
-        let doc = config::interface::PeppyInterfaceParser::from_content(
+        let doc = daemon_config::interface::PeppyInterfaceParser::from_content(
             r#"{
                 peppy_schema: "interface/v1",
                 manifest: { name: "uvc_camera", tag: "v1" },

--- a/crates/core-node-internal/src/services/stack/launch.rs
+++ b/crates/core-node-internal/src/services/stack/launch.rs
@@ -11,8 +11,9 @@ use crate::services::node::{
 };
 use chrono::Local;
 use config::apply_parameter_defaults;
-use config::consts::{DEFAULT_MESSAGING_HOST, DEFAULT_MESSAGING_PORT, PeppyDirs};
-use config::launcher::{Deployment, DeploymentSource, PeppyLauncherParser};
+use config::consts::{DEFAULT_MESSAGING_HOST, DEFAULT_MESSAGING_PORT};
+use daemon_config::consts::PeppyDirs;
+use daemon_config::launcher::{Deployment, DeploymentSource, PeppyLauncherParser};
 use config::runtime::RuntimeConfig;
 use core_node_api::encoding::{
     LaunchFeedback, LaunchFeedbackStep, LaunchGoal, LaunchGoalResponse, LaunchResult,
@@ -285,7 +286,7 @@ pub const STACK_LAUNCH_GIT_HASH: &str = "stack-launch";
 /// value > daemon default > wall" precedence so the spawned node receives
 /// one concrete value and never has to re-implement the fallback.
 fn resolve_framework(
-    overrides: &config::launcher::FrameworkOverrides,
+    overrides: &daemon_config::launcher::FrameworkOverrides,
     daemon_default_use_sim_time: bool,
 ) -> config::runtime::ResolvedFramework {
     config::runtime::ResolvedFramework {
@@ -960,7 +961,7 @@ async fn resolve_deployments(
     }
 
     if !planning_errors.is_empty() {
-        let msg = config::format_bulleted(&planning_errors);
+        let msg = daemon_config::format_bulleted(&planning_errors);
         publish_stderr(ctx, msg.clone(), LaunchFeedbackStep::LauncherStep).await;
         return Err(LaunchResult::failure(&ctx.log_path, msg));
     }
@@ -1026,7 +1027,7 @@ async fn validate_and_order_dependencies(
         .collect();
 
     if !dependency_errors.is_empty() {
-        let msg = config::format_bulleted(&dependency_errors);
+        let msg = daemon_config::format_bulleted(&dependency_errors);
         publish_stderr(ctx, msg.clone(), LaunchFeedbackStep::LauncherStep).await;
         return Err(LaunchResult::failure(&ctx.log_path, msg));
     }
@@ -1046,9 +1047,9 @@ async fn validate_and_order_dependencies(
         .instances()
         .first()
         .map(|inst| inst.instance_id().as_str().to_owned());
-    let root_instances: Vec<config::launcher::DeploymentInstance> = root_instance_id_str
-        .and_then(|id_str| config::launcher::Name::new(id_str).ok())
-        .map(|instance_id| config::launcher::DeploymentInstance {
+    let root_instances: Vec<daemon_config::launcher::DeploymentInstance> = root_instance_id_str
+        .and_then(|id_str| config::runtime::Name::new(id_str).ok())
+        .map(|instance_id| daemon_config::launcher::DeploymentInstance {
             instance_id,
             arguments: Default::default(),
             env_vars: Default::default(),
@@ -1058,9 +1059,9 @@ async fn validate_and_order_dependencies(
         .into_iter()
         .collect();
 
-    let mut binding_items: Vec<config::launcher::BindingValidationItem<'_>> = planned
+    let mut binding_items: Vec<daemon_config::launcher::BindingValidationItem<'_>> = planned
         .iter()
-        .map(|p| config::launcher::BindingValidationItem {
+        .map(|p| daemon_config::launcher::BindingValidationItem {
             node_name: &p.node_name,
             node_tag: &p.node_tag,
             instances: &p.deployment.instances,
@@ -1069,7 +1070,7 @@ async fn validate_and_order_dependencies(
         })
         .collect();
     if !root_instances.is_empty() {
-        binding_items.push(config::launcher::BindingValidationItem {
+        binding_items.push(daemon_config::launcher::BindingValidationItem {
             node_name: root_config.manifest.name.as_str(),
             node_tag: root_config.manifest.tag.as_str(),
             instances: &root_instances,
@@ -1081,9 +1082,9 @@ async fn validate_and_order_dependencies(
     // stacks are daemon-scoped, so the launching daemon is where every
     // producer instance in the snapshot lives.
     let validated =
-        config::launcher::validate_bindings(&binding_items, ctx.bound_core_node.as_str());
+        daemon_config::launcher::validate_bindings(&binding_items, ctx.bound_core_node.as_str());
     if !validated.errors.is_empty() {
-        let msg = config::format_bulleted(&validated.errors);
+        let msg = daemon_config::format_bulleted(&validated.errors);
         publish_stderr(ctx, msg.clone(), LaunchFeedbackStep::LauncherStep).await;
         return Err(LaunchResult::failure(&ctx.log_path, msg));
     }
@@ -1991,12 +1992,12 @@ mod tests {
     /// `Some(false)` forces wall even when the daemon default is sim.
     #[test]
     fn resolve_framework_per_instance_wins() {
-        let force_sim = config::launcher::FrameworkOverrides {
+        let force_sim = daemon_config::launcher::FrameworkOverrides {
             use_sim_time: Some(true),
         };
         assert!(resolve_framework(&force_sim, false).use_sim_time);
 
-        let force_wall = config::launcher::FrameworkOverrides {
+        let force_wall = daemon_config::launcher::FrameworkOverrides {
             use_sim_time: Some(false),
         };
         assert!(!resolve_framework(&force_wall, true).use_sim_time);
@@ -2005,7 +2006,7 @@ mod tests {
     /// When the instance omits the override, the daemon default decides.
     #[test]
     fn resolve_framework_falls_through_to_daemon_default() {
-        let none = config::launcher::FrameworkOverrides::default();
+        let none = daemon_config::launcher::FrameworkOverrides::default();
         assert!(!resolve_framework(&none, false).use_sim_time);
         assert!(resolve_framework(&none, true).use_sim_time);
     }

--- a/crates/core-node-internal/src/services/tests.rs
+++ b/crates/core-node-internal/src/services/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use config::consts::PeppyDirs;
+use daemon_config::consts::PeppyDirs;
 use pmi::{Messenger, MessengerAdapter, MessengerBackend, MockAdapter};
 use std::sync::Arc;
 use tokio::sync::Mutex;
@@ -39,7 +39,7 @@ fn test_core_node_config(
         arguments: test_node_arguments(),
         root_dir: std::env::temp_dir(),
         peppy_dirs,
-        peppy_config: config::peppy_config::PeppyConfig::default(),
+        peppy_config: daemon_config::peppy_config::PeppyConfig::default(),
         organization_namespace: "local".to_string(),
         shutdown_token: tokio_util::sync::CancellationToken::new(),
     }

--- a/crates/core-node-internal/tests/clock_zenoh_e2e.rs
+++ b/crates/core-node-internal/tests/clock_zenoh_e2e.rs
@@ -13,7 +13,7 @@ use common::{
     CALLER_INSTANCE_ID, assert_clock_round_trip, assert_clock_topic_emits_monotonic_ticks,
     start_core_node_with_real_messenger_mode,
 };
-use config::peppy_config::Mode;
+use daemon_config::peppy_config::Mode;
 use std::time::Duration;
 
 #[rstest::rstest]

--- a/crates/core-node-internal/tests/common.rs
+++ b/crates/core-node-internal/tests/common.rs
@@ -1,8 +1,7 @@
 #![allow(dead_code)]
 
-use config::consts::{
-    DEFAULT_MESSAGING_HOST, NODE_CONFIG_FILE, PEPPY_OUTPUT_DIR, PEPPYGEN_OUTPUT_PATH, PeppyDirs,
-};
+use config::consts::{DEFAULT_MESSAGING_HOST, NODE_CONFIG_FILE, PEPPYGEN_OUTPUT_PATH};
+use daemon_config::consts::{PEPPY_OUTPUT_DIR, PeppyDirs};
 use config::node::{PeppygenLanguage, QoSProfile};
 use core_node::names;
 use core_node::nodes_repo_cache_path;
@@ -416,7 +415,7 @@ pub fn build_runtime_config_json5(
         config::runtime::NodeInstanceConfig {
             arguments,
             ..config::runtime::NodeInstanceConfig::new(
-                config::launcher::Name::new(instance_id).expect("valid instance id"),
+                config::runtime::Name::new(instance_id).expect("valid instance id"),
             )
         },
         node_name,
@@ -1195,7 +1194,7 @@ impl TestPackagesCache {
         self
     }
 
-    pub fn write(self, peppy_dirs: &config::consts::PeppyDirs) {
+    pub fn write(self, peppy_dirs: &daemon_config::consts::PeppyDirs) {
         let cache_dir = peppy_dirs.cache_dir();
         std::fs::create_dir_all(&cache_dir).expect("failed to create cache dir");
         let content =
@@ -1621,7 +1620,7 @@ pub async fn start_core_node_with_mock_messenger() -> StartedCoreNode {
         default_node_arguments(),
         data_dir,
         peppy_dirs,
-        config::peppy_config::PeppyConfig::default(),
+        daemon_config::peppy_config::PeppyConfig::default(),
     )
     .await
 }
@@ -1640,7 +1639,7 @@ pub async fn start_core_node_with_sim_clock() -> StartedCoreNode {
         args,
         data_dir,
         peppy_dirs,
-        config::peppy_config::PeppyConfig::default(),
+        daemon_config::peppy_config::PeppyConfig::default(),
     )
     .await
 }
@@ -1656,7 +1655,7 @@ pub async fn start_core_node_with_real_messenger() -> StartedCoreNode {
 /// Convenience wrapper over [`start_core_node_with_real_messenger_in_mode`] with
 /// the default timeouts, for the dual-mode e2e tests parameterized over the mode.
 pub async fn start_core_node_with_real_messenger_mode(
-    mode: config::peppy_config::Mode,
+    mode: daemon_config::peppy_config::Mode,
 ) -> StartedCoreNode {
     start_core_node_with_real_messenger_in_mode(
         Duration::from_secs(10),
@@ -1673,7 +1672,7 @@ pub async fn start_core_node_with_real_messenger_and_timeouts(
     start_core_node_with_real_messenger_in_mode(
         node_startup_timeout,
         node_start_health_timeout,
-        config::peppy_config::Mode::Peer,
+        daemon_config::peppy_config::Mode::Peer,
     )
     .await
 }
@@ -1685,7 +1684,7 @@ pub async fn start_core_node_with_real_messenger_and_timeouts(
 pub async fn start_core_node_with_real_messenger_in_mode(
     node_startup_timeout: Duration,
     node_start_health_timeout: Duration,
-    mode: config::peppy_config::Mode,
+    mode: daemon_config::peppy_config::Mode,
 ) -> StartedCoreNode {
     let (data_dir, peppy_dirs) = init_test_data_dir();
     let mut instance = pmi::ZenohAdapter::start_router_ephemeral_in_mode(
@@ -1711,7 +1710,7 @@ pub async fn start_core_node_with_real_messenger_in_mode(
     let mut args = default_node_arguments();
     args.node_startup_timeout = node_startup_timeout;
     args.node_start_health_timeout = node_start_health_timeout;
-    let peppy_config = config::peppy_config::PeppyConfig {
+    let peppy_config = daemon_config::peppy_config::PeppyConfig {
         mode,
         ..Default::default()
     };
@@ -1726,8 +1725,8 @@ pub async fn start_core_node_with_real_messenger_in_mode(
 pub async fn start_core_node_with_shutdown_grace(shutdown_grace_secs: u64) -> StartedCoreNode {
     let (data_dir, peppy_dirs) = init_test_data_dir();
     let shared_messenger = create_mock_messenger().await;
-    let peppy_config = config::peppy_config::PeppyConfig {
-        lifecycle: config::peppy_config::LifecycleConfig {
+    let peppy_config = daemon_config::peppy_config::PeppyConfig {
+        lifecycle: daemon_config::peppy_config::LifecycleConfig {
             shutdown_grace_secs,
             ..Default::default()
         },
@@ -1755,7 +1754,7 @@ pub async fn start_core_node_with_health_timeout(
         args,
         data_dir,
         peppy_dirs,
-        config::peppy_config::PeppyConfig::default(),
+        daemon_config::peppy_config::PeppyConfig::default(),
     )
     .await
 }
@@ -1774,7 +1773,7 @@ pub async fn start_core_node_with_health_monitor(
         args,
         data_dir,
         peppy_dirs,
-        config::peppy_config::PeppyConfig::default(),
+        daemon_config::peppy_config::PeppyConfig::default(),
     )
     .await
 }
@@ -1784,7 +1783,7 @@ async fn start_core_node_with_messenger(
     node_arguments: CoreNodeArguments,
     data_dir: TempDir,
     peppy_dirs: PeppyDirs,
-    peppy_config: config::peppy_config::PeppyConfig,
+    peppy_config: daemon_config::peppy_config::PeppyConfig,
 ) -> StartedCoreNode {
     let caller_handle = MessengerHandle::from_shared(Arc::clone(&shared_messenger));
     let root_dir = std::env::current_dir().expect("failed to get current directory");

--- a/crates/core-node-internal/tests/container_e2e.rs
+++ b/crates/core-node-internal/tests/container_e2e.rs
@@ -8,7 +8,7 @@ mod container_e2e_tests {
         send_node_build_and_wait_forced, send_node_run_and_wait,
         start_core_node_with_real_messenger_and_timeouts, write_peppy_json5,
     };
-    use config::consts::DEFAULT_ALPINE_BASE_IMAGE;
+    use daemon_config::consts::DEFAULT_ALPINE_BASE_IMAGE;
     use config::node::Name as NodeName;
     use config::node::Toolchain;
     use core_node_api::encoding::NodeInitRequest;

--- a/crates/core-node-internal/tests/datastore_zenoh_e2e.rs
+++ b/crates/core-node-internal/tests/datastore_zenoh_e2e.rs
@@ -8,7 +8,7 @@
 mod common;
 
 use common::{assert_datastore_binary_round_trip, start_core_node_with_real_messenger_mode};
-use config::peppy_config::Mode;
+use daemon_config::peppy_config::Mode;
 
 #[rstest::rstest]
 #[case::peer(Mode::Peer)]

--- a/crates/core-node-internal/tests/latency/harness.rs
+++ b/crates/core-node-internal/tests/latency/harness.rs
@@ -27,7 +27,7 @@ use std::sync::OnceLock;
 use std::time::Duration;
 
 use config::consts::{PEPPYGEN_OUTPUT_PATH, RUNTIME_CONFIG_VAR_NAME};
-use config::launcher::Name;
+use config::runtime::Name;
 use config::runtime::{NodeInstanceConfig, RuntimeConfig};
 use generator::LanguageGenerator;
 use peppylib::MessengerHandle;

--- a/crates/core-node-internal/tests/listen_for_launch.rs
+++ b/crates/core-node-internal/tests/listen_for_launch.rs
@@ -1,7 +1,8 @@
 mod common;
 
 use common::{AbortOnDrop, CALLER_INSTANCE_ID, start_core_node_with_health_timeout};
-use config::consts::{NODE_CONFIG_FILE, PEPPY_OUTPUT_DIR, PEPPYGEN_OUTPUT_PATH};
+use config::consts::{NODE_CONFIG_FILE, PEPPYGEN_OUTPUT_PATH};
+use daemon_config::consts::PEPPY_OUTPUT_DIR;
 use config::node::Name;
 use config::node::NodeConfigParser;
 use core_node::names;

--- a/crates/core-node-internal/tests/listen_for_node_add.rs
+++ b/crates/core-node-internal/tests/listen_for_node_add.rs
@@ -8,7 +8,8 @@ use common::{
     send_node_add_and_wait, send_node_add_and_wait_with_force, spawn_real_stuck_instance,
     start_core_node_with_mock_messenger, wait_until_service_reachable, write_peppy_json5,
 };
-use config::consts::{NODE_CONFIG_FILE, PEPPY_OUTPUT_DIR, PEPPYGEN_OUTPUT_PATH};
+use config::consts::{NODE_CONFIG_FILE, PEPPYGEN_OUTPUT_PATH};
+use daemon_config::consts::PEPPY_OUTPUT_DIR;
 use config::node::QoSProfile;
 use config_test_support as test_helpers;
 use core_node::names;

--- a/crates/core-node-internal/tests/listen_for_node_add/failures.rs
+++ b/crates/core-node-internal/tests/listen_for_node_add/failures.rs
@@ -238,7 +238,7 @@ async fn listen_for_node_add_git_hash_mismatch_fails() {
     let peppy_json5 = minimal_node_config("git_hash_mismatch_node", "v1", &[]);
     write_peppy_json5(source_dir.path(), &peppy_json5);
 
-    let peppy_dir = source_dir.path().join(config::consts::PEPPY_OUTPUT_DIR);
+    let peppy_dir = source_dir.path().join(daemon_config::consts::PEPPY_OUTPUT_DIR);
     std::fs::create_dir_all(&peppy_dir).expect("failed to create .peppy dir");
     std::fs::write(peppy_dir.join("git.hash"), "wrong-hash\n")
         .expect("failed to write wrong git hash file");

--- a/crates/core-node-internal/tests/listen_for_node_build.rs
+++ b/crates/core-node-internal/tests/listen_for_node_build.rs
@@ -5,7 +5,7 @@ use common::{
     send_node_build_and_wait, send_node_build_and_wait_forced, start_core_node_with_mock_messenger,
     write_peppy_json5,
 };
-use config::consts::DEFAULT_ALPINE_BASE_IMAGE;
+use daemon_config::consts::DEFAULT_ALPINE_BASE_IMAGE;
 use core_node_api::encoding::NodeBuildFeedback;
 use std::path::{Path, PathBuf};
 use std::time::Duration;

--- a/crates/core-node-internal/tests/listen_for_node_init.rs
+++ b/crates/core-node-internal/tests/listen_for_node_init.rs
@@ -1,9 +1,9 @@
 mod common;
 
 use common::{CALLER_INSTANCE_ID, start_core_node_with_mock_messenger};
-use config::consts::{
-    DEFAULT_PYTHON_BASE_IMAGE, DEFAULT_RUST_BASE_IMAGE, NODE_CONFIG_FILE, PEPPY_OUTPUT_DIR,
-    PEPPYGEN_OUTPUT_PATH, PEPPYLIB_OUTPUT_PATH,
+use config::consts::{NODE_CONFIG_FILE, PEPPYGEN_OUTPUT_PATH};
+use daemon_config::consts::{
+    DEFAULT_PYTHON_BASE_IMAGE, DEFAULT_RUST_BASE_IMAGE, PEPPY_OUTPUT_DIR, PEPPYLIB_OUTPUT_PATH,
 };
 use config::node::Toolchain;
 use config_test_support::assert_contains_all;

--- a/crates/core-node-internal/tests/listen_for_node_run.rs
+++ b/crates/core-node-internal/tests/listen_for_node_run.rs
@@ -6,7 +6,7 @@ use common::{
     start_core_node_with_health_monitor, start_core_node_with_health_timeout,
     start_core_node_with_mock_messenger, start_core_node_with_real_messenger, write_peppy_json5,
 };
-use config::consts::DEFAULT_ALPINE_BASE_IMAGE;
+use daemon_config::consts::DEFAULT_ALPINE_BASE_IMAGE;
 use config::node::Name as NodeName;
 use core_node_api::encoding::NodeRunFeedback;
 use peppylib::messaging::MessengerHandle;

--- a/crates/core-node-internal/tests/listen_for_node_sync.rs
+++ b/crates/core-node-internal/tests/listen_for_node_sync.rs
@@ -3,7 +3,8 @@ mod common;
 use common::{
     CALLER_INSTANCE_ID, StartedCoreNode, TestPackagesCache, start_core_node_with_mock_messenger,
 };
-use config::consts::{NODE_CONFIG_FILE, PEPPY_OUTPUT_DIR, PEPPYGEN_OUTPUT_PATH};
+use config::consts::{NODE_CONFIG_FILE, PEPPYGEN_OUTPUT_PATH};
+use daemon_config::consts::PEPPY_OUTPUT_DIR;
 use core_node_api::encoding::{NodeSyncRequest, RepoSourceKind};
 use peppylib::core_node::transport::poll_node_sync;
 use std::fs;

--- a/crates/daemon-config-internal/Cargo.toml
+++ b/crates/daemon-config-internal/Cargo.toml
@@ -1,0 +1,26 @@
+# Daemon-side Peppy configuration documents, extracted from the shared
+# `peppy-config-model` crate (which stays the home of the wire-facing node
+# config model this crate builds on).
+
+[package]
+name = "daemon-config"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+
+[dependencies]
+config = { workspace = true }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+serde_json5 = "0.2"
+serde_path_to_error = "0.1"
+thiserror = "2.0"
+tracing = "0.1"
+# Production dependency: `atomic_write::publish_atomic` stages through
+# `NamedTempFile` siblings.
+tempfile = "3"
+# Home-directory resolution for the production `PeppyDirs` root.
+dirs = "6"
+# Compile-time string concatenation so the bundled peppy_config template
+# splices in its numeric defaults instead of duplicating the literals.
+const_format = "0.2"

--- a/crates/daemon-config-internal/src/atomic_write.rs
+++ b/crates/daemon-config-internal/src/atomic_write.rs
@@ -1,0 +1,99 @@
+//! Atomic file publication helper used across the workspace.
+//!
+//! All four current call sites (`repo` cache writes, build-artifact
+//! publication, embedded-binary extraction) follow the same pattern:
+//! create the parent dir, stage to a unique sibling tmp file, then
+//! rename. Centralizing avoids drift across hand-rolled copies.
+
+use std::path::{Path, PathBuf};
+
+/// Stage `final_path`'s contents through a unique sibling tmp file and
+/// atomically rename into place. The `write` closure receives the tmp
+/// path and is responsible for creating and populating the file (and,
+/// if needed, setting permissions).
+///
+/// Concurrent readers never observe a partial file, and concurrent
+/// writers don't race over a shared staging path. Staging in the same
+/// directory keeps the rename on the same filesystem (cross-fs
+/// `rename(2)` returns `EXDEV`). On any error — closure failure or
+/// rename failure — the tmp file is removed before returning.
+pub fn publish_atomic<F>(final_path: &Path, write: F) -> std::io::Result<PathBuf>
+where
+    F: FnOnce(&Path) -> std::io::Result<()>,
+{
+    let parent = final_path.parent().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("final path has no parent: {}", final_path.display()),
+        )
+    })?;
+    std::fs::create_dir_all(parent)?;
+    // `NamedTempFile::new_in` produces a unique sibling and deletes it
+    // on drop, so a panic or early return between stage and rename
+    // doesn't leave a stray.
+    let tmp = tempfile::NamedTempFile::new_in(parent)?;
+    let tmp_path = tmp.path().to_path_buf();
+    write(&tmp_path)?;
+    tmp.persist(final_path).map_err(|e| e.error)?;
+    Ok(final_path.to_path_buf())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::ErrorKind;
+
+    #[test]
+    fn writes_contents_and_returns_final_path() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let target = dir.path().join("out.txt");
+
+        let returned =
+            publish_atomic(&target, |tmp| std::fs::write(tmp, b"hello")).expect("publish");
+
+        assert_eq!(returned, target);
+        assert_eq!(std::fs::read(&target).expect("read back"), b"hello");
+    }
+
+    #[test]
+    fn creates_missing_parent_directories() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        // Two levels that do not exist yet — publish_atomic must create them.
+        let target = dir.path().join("nested").join("deeper").join("out.txt");
+
+        publish_atomic(&target, |tmp| std::fs::write(tmp, b"x")).expect("publish");
+
+        assert!(target.exists(), "expected {} to exist", target.display());
+    }
+
+    #[test]
+    fn leaves_no_file_when_the_write_closure_fails() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let target = dir.path().join("out.txt");
+
+        let err = publish_atomic(&target, |_tmp| Err(std::io::Error::other("boom")))
+            .expect_err("closure failure should propagate");
+
+        assert_eq!(err.kind(), ErrorKind::Other);
+        // The staging tmp file is cleaned up on drop and nothing was renamed
+        // into place, so the destination must not exist.
+        assert!(!target.exists(), "partial file must not be published");
+        // The staging tmp file must not linger in the parent directory either.
+        let leftovers: Vec<_> = std::fs::read_dir(dir.path())
+            .expect("read dir")
+            .filter_map(|e| e.ok())
+            .collect();
+        assert!(
+            leftovers.is_empty(),
+            "expected no staging leftovers, found {leftovers:?}"
+        );
+    }
+
+    #[test]
+    fn errors_when_final_path_has_no_parent() {
+        // The filesystem root has no parent, so staging a sibling is impossible.
+        let err = publish_atomic(Path::new("/"), |tmp| std::fs::write(tmp, b"x"))
+            .expect_err("root path has no parent");
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+    }
+}

--- a/crates/daemon-config-internal/src/consts.rs
+++ b/crates/daemon-config-internal/src/consts.rs
@@ -1,9 +1,5 @@
-pub const NODE_CONFIG_FILE: &str = "peppy.json5";
-pub const RUNTIME_CONFIG_VAR_NAME: &str = "PEPPY_RUNTIME_CONFIG";
 /// The peppy output directory relative to node_dir (contains generated libraries).
 pub const PEPPY_OUTPUT_DIR: &str = ".peppy";
-/// The standard output directory for generated peppygen libraries relative to node_dir.
-pub const PEPPYGEN_OUTPUT_PATH: &str = ".peppy/libs/peppygen";
 pub const PEPPYLIB_OUTPUT_PATH: &str = ".peppy/libs/peppylib";
 pub const DAEMON_STATE_FILE_ENV: &str = "PEPPY_DAEMON_STATE_FILE";
 
@@ -12,35 +8,7 @@ pub const DAEMON_STATE_FILE_ENV: &str = "PEPPY_DAEMON_STATE_FILE";
 /// login` flow; never committed and never world-readable.
 pub const CREDENTIALS_FILE: &str = "credentials.json5";
 
-/// Overrides the peppy data root (the `.peppy` directory itself). Mirrors the
-/// `PEPPY_HOME` install prefix from scripts/install.sh. When set and non-empty,
-/// it is used verbatim as `PeppyDirs::root`.
-pub const PEPPY_HOME_ENV: &str = "PEPPY_HOME";
-
-pub const DEFAULT_MESSAGING_HOST: &str = "127.0.0.1";
-pub const DEFAULT_MESSAGING_PORT: u16 = 7448;
 pub const PEPPY_MESSAGING_PORT_VAR_NAME: &str = "PEPPY_MESSAGING_PORT";
-
-pub const ALLOWED_CONFIG_CHARS: &str =
-    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-";
-
-/// Reserved literal that occupies the `link_id` slot on the wire when a
-/// producer is launched without an explicit binding. Consumers that opt into
-/// the producer-default path subscribe with this literal as their `link_id`
-/// filter. `pmi::DEFAULT_LINK_ID` re-exports this so the wire layer and the
-/// config layer share one source of truth.
-pub const DEFAULT_LINK_ID_SENTINEL: &str = "_";
-
-/// Minimum Python version required by peppylib and peppygen projects (e.g. "3.11").
-///
-/// NOTE: When updating, also update the static files in `peppylib-py/`
-/// (`Cargo.toml` abi3 feature, `pyproject.toml`, `pixi.toml`, `Readme.md`)
-/// which cannot be programmatically derived from this constant.
-pub const PYTHON_MIN_VERSION: &str = "3.11";
-
-/// Maximum Python version supported (exclusive, e.g. "3.14").
-/// Driven by pycapnp wheel availability (wheels not yet available for Python 3.14 as of Feb 2026).
-pub const PYTHON_MAX_VERSION: &str = "3.14";
 
 /// Default base container image for Rust nodes (Ubuntu 24.04 + Rust via rustup, build-essential).
 pub const DEFAULT_RUST_BASE_IMAGE: &str = "tuatini/peppy-rust-cargo-base:latest";
@@ -216,7 +184,7 @@ impl PeppyDirs {
 /// rather than rooting at the empty path, matching `env_state_file_path()` in
 /// `daemon_state.rs`.
 pub fn peppy_root_dir() -> PathBuf {
-    resolve_root(std::env::var_os(PEPPY_HOME_ENV))
+    resolve_root(std::env::var_os(config::consts::PEPPY_HOME_ENV))
 }
 
 /// Implementation of [`peppy_root_dir`] with the `PEPPY_HOME` value made
@@ -264,60 +232,4 @@ mod tests {
         );
     }
 
-    /// Ensures that static files in peppylib-py/ that cannot be programmatically
-    /// templated stay in sync with the canonical PYTHON_MIN_VERSION/PYTHON_MAX_VERSION constants.
-    #[test]
-    fn python_version_consistency_in_static_files() {
-        let manifest_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        // peppylib-py was moved out of the peppyos workspace into
-        // public-peppy-libs/peppyos-shared (resolves only in the superproject checkout).
-        let peppylib_py_dir =
-            manifest_dir.join("../../../public-peppy-libs/peppyos-shared/peppylib-py");
-
-        let pyproject_path = peppylib_py_dir.join("pyproject.toml");
-        let pyproject_contents = std::fs::read_to_string(&pyproject_path)
-            .unwrap_or_else(|e| panic!("Failed to read {}: {}", pyproject_path.display(), e));
-        let min_spec_ok = pyproject_contents.contains(format!(">={}", PYTHON_MIN_VERSION).as_str())
-            || pyproject_contents.contains(format!(">= {}", PYTHON_MIN_VERSION).as_str());
-        let max_spec_ok = pyproject_contents.contains(format!("<{}", PYTHON_MAX_VERSION).as_str())
-            || pyproject_contents.contains(format!("< {}", PYTHON_MAX_VERSION).as_str());
-        assert!(
-            pyproject_contents.contains("requires-python") && min_spec_ok && max_spec_ok,
-            "File {} must declare requires-python with both min and max constraints: \
-             expected >= {} and < {}",
-            pyproject_path.display(),
-            PYTHON_MIN_VERSION,
-            PYTHON_MAX_VERSION,
-        );
-
-        let files_and_patterns: &[(&str, String)] = &[
-            ("Readme.md", format!("Python >= {}", PYTHON_MIN_VERSION)),
-            (
-                "pixi.toml",
-                format!(
-                    "python = \">={},<{}\"",
-                    PYTHON_MIN_VERSION, PYTHON_MAX_VERSION
-                ),
-            ),
-            (
-                "Cargo.toml",
-                format!("abi3-py{}", PYTHON_MIN_VERSION.replace('.', "")),
-            ),
-        ];
-
-        for (filename, expected_pattern) in files_and_patterns {
-            let file_path = peppylib_py_dir.join(filename);
-            let contents = std::fs::read_to_string(&file_path)
-                .unwrap_or_else(|e| panic!("Failed to read {}: {}", file_path.display(), e));
-            assert!(
-                contents.contains(expected_pattern.as_str()),
-                "File {} does not contain expected pattern '{}'. \
-                 Update this file to match PYTHON_MIN_VERSION = \"{}\" / PYTHON_MAX_VERSION = \"{}\"",
-                file_path.display(),
-                expected_pattern,
-                PYTHON_MIN_VERSION,
-                PYTHON_MAX_VERSION,
-            );
-        }
-    }
 }

--- a/crates/daemon-config-internal/src/consts.rs
+++ b/crates/daemon-config-internal/src/consts.rs
@@ -1,0 +1,323 @@
+pub const NODE_CONFIG_FILE: &str = "peppy.json5";
+pub const RUNTIME_CONFIG_VAR_NAME: &str = "PEPPY_RUNTIME_CONFIG";
+/// The peppy output directory relative to node_dir (contains generated libraries).
+pub const PEPPY_OUTPUT_DIR: &str = ".peppy";
+/// The standard output directory for generated peppygen libraries relative to node_dir.
+pub const PEPPYGEN_OUTPUT_PATH: &str = ".peppy/libs/peppygen";
+pub const PEPPYLIB_OUTPUT_PATH: &str = ".peppy/libs/peppylib";
+pub const DAEMON_STATE_FILE_ENV: &str = "PEPPY_DAEMON_STATE_FILE";
+
+/// Filename of the CLI's cached OAuth credentials, stored under `~/.peppy/conf`
+/// (i.e. `conf_dir().join(CREDENTIALS_FILE)`). Written `0600` by the `peppy
+/// login` flow; never committed and never world-readable.
+pub const CREDENTIALS_FILE: &str = "credentials.json5";
+
+/// Overrides the peppy data root (the `.peppy` directory itself). Mirrors the
+/// `PEPPY_HOME` install prefix from scripts/install.sh. When set and non-empty,
+/// it is used verbatim as `PeppyDirs::root`.
+pub const PEPPY_HOME_ENV: &str = "PEPPY_HOME";
+
+pub const DEFAULT_MESSAGING_HOST: &str = "127.0.0.1";
+pub const DEFAULT_MESSAGING_PORT: u16 = 7448;
+pub const PEPPY_MESSAGING_PORT_VAR_NAME: &str = "PEPPY_MESSAGING_PORT";
+
+pub const ALLOWED_CONFIG_CHARS: &str =
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-";
+
+/// Reserved literal that occupies the `link_id` slot on the wire when a
+/// producer is launched without an explicit binding. Consumers that opt into
+/// the producer-default path subscribe with this literal as their `link_id`
+/// filter. `pmi::DEFAULT_LINK_ID` re-exports this so the wire layer and the
+/// config layer share one source of truth.
+pub const DEFAULT_LINK_ID_SENTINEL: &str = "_";
+
+/// Minimum Python version required by peppylib and peppygen projects (e.g. "3.11").
+///
+/// NOTE: When updating, also update the static files in `peppylib-py/`
+/// (`Cargo.toml` abi3 feature, `pyproject.toml`, `pixi.toml`, `Readme.md`)
+/// which cannot be programmatically derived from this constant.
+pub const PYTHON_MIN_VERSION: &str = "3.11";
+
+/// Maximum Python version supported (exclusive, e.g. "3.14").
+/// Driven by pycapnp wheel availability (wheels not yet available for Python 3.14 as of Feb 2026).
+pub const PYTHON_MAX_VERSION: &str = "3.14";
+
+/// Default base container image for Rust nodes (Ubuntu 24.04 + Rust via rustup, build-essential).
+pub const DEFAULT_RUST_BASE_IMAGE: &str = "tuatini/peppy-rust-cargo-base:latest";
+
+/// Default base container image for Python nodes (Ubuntu 24.04 + Python 3, uv).
+pub const DEFAULT_PYTHON_BASE_IMAGE: &str = "tuatini/peppy-python-uv-base:latest";
+
+/// Default base container image for lightweight test containers (Google mirror — CI-friendly).
+pub const DEFAULT_ALPINE_BASE_IMAGE: &str = "mirror.gcr.io/library/alpine:3.20";
+
+// Application runtime environment (dev/prod) tracked internally.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AppEnv {
+    Dev,
+    Prod,
+}
+
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+static APP_ENV: OnceLock<AppEnv> = OnceLock::new();
+
+/// Records the process-wide application environment (dev vs prod).
+///
+/// This is the crate's only mutable global state. It is **set-once**: the
+/// first call wins and every later call is silently ignored (so a binary can
+/// pin the environment at startup without callers downstream being able to
+/// flip it). It is also **optional** — if never called, the environment
+/// defaults to [`AppEnv::Dev`].
+///
+/// The only thing it influences is the *default* peppy data root: it shifts
+/// [`peppy_root_dir`] (and therefore [`PeppyDirs::default`]) between
+/// `~/.peppy` (prod) and `/tmp/.peppy` (dev). It has no effect on parsing,
+/// validation, or any [`PeppyDirs`] constructed explicitly via
+/// [`PeppyDirs::new`]. Code that wants a deterministic root — including tests —
+/// should construct [`PeppyDirs::new`] directly rather than rely on this
+/// global; that keeps it independent of call ordering across threads.
+pub fn set_app_env(env: AppEnv) {
+    APP_ENV.set(env).ok();
+}
+
+/// Returns the process-wide application environment, defaulting to
+/// [`AppEnv::Dev`] if [`set_app_env`] was never called. Reads only; see
+/// [`set_app_env`] for the set-once contract and what it affects.
+pub fn app_env() -> AppEnv {
+    *APP_ENV.get_or_init(|| AppEnv::Dev)
+}
+
+/// Directory layout for peppy data (added nodes, instances, logs, caches).
+///
+/// Threading this struct through production code instead of using a global static
+/// ensures tests can run in parallel with fully isolated filesystem state.
+#[derive(Clone, Debug)]
+pub struct PeppyDirs {
+    root: PathBuf,
+}
+
+impl PeppyDirs {
+    /// Creates a `PeppyDirs` rooted at the given path.
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self { root: root.into() }
+    }
+
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// Build outputs from `node build` (`.sif` container images and `.tar.zst` archives).
+    pub fn built_nodes_dir(&self) -> PathBuf {
+        self.root.join("built_nodes")
+    }
+
+    /// Extracted archives for running node instances.
+    pub fn instances_dir(&self) -> PathBuf {
+        self.root.join("instances")
+    }
+
+    /// Log directory for `node add` operations.
+    pub fn logs_dir_add(&self) -> PathBuf {
+        self.root.join("logs").join("add")
+    }
+
+    /// Log directory for `node build` operations.
+    pub fn logs_dir_build(&self) -> PathBuf {
+        self.root.join("logs").join("build")
+    }
+
+    /// Log directory for `node run` operations.
+    pub fn logs_dir_run(&self) -> PathBuf {
+        self.root.join("logs").join("run")
+    }
+
+    /// Log directory for `stack launch` operations.
+    pub fn logs_dir_launch(&self) -> PathBuf {
+        self.root.join("logs").join("launch")
+    }
+
+    /// Runtime configuration directory.
+    pub fn runtime_config_dir(&self) -> PathBuf {
+        self.root.join("runtime")
+    }
+
+    /// Temporary download directory for HTTP-sourced node archives.
+    pub fn http_downloads_dir(&self) -> PathBuf {
+        self.root.join("http_downloads")
+    }
+
+    /// Temporary working directory for operations that may involve containers.
+    ///
+    /// On macOS with Lima, temp directories must be under `$HOME` to be
+    /// visible inside the guest VM. Use this instead of `std::env::temp_dir()`.
+    ///
+    /// In production this resolves to `~/.peppy/tmp`, which doubles as the
+    /// persistent build cache root used by `build_helpers::cache_dir` — never
+    /// bulk-clean this directory.
+    pub fn tmp_dir(&self) -> PathBuf {
+        self.root.join("tmp")
+    }
+
+    /// Path to the stack operations log file.
+    ///
+    /// Records daemon-initiated lifecycle events (e.g. automatic instance
+    /// removal after health-check failures) so users can audit what happened
+    /// without digging through debug logs.
+    pub fn stack_log_path(&self) -> PathBuf {
+        self.root.join("stack_log.log")
+    }
+
+    /// Shared Rust crate cache directory for a given cache key.
+    pub fn rust_libs_cache_dir(&self, cache_key: &str) -> PathBuf {
+        self.root.join("libs").join("rust").join(cache_key)
+    }
+
+    /// Shared Python library cache directory for a given cache key.
+    pub fn python_libs_cache_dir(&self, cache_key: &str) -> PathBuf {
+        self.root.join("libs").join("python").join(cache_key)
+    }
+
+    /// Configuration directory for user-editable config files (e.g. repositories.json5).
+    pub fn conf_dir(&self) -> PathBuf {
+        self.root.join("conf")
+    }
+
+    /// Cache directory for repo refresh results and other cached data.
+    pub fn cache_dir(&self) -> PathBuf {
+        self.root.join("cache")
+    }
+
+    /// Persistent Git checkouts shared across `node add` batches.
+    /// Directories are keyed by `<slug>-<hash>` where the hash covers
+    /// repo_url + ref so distinct refs coexist.
+    pub fn git_checkouts_dir(&self) -> PathBuf {
+        self.cache_dir().join("git_checkouts")
+    }
+
+    /// Persistent HTTP bundle extractions shared across `node add`
+    /// batches. Directories are keyed by `<slug>-<hash>` over the URL
+    /// + optional SHA256.
+    pub fn http_bundles_dir(&self) -> PathBuf {
+        self.cache_dir().join("http_bundles")
+    }
+}
+
+/// Resolves the peppy data root (the `.peppy` directory).
+///
+/// Precedence:
+/// 1. `PEPPY_HOME` if set and non-empty, used verbatim as the root.
+/// 2. Otherwise the standard application data directory:
+///    - Production: `~/.peppy`
+///    - Development: `/tmp/.peppy`
+///
+/// `var_os` plus the empty-string guard means `PEPPY_HOME=` is treated as unset
+/// rather than rooting at the empty path, matching `env_state_file_path()` in
+/// `daemon_state.rs`.
+pub fn peppy_root_dir() -> PathBuf {
+    resolve_root(std::env::var_os(PEPPY_HOME_ENV))
+}
+
+/// Implementation of [`peppy_root_dir`] with the `PEPPY_HOME` value made
+/// explicit, so the precedence can be tested without mutating process env.
+fn resolve_root(home_override: Option<std::ffi::OsString>) -> PathBuf {
+    if let Some(home) = home_override.filter(|v| !v.is_empty()) {
+        return PathBuf::from(home);
+    }
+    match app_env() {
+        AppEnv::Prod => dirs::home_dir()
+            .unwrap_or_else(std::env::temp_dir)
+            .join(".peppy"),
+        AppEnv::Dev => std::env::temp_dir().join(".peppy"),
+    }
+}
+
+/// Uses the standard application data directory (see [`peppy_root_dir`]).
+impl Default for PeppyDirs {
+    fn default() -> Self {
+        Self::new(peppy_root_dir())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_root_uses_peppy_home_override_verbatim() {
+        let root = resolve_root(Some("/custom/run-home".into()));
+        assert_eq!(root, PathBuf::from("/custom/run-home"));
+    }
+
+    #[test]
+    fn resolve_root_ignores_empty_override_and_falls_back_to_default() {
+        // Empty PEPPY_HOME is treated as unset, not as the empty path.
+        let with_empty = resolve_root(Some(std::ffi::OsString::new()));
+        let unset = resolve_root(None);
+        assert_eq!(with_empty, unset);
+        // The fallback still ends in `.peppy` (Dev or Prod root).
+        assert!(
+            unset.ends_with(".peppy"),
+            "fallback root: {}",
+            unset.display()
+        );
+    }
+
+    /// Ensures that static files in peppylib-py/ that cannot be programmatically
+    /// templated stay in sync with the canonical PYTHON_MIN_VERSION/PYTHON_MAX_VERSION constants.
+    #[test]
+    fn python_version_consistency_in_static_files() {
+        let manifest_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        // peppylib-py was moved out of the peppyos workspace into
+        // public-peppy-libs/peppyos-shared (resolves only in the superproject checkout).
+        let peppylib_py_dir =
+            manifest_dir.join("../../../public-peppy-libs/peppyos-shared/peppylib-py");
+
+        let pyproject_path = peppylib_py_dir.join("pyproject.toml");
+        let pyproject_contents = std::fs::read_to_string(&pyproject_path)
+            .unwrap_or_else(|e| panic!("Failed to read {}: {}", pyproject_path.display(), e));
+        let min_spec_ok = pyproject_contents.contains(format!(">={}", PYTHON_MIN_VERSION).as_str())
+            || pyproject_contents.contains(format!(">= {}", PYTHON_MIN_VERSION).as_str());
+        let max_spec_ok = pyproject_contents.contains(format!("<{}", PYTHON_MAX_VERSION).as_str())
+            || pyproject_contents.contains(format!("< {}", PYTHON_MAX_VERSION).as_str());
+        assert!(
+            pyproject_contents.contains("requires-python") && min_spec_ok && max_spec_ok,
+            "File {} must declare requires-python with both min and max constraints: \
+             expected >= {} and < {}",
+            pyproject_path.display(),
+            PYTHON_MIN_VERSION,
+            PYTHON_MAX_VERSION,
+        );
+
+        let files_and_patterns: &[(&str, String)] = &[
+            ("Readme.md", format!("Python >= {}", PYTHON_MIN_VERSION)),
+            (
+                "pixi.toml",
+                format!(
+                    "python = \">={},<{}\"",
+                    PYTHON_MIN_VERSION, PYTHON_MAX_VERSION
+                ),
+            ),
+            (
+                "Cargo.toml",
+                format!("abi3-py{}", PYTHON_MIN_VERSION.replace('.', "")),
+            ),
+        ];
+
+        for (filename, expected_pattern) in files_and_patterns {
+            let file_path = peppylib_py_dir.join(filename);
+            let contents = std::fs::read_to_string(&file_path)
+                .unwrap_or_else(|e| panic!("Failed to read {}: {}", file_path.display(), e));
+            assert!(
+                contents.contains(expected_pattern.as_str()),
+                "File {} does not contain expected pattern '{}'. \
+                 Update this file to match PYTHON_MIN_VERSION = \"{}\" / PYTHON_MAX_VERSION = \"{}\"",
+                file_path.display(),
+                expected_pattern,
+                PYTHON_MIN_VERSION,
+                PYTHON_MAX_VERSION,
+            );
+        }
+    }
+}

--- a/crates/daemon-config-internal/src/error.rs
+++ b/crates/daemon-config-internal/src/error.rs
@@ -1,0 +1,530 @@
+use thiserror::Error;
+
+pub type Result<T> = core::result::Result<T, Error>;
+
+/// Formats `items` as a `\n  - `-prefixed bulleted list (no leading or
+/// trailing newline outside the bullets themselves). Used to render
+/// validation/binding error collections inside parent diagnostic strings.
+pub fn format_bulleted<T, I>(items: I) -> String
+where
+    T: core::fmt::Display,
+    I: IntoIterator<Item = T>,
+{
+    items.into_iter().map(|e| format!("\n  - {e}")).collect()
+}
+
+/// Deserializes JSON5 content with field-path tracking.
+///
+/// On error, prepends the JSON path (e.g. `execution.run_cmd`) to standard
+/// serde error messages. `StructuredError`s (custom validation) are propagated
+/// unchanged since they already contain descriptive messages.
+pub fn deserialize_json5_with_path<'de, T>(content: &'de str) -> Result<T>
+where
+    T: serde::de::Deserialize<'de>,
+{
+    // Phase 1: parse JSON5 syntax. If this fails, there's no field path.
+    let mut deserializer = serde_json5::Deserializer::from_str(content)
+        .map_err(|e| Error::Parsing(ParsingError::from(e)))?;
+
+    // Phase 2: deserialize with path tracking.
+    serde_path_to_error::deserialize(&mut deserializer).map_err(|path_err| {
+        let path = path_err.path().to_string();
+        let inner: serde_json5::Error = path_err.into_inner();
+
+        match inner {
+            serde_json5::Error::Message { ref msg, .. } => {
+                // Check if it's a StructuredError (custom validation).
+                // These already have rich messages; don't prepend path.
+                if let Ok(structured) = serde_json5::from_str::<StructuredError>(msg) {
+                    return Error::Parsing(ParsingError::from(structured));
+                }
+
+                // Standard serde error: prepend path if non-empty.
+                let message = if path.is_empty() || path == "." {
+                    msg.clone()
+                } else {
+                    format!("{path}: {msg}")
+                };
+                Error::Parsing(ParsingError::CannotParseConfig(message))
+            }
+        }
+    })
+}
+
+/// Whether a declared slot is a node dep (matched by `(name, tag)` identity)
+/// or an interface dep (matched against the producer's `conforms_to`). Used
+/// in error payloads so messages can name the expected category in singular
+/// human form instead of leaking the `depends_on.nodes` / `depends_on.interfaces`
+/// field path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SlotKind {
+    Node,
+    Interface,
+}
+
+impl core::fmt::Display for SlotKind {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(match self {
+            SlotKind::Node => "node",
+            SlotKind::Interface => "interface",
+        })
+    }
+}
+
+/// Payload for [`ParsingError::BindingMissingForPinnedDep`]. Boxed in the
+/// variant so the five `String` fields do not inflate `ParsingError` past
+/// the `clippy::result_large_err` threshold.
+#[derive(Debug, Clone, Error)]
+#[error(
+    "instance `{owner_instance_id}`: slot `{link_id}` is unbound \
+     (expected {kind} `{expected_name}:{expected_tag}`)"
+)]
+pub struct BindingMissingForPinnedDep {
+    pub owner_instance_id: String,
+    pub link_id: String,
+    pub kind: SlotKind,
+    pub expected_name: String,
+    pub expected_tag: String,
+}
+
+/// Payload for [`ParsingError::BindingTargetMismatch`]. Kept as a separate
+/// struct (and boxed in the variant) so the seven `String` fields do not
+/// inflate `ParsingError` past the `clippy::result_large_err` threshold.
+#[derive(Debug, Clone, Error)]
+#[error(
+    "binding `{binding}` on instance `{owner_instance_id}`: target \
+     `{target_instance_id}` deploys node `{actual_name}:{actual_tag}`, \
+     but slot expects node `{expected_name}:{expected_tag}`"
+)]
+pub struct BindingTargetMismatch {
+    pub owner_instance_id: String,
+    pub binding: String,
+    pub target_instance_id: String,
+    pub expected_name: String,
+    pub expected_tag: String,
+    pub actual_name: String,
+    pub actual_tag: String,
+}
+
+/// Payload for [`ParsingError::BindingInterfaceNotConformed`]. Raised when a
+/// `--bind` targets an interface slot but the producer's `interfaces.conforms_to`
+/// list does not include the requested `(interface_name, interface_tag)`.
+///
+/// Boxed in the variant for the same `clippy::result_large_err` reason as the
+/// other binding error payloads.
+#[derive(Debug, Clone, Error)]
+#[error(
+    "binding `{binding}` on instance `{owner_instance_id}`: target \
+     `{target_instance_id}` deploys `{producer_name}:{producer_tag}`, but \
+     the slot requires interface `{interface_name}:{interface_tag}` (add it \
+     to the producer's `conforms_to`)"
+)]
+pub struct BindingInterfaceNotConformed {
+    pub owner_instance_id: String,
+    pub binding: String,
+    pub target_instance_id: String,
+    pub interface_name: String,
+    pub interface_tag: String,
+    pub producer_name: String,
+    pub producer_tag: String,
+}
+
+/// Payload for [`ParsingError::DuplicateInstanceIdAcrossStack`]. Boxed in
+/// the variant for the same `result_large_err` reason as the other binding
+/// variants.
+///
+/// Two instances anywhere in the running stack (any `(node_name,
+/// node_tag)`) share an `instance_id`. The binding model addresses
+/// producers by `instance_id` only, so a stack-wide duplicate would make
+/// `--bind KEY@id` ambiguous.
+#[derive(Debug, Clone, Error)]
+#[error(
+    "duplicate instance_id `{instance_id}`: used by both `{name_a}:{tag_a}` \
+     and `{name_b}:{tag_b}` (instance_ids must be unique across the stack)"
+)]
+pub struct DuplicateInstanceIdAcrossStack {
+    pub instance_id: String,
+    pub name_a: String,
+    pub tag_a: String,
+    pub name_b: String,
+    pub tag_b: String,
+}
+
+/// Payload for [`ParsingError::BindingDeadKey`]. Boxed for the same
+/// `result_large_err` reason as the other binding variants — the six
+/// `String` fields push the enum past the lint threshold otherwise.
+#[derive(Debug, Clone, Error)]
+#[error(
+    "binding `{binding}` on instance `{owner_instance_id}` matches no \
+     declared slot, and no `from_any` slot accepts target \
+     `{target_instance_id}` (deploys `{producer_name}:{producer_tag}`); \
+     declared link_ids: [{declared_link_ids}]"
+)]
+pub struct BindingDeadKey {
+    pub owner_instance_id: String,
+    pub binding: String,
+    pub target_instance_id: String,
+    pub producer_name: String,
+    pub producer_tag: String,
+    pub declared_link_ids: String,
+}
+
+/// Payload for [`ParsingError::MissingInterface`]. Boxed in the variant so
+/// the six `String` fields do not inflate `ParsingError` past the
+/// `clippy::result_large_err` threshold.
+#[derive(Debug, Clone, Error)]
+#[error(
+    "`{dependant}`:{dependant_tag} expects {interface_kind} `{interface_name}` from \
+     `{dependency}`:{dependency_tag}, but it is not exposed"
+)]
+pub struct MissingInterface {
+    pub dependant: String,
+    pub dependant_tag: String,
+    pub dependency: String,
+    pub dependency_tag: String,
+    pub interface_kind: String,
+    pub interface_name: String,
+}
+
+#[derive(Debug, Error, Clone)]
+pub enum ParsingError {
+    // -- General yaml syntax
+    #[error("Cannot read {0}: {1}")]
+    CannotRead(String, std::io::ErrorKind),
+    #[error("Cannot parse configuration: {0}")]
+    CannotParseConfig(String),
+    #[error("Empty content found in: {0}")]
+    EmptyContent(String),
+
+    // -- node_config
+    #[error("Invalid name: {0}, allowed characters: {1}")]
+    InvalidName(String, String),
+    #[error("Empty name")]
+    EmptyName,
+    #[error("Duplicate name: {0}")]
+    DuplicateName(String),
+    #[error(
+        "Duplicate link_id `{0}` in manifest.depends_on (link_ids must be unique across nodes and interfaces)"
+    )]
+    DuplicateLinkId(String),
+    #[error(
+        "Conflicting `from_any: true` for dependency `{name}` (tag `{tag}`) in manifest.depends_on: only one entry per (name, tag) may set from_any=true"
+    )]
+    ConflictingFromAny { name: String, tag: String },
+
+    // -- deployments
+    #[error("Invalid deployment source: {0}")]
+    InvalidDeploymentSource(String),
+
+    // -- build system
+    #[error("Invalid toolchain {0}")]
+    InvalidToolchain(String),
+
+    // -- node config: process vs container
+    #[error("Node config must have exactly one of `process` or `container`, not both")]
+    ProcessAndContainerConflict,
+    #[error("Node config must have either `process` or `container`")]
+    NoProcessOrContainer,
+    #[error("Node config `execution.run_cmd` must not be empty")]
+    EmptyRunCmd,
+
+    // -- node config: execution
+    #[error("Node config `execution.language` is required when an execution block is defined")]
+    MissingExecutionLanguage,
+
+    // -- launcher: interface bindings
+    #[error(
+        "interface binding `{binding}` on instance `{owner_instance_id}` refers to unknown instance_id `{instance_id}`"
+    )]
+    UnknownInstanceId {
+        owner_instance_id: String,
+        binding: String,
+        instance_id: String,
+    },
+    #[error(
+        "binding key `{binding}` on instance `{owner_instance_id}` is the reserved producer-default sentinel and cannot be used as a binding slot"
+    )]
+    BindingSentinelKey {
+        owner_instance_id: String,
+        binding: String,
+    },
+    /// `--bind KEY@VALUE` whose `KEY` neither matches a declared pinned
+    /// `link_id` nor a declared `from_any` slot for VALUE's `(name, tag)`.
+    /// Boxed for the same `result_large_err` reason as the other binding
+    /// variants.
+    #[error(transparent)]
+    BindingDeadKey(Box<BindingDeadKey>),
+    /// Two `--bind KEY@…` entries on the same invocation share the same
+    /// `KEY`. Each `KEY` is the binding's label — pinned KEYs match a
+    /// declared link_id; `from_any` KEYs are free-form — and must be
+    /// distinct so the validator can resolve each to a slot
+    /// unambiguously.
+    #[error(
+        "duplicate binding key `{binding}` on instance `{owner_instance_id}` (each --bind KEY must be distinct)"
+    )]
+    BindingDuplicateKey {
+        owner_instance_id: String,
+        binding: String,
+    },
+    /// Boxed payload for the same reason as
+    /// [`ParsingError::BindingTargetMismatch`]: keeps the variant's
+    /// String-heavy struct from inflating `ParsingError`'s size past the
+    /// `clippy::result_large_err` threshold.
+    #[error(transparent)]
+    BindingMissingForPinnedDep(Box<BindingMissingForPinnedDep>),
+    /// Boxed payload so this variant does not grow `ParsingError` past the
+    /// `clippy::result_large_err` threshold; without the indirection, the
+    /// seven `String` fields would inflate every `Result<_, _>` that
+    /// transitively wraps a `ParsingError` (notably code generated against
+    /// `peppylib::PeppyError`).
+    #[error(transparent)]
+    BindingTargetMismatch(Box<BindingTargetMismatch>),
+    /// Pinned `--bind` targets an interface slot but the producer doesn't
+    /// declare conformance to the requested interface. Boxed for the same
+    /// `result_large_err` reason as the other binding variants.
+    #[error(transparent)]
+    BindingInterfaceNotConformed(Box<BindingInterfaceNotConformed>),
+    /// Two instances anywhere in the running stack share an `instance_id`.
+    /// Boxed for the same `result_large_err` reason as the other binding
+    /// variants.
+    #[error(transparent)]
+    DuplicateInstanceIdAcrossStack(Box<DuplicateInstanceIdAcrossStack>),
+
+    // -- container config: mount paths
+    #[error(
+        "Invalid mount path `{0}`: top-level system directories ({1}) cannot be used as mount sources — use a subdirectory instead (e.g., /tmp/my_app)"
+    )]
+    InvalidMountPath(String, String),
+    #[error("Invalid parameter reference `${{parameters:{0}}}` in mount path: {1}")]
+    InvalidMountPathParameterRef(String, String),
+
+    // -- node dependency validation
+    #[error(
+        "`{dependant}:{dependant_tag}` depends on `{dependency}:{dependency_tag}`, but it does not exist in the stack"
+    )]
+    MissingDependency {
+        dependant: String,
+        dependant_tag: String,
+        dependency: String,
+        dependency_tag: String,
+    },
+    #[error(
+        "`{dependant}:{dependant_tag}` references undeclared link_id `{link_id}` in consumed interfaces"
+    )]
+    UndeclaredLinkId {
+        dependant: String,
+        dependant_tag: String,
+        link_id: String,
+    },
+    /// Boxed payload for the same reason as
+    /// [`ParsingError::BindingTargetMismatch`]: keeps the variant's
+    /// String-heavy struct from inflating `ParsingError`'s size past the
+    /// `clippy::result_large_err` threshold.
+    #[error(transparent)]
+    MissingInterface(Box<MissingInterface>),
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub enum StructuredError {
+    InvalidDeploymentSource(String),
+    DuplicateName(String),
+    InvalidName {
+        name: String,
+        allowed: String,
+    },
+    EmptyName,
+    MissingExecutionLanguage,
+    UnknownInstanceId {
+        owner_instance_id: String,
+        binding: String,
+        instance_id: String,
+    },
+    BindingSentinelKey {
+        owner_instance_id: String,
+        binding: String,
+    },
+}
+
+impl StructuredError {
+    pub(crate) fn json5_message(&self) -> String {
+        serde_json5::to_string(self).unwrap_or_else(|_| "serialization error".to_string())
+    }
+}
+
+impl From<StructuredError> for ParsingError {
+    fn from(s: StructuredError) -> Self {
+        match s {
+            StructuredError::InvalidDeploymentSource(detail) => {
+                ParsingError::InvalidDeploymentSource(detail)
+            }
+            StructuredError::DuplicateName(id) => ParsingError::DuplicateName(id),
+            StructuredError::InvalidName { name, allowed } => {
+                ParsingError::InvalidName(name, allowed)
+            }
+            StructuredError::EmptyName => ParsingError::EmptyName,
+            StructuredError::MissingExecutionLanguage => ParsingError::MissingExecutionLanguage,
+            StructuredError::UnknownInstanceId {
+                owner_instance_id,
+                binding,
+                instance_id,
+            } => ParsingError::UnknownInstanceId {
+                owner_instance_id,
+                binding,
+                instance_id,
+            },
+            StructuredError::BindingSentinelKey {
+                owner_instance_id,
+                binding,
+            } => ParsingError::BindingSentinelKey {
+                owner_instance_id,
+                binding,
+            },
+        }
+    }
+}
+
+impl From<serde_json5::Error> for ParsingError {
+    fn from(err: serde_json5::Error) -> Self {
+        match err {
+            serde_json5::Error::Message { msg, .. } => {
+                if let Ok(structured) = serde_json5::from_str::<StructuredError>(&msg) {
+                    ParsingError::from(structured)
+                } else {
+                    ParsingError::CannotParseConfig(msg)
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum Error {
+    // -- general
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error("Capnp error: {0}")]
+    Capnp(#[from] capnp::Error),
+
+    // -- Parsing error
+    #[error(transparent)]
+    Parsing(#[from] ParsingError),
+    #[error("Serialize error: {0}")]
+    Serialize(String),
+    #[error("Encoding error: {0}")]
+    Encoding(String),
+
+    // -- Fingerprint
+    #[error(
+        "Node config fingerprint mismatch: expected {expected}, got {actual}. The config may have been modified after code generation. Run `node sync` to update the peppygen lib on your node."
+    )]
+    FingerprintMismatch { expected: String, actual: String },
+    #[error(
+        "Release fingerprint mismatch: node was generated with peppy version {node_version}, but current peppy version is {current_version}. Run `node sync` to regenerate with the current version."
+    )]
+    ReleaseFingerprintMismatch {
+        node_version: String,
+        current_version: String,
+    },
+    #[error("Release fingerprint missing: {0}")]
+    ReleaseFingerprintMissing(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_structured_error_deserialization() {
+        // Helper to create a serde_json5 error from a string
+        fn make_err(msg: &str) -> serde_json5::Error {
+            serde::de::Error::custom(msg)
+        }
+
+        // InvalidDeploymentSource
+        let json = serde_json5::to_string(&StructuredError::InvalidDeploymentSource(
+            "bad source".to_string(),
+        ))
+        .unwrap();
+        let err = ParsingError::from(make_err(&json));
+        if let ParsingError::InvalidDeploymentSource(msg) = err {
+            assert_eq!(msg, "bad source");
+        } else {
+            panic!("Expected InvalidDeploymentSource, got {:?}", err);
+        }
+
+        // DuplicateName
+        let json =
+            serde_json5::to_string(&StructuredError::DuplicateName("id1".to_string())).unwrap();
+        let err = ParsingError::from(make_err(&json));
+        if let ParsingError::DuplicateName(id) = err {
+            assert_eq!(id, "id1");
+        } else {
+            panic!("Expected DuplicateName, got {:?}", err);
+        }
+
+        // InvalidName
+        let json = serde_json5::to_string(&StructuredError::InvalidName {
+            name: "bad".to_string(),
+            allowed: "a-z".to_string(),
+        })
+        .unwrap();
+        let err = ParsingError::from(make_err(&json));
+        if let ParsingError::InvalidName(name, allowed) = err {
+            assert_eq!(name, "bad");
+            assert_eq!(allowed, "a-z");
+        } else {
+            panic!("Expected InvalidName, got {:?}", err);
+        }
+
+        // EmptyName
+        let json = serde_json5::to_string(&StructuredError::EmptyName).unwrap();
+        let err = ParsingError::from(make_err(&json));
+        if !matches!(err, ParsingError::EmptyName) {
+            panic!("Expected EmptyName, got {:?}", err);
+        }
+    }
+
+    #[test]
+    fn test_fallback_mechanism() {
+        fn make_err(msg: &str) -> serde_json5::Error {
+            serde::de::Error::custom(msg)
+        }
+
+        let raw_msg = "This is not JSON";
+        let err = ParsingError::from(make_err(raw_msg));
+        if let ParsingError::CannotParseConfig(msg) = err {
+            assert_eq!(msg, raw_msg);
+        } else {
+            panic!("Expected CannotParseConfig, got {:?}", err);
+        }
+
+        let broken_json = "{ invalid json";
+        let err = ParsingError::from(make_err(broken_json));
+        if let ParsingError::CannotParseConfig(msg) = err {
+            assert_eq!(msg, broken_json);
+        } else {
+            panic!("Expected CannotParseConfig, got {:?}", err);
+        }
+    }
+
+    #[test]
+    fn format_bulleted_empty_input_is_empty_string() {
+        let out = format_bulleted(Vec::<String>::new());
+        assert_eq!(out, "");
+    }
+
+    #[test]
+    fn format_bulleted_prefixes_each_item_with_a_newline_bullet() {
+        let out = format_bulleted(["first", "second"]);
+        // Each item gets a leading "\n  - "; nothing is emitted around the list,
+        // so it can be spliced straight into a parent diagnostic string.
+        assert_eq!(out, "\n  - first\n  - second");
+    }
+
+    #[test]
+    fn format_bulleted_accepts_any_display_type() {
+        // Exercises the generic `T: Display` bound with a non-string item.
+        let out = format_bulleted(1..=3);
+        assert_eq!(out, "\n  - 1\n  - 2\n  - 3");
+    }
+}

--- a/crates/daemon-config-internal/src/error.rs
+++ b/crates/daemon-config-internal/src/error.rs
@@ -1,3 +1,14 @@
+//! Errors for the daemon-side document models.
+//!
+//! `deserialize_json5_with_path`, the private `StructuredError` bridge, and
+//! `parsing::read_non_empty_file` are deliberate small copies of their
+//! `config` (peppy-config-model) counterparts: the shared crate keeps those
+//! private to its own parsers, and duplicating a few dozen bounded lines
+//! beats widening the shared public surface to internals. `ParsingError`
+//! here carries the daemon-domain variants (deployment sources, launcher
+//! instances, bindings); general document errors raised by the shared node
+//! parser stay in `config::ParsingError`.
+
 use thiserror::Error;
 
 pub type Result<T> = core::result::Result<T, Error>;
@@ -169,23 +180,6 @@ pub struct BindingDeadKey {
     pub declared_link_ids: String,
 }
 
-/// Payload for [`ParsingError::MissingInterface`]. Boxed in the variant so
-/// the six `String` fields do not inflate `ParsingError` past the
-/// `clippy::result_large_err` threshold.
-#[derive(Debug, Clone, Error)]
-#[error(
-    "`{dependant}`:{dependant_tag} expects {interface_kind} `{interface_name}` from \
-     `{dependency}`:{dependency_tag}, but it is not exposed"
-)]
-pub struct MissingInterface {
-    pub dependant: String,
-    pub dependant_tag: String,
-    pub dependency: String,
-    pub dependency_tag: String,
-    pub interface_kind: String,
-    pub interface_name: String,
-}
-
 #[derive(Debug, Error, Clone)]
 pub enum ParsingError {
     // -- General yaml syntax
@@ -196,41 +190,13 @@ pub enum ParsingError {
     #[error("Empty content found in: {0}")]
     EmptyContent(String),
 
-    // -- node_config
-    #[error("Invalid name: {0}, allowed characters: {1}")]
-    InvalidName(String, String),
-    #[error("Empty name")]
-    EmptyName,
+    // -- launcher instances
     #[error("Duplicate name: {0}")]
     DuplicateName(String),
-    #[error(
-        "Duplicate link_id `{0}` in manifest.depends_on (link_ids must be unique across nodes and interfaces)"
-    )]
-    DuplicateLinkId(String),
-    #[error(
-        "Conflicting `from_any: true` for dependency `{name}` (tag `{tag}`) in manifest.depends_on: only one entry per (name, tag) may set from_any=true"
-    )]
-    ConflictingFromAny { name: String, tag: String },
 
     // -- deployments
     #[error("Invalid deployment source: {0}")]
     InvalidDeploymentSource(String),
-
-    // -- build system
-    #[error("Invalid toolchain {0}")]
-    InvalidToolchain(String),
-
-    // -- node config: process vs container
-    #[error("Node config must have exactly one of `process` or `container`, not both")]
-    ProcessAndContainerConflict,
-    #[error("Node config must have either `process` or `container`")]
-    NoProcessOrContainer,
-    #[error("Node config `execution.run_cmd` must not be empty")]
-    EmptyRunCmd,
-
-    // -- node config: execution
-    #[error("Node config `execution.language` is required when an execution block is defined")]
-    MissingExecutionLanguage,
 
     // -- launcher: interface bindings
     #[error(
@@ -289,51 +255,12 @@ pub enum ParsingError {
     /// variants.
     #[error(transparent)]
     DuplicateInstanceIdAcrossStack(Box<DuplicateInstanceIdAcrossStack>),
-
-    // -- container config: mount paths
-    #[error(
-        "Invalid mount path `{0}`: top-level system directories ({1}) cannot be used as mount sources — use a subdirectory instead (e.g., /tmp/my_app)"
-    )]
-    InvalidMountPath(String, String),
-    #[error("Invalid parameter reference `${{parameters:{0}}}` in mount path: {1}")]
-    InvalidMountPathParameterRef(String, String),
-
-    // -- node dependency validation
-    #[error(
-        "`{dependant}:{dependant_tag}` depends on `{dependency}:{dependency_tag}`, but it does not exist in the stack"
-    )]
-    MissingDependency {
-        dependant: String,
-        dependant_tag: String,
-        dependency: String,
-        dependency_tag: String,
-    },
-    #[error(
-        "`{dependant}:{dependant_tag}` references undeclared link_id `{link_id}` in consumed interfaces"
-    )]
-    UndeclaredLinkId {
-        dependant: String,
-        dependant_tag: String,
-        link_id: String,
-    },
-    /// Boxed payload for the same reason as
-    /// [`ParsingError::BindingTargetMismatch`]: keeps the variant's
-    /// String-heavy struct from inflating `ParsingError`'s size past the
-    /// `clippy::result_large_err` threshold.
-    #[error(transparent)]
-    MissingInterface(Box<MissingInterface>),
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub enum StructuredError {
     InvalidDeploymentSource(String),
     DuplicateName(String),
-    InvalidName {
-        name: String,
-        allowed: String,
-    },
-    EmptyName,
-    MissingExecutionLanguage,
     UnknownInstanceId {
         owner_instance_id: String,
         binding: String,
@@ -358,11 +285,6 @@ impl From<StructuredError> for ParsingError {
                 ParsingError::InvalidDeploymentSource(detail)
             }
             StructuredError::DuplicateName(id) => ParsingError::DuplicateName(id),
-            StructuredError::InvalidName { name, allowed } => {
-                ParsingError::InvalidName(name, allowed)
-            }
-            StructuredError::EmptyName => ParsingError::EmptyName,
-            StructuredError::MissingExecutionLanguage => ParsingError::MissingExecutionLanguage,
             StructuredError::UnknownInstanceId {
                 owner_instance_id,
                 binding,
@@ -402,31 +324,12 @@ pub enum Error {
     // -- general
     #[error(transparent)]
     Io(#[from] std::io::Error),
-    #[error("Capnp error: {0}")]
-    Capnp(#[from] capnp::Error),
 
     // -- Parsing error
     #[error(transparent)]
     Parsing(#[from] ParsingError),
     #[error("Serialize error: {0}")]
     Serialize(String),
-    #[error("Encoding error: {0}")]
-    Encoding(String),
-
-    // -- Fingerprint
-    #[error(
-        "Node config fingerprint mismatch: expected {expected}, got {actual}. The config may have been modified after code generation. Run `node sync` to update the peppygen lib on your node."
-    )]
-    FingerprintMismatch { expected: String, actual: String },
-    #[error(
-        "Release fingerprint mismatch: node was generated with peppy version {node_version}, but current peppy version is {current_version}. Run `node sync` to regenerate with the current version."
-    )]
-    ReleaseFingerprintMismatch {
-        node_version: String,
-        current_version: String,
-    },
-    #[error("Release fingerprint missing: {0}")]
-    ReleaseFingerprintMissing(String),
 }
 
 #[cfg(test)]
@@ -462,26 +365,6 @@ mod tests {
             panic!("Expected DuplicateName, got {:?}", err);
         }
 
-        // InvalidName
-        let json = serde_json5::to_string(&StructuredError::InvalidName {
-            name: "bad".to_string(),
-            allowed: "a-z".to_string(),
-        })
-        .unwrap();
-        let err = ParsingError::from(make_err(&json));
-        if let ParsingError::InvalidName(name, allowed) = err {
-            assert_eq!(name, "bad");
-            assert_eq!(allowed, "a-z");
-        } else {
-            panic!("Expected InvalidName, got {:?}", err);
-        }
-
-        // EmptyName
-        let json = serde_json5::to_string(&StructuredError::EmptyName).unwrap();
-        let err = ParsingError::from(make_err(&json));
-        if !matches!(err, ParsingError::EmptyName) {
-            panic!("Expected EmptyName, got {:?}", err);
-        }
     }
 
     #[test]

--- a/crates/daemon-config-internal/src/interface.rs
+++ b/crates/daemon-config-internal/src/interface.rs
@@ -1,0 +1,11 @@
+mod parse;
+mod types;
+
+// Defines the parsing of interface documents (`peppy_schema: "interface/v1"`).
+// Interface files are stand-alone JSON5 documents that declare a reusable
+// contract — the topics, services, and actions a node claims to expose.
+// Filenames are not fixed; any `.json5` whose body carries the
+// `interface/v1` schema tag is an interface.
+pub use parse::PeppyInterfaceParser;
+pub(crate) use types::validate_named_items;
+pub use types::{Interfaces, Manifest, PeppyInterface};

--- a/crates/daemon-config-internal/src/interface/parse.rs
+++ b/crates/daemon-config-internal/src/interface/parse.rs
@@ -1,0 +1,110 @@
+use super::types::PeppyInterface;
+use crate::{error::Result, parsing::read_non_empty_file};
+use std::path::Path;
+
+/// Parser responsible for extracting interface documents.
+///
+/// Interface files are stand-alone JSON5 documents declaring
+/// `peppy_schema: "interface/v1"`. Like launchers, they are filename-agnostic
+/// — schema and shape validation are handled by serde so callers walking a
+/// repository can attempt to parse and treat failures as "not an interface."
+pub struct PeppyInterfaceParser;
+
+impl PeppyInterfaceParser {
+    pub fn from_path(file: impl AsRef<Path>) -> Result<PeppyInterface> {
+        let path = file.as_ref();
+        let content = read_non_empty_file(path)?;
+        Self::from_content(&content)
+    }
+
+    /// Takes a JSON5 content string and parses it as an interface document.
+    pub fn from_content(content: &str) -> Result<PeppyInterface> {
+        crate::error::deserialize_json5_with_path(content)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        error::{Error, ParsingError},
+        schema::PeppySchema,
+    };
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn from_content_parses_interface() {
+        let json5 = r#"{
+            peppy_schema: "interface/v1",
+            manifest: { name: "depth_camera", tag: "v1" },
+            interfaces: {
+                topics: [
+                    { name: "video_stream", qos_profile: "sensor_data" }
+                ]
+            }
+        }"#;
+        let parsed = PeppyInterfaceParser::from_content(json5).expect("should parse");
+        assert_eq!(parsed.peppy_schema, PeppySchema::InterfaceV1);
+        assert_eq!(parsed.manifest.name.as_str(), "depth_camera");
+        assert_eq!(parsed.interfaces.topics.len(), 1);
+    }
+
+    #[test]
+    fn from_path_loads_file() {
+        let tmp = NamedTempFile::new().unwrap();
+        let json5 = r#"{
+            peppy_schema: "interface/v1",
+            manifest: { name: "ping", tag: "v1" },
+            interfaces: {}
+        }"#;
+        std::fs::write(tmp.path(), json5).unwrap();
+        let parsed = PeppyInterfaceParser::from_path(tmp.path()).expect("should parse");
+        assert_eq!(parsed.manifest.name.as_str(), "ping");
+    }
+
+    #[test]
+    fn empty_file_rejected() {
+        let tmp = NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), b"").unwrap();
+        let result = PeppyInterfaceParser::from_path(tmp.path());
+        assert!(matches!(
+            result.unwrap_err(),
+            Error::Parsing(ParsingError::EmptyContent(_))
+        ));
+    }
+
+    #[test]
+    fn missing_file_rejected() {
+        let result = PeppyInterfaceParser::from_path("/path/does/not/exist.json5");
+        assert!(matches!(
+            result.unwrap_err(),
+            Error::Parsing(ParsingError::CannotRead(..))
+        ));
+    }
+
+    #[test]
+    fn malformed_json5_rejected() {
+        let result = PeppyInterfaceParser::from_content("{ manifest: [unclosed");
+        assert!(matches!(
+            result.unwrap_err(),
+            Error::Parsing(ParsingError::CannotParseConfig(_))
+        ));
+    }
+
+    /// A launcher document must not be misread as an interface, even though
+    /// both lack a node's `execution` block. The schema field is the source
+    /// of truth.
+    #[test]
+    fn launcher_document_rejected() {
+        let json5 = r#"{
+            peppy_schema: "launcher/v1",
+            deployments: []
+        }"#;
+        let err = PeppyInterfaceParser::from_content(json5)
+            .expect_err("launcher must not parse as interface");
+        assert!(
+            err.to_string().contains("interface/v1"),
+            "error should mention expected schema, got: {err}"
+        );
+    }
+}

--- a/crates/daemon-config-internal/src/interface/parse.rs
+++ b/crates/daemon-config-internal/src/interface/parse.rs
@@ -26,10 +26,8 @@ impl PeppyInterfaceParser {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        error::{Error, ParsingError},
-        schema::PeppySchema,
-    };
+    use crate::error::{Error, ParsingError};
+    use config::schema::PeppySchema;
     use tempfile::NamedTempFile;
 
     #[test]

--- a/crates/daemon-config-internal/src/interface/types.rs
+++ b/crates/daemon-config-internal/src/interface/types.rs
@@ -1,0 +1,497 @@
+use crate::{
+    node::{EmittedTopic, ExposedAction, ExposedService, Name},
+    schema::PeppySchema,
+};
+use serde::{
+    Deserialize, Serialize,
+    de::{self, Deserializer},
+};
+use std::collections::HashSet;
+
+/// Reject any `peppy_schema` value other than `interface/v1` so a node or
+/// launcher document can't slip through `PeppyInterfaceParser`.
+fn deserialize_interface_v1_schema<'de, D>(deserializer: D) -> Result<PeppySchema, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    PeppySchema::deserialize_expecting(deserializer, PeppySchema::InterfaceV1)
+}
+
+/// A reusable contract describing the topics, services, and actions a node
+/// claims to expose. Interface documents are stand-alone JSON5 files identified
+/// by `peppy_schema: "interface/v1"`; nodes reference them by name/tag to
+/// declare conformance.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct PeppyInterface {
+    #[serde(deserialize_with = "deserialize_interface_v1_schema")]
+    pub peppy_schema: PeppySchema,
+    pub manifest: Manifest,
+    pub interfaces: Interfaces,
+}
+
+/// Identity of an interface document. Interfaces do not have build/runtime
+/// concerns, so the manifest is narrower than a node manifest: `depends_on`
+/// is rejected because an interface is a passive contract. `labels` are
+/// allowed as descriptive metadata to help discovery and filtering.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct Manifest {
+    pub name: Name,
+    #[serde(deserialize_with = "deserialize_tag")]
+    pub tag: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub labels: Option<Vec<String>>,
+}
+
+/// Enforce the repo-ID tag contract on the manifest tag at parse time, reusing
+/// the shared rules from `repo_node_id` so a `name`/`tag` pair from an interface
+/// document matches node dependencies the same way everywhere.
+fn deserialize_tag<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let tag = String::deserialize(deserializer)?;
+    crate::internal::repo_node_id::validate_repo_node_tag(&tag, "tag")
+        .map_err(de::Error::custom)?;
+    Ok(tag)
+}
+
+/// The body of an interface document. Each section is a flat list of items
+/// — there is no `emits`/`consumes` split because an interface describes the
+/// provider side only. Conformance for the consumer side is checked separately
+/// against the node's declared interfaces.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct Interfaces {
+    #[serde(
+        default,
+        skip_serializing_if = "Vec::is_empty",
+        deserialize_with = "deserialize_topics"
+    )]
+    pub topics: Vec<EmittedTopic>,
+    #[serde(
+        default,
+        skip_serializing_if = "Vec::is_empty",
+        deserialize_with = "deserialize_services"
+    )]
+    pub services: Vec<ExposedService>,
+    #[serde(
+        default,
+        skip_serializing_if = "Vec::is_empty",
+        deserialize_with = "deserialize_actions"
+    )]
+    pub actions: Vec<ExposedAction>,
+}
+
+fn deserialize_topics<'de, D>(deserializer: D) -> Result<Vec<EmittedTopic>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let items = Vec::<EmittedTopic>::deserialize(deserializer)?;
+    validate_named_items(items.iter().map(|t| t.name.as_str()), "topic")
+        .map_err(de::Error::custom)?;
+    Ok(items)
+}
+
+fn deserialize_services<'de, D>(deserializer: D) -> Result<Vec<ExposedService>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let items = Vec::<ExposedService>::deserialize(deserializer)?;
+    validate_named_items(items.iter().map(|s| s.name.as_str()), "service")
+        .map_err(de::Error::custom)?;
+    Ok(items)
+}
+
+fn deserialize_actions<'de, D>(deserializer: D) -> Result<Vec<ExposedAction>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let items = Vec::<ExposedAction>::deserialize(deserializer)?;
+    validate_named_items(items.iter().map(|a| a.name.as_str()), "action")
+        .map_err(de::Error::custom)?;
+    Ok(items)
+}
+
+/// Rejects empty/whitespace names and duplicates within a single list. Both
+/// states would otherwise survive parsing because the underlying item types
+/// default `name` to `""` for ergonomics in node configs.
+pub(crate) fn validate_named_items<'a>(
+    names: impl Iterator<Item = &'a str>,
+    kind: &'static str,
+) -> Result<(), String> {
+    let mut seen = HashSet::new();
+    for (index, name) in names.enumerate() {
+        if name.trim().is_empty() {
+            return Err(format!(
+                "interface {kind} at index {index} has an empty `name`"
+            ));
+        }
+        if !seen.insert(name) {
+            return Err(format!("duplicate interface {kind} name: `{name}`"));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::node::{ArrayKind, MessageFormat, QoSProfile, SchemaType, TypeToken};
+
+    /// The depth-camera example from the schema doc parses end-to-end and
+    /// exposes every field the way the user wrote it.
+    #[test]
+    fn parses_depth_camera_example() {
+        let json5 = r#"{
+            peppy_schema: "interface/v1",
+            manifest: {
+                name: "depth_camera",
+                tag: "v1"
+            },
+            interfaces: {
+                topics: [
+                    {
+                        name: "video_stream",
+                        qos_profile: "sensor_data",
+                        message_format: {
+                            header: {
+                                $type: "object",
+                                stamp: "time",
+                                frame_id: "u32",
+                            },
+                            encoding: "string",
+                            width: "u32",
+                            height: "u32",
+                            frame: {
+                                $type: "array",
+                                $items: "u8",
+                                $length: 4
+                            },
+                        },
+                    }
+                ],
+                services: [
+                    {
+                        name: "video_stream_info",
+                        response_message_format: {
+                            width: "u32",
+                            height: "u32",
+                            frames_per_second: "u8",
+                            encoding: "string",
+                        }
+                    },
+                    {
+                        name: "set_contrast",
+                        request_message_format: {
+                            value: "i32",
+                        },
+                        response_message_format: {
+                            success: "bool",
+                            message: "string",
+                            current_value: "i32",
+                        },
+                    }
+                ]
+            }
+        }"#;
+
+        let parsed: PeppyInterface =
+            serde_json5::from_str(json5).expect("depth_camera example should parse");
+
+        assert_eq!(parsed.peppy_schema, PeppySchema::InterfaceV1);
+        assert_eq!(parsed.manifest.name.as_str(), "depth_camera");
+        assert_eq!(parsed.manifest.tag, "v1");
+
+        assert_eq!(parsed.interfaces.topics.len(), 1);
+        let topic = &parsed.interfaces.topics[0];
+        assert_eq!(topic.name, "video_stream");
+        assert_eq!(topic.qos_profile, QoSProfile::SensorData);
+        let mf = topic.message_format.as_ref().expect("message_format set");
+        assert!(matches!(
+            mf.0.get("encoding"),
+            Some(SchemaType::Type(TypeToken::String))
+        ));
+        let SchemaType::Array(frame) = mf.0.get("frame").unwrap() else {
+            panic!("frame should be an array");
+        };
+        assert_eq!(frame.kind, ArrayKind::Array);
+        assert_eq!(frame.length, Some(4));
+
+        assert_eq!(parsed.interfaces.services.len(), 2);
+        let svc = &parsed.interfaces.services[0];
+        assert_eq!(svc.name, "video_stream_info");
+        assert!(svc.request_message_format.is_none());
+        assert!(svc.response_message_format.is_some());
+
+        let set_contrast = &parsed.interfaces.services[1];
+        assert_eq!(set_contrast.name, "set_contrast");
+        assert!(set_contrast.request_message_format.is_some());
+        assert!(set_contrast.response_message_format.is_some());
+
+        assert!(parsed.interfaces.actions.is_empty());
+    }
+
+    #[test]
+    fn minimal_interface_with_only_manifest_parses() {
+        let json5 = r#"{
+            peppy_schema: "interface/v1",
+            manifest: { name: "empty_iface", tag: "v1" },
+            interfaces: {}
+        }"#;
+
+        let parsed: PeppyInterface = serde_json5::from_str(json5).expect("should parse");
+        assert!(parsed.interfaces.topics.is_empty());
+        assert!(parsed.interfaces.services.is_empty());
+        assert!(parsed.interfaces.actions.is_empty());
+    }
+
+    #[test]
+    fn actions_can_be_declared() {
+        let json5 = r#"{
+            peppy_schema: "interface/v1",
+            manifest: { name: "arm", tag: "v1" },
+            interfaces: {
+                actions: [
+                    {
+                        name: "move_arm",
+                        goal_service: {
+                            request_message_format: { x: "f64" },
+                            response_message_format: { accepted: "bool" },
+                        },
+                        result_service: {
+                            response_message_format: { success: "bool" },
+                        }
+                    }
+                ]
+            }
+        }"#;
+
+        let parsed: PeppyInterface = serde_json5::from_str(json5).expect("should parse");
+        assert_eq!(parsed.interfaces.actions.len(), 1);
+        let action = &parsed.interfaces.actions[0];
+        assert_eq!(action.name, "move_arm");
+        assert!(action.goal_service.is_some());
+        assert!(action.result_service.is_some());
+        assert!(action.feedback_topic.is_none());
+    }
+
+    /// The schema field is the source of truth — a node-shaped document
+    /// must not be accepted by the interface parser, even if no
+    /// interface-specific field is present.
+    #[test]
+    fn rejects_wrong_schema_tag() {
+        let json5 = r#"{
+            peppy_schema: "node/v1",
+            manifest: { name: "x", tag: "v1" },
+            interfaces: {}
+        }"#;
+        let err =
+            serde_json5::from_str::<PeppyInterface>(json5).expect_err("node/v1 must be rejected");
+        assert!(
+            err.to_string().contains("interface/v1"),
+            "error should mention expected schema, got: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_top_level_fields() {
+        let json5 = r#"{
+            peppy_schema: "interface/v1",
+            manifest: { name: "x", tag: "v1" },
+            interfaces: {},
+            execution: { language: "rust" }
+        }"#;
+        assert!(serde_json5::from_str::<PeppyInterface>(json5).is_err());
+    }
+
+    #[test]
+    fn rejects_unknown_interfaces_fields() {
+        let json5 = r#"{
+            peppy_schema: "interface/v1",
+            manifest: { name: "x", tag: "v1" },
+            interfaces: { mystery: [] }
+        }"#;
+        assert!(serde_json5::from_str::<PeppyInterface>(json5).is_err());
+    }
+
+    /// Interface manifests intentionally drop `depends_on`: an interface
+    /// is a passive contract and cannot depend on other nodes.
+    #[test]
+    fn rejects_manifest_depends_on() {
+        let json5 = r#"{
+            peppy_schema: "interface/v1",
+            manifest: {
+                name: "x",
+                tag: "v1",
+                depends_on: { nodes: [] }
+            },
+            interfaces: {}
+        }"#;
+        assert!(serde_json5::from_str::<PeppyInterface>(json5).is_err());
+    }
+
+    /// `labels` are descriptive metadata on the manifest — accepted so
+    /// catalog tooling can filter interfaces (e.g., `vendor`, `domain`)
+    /// without changing the contract itself.
+    #[test]
+    fn accepts_manifest_labels() {
+        let json5 = r#"{
+            peppy_schema: "interface/v1",
+            manifest: {
+                name: "x",
+                tag: "v1",
+                labels: ["a", "b"]
+            },
+            interfaces: {}
+        }"#;
+        let parsed: PeppyInterface =
+            serde_json5::from_str(json5).expect("labels should be accepted");
+        assert_eq!(
+            parsed.manifest.labels.as_deref(),
+            Some(["a".to_string(), "b".to_string()].as_slice())
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_manifest_name() {
+        let json5 = r#"{
+            peppy_schema: "interface/v1",
+            manifest: { name: "bad/name", tag: "v1" },
+            interfaces: {}
+        }"#;
+        assert!(serde_json5::from_str::<PeppyInterface>(json5).is_err());
+    }
+
+    /// The manifest tag must satisfy the same repo-ID rules as node
+    /// dependencies (`repo_node_id::validate_repo_node_tag`); a tag that does
+    /// not start with an ASCII letter is rejected at parse time.
+    #[test]
+    fn rejects_invalid_manifest_tag() {
+        let json5 = r#"{
+            peppy_schema: "interface/v1",
+            manifest: { name: "x", tag: "1bad" },
+            interfaces: {}
+        }"#;
+        let err = serde_json5::from_str::<PeppyInterface>(json5)
+            .expect_err("invalid tag must be rejected");
+        assert!(
+            err.to_string().contains("must start with an ASCII letter"),
+            "error: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_empty_topic_name() {
+        let json5 = r#"{
+            peppy_schema: "interface/v1",
+            manifest: { name: "x", tag: "v1" },
+            interfaces: {
+                topics: [ { qos_profile: "standard" } ]
+            }
+        }"#;
+        let err = serde_json5::from_str::<PeppyInterface>(json5)
+            .expect_err("empty name must be rejected");
+        assert!(err.to_string().contains("empty"), "error: {err}");
+    }
+
+    #[test]
+    fn rejects_duplicate_topic_names() {
+        let json5 = r#"{
+            peppy_schema: "interface/v1",
+            manifest: { name: "x", tag: "v1" },
+            interfaces: {
+                topics: [
+                    { name: "stream" },
+                    { name: "stream" }
+                ]
+            }
+        }"#;
+        let err = serde_json5::from_str::<PeppyInterface>(json5)
+            .expect_err("duplicate topic name must be rejected");
+        assert!(err.to_string().contains("duplicate"), "error: {err}");
+    }
+
+    #[test]
+    fn rejects_duplicate_service_names() {
+        let json5 = r#"{
+            peppy_schema: "interface/v1",
+            manifest: { name: "x", tag: "v1" },
+            interfaces: {
+                services: [
+                    { name: "svc" },
+                    { name: "svc" }
+                ]
+            }
+        }"#;
+        assert!(serde_json5::from_str::<PeppyInterface>(json5).is_err());
+    }
+
+    #[test]
+    fn rejects_duplicate_action_names() {
+        let json5 = r#"{
+            peppy_schema: "interface/v1",
+            manifest: { name: "x", tag: "v1" },
+            interfaces: {
+                actions: [
+                    { name: "act" },
+                    { name: "act" }
+                ]
+            }
+        }"#;
+        assert!(serde_json5::from_str::<PeppyInterface>(json5).is_err());
+    }
+
+    /// A topic with the same name as a service is allowed: the daemon
+    /// addresses them through distinct namespaces, so an interface can
+    /// reasonably emit `/status` while also exposing a `status` service.
+    #[test]
+    fn allows_same_name_across_kinds() {
+        let json5 = r#"{
+            peppy_schema: "interface/v1",
+            manifest: { name: "x", tag: "v1" },
+            interfaces: {
+                topics: [ { name: "ping" } ],
+                services: [ { name: "ping" } ],
+                actions: [ { name: "ping" } ]
+            }
+        }"#;
+        let parsed: PeppyInterface =
+            serde_json5::from_str(json5).expect("cross-kind name collisions are allowed");
+        assert_eq!(parsed.interfaces.topics.len(), 1);
+        assert_eq!(parsed.interfaces.services.len(), 1);
+        assert_eq!(parsed.interfaces.actions.len(), 1);
+    }
+
+    /// Round-tripping survives canonicalization — the parsed AST serializes
+    /// back to a form that re-parses to the same AST.
+    #[test]
+    fn round_trips_through_serde() {
+        let original = PeppyInterface {
+            peppy_schema: PeppySchema::InterfaceV1,
+            manifest: Manifest {
+                name: Name::new("camera").unwrap(),
+                tag: "v123".to_string(),
+                labels: Some(vec!["vendor".to_string(), "sensor".to_string()]),
+            },
+            interfaces: Interfaces {
+                topics: vec![EmittedTopic {
+                    name: "stream".to_string(),
+                    qos_profile: QoSProfile::SensorData,
+                    message_format: Some(MessageFormat(
+                        [("width".to_string(), SchemaType::Type(TypeToken::U32))]
+                            .into_iter()
+                            .collect(),
+                    )),
+                }],
+                services: vec![],
+                actions: vec![],
+            },
+        };
+
+        let serialized = serde_json5::to_string(&original).expect("serialize");
+        let reparsed: PeppyInterface = serde_json5::from_str(&serialized).expect("re-parse");
+        assert_eq!(original, reparsed);
+    }
+}

--- a/crates/daemon-config-internal/src/interface/types.rs
+++ b/crates/daemon-config-internal/src/interface/types.rs
@@ -1,4 +1,4 @@
-use crate::{
+use config::{
     node::{EmittedTopic, ExposedAction, ExposedService, Name},
     schema::PeppySchema,
 };
@@ -52,7 +52,7 @@ where
     D: Deserializer<'de>,
 {
     let tag = String::deserialize(deserializer)?;
-    crate::internal::repo_node_id::validate_repo_node_tag(&tag, "tag")
+    config::repo_node_id::validate_repo_node_tag(&tag, "tag")
         .map_err(de::Error::custom)?;
     Ok(tag)
 }
@@ -138,7 +138,7 @@ pub(crate) fn validate_named_items<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::node::{ArrayKind, MessageFormat, QoSProfile, SchemaType, TypeToken};
+    use config::node::{ArrayKind, MessageFormat, QoSProfile, SchemaType, TypeToken};
 
     /// The depth-camera example from the schema doc parses end-to-end and
     /// exposes every field the way the user wrote it.

--- a/crates/daemon-config-internal/src/launcher.rs
+++ b/crates/daemon-config-internal/src/launcher.rs
@@ -1,0 +1,15 @@
+mod bindings;
+mod parse;
+mod types;
+
+// Defines the parsing of launcher documents (`peppy_schema: "launcher/v1"`).
+// The conventional filename is `peppy_launcher.json5` for standalone projects,
+// but the parser is filename-agnostic — repository discovery accepts any
+// `.json5` file whose body declares the launcher schema.
+pub use bindings::{BindingValidationItem, ValidatedBindings, validate_bindings};
+pub use parse::PeppyLauncherParser;
+pub use types::{
+    Deployment, DeploymentGitSource, DeploymentInstance, DeploymentLocalSource,
+    DeploymentRepoSource, DeploymentSource, DeploymentUrlSource, FrameworkOverrides, Name,
+    PeppyLauncher,
+};

--- a/crates/daemon-config-internal/src/launcher.rs
+++ b/crates/daemon-config-internal/src/launcher.rs
@@ -10,6 +10,6 @@ pub use bindings::{BindingValidationItem, ValidatedBindings, validate_bindings};
 pub use parse::PeppyLauncherParser;
 pub use types::{
     Deployment, DeploymentGitSource, DeploymentInstance, DeploymentLocalSource,
-    DeploymentRepoSource, DeploymentSource, DeploymentUrlSource, FrameworkOverrides, Name,
+    DeploymentRepoSource, DeploymentSource, DeploymentUrlSource, FrameworkOverrides,
     PeppyLauncher,
 };

--- a/crates/daemon-config-internal/src/launcher/bindings.rs
+++ b/crates/daemon-config-internal/src/launcher/bindings.rs
@@ -1,0 +1,1422 @@
+//! Plan-phase validation for the launcher's per-instance `bindings`
+//! field. Runs after node configs are loaded so the validator can
+//! cross-reference each consumer's `depends_on` against the running
+//! stack snapshot's `instance_id → (name, tag)` lookup.
+//!
+//! In the binding-driven dispatch model, every `(KEY, VALUE)` binding
+//! resolves to one of the consumer's declared slots:
+//!
+//! - If `KEY` matches a declared pinned `link_id`, the binding pins
+//!   that slot to producer `VALUE`.
+//! - Else, if a `from_any: true` slot exists for `VALUE`'s `(name,
+//!   tag)`, the binding attaches `VALUE` to that slot under the
+//!   free-form label `KEY`. Multiple bindings on the same from_any
+//!   slot accumulate.
+//! - Else, the binding is dead (rejected).
+//!
+//! The validator emits both errors and the resolved per-slot
+//! `SlotBinding` map per consumer instance, which the caller
+//! serializes into [`crate::runtime::NodeInstanceConfig::slot_bindings`].
+
+use crate::error::{
+    BindingDeadKey, BindingInterfaceNotConformed, BindingMissingForPinnedDep,
+    BindingTargetMismatch, DuplicateInstanceIdAcrossStack, ParsingError, SlotKind,
+};
+use crate::node::{ConformsToItem, DependsOn};
+use crate::runtime::{ProducerRef, SlotBinding};
+use std::collections::BTreeMap;
+
+use super::types::DeploymentInstance;
+
+/// Minimal view of one planned deployment needed for binding
+/// validation. Built by the launcher with borrowed references to avoid
+/// cloning the full planned-deployment graph; consumed by
+/// [`validate_bindings`].
+pub struct BindingValidationItem<'a> {
+    pub node_name: &'a str,
+    pub node_tag: &'a str,
+    pub instances: &'a [DeploymentInstance],
+    pub depends_on: Option<&'a DependsOn>,
+    /// Producer's `interfaces.conforms_to` list, borrowed as a slice.
+    /// Empty when the node declares no conformance. Used by the validator
+    /// to decide whether this node can satisfy a consumer's interface
+    /// slot.
+    pub conforms_to: &'a [ConformsToItem],
+}
+
+/// Per-slot metadata extracted from `depends_on` during validation.
+/// Carrying `kind` inline lets both pinned and from_any paths branch
+/// without re-scanning `depends_on` per binding.
+#[derive(Clone, Copy)]
+struct SlotMeta<'a> {
+    name: &'a str,
+    tag: &'a str,
+    kind: SlotKind,
+}
+
+/// Outcome of [`validate_bindings`]. `errors` aggregates every validator
+/// rule violation; `slot_bindings` carries the resolved per-slot view
+/// for every consumer instance whose bindings parsed cleanly. The caller
+/// must check `errors.is_empty()` before consuming the resolution.
+#[derive(Debug, Default)]
+pub struct ValidatedBindings {
+    pub errors: Vec<ParsingError>,
+    /// `consumer_instance_id → link_id → SlotBinding`.
+    pub slot_bindings: BTreeMap<String, BTreeMap<String, SlotBinding>>,
+}
+
+/// Run all binding validator rules over the snapshot. Returns
+/// aggregated errors (ordering is deterministic across runs) plus the
+/// resolved per-slot bindings for each consumer instance.
+///
+/// `producer_core_node` is the core_node of the daemon this stack
+/// deploys under. The raw `--bind KEY@instance_id` syntax names
+/// producers by `instance_id` alone (unique within one stack); the wire
+/// addresses producers by the `(core_node, instance_id)` pair, so this
+/// validator is the single point where every resolved binding is
+/// stamped with the full [`ProducerRef`]. Stacks are daemon-scoped, so
+/// every producer in the snapshot lives on the launching daemon. If
+/// cross-daemon stacks ever land, the launcher knows each instance's
+/// target daemon and the stamp generalizes to a per-instance input.
+///
+/// Rules enforced (numbered to match `BINDING_ROUTING.md`):
+/// 1. Every pinned `depends_on` entry has a matching `--bind` whose
+///    `KEY` equals the slot's `link_id`. Otherwise
+///    [`ParsingError::BindingMissingForPinnedDep`].
+/// 3. Free-form `--bind KEY@VALUE` where `KEY` doesn't match a pinned
+///    `link_id` is accepted if a `from_any: true` slot exists for
+///    VALUE's `(name, tag)`. Multiple bindings on the same from_any
+///    slot accumulate.
+/// 4. A `--bind` whose `KEY` matches neither a pinned `link_id` nor a
+///    `from_any` slot for VALUE's `(name, tag)` is
+///    [`ParsingError::BindingDeadKey`].
+/// 5. A pinned binding whose target instance deploys the wrong node
+///    is [`ParsingError::BindingTargetMismatch`].
+/// 6. `--bind KEY` uniqueness within one invocation is enforced by the
+///    CLI parser and the deserializer; this validator surfaces any
+///    residual duplicates as
+///    [`ParsingError::BindingDuplicateKey`] (defensive — should not
+///    fire in practice).
+/// 7. Stack-wide `instance_id` uniqueness across every entry in
+///    `items.instances` is enforced; collisions emit
+///    [`ParsingError::DuplicateInstanceIdAcrossStack`].
+pub fn validate_bindings(
+    items: &[BindingValidationItem<'_>],
+    producer_core_node: &str,
+) -> ValidatedBindings {
+    let mut out = ValidatedBindings::default();
+
+    check_stack_wide_instance_id_uniqueness(items, &mut out.errors);
+
+    let instance_to_item = build_instance_lookup(items);
+
+    for item in items {
+        let (declared_pinned, declared_from_any) = collect_declared_slots(item.depends_on);
+        let declared_csv = format_declared_keys(&declared_pinned, &declared_from_any);
+
+        for instance in item.instances {
+            let mut resolved: BTreeMap<String, SlotBinding> = BTreeMap::new();
+            let mut from_any_explicit: BTreeMap<String, Vec<String>> = BTreeMap::new();
+            let mut seen_keys: std::collections::BTreeSet<&str> = std::collections::BTreeSet::new();
+            // Pinned link_ids whose KEY appeared in the binding map
+            // (even if the resolution errored). Used to skip rule 1's
+            // pinned-unbound report so we don't double-emit on top of a
+            // BindingTargetMismatch / UnknownInstanceId for the same
+            // slot.
+            let mut pinned_keys_seen: std::collections::BTreeSet<&str> =
+                std::collections::BTreeSet::new();
+
+            for (binding_key, target_id) in &instance.bindings {
+                // Rule 6 defensive check.
+                if !seen_keys.insert(binding_key.as_str()) {
+                    out.errors.push(ParsingError::BindingDuplicateKey {
+                        owner_instance_id: instance.instance_id.to_string(),
+                        binding: binding_key.clone(),
+                    });
+                    continue;
+                }
+
+                if let Some(slot) = declared_pinned.get(binding_key.as_str()).copied() {
+                    // Rule 2: KEY matches a declared pinned link_id.
+                    pinned_keys_seen.insert(binding_key.as_str());
+                    let Some(target_item) = instance_to_item.get(target_id.as_str()) else {
+                        out.errors.push(ParsingError::UnknownInstanceId {
+                            owner_instance_id: instance.instance_id.to_string(),
+                            binding: binding_key.clone(),
+                            instance_id: target_id.clone(),
+                        });
+                        continue;
+                    };
+                    if !slot_matches_producer(&slot, target_item) {
+                        out.errors.push(match slot.kind {
+                            SlotKind::Node => ParsingError::BindingTargetMismatch(Box::new(
+                                BindingTargetMismatch {
+                                    owner_instance_id: instance.instance_id.to_string(),
+                                    binding: binding_key.clone(),
+                                    target_instance_id: target_id.clone(),
+                                    expected_name: slot.name.to_string(),
+                                    expected_tag: slot.tag.to_string(),
+                                    actual_name: target_item.node_name.to_string(),
+                                    actual_tag: target_item.node_tag.to_string(),
+                                },
+                            )),
+                            SlotKind::Interface => ParsingError::BindingInterfaceNotConformed(
+                                Box::new(BindingInterfaceNotConformed {
+                                    owner_instance_id: instance.instance_id.to_string(),
+                                    binding: binding_key.clone(),
+                                    target_instance_id: target_id.clone(),
+                                    interface_name: slot.name.to_string(),
+                                    interface_tag: slot.tag.to_string(),
+                                    producer_name: target_item.node_name.to_string(),
+                                    producer_tag: target_item.node_tag.to_string(),
+                                }),
+                            ),
+                        });
+                        continue;
+                    }
+                    resolved.insert(
+                        binding_key.clone(),
+                        SlotBinding::Pinned {
+                            producer: ProducerRef::new(producer_core_node, target_id.clone()),
+                        },
+                    );
+                    continue;
+                }
+
+                // KEY does not match a pinned link_id. Try to attach to a
+                // from_any slot. Node slots match by `(name, tag)`;
+                // interface slots match against the producer's
+                // `conforms_to` claim.
+                let Some(target_item) = instance_to_item.get(target_id.as_str()) else {
+                    out.errors.push(ParsingError::UnknownInstanceId {
+                        owner_instance_id: instance.instance_id.to_string(),
+                        binding: binding_key.clone(),
+                        instance_id: target_id.clone(),
+                    });
+                    continue;
+                };
+                let mut attached = false;
+                for (slot_link_id, slot) in &declared_from_any {
+                    if slot_matches_producer(slot, target_item) {
+                        from_any_explicit
+                            .entry((*slot_link_id).to_string())
+                            .or_default()
+                            .push(target_id.clone());
+                        attached = true;
+                        break;
+                    }
+                }
+                if !attached {
+                    out.errors
+                        .push(ParsingError::BindingDeadKey(Box::new(BindingDeadKey {
+                            owner_instance_id: instance.instance_id.to_string(),
+                            binding: binding_key.clone(),
+                            target_instance_id: target_id.clone(),
+                            producer_name: target_item.node_name.to_string(),
+                            producer_tag: target_item.node_tag.to_string(),
+                            declared_link_ids: declared_csv.clone(),
+                        })));
+                }
+            }
+
+            // After processing all bindings, materialize from_any slots.
+            for slot_link_id in declared_from_any.keys() {
+                let producers = from_any_explicit.remove(*slot_link_id);
+                let slot = match producers {
+                    Some(ids) => {
+                        // Distinct `--bind KEY@id` entries may name the same
+                        // target; collapse duplicates (preserving first-seen
+                        // order) so the slot doesn't pin one producer twice.
+                        let mut seen = std::collections::BTreeSet::new();
+                        SlotBinding::FromAnyBound {
+                            producers: ids
+                                .into_iter()
+                                .filter(|id| seen.insert(id.clone()))
+                                .map(|id| ProducerRef::new(producer_core_node, id))
+                                .collect(),
+                        }
+                    }
+                    None => SlotBinding::FromAnyUnbound,
+                };
+                resolved.insert((*slot_link_id).to_string(), slot);
+            }
+
+            // Rule 1: every pinned slot must be bound. Suppress when
+            // the slot's KEY was present in the binding map but
+            // errored elsewhere — surfacing both
+            // `BindingTargetMismatch` and `BindingMissingForPinnedDep`
+            // for the same slot is double-reporting one root cause.
+            for (slot_link_id, slot) in &declared_pinned {
+                if resolved.contains_key(*slot_link_id) {
+                    continue;
+                }
+                if pinned_keys_seen.contains(*slot_link_id) {
+                    continue;
+                }
+                out.errors
+                    .push(ParsingError::BindingMissingForPinnedDep(Box::new(
+                        BindingMissingForPinnedDep {
+                            owner_instance_id: instance.instance_id.to_string(),
+                            link_id: (*slot_link_id).to_string(),
+                            kind: slot.kind,
+                            expected_name: slot.name.to_string(),
+                            expected_tag: slot.tag.to_string(),
+                        },
+                    )));
+            }
+
+            if !resolved.is_empty() {
+                out.slot_bindings
+                    .insert(instance.instance_id.to_string(), resolved);
+            }
+        }
+    }
+
+    out
+}
+
+/// Build `instance_id → BindingValidationItem` lookup. Duplicate IDs
+/// across `items` are surfaced separately by
+/// [`check_stack_wide_instance_id_uniqueness`]; this builder uses
+/// insertion-wins (alphabetical first occurrence) so subsequent checks
+/// still have a usable lookup even when a duplicate exists.
+fn build_instance_lookup<'a>(
+    items: &'a [BindingValidationItem<'a>],
+) -> BTreeMap<&'a str, &'a BindingValidationItem<'a>> {
+    let mut lookup = BTreeMap::new();
+    for item in items {
+        for instance in item.instances {
+            lookup.entry(instance.instance_id.as_str()).or_insert(item);
+        }
+    }
+    lookup
+}
+
+/// Stack-wide `instance_id` uniqueness (rule 7). Two entries anywhere
+/// in `items.instances` (across any `(node_name, node_tag)`) sharing
+/// an `instance_id` is a hard error: `--bind KEY@id` would be
+/// ambiguous.
+fn check_stack_wide_instance_id_uniqueness(
+    items: &[BindingValidationItem<'_>],
+    errors: &mut Vec<ParsingError>,
+) {
+    // (name, tag) of the first occurrence of each instance_id.
+    let mut seen: BTreeMap<&str, (&str, &str)> = BTreeMap::new();
+    for item in items {
+        for instance in item.instances {
+            let id = instance.instance_id.as_str();
+            if let Some((name_a, tag_a)) = seen.get(id) {
+                // Report every cross-item duplicate, even when the two
+                // colliding entries share the same `(node_name,
+                // node_tag)`. `deserialize_instances` only dedupes
+                // within a single deployment's `instances` array, so two
+                // SEPARATE planned items carrying the same `(name, tag)`
+                // can each hold the same `instance_id` and slip past that
+                // check. If we skipped them here, `build_instance_lookup`
+                // would silently resolve the collision by first
+                // insertion, making `--bind KEY@id` ambiguous.
+                errors.push(ParsingError::DuplicateInstanceIdAcrossStack(Box::new(
+                    DuplicateInstanceIdAcrossStack {
+                        instance_id: id.to_string(),
+                        name_a: (*name_a).to_string(),
+                        tag_a: (*tag_a).to_string(),
+                        name_b: item.node_name.to_string(),
+                        tag_b: item.node_tag.to_string(),
+                    },
+                )));
+            } else {
+                seen.insert(id, (item.node_name, item.node_tag));
+            }
+        }
+    }
+}
+
+type DeclaredSlots<'a> = BTreeMap<&'a str, SlotMeta<'a>>;
+
+/// Split declared `depends_on` entries into pinned (`from_any: false`)
+/// and `from_any: true` slots. Each map is keyed by `link_id` and
+/// values carry the dep's `(name, tag, kind)` so the matching paths can
+/// branch on node-vs-interface without re-scanning the manifest.
+fn collect_declared_slots(
+    depends_on: Option<&DependsOn>,
+) -> (DeclaredSlots<'_>, DeclaredSlots<'_>) {
+    let mut pinned = BTreeMap::new();
+    let mut from_any = BTreeMap::new();
+    if let Some(deps) = depends_on {
+        for dep in &deps.nodes {
+            let meta = SlotMeta {
+                name: dep.name.as_str(),
+                tag: dep.tag.as_str(),
+                kind: SlotKind::Node,
+            };
+            if dep.from_any {
+                from_any.insert(dep.link_id.as_str(), meta);
+            } else {
+                pinned.insert(dep.link_id.as_str(), meta);
+            }
+        }
+        for dep in &deps.interfaces {
+            let meta = SlotMeta {
+                name: dep.name.as_str(),
+                tag: dep.tag.as_str(),
+                kind: SlotKind::Interface,
+            };
+            if dep.from_any {
+                from_any.insert(dep.link_id.as_str(), meta);
+            } else {
+                pinned.insert(dep.link_id.as_str(), meta);
+            }
+        }
+    }
+    (pinned, from_any)
+}
+
+/// Does a producer satisfy a declared slot? Node slots match by
+/// `(name, tag)` identity; interface slots match against the producer's
+/// `conforms_to`. sha256 is not cross-checked here — each side
+/// independently verifies its own declared sha256 against the on-disk
+/// interface document at cache resolution time.
+fn slot_matches_producer(slot: &SlotMeta<'_>, producer: &BindingValidationItem<'_>) -> bool {
+    match slot.kind {
+        SlotKind::Node => producer.node_name == slot.name && producer.node_tag == slot.tag,
+        SlotKind::Interface => producer
+            .conforms_to
+            .iter()
+            .any(|item| item.name.as_str() == slot.name && item.tag.as_str() == slot.tag),
+    }
+}
+
+fn format_declared_keys(pinned: &DeclaredSlots<'_>, from_any: &DeclaredSlots<'_>) -> String {
+    let mut keys: Vec<&str> = pinned.keys().chain(from_any.keys()).copied().collect();
+    keys.sort();
+    keys.dedup();
+    keys.join(", ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The launching daemon's core_node stamped into every resolved
+    /// binding by these tests.
+    const TEST_CORE: &str = "core_a";
+
+    fn parse_instances(json5: &str) -> Vec<DeploymentInstance> {
+        serde_json5::from_str(json5).expect("instances fixture should parse")
+    }
+
+    fn parse_depends_on(json5: &str) -> DependsOn {
+        serde_json5::from_str(json5).expect("depends_on fixture should parse")
+    }
+
+    fn parse_conforms_to(json5: &str) -> Vec<ConformsToItem> {
+        serde_json5::from_str(json5).expect("conforms_to fixture should parse")
+    }
+
+    /// Convenience: build a `BindingValidationItem` whose lifetimes
+    /// stay tethered to the caller's locals.
+    fn item<'a>(
+        node_name: &'a str,
+        node_tag: &'a str,
+        instances: &'a [DeploymentInstance],
+        depends_on: Option<&'a DependsOn>,
+    ) -> BindingValidationItem<'a> {
+        BindingValidationItem {
+            node_name,
+            node_tag,
+            instances,
+            depends_on,
+            conforms_to: &[],
+        }
+    }
+
+    /// Like `item` but also threads a `conforms_to` slice — for tests
+    /// that exercise interface-conformance matching.
+    fn item_with_conforms_to<'a>(
+        node_name: &'a str,
+        node_tag: &'a str,
+        instances: &'a [DeploymentInstance],
+        depends_on: Option<&'a DependsOn>,
+        conforms_to: &'a [ConformsToItem],
+    ) -> BindingValidationItem<'a> {
+        BindingValidationItem {
+            node_name,
+            node_tag,
+            instances,
+            depends_on,
+            conforms_to,
+        }
+    }
+
+    fn slot_binding(out: &ValidatedBindings, instance: &str, link_id: &str) -> Option<SlotBinding> {
+        out.slot_bindings
+            .get(instance)
+            .and_then(|m| m.get(link_id))
+            .cloned()
+    }
+
+    #[test]
+    fn empty_planned_set_returns_no_errors() {
+        let out = validate_bindings(&[], TEST_CORE);
+        assert!(out.errors.is_empty());
+        assert!(out.slot_bindings.is_empty());
+    }
+
+    /// A consumer with no `depends_on` and no `bindings` is trivially
+    /// valid.
+    #[test]
+    fn consumer_without_depends_on_and_without_bindings_is_valid() {
+        let instances = parse_instances(r#"[{ instance_id: "cons1" }]"#);
+        let items = vec![item("cons", "v1", &instances, None)];
+        let out = validate_bindings(&items, TEST_CORE);
+        assert!(out.errors.is_empty(), "unexpected errors: {:?}", out.errors);
+        assert!(out.slot_bindings.is_empty());
+    }
+
+    /// Rule 4: a `--bind KEY@VALUE` whose KEY matches neither a pinned
+    /// link_id nor a from_any slot for VALUE's (name, tag) is dead.
+    #[test]
+    fn rule4_rejects_dead_binding_key() {
+        let instances = parse_instances(
+            r#"[{
+                instance_id: "cons1",
+                bindings: { main: "prod1", stale_slot: "prod1" }
+            }]"#,
+        );
+        let depends_on = parse_depends_on(
+            r#"{
+                nodes: [{ name: "camera", tag: "v1", link_id: "main" }]
+            }"#,
+        );
+        let prod_instances = parse_instances(r#"[{ instance_id: "prod1" }]"#);
+        let items = vec![
+            item("cons", "v1", &instances, Some(&depends_on)),
+            item("camera", "v1", &prod_instances, None),
+        ];
+        let out = validate_bindings(&items, TEST_CORE);
+        assert_eq!(
+            out.errors.len(),
+            1,
+            "expected one error, got {:?}",
+            out.errors
+        );
+        let ParsingError::BindingDeadKey(info) = &out.errors[0] else {
+            panic!("expected BindingDeadKey, got {:?}", out.errors[0]);
+        };
+        assert_eq!(info.owner_instance_id, "cons1");
+        assert_eq!(info.binding, "stale_slot");
+        assert_eq!(info.target_instance_id, "prod1");
+        assert_eq!(info.producer_name, "camera");
+        assert_eq!(info.producer_tag, "v1");
+        assert_eq!(info.declared_link_ids, "main");
+    }
+
+    /// Rule 1: pinned-unbound is a hard error.
+    #[test]
+    fn rule1_rejects_pinned_unbound() {
+        let instances = parse_instances(r#"[{ instance_id: "cons1" }]"#);
+        let depends_on = parse_depends_on(
+            r#"{
+                nodes: [{ name: "camera", tag: "v1", link_id: "main" }]
+            }"#,
+        );
+        let items = vec![item("cons", "v1", &instances, Some(&depends_on))];
+        let out = validate_bindings(&items, TEST_CORE);
+        assert_eq!(out.errors.len(), 1);
+        let ParsingError::BindingMissingForPinnedDep(info) = &out.errors[0] else {
+            panic!(
+                "expected BindingMissingForPinnedDep, got {:?}",
+                out.errors[0]
+            );
+        };
+        assert_eq!(info.owner_instance_id, "cons1");
+        assert_eq!(info.link_id, "main");
+        assert_eq!(info.kind, SlotKind::Node);
+        assert_eq!(info.expected_name, "camera");
+        assert_eq!(info.expected_tag, "v1");
+        let msg = info.to_string();
+        assert!(
+            msg.contains("slot `main` is unbound"),
+            "unexpected error message: {msg}"
+        );
+        assert!(
+            msg.contains("expected node `camera:v1`"),
+            "unexpected error message: {msg}"
+        );
+    }
+
+    /// Rule 2 (happy path): pinned binding resolves to
+    /// `SlotBinding::Pinned`.
+    #[test]
+    fn rule2_pinned_binding_resolves_to_pinned() {
+        let cons_instances = parse_instances(
+            r#"[{
+                instance_id: "cons1",
+                bindings: { main: "prod1" }
+            }]"#,
+        );
+        let depends_on = parse_depends_on(
+            r#"{
+                nodes: [{ name: "camera", tag: "v1", link_id: "main" }]
+            }"#,
+        );
+        let prod_instances = parse_instances(r#"[{ instance_id: "prod1" }]"#);
+        let items = vec![
+            item("cons", "v1", &cons_instances, Some(&depends_on)),
+            item("camera", "v1", &prod_instances, None),
+        ];
+        let out = validate_bindings(&items, TEST_CORE);
+        assert!(out.errors.is_empty(), "unexpected errors: {:?}", out.errors);
+        assert_eq!(
+            slot_binding(&out, "cons1", "main"),
+            Some(SlotBinding::Pinned {
+                producer: ProducerRef::new(TEST_CORE, "prod1")
+            })
+        );
+    }
+
+    /// Rule 3 (happy path): a free-form key whose target's (name, tag)
+    /// matches a from_any slot attaches the binding to that slot.
+    #[test]
+    fn rule3_free_form_key_resolves_to_from_any_slot() {
+        let cons_instances = parse_instances(
+            r#"[{
+                instance_id: "cons1",
+                bindings: { the_extra: "prod1" }
+            }]"#,
+        );
+        let depends_on = parse_depends_on(
+            r#"{
+                nodes: [{ name: "camera", tag: "v1", link_id: "extra", from_any: true }]
+            }"#,
+        );
+        let prod_instances = parse_instances(r#"[{ instance_id: "prod1" }]"#);
+        let items = vec![
+            item("cons", "v1", &cons_instances, Some(&depends_on)),
+            item("camera", "v1", &prod_instances, None),
+        ];
+        let out = validate_bindings(&items, TEST_CORE);
+        assert!(out.errors.is_empty(), "unexpected errors: {:?}", out.errors);
+        assert_eq!(
+            slot_binding(&out, "cons1", "extra"),
+            Some(SlotBinding::FromAnyBound {
+                producers: vec![ProducerRef::new(TEST_CORE, "prod1")]
+            })
+        );
+    }
+
+    /// Rule 3: multiple free-form keys on the same from_any slot
+    /// accumulate.
+    #[test]
+    fn rule3_multiple_free_form_keys_accumulate_on_from_any_slot() {
+        let cons_instances = parse_instances(
+            r#"[{
+                instance_id: "cons1",
+                bindings: { alpha: "prod1", beta: "prod2" }
+            }]"#,
+        );
+        let depends_on = parse_depends_on(
+            r#"{
+                nodes: [{ name: "camera", tag: "v1", link_id: "extra", from_any: true }]
+            }"#,
+        );
+        let prod_instances = parse_instances(
+            r#"[
+                { instance_id: "prod1" },
+                { instance_id: "prod2" }
+            ]"#,
+        );
+        let items = vec![
+            item("cons", "v1", &cons_instances, Some(&depends_on)),
+            item("camera", "v1", &prod_instances, None),
+        ];
+        let out = validate_bindings(&items, TEST_CORE);
+        assert!(out.errors.is_empty(), "unexpected errors: {:?}", out.errors);
+        let Some(SlotBinding::FromAnyBound { producers }) = slot_binding(&out, "cons1", "extra")
+        else {
+            panic!(
+                "expected FromAnyBound, got {:?}",
+                slot_binding(&out, "cons1", "extra")
+            );
+        };
+        let mut producers = producers;
+        producers.sort();
+        assert_eq!(
+            producers,
+            vec![
+                ProducerRef::new(TEST_CORE, "prod1"),
+                ProducerRef::new(TEST_CORE, "prod2"),
+            ]
+        );
+    }
+
+    /// Rule 3: two free-form keys naming the same target collapse to a
+    /// single producer entry on the from_any slot.
+    #[test]
+    fn rule3_duplicate_free_form_targets_dedupe_on_from_any_slot() {
+        let cons_instances = parse_instances(
+            r#"[{
+                instance_id: "cons1",
+                bindings: { alpha: "prod1", beta: "prod1" }
+            }]"#,
+        );
+        let depends_on = parse_depends_on(
+            r#"{
+                nodes: [{ name: "camera", tag: "v1", link_id: "extra", from_any: true }]
+            }"#,
+        );
+        let prod_instances = parse_instances(r#"[{ instance_id: "prod1" }]"#);
+        let items = vec![
+            item("cons", "v1", &cons_instances, Some(&depends_on)),
+            item("camera", "v1", &prod_instances, None),
+        ];
+        let out = validate_bindings(&items, TEST_CORE);
+        assert!(out.errors.is_empty(), "unexpected errors: {:?}", out.errors);
+        assert_eq!(
+            slot_binding(&out, "cons1", "extra"),
+            Some(SlotBinding::FromAnyBound {
+                producers: vec![ProducerRef::new(TEST_CORE, "prod1")]
+            })
+        );
+    }
+
+    /// Rule 3: a free-form key whose target's (name, tag) doesn't
+    /// match any from_any slot is dead.
+    #[test]
+    fn rule3_free_form_key_without_matching_from_any_is_dead() {
+        let cons_instances = parse_instances(
+            r#"[{
+                instance_id: "cons1",
+                bindings: { the_extra: "lidar_inst" }
+            }]"#,
+        );
+        let depends_on = parse_depends_on(
+            r#"{
+                nodes: [{ name: "camera", tag: "v1", link_id: "extra", from_any: true }]
+            }"#,
+        );
+        let prod_instances = parse_instances(r#"[{ instance_id: "lidar_inst" }]"#);
+        let items = vec![
+            item("cons", "v1", &cons_instances, Some(&depends_on)),
+            item("lidar", "v1", &prod_instances, None),
+        ];
+        let out = validate_bindings(&items, TEST_CORE);
+        assert_eq!(out.errors.len(), 1);
+        assert!(matches!(out.errors[0], ParsingError::BindingDeadKey(_)));
+    }
+
+    /// A `from_any` slot with no bindings resolves to
+    /// `SlotBinding::FromAnyUnbound`.
+    #[test]
+    fn from_any_without_bindings_resolves_to_unbound() {
+        let cons_instances = parse_instances(r#"[{ instance_id: "cons1" }]"#);
+        let depends_on = parse_depends_on(
+            r#"{
+                nodes: [{ name: "camera", tag: "v1", link_id: "extra", from_any: true }]
+            }"#,
+        );
+        let items = vec![item("cons", "v1", &cons_instances, Some(&depends_on))];
+        let out = validate_bindings(&items, TEST_CORE);
+        assert!(out.errors.is_empty(), "unexpected errors: {:?}", out.errors);
+        assert_eq!(
+            slot_binding(&out, "cons1", "extra"),
+            Some(SlotBinding::FromAnyUnbound)
+        );
+    }
+
+    /// Rule 1 (interface variant): pinned interface dep without
+    /// binding fails the same way.
+    #[test]
+    fn rule1_rejects_missing_binding_for_pinned_interface_dep() {
+        let instances = parse_instances(r#"[{ instance_id: "cons1" }]"#);
+        let depends_on = parse_depends_on(
+            r#"{
+                nodes: [],
+                interfaces: [{
+                    name: "depth_camera",
+                    tag: "v1",
+                    link_id: "depth"
+                }]
+            }"#,
+        );
+        let items = vec![item("cons", "v1", &instances, Some(&depends_on))];
+        let out = validate_bindings(&items, TEST_CORE);
+        assert_eq!(out.errors.len(), 1);
+        let ParsingError::BindingMissingForPinnedDep(info) = &out.errors[0] else {
+            panic!(
+                "expected BindingMissingForPinnedDep, got {:?}",
+                out.errors[0]
+            );
+        };
+        assert_eq!(info.kind, SlotKind::Interface);
+        assert_eq!(info.link_id, "depth");
+    }
+
+    /// Rule 5: pinned binding whose target deploys the wrong node.
+    #[test]
+    fn rule5_rejects_target_node_mismatch() {
+        let cons_instances = parse_instances(
+            r#"[{
+                instance_id: "cons1",
+                bindings: { main: "actually_lidar" }
+            }]"#,
+        );
+        let depends_on = parse_depends_on(
+            r#"{
+                nodes: [{ name: "camera", tag: "v1", link_id: "main" }]
+            }"#,
+        );
+        let prod_instances = parse_instances(r#"[{ instance_id: "actually_lidar" }]"#);
+        let items = vec![
+            item("cons", "v1", &cons_instances, Some(&depends_on)),
+            item("lidar", "v1", &prod_instances, None),
+        ];
+        let out = validate_bindings(&items, TEST_CORE);
+        assert_eq!(out.errors.len(), 1);
+        let ParsingError::BindingTargetMismatch(info) = &out.errors[0] else {
+            panic!("expected BindingTargetMismatch, got {:?}", out.errors[0]);
+        };
+        assert_eq!(info.owner_instance_id, "cons1");
+        assert_eq!(info.binding, "main");
+        assert_eq!(info.target_instance_id, "actually_lidar");
+    }
+
+    /// Pinned interface bindings check the producer's `conforms_to`
+    /// (not just node identity). A producer with no matching
+    /// `conforms_to` entry is rejected with
+    /// `BindingInterfaceNotConformed`.
+    #[test]
+    fn pinned_interface_binding_rejects_non_conforming_producer() {
+        let cons_instances = parse_instances(
+            r#"[{
+                instance_id: "cons1",
+                bindings: { depth: "any_producer" }
+            }]"#,
+        );
+        let depends_on = parse_depends_on(
+            r#"{
+                nodes: [],
+                interfaces: [{
+                    name: "depth_camera",
+                    tag: "v1",
+                    link_id: "depth"
+                }]
+            }"#,
+        );
+        let prod_instances = parse_instances(r#"[{ instance_id: "any_producer" }]"#);
+        let items = vec![
+            item("cons", "v1", &cons_instances, Some(&depends_on)),
+            item("whatever", "v1", &prod_instances, None),
+        ];
+        let out = validate_bindings(&items, TEST_CORE);
+        assert_eq!(out.errors.len(), 1, "errors: {:?}", out.errors);
+        let ParsingError::BindingInterfaceNotConformed(info) = &out.errors[0] else {
+            panic!(
+                "expected BindingInterfaceNotConformed, got {:?}",
+                out.errors[0]
+            );
+        };
+        assert_eq!(info.binding, "depth");
+        assert_eq!(info.interface_name, "depth_camera");
+        assert_eq!(info.interface_tag, "v1");
+        assert_eq!(info.producer_name, "whatever");
+        assert_eq!(info.producer_tag, "v1");
+    }
+
+    /// Pinned interface dep targets a producer whose `conforms_to`
+    /// includes the requested interface: accepted as `SlotBinding::Pinned`.
+    /// The producer's node name is intentionally different from the
+    /// interface name so this test exercises the conformance path
+    /// rather than a coincidental identity match.
+    #[test]
+    fn pinned_interface_binding_accepts_conforming_producer() {
+        let cons_instances = parse_instances(
+            r#"[{
+                instance_id: "cons1",
+                bindings: { depth: "webcam_inst_1" }
+            }]"#,
+        );
+        let depends_on = parse_depends_on(
+            r#"{
+                nodes: [],
+                interfaces: [{
+                    name: "depth_camera",
+                    tag: "v1",
+                    link_id: "depth"
+                }]
+            }"#,
+        );
+        let prod_instances = parse_instances(r#"[{ instance_id: "webcam_inst_1" }]"#);
+        let producer_conforms = parse_conforms_to(r#"[{ name: "depth_camera", tag: "v1" }]"#);
+        let items = vec![
+            item("cons", "v1", &cons_instances, Some(&depends_on)),
+            item_with_conforms_to("webcam", "v1", &prod_instances, None, &producer_conforms),
+        ];
+        let out = validate_bindings(&items, TEST_CORE);
+        assert!(out.errors.is_empty(), "unexpected errors: {:?}", out.errors);
+        assert_eq!(
+            slot_binding(&out, "cons1", "depth"),
+            Some(SlotBinding::Pinned {
+                producer: ProducerRef::new(TEST_CORE, "webcam_inst_1")
+            })
+        );
+    }
+
+    /// A well-formed launcher (matching the spec's openarm01_backbone
+    /// example: two pinned slots and a from_any slot) passes with no
+    /// errors and all slots resolve.
+    #[test]
+    fn openarm_style_manifest_resolves_all_slots() {
+        let cons_instances = parse_instances(
+            r#"[{
+                instance_id: "backbone_inst_1",
+                bindings: {
+                    wrist_left_camera: "depth_cam_inst1",
+                    wrist_right_camera: "depth_cam_inst1",
+                    the_extra_camera: "depth_cam_inst1"
+                }
+            }]"#,
+        );
+        let depends_on = parse_depends_on(
+            r#"{
+                nodes: [],
+                interfaces: [
+                    { name: "depth_camera", tag: "v1", link_id: "wrist_left_camera" },
+                    { name: "depth_camera", tag: "v1", link_id: "wrist_right_camera" },
+                    { name: "depth_camera", tag: "v1", link_id: "extra_cam", from_any: true }
+                ]
+            }"#,
+        );
+        let prod_instances = parse_instances(r#"[{ instance_id: "depth_cam_inst1" }]"#);
+        // Producer's node name coincidentally matches the interface
+        // name+tag, but the validator only honors explicit `conforms_to`
+        // claims — node-identity matching never satisfies an interface
+        // slot.
+        let producer_conforms = parse_conforms_to(r#"[{ name: "depth_camera", tag: "v1" }]"#);
+        let items = vec![
+            item(
+                "openarm01_backbone",
+                "v1",
+                &cons_instances,
+                Some(&depends_on),
+            ),
+            item_with_conforms_to(
+                "depth_camera",
+                "v1",
+                &prod_instances,
+                None,
+                &producer_conforms,
+            ),
+        ];
+        let out = validate_bindings(&items, TEST_CORE);
+        assert!(out.errors.is_empty(), "unexpected errors: {:?}", out.errors);
+        assert_eq!(
+            slot_binding(&out, "backbone_inst_1", "wrist_left_camera"),
+            Some(SlotBinding::Pinned {
+                producer: ProducerRef::new(TEST_CORE, "depth_cam_inst1")
+            })
+        );
+        assert_eq!(
+            slot_binding(&out, "backbone_inst_1", "wrist_right_camera"),
+            Some(SlotBinding::Pinned {
+                producer: ProducerRef::new(TEST_CORE, "depth_cam_inst1")
+            })
+        );
+        assert_eq!(
+            slot_binding(&out, "backbone_inst_1", "extra_cam"),
+            Some(SlotBinding::FromAnyBound {
+                producers: vec![ProducerRef::new(TEST_CORE, "depth_cam_inst1")]
+            })
+        );
+    }
+
+    /// An "inert" item (`depends_on: None`) must NOT trigger Rule 1
+    /// against the slots it would have declared if `depends_on` were
+    /// populated — it represents a node whose bindings were already
+    /// resolved at spawn time. At the same time, its instances and
+    /// `conforms_to` must still feed the producer-lookup index so a
+    /// live consumer in the same `validate_bindings` call can satisfy
+    /// pinned node / interface deps against them.
+    ///
+    /// This locks in the contract that
+    /// `peppy::commands::node::run::validate_binds_against_stack`
+    /// relies on when it folds already-running stack nodes into the
+    /// validator snapshot without re-checking their bindings.
+    #[test]
+    fn inert_item_with_no_depends_on_does_not_trigger_rule1_but_remains_a_producer() {
+        // Live consumer with a pinned node dep + a pinned interface dep.
+        let cons_instances = parse_instances(
+            r#"[{
+                instance_id: "cons1",
+                bindings: { cam: "node_prod_inst", depth: "iface_prod_inst" }
+            }]"#,
+        );
+        let cons_depends_on = parse_depends_on(
+            r#"{
+                nodes: [{ name: "camera", tag: "v1", link_id: "cam" }],
+                interfaces: [{ name: "depth_camera", tag: "v1", link_id: "depth" }]
+            }"#,
+        );
+
+        // Inert node producer: depends_on omitted entirely, even though
+        // it WOULD declare deps in real life. If Rule 1 fired against
+        // inert items, this is where the false positive would surface.
+        let node_prod_instances = parse_instances(r#"[{ instance_id: "node_prod_inst" }]"#);
+
+        // Inert interface producer: same shape, plus a `conforms_to`
+        // entry that should still match the consumer's interface dep.
+        let iface_prod_instances = parse_instances(r#"[{ instance_id: "iface_prod_inst" }]"#);
+        let iface_prod_conforms = parse_conforms_to(r#"[{ name: "depth_camera", tag: "v1" }]"#);
+
+        let items = vec![
+            item("cons", "v1", &cons_instances, Some(&cons_depends_on)),
+            // Inert items: depends_on intentionally `None`.
+            item("camera", "v1", &node_prod_instances, None),
+            item_with_conforms_to(
+                "webcam",
+                "v1",
+                &iface_prod_instances,
+                None,
+                &iface_prod_conforms,
+            ),
+        ];
+        let out = validate_bindings(&items, TEST_CORE);
+        assert!(out.errors.is_empty(), "unexpected errors: {:?}", out.errors);
+        assert_eq!(
+            slot_binding(&out, "cons1", "cam"),
+            Some(SlotBinding::Pinned {
+                producer: ProducerRef::new(TEST_CORE, "node_prod_inst")
+            })
+        );
+        assert_eq!(
+            slot_binding(&out, "cons1", "depth"),
+            Some(SlotBinding::Pinned {
+                producer: ProducerRef::new(TEST_CORE, "iface_prod_inst")
+            })
+        );
+    }
+
+    /// Defensive: an instance lookup miss for a binding target.
+    #[test]
+    fn rejects_binding_whose_target_is_unknown_to_planner() {
+        let cons_instances = parse_instances(
+            r#"[{
+                instance_id: "cons1",
+                bindings: { main: "ghost_producer" }
+            }]"#,
+        );
+        let depends_on = parse_depends_on(
+            r#"{
+                nodes: [{ name: "camera", tag: "v1", link_id: "main" }]
+            }"#,
+        );
+        let items = vec![item("cons", "v1", &cons_instances, Some(&depends_on))];
+        let out = validate_bindings(&items, TEST_CORE);
+        assert_eq!(out.errors.len(), 1);
+        let ParsingError::UnknownInstanceId {
+            owner_instance_id,
+            binding,
+            instance_id,
+        } = &out.errors[0]
+        else {
+            panic!("expected UnknownInstanceId, got {:?}", out.errors[0]);
+        };
+        assert_eq!(owner_instance_id, "cons1");
+        assert_eq!(binding, "main");
+        assert_eq!(instance_id, "ghost_producer");
+    }
+
+    /// Rule 7: stack-wide instance_id duplicate across different
+    /// (node_name, node_tag).
+    #[test]
+    fn rule7_rejects_stack_wide_duplicate_instance_id() {
+        let camera_instances = parse_instances(r#"[{ instance_id: "shared_inst" }]"#);
+        let lidar_instances = parse_instances(r#"[{ instance_id: "shared_inst" }]"#);
+        let items = vec![
+            item("camera", "v1", &camera_instances, None),
+            item("lidar", "v1", &lidar_instances, None),
+        ];
+        let out = validate_bindings(&items, TEST_CORE);
+        assert_eq!(out.errors.len(), 1, "errors: {:?}", out.errors);
+        let ParsingError::DuplicateInstanceIdAcrossStack(info) = &out.errors[0] else {
+            panic!(
+                "expected DuplicateInstanceIdAcrossStack, got {:?}",
+                out.errors[0]
+            );
+        };
+        assert_eq!(info.instance_id, "shared_inst");
+        assert_eq!(info.name_a, "camera");
+        assert_eq!(info.tag_a, "v1");
+        assert_eq!(info.name_b, "lidar");
+        assert_eq!(info.tag_b, "v1");
+    }
+
+    /// Stack-wide check reports duplicate `instance_id`s even when the
+    /// colliding entries share the same `(name, tag)`. In real parsing
+    /// the deserializer's `deserialize_instances` rejects intra-array
+    /// duplicates before they reach the validator, but the validator
+    /// cannot distinguish that case from two separate planned items that
+    /// happen to share `(name, tag)`, so it reports defensively rather
+    /// than silently letting `build_instance_lookup` resolve by first
+    /// insertion.
+    #[test]
+    fn rule7_reports_duplicate_instance_id_even_for_same_name_tag() {
+        let camera_instances = parse_instances(
+            r#"[
+                { instance_id: "shared_inst" },
+                { instance_id: "shared_inst" }
+            ]"#,
+        );
+        let items = vec![item("camera", "v1", &camera_instances, None)];
+        let out = validate_bindings(&items, TEST_CORE);
+        assert_eq!(out.errors.len(), 1, "errors: {:?}", out.errors);
+        let ParsingError::DuplicateInstanceIdAcrossStack(info) = &out.errors[0] else {
+            panic!(
+                "expected DuplicateInstanceIdAcrossStack, got {:?}",
+                out.errors[0]
+            );
+        };
+        assert_eq!(info.instance_id, "shared_inst");
+        assert_eq!(info.name_a, "camera");
+        assert_eq!(info.tag_a, "v1");
+        assert_eq!(info.name_b, "camera");
+        assert_eq!(info.tag_b, "v1");
+    }
+
+    /// Pinned and from_any errors aggregate (no short-circuit).
+    #[test]
+    fn aggregates_multiple_errors() {
+        let cons_instances = parse_instances(
+            r#"[{
+                instance_id: "cons1",
+                bindings: { unknown_slot: "prod1" }
+            }]"#,
+        );
+        let depends_on = parse_depends_on(
+            r#"{
+                nodes: [{ name: "camera", tag: "v1", link_id: "main" }]
+            }"#,
+        );
+        let prod_instances = parse_instances(r#"[{ instance_id: "prod1" }]"#);
+        let items = vec![
+            item("cons", "v1", &cons_instances, Some(&depends_on)),
+            item("camera", "v1", &prod_instances, None),
+        ];
+        let out = validate_bindings(&items, TEST_CORE);
+        assert_eq!(
+            out.errors.len(),
+            2,
+            "expected two errors, got {:?}",
+            out.errors
+        );
+        // BindingDeadKey is emitted first (in iteration order),
+        // BindingMissingForPinnedDep after.
+        assert!(matches!(out.errors[0], ParsingError::BindingDeadKey(_)));
+        assert!(matches!(
+            out.errors[1],
+            ParsingError::BindingMissingForPinnedDep(_)
+        ));
+    }
+
+    /// A `from_any` interface dep accepts a producer whose
+    /// `interfaces.conforms_to` includes the requested interface, even
+    /// when the producer's node name differs from the interface name.
+    #[test]
+    fn from_any_interface_dep_accepts_producer_via_conforms_to() {
+        let cons_instances = parse_instances(
+            r#"[{
+                instance_id: "cons1",
+                bindings: { extra_cam: "webcam_inst_1" }
+            }]"#,
+        );
+        let depends_on = parse_depends_on(
+            r#"{
+                nodes: [],
+                interfaces: [{
+                    name: "depth_camera",
+                    tag: "v1",
+                    link_id: "extra_cam",
+                    from_any: true
+                }]
+            }"#,
+        );
+        let prod_instances = parse_instances(r#"[{ instance_id: "webcam_inst_1" }]"#);
+        let producer_conforms = parse_conforms_to(r#"[{ name: "depth_camera", tag: "v1" }]"#);
+        let items = vec![
+            item("cons", "v1", &cons_instances, Some(&depends_on)),
+            item_with_conforms_to("webcam", "v1", &prod_instances, None, &producer_conforms),
+        ];
+        let out = validate_bindings(&items, TEST_CORE);
+        assert!(out.errors.is_empty(), "unexpected errors: {:?}", out.errors);
+        assert_eq!(
+            slot_binding(&out, "cons1", "extra_cam"),
+            Some(SlotBinding::FromAnyBound {
+                producers: vec![ProducerRef::new(TEST_CORE, "webcam_inst_1")]
+            })
+        );
+    }
+
+    /// A `from_any` interface dep rejects a producer that lacks the
+    /// matching `conforms_to`, even when its node name coincidentally
+    /// equals the requested interface name+tag. Interface satisfaction
+    /// is determined solely by `conforms_to`, never by node identity.
+    #[test]
+    fn from_any_interface_dep_rejects_producer_without_conforms_to() {
+        let cons_instances = parse_instances(
+            r#"[{
+                instance_id: "cons1",
+                bindings: { extra_cam: "depth_cam_inst_1" }
+            }]"#,
+        );
+        let depends_on = parse_depends_on(
+            r#"{
+                nodes: [],
+                interfaces: [{
+                    name: "depth_camera",
+                    tag: "v1",
+                    link_id: "extra_cam",
+                    from_any: true
+                }]
+            }"#,
+        );
+        let prod_instances = parse_instances(r#"[{ instance_id: "depth_cam_inst_1" }]"#);
+        // Producer's node identity coincidentally matches the interface
+        // name+tag, but it declares no `conforms_to` — must be rejected
+        // (the binding's `KEY` doesn't match any pinned link_id either,
+        // so this falls through to `BindingDeadKey`).
+        let items = vec![
+            item("cons", "v1", &cons_instances, Some(&depends_on)),
+            item("depth_camera", "v1", &prod_instances, None),
+        ];
+        let out = validate_bindings(&items, TEST_CORE);
+        assert_eq!(out.errors.len(), 1, "errors: {:?}", out.errors);
+        let ParsingError::BindingDeadKey(info) = &out.errors[0] else {
+            panic!("expected BindingDeadKey, got {:?}", out.errors[0]);
+        };
+        assert_eq!(info.binding, "extra_cam");
+        assert_eq!(info.target_instance_id, "depth_cam_inst_1");
+        assert_eq!(info.producer_name, "depth_camera");
+        assert_eq!(info.producer_tag, "v1");
+    }
+
+    /// `conforms_to` matching is strict on `(name, tag)`: a producer
+    /// declaring a different tag for the same interface name is
+    /// rejected.
+    #[test]
+    fn interface_dep_with_wrong_tag_in_conforms_to_is_rejected() {
+        let cons_instances = parse_instances(
+            r#"[{
+                instance_id: "cons1",
+                bindings: { depth: "webcam_inst_1" }
+            }]"#,
+        );
+        let depends_on = parse_depends_on(
+            r#"{
+                nodes: [],
+                interfaces: [{
+                    name: "depth_camera",
+                    tag: "v1",
+                    link_id: "depth"
+                }]
+            }"#,
+        );
+        let prod_instances = parse_instances(r#"[{ instance_id: "webcam_inst_1" }]"#);
+        let producer_conforms = parse_conforms_to(r#"[{ name: "depth_camera", tag: "v2" }]"#);
+        let items = vec![
+            item("cons", "v1", &cons_instances, Some(&depends_on)),
+            item_with_conforms_to("webcam", "v1", &prod_instances, None, &producer_conforms),
+        ];
+        let out = validate_bindings(&items, TEST_CORE);
+        assert_eq!(out.errors.len(), 1, "errors: {:?}", out.errors);
+        let ParsingError::BindingInterfaceNotConformed(info) = &out.errors[0] else {
+            panic!(
+                "expected BindingInterfaceNotConformed, got {:?}",
+                out.errors[0]
+            );
+        };
+        assert_eq!(info.interface_tag, "v1");
+        assert_eq!(info.producer_name, "webcam");
+    }
+
+    /// A producer declaring multiple `conforms_to` entries can satisfy
+    /// any of them. Two consumers (each asking for a different
+    /// interface) both successfully bind to the same producer.
+    #[test]
+    fn producer_with_multiple_conforms_to_can_satisfy() {
+        let depth_consumer = parse_instances(
+            r#"[{
+                instance_id: "depth_cons",
+                bindings: { feed: "multi_prod" }
+            }]"#,
+        );
+        let depth_deps = parse_depends_on(
+            r#"{
+                nodes: [],
+                interfaces: [{
+                    name: "depth_camera",
+                    tag: "v1",
+                    link_id: "feed"
+                }]
+            }"#,
+        );
+        let uvc_consumer = parse_instances(
+            r#"[{
+                instance_id: "uvc_cons",
+                bindings: { feed: "multi_prod" }
+            }]"#,
+        );
+        let uvc_deps = parse_depends_on(
+            r#"{
+                nodes: [],
+                interfaces: [{
+                    name: "uvc_camera",
+                    tag: "v1",
+                    link_id: "feed"
+                }]
+            }"#,
+        );
+        let prod_instances = parse_instances(r#"[{ instance_id: "multi_prod" }]"#);
+        let producer_conforms = parse_conforms_to(
+            r#"[
+                { name: "depth_camera", tag: "v1" },
+                { name: "uvc_camera", tag: "v1" }
+            ]"#,
+        );
+        let items = vec![
+            item("depth_cons_node", "v1", &depth_consumer, Some(&depth_deps)),
+            item("uvc_cons_node", "v1", &uvc_consumer, Some(&uvc_deps)),
+            item_with_conforms_to(
+                "multi_camera",
+                "v1",
+                &prod_instances,
+                None,
+                &producer_conforms,
+            ),
+        ];
+        let out = validate_bindings(&items, TEST_CORE);
+        assert!(out.errors.is_empty(), "unexpected errors: {:?}", out.errors);
+        assert_eq!(
+            slot_binding(&out, "depth_cons", "feed"),
+            Some(SlotBinding::Pinned {
+                producer: ProducerRef::new(TEST_CORE, "multi_prod")
+            })
+        );
+        assert_eq!(
+            slot_binding(&out, "uvc_cons", "feed"),
+            Some(SlotBinding::Pinned {
+                producer: ProducerRef::new(TEST_CORE, "multi_prod")
+            })
+        );
+    }
+
+    /// When a producer's `conforms_to` could match multiple from_any
+    /// interface slots, the validator picks the first slot in
+    /// `BTreeMap` (alphabetical by link_id) order and attaches the
+    /// producer there. Other matching slots remain unbound. Documents
+    /// the deterministic first-match-wins shadowing.
+    #[test]
+    fn from_any_multiple_slots_first_match_wins() {
+        let cons_instances = parse_instances(
+            r#"[{
+                instance_id: "cons1",
+                bindings: { whatever: "multi_prod" }
+            }]"#,
+        );
+        let depends_on = parse_depends_on(
+            r#"{
+                nodes: [],
+                interfaces: [
+                    { name: "alpha_iface", tag: "v1", link_id: "slot_a", from_any: true },
+                    { name: "beta_iface", tag: "v1", link_id: "slot_b", from_any: true }
+                ]
+            }"#,
+        );
+        let prod_instances = parse_instances(r#"[{ instance_id: "multi_prod" }]"#);
+        let producer_conforms = parse_conforms_to(
+            r#"[
+                { name: "alpha_iface", tag: "v1" },
+                { name: "beta_iface", tag: "v1" }
+            ]"#,
+        );
+        let items = vec![
+            item("cons", "v1", &cons_instances, Some(&depends_on)),
+            item_with_conforms_to(
+                "multi_iface_node",
+                "v1",
+                &prod_instances,
+                None,
+                &producer_conforms,
+            ),
+        ];
+        let out = validate_bindings(&items, TEST_CORE);
+        assert!(out.errors.is_empty(), "unexpected errors: {:?}", out.errors);
+        // `slot_a` sorts before `slot_b`, so the producer lands on
+        // slot_a; slot_b stays unbound.
+        assert_eq!(
+            slot_binding(&out, "cons1", "slot_a"),
+            Some(SlotBinding::FromAnyBound {
+                producers: vec![ProducerRef::new(TEST_CORE, "multi_prod")]
+            })
+        );
+        assert_eq!(
+            slot_binding(&out, "cons1", "slot_b"),
+            Some(SlotBinding::FromAnyUnbound)
+        );
+    }
+
+    /// Stamping: every producer reference the validator emits — pinned
+    /// and from_any-bound alike — carries exactly the
+    /// `producer_core_node` passed by the caller (the launching
+    /// daemon). This is the single point where the instance-only
+    /// `--bind` syntax becomes a wire-complete address.
+    #[test]
+    fn every_resolved_binding_is_stamped_with_the_launching_core_node() {
+        let cons_instances = parse_instances(
+            r#"[{
+                instance_id: "cons1",
+                bindings: { main: "prod1", extra_feed: "prod2" }
+            }]"#,
+        );
+        let depends_on = parse_depends_on(
+            r#"{
+                nodes: [
+                    { name: "camera", tag: "v1", link_id: "main" },
+                    { name: "camera", tag: "v1", link_id: "extra", from_any: true }
+                ]
+            }"#,
+        );
+        let prod_instances = parse_instances(
+            r#"[
+                { instance_id: "prod1" },
+                { instance_id: "prod2" }
+            ]"#,
+        );
+        let items = vec![
+            item("cons", "v1", &cons_instances, Some(&depends_on)),
+            item("camera", "v1", &prod_instances, None),
+        ];
+        let out = validate_bindings(&items, "daemon_west");
+        assert!(out.errors.is_empty(), "unexpected errors: {:?}", out.errors);
+        let resolved = out.slot_bindings.get("cons1").expect("cons1 bindings");
+        let mut producer_count = 0;
+        for binding in resolved.values() {
+            match binding {
+                SlotBinding::Pinned { producer } => {
+                    producer_count += 1;
+                    assert_eq!(producer.core_node, "daemon_west");
+                }
+                SlotBinding::FromAnyBound { producers } => {
+                    for producer in producers {
+                        producer_count += 1;
+                        assert_eq!(producer.core_node, "daemon_west");
+                    }
+                }
+                SlotBinding::FromAnyUnbound => {}
+            }
+        }
+        assert_eq!(
+            producer_count, 2,
+            "both the pinned and the from_any producer must be stamped"
+        );
+    }
+}

--- a/crates/daemon-config-internal/src/launcher/bindings.rs
+++ b/crates/daemon-config-internal/src/launcher/bindings.rs
@@ -16,14 +16,14 @@
 //!
 //! The validator emits both errors and the resolved per-slot
 //! `SlotBinding` map per consumer instance, which the caller
-//! serializes into [`crate::runtime::NodeInstanceConfig::slot_bindings`].
+//! serializes into [`config::runtime::NodeInstanceConfig::slot_bindings`].
 
 use crate::error::{
     BindingDeadKey, BindingInterfaceNotConformed, BindingMissingForPinnedDep,
     BindingTargetMismatch, DuplicateInstanceIdAcrossStack, ParsingError, SlotKind,
 };
-use crate::node::{ConformsToItem, DependsOn};
-use crate::runtime::{ProducerRef, SlotBinding};
+use config::node::{ConformsToItem, DependsOn};
+use config::runtime::{ProducerRef, SlotBinding};
 use std::collections::BTreeMap;
 
 use super::types::DeploymentInstance;

--- a/crates/daemon-config-internal/src/launcher/parse.rs
+++ b/crates/daemon-config-internal/src/launcher/parse.rs
@@ -1,0 +1,192 @@
+use super::types::PeppyLauncher;
+use crate::{error::Result, parsing::read_non_empty_file};
+use std::path::Path;
+
+/// Parser responsible for extracting launcher documents.
+///
+/// Launcher files have no fixed name — any `.json5` file whose body
+/// declares `peppy_schema: "launcher/v1"` is a launcher. Schema and
+/// shape validation are handled by serde
+/// (`#[serde(deny_unknown_fields)]` + the typed `PeppySchema` enum), so
+/// callers that walk a repository can just attempt to parse and treat
+/// failures as "not a launcher."
+pub struct PeppyLauncherParser;
+
+impl PeppyLauncherParser {
+    pub fn from_path(file: impl AsRef<Path>) -> Result<PeppyLauncher> {
+        let path = file.as_ref();
+        let content = read_non_empty_file(path)?;
+        Self::from_content(&content)
+    }
+
+    /// Takes a JSON5 content as parameter
+    pub fn from_content(content: &str) -> Result<PeppyLauncher> {
+        // Strict schema validation is handled by serde via #[serde(deny_unknown_fields)]
+        crate::error::deserialize_json5_with_path(content)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{launcher::DeploymentSource, schema::PeppySchema};
+    use tempfile::tempdir;
+
+    use super::PeppyLauncherParser;
+
+    #[test]
+    fn test_parse_peppy_config() {
+        let json5 = r#"{
+            peppy_schema: "launcher/v1",
+            deployments: [
+                {
+                    source: {
+                        url: "https://example.com/fake_robot_brain.tar.zst",
+                        sha256: "33e83da60a54e3bb487a9a3b67705918602143b30f158143b6909acaf017a36a"
+                    },
+                    instances: [
+                        {
+                            instance_id: "the_brain",
+                            arguments: {}
+                        }
+                    ]
+                },
+                {
+                    source: {
+                        repo: "https://github.com/Peppy-bot/nodes_hub.git",
+                        path: "fake_openarm01_controller",
+                        ref: "0.1.0"
+                    },
+                    instances: [
+                        {
+                            instance_id: "the_nervous_system",
+                            arguments: {}
+                        }
+                    ]
+                },
+                {
+                    source: { local: "./esp32_board" },
+                    instances: [
+                        {
+                            instance_id: "esp32_1",
+                            env_vars: {
+                                ESP32_DEVICE: "/dev/ttyUSB0"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }"#;
+
+        let cfg = PeppyLauncherParser::from_content(json5).unwrap();
+        let deployments = cfg.deployments;
+        assert_eq!(deployments.len(), 3);
+
+        // Check first deployment
+        let DeploymentSource::Url(url) = &deployments[0].source else {
+            panic!("expected url source");
+        };
+        assert_eq!(url.url, "https://example.com/fake_robot_brain.tar.zst");
+        assert_eq!(deployments[0].instances[0].instance_id, "the_brain");
+        assert!(deployments[0].instances[0].arguments.is_empty());
+
+        // Check second deployment
+        let DeploymentSource::Git(git) = &deployments[1].source else {
+            panic!("expected git source");
+        };
+        assert_eq!(git.ref_, "0.1.0");
+        assert_eq!(
+            deployments[1].instances[0].instance_id,
+            "the_nervous_system"
+        );
+        assert!(deployments[1].instances[0].arguments.is_empty());
+
+        // Check third deployment
+        let DeploymentSource::Local(local) = &deployments[2].source else {
+            panic!("expected local source");
+        };
+        assert_eq!(local.local, std::path::PathBuf::from("esp32_board"));
+        assert_eq!(deployments[2].instances.len(), 1);
+        assert_eq!(deployments[2].instances[0].instance_id, "esp32_1");
+        assert!(deployments[2].instances[0].arguments.is_empty());
+        assert_eq!(
+            deployments[2].instances[0]
+                .env_vars
+                .get("ESP32_DEVICE")
+                .map(String::as_str),
+            Some("/dev/ttyUSB0")
+        );
+    }
+
+    /// Launcher files have no fixed name — any path with valid launcher
+    /// content parses regardless of basename.
+    #[test]
+    fn test_from_path_accepts_arbitrary_file_name() {
+        let dir = tempdir().unwrap();
+        let json5 = r#"{
+            peppy_schema: "launcher/v1",
+            deployments: []
+        }"#;
+
+        for name in ["openarm01_sim_teleop.json5", "demo.json5", "anything.json5"] {
+            let path = dir.path().join(name);
+            std::fs::write(&path, json5).unwrap();
+            let cfg = PeppyLauncherParser::from_path(&path)
+                .unwrap_or_else(|e| panic!("{name} should parse as launcher: {e}"));
+            assert_eq!(cfg.peppy_schema, PeppySchema::LauncherV1);
+            assert!(cfg.deployments.is_empty());
+        }
+    }
+
+    /// A file declaring `peppy_schema: "node/v1"` is not a launcher.
+    /// The strict deserializer either rejects unexpected node fields or
+    /// the caller can gate on `peppy_schema` after parsing — either way
+    /// node configs do not slip through `from_path`.
+    #[test]
+    fn test_from_path_rejects_node_schema() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("anything.json5");
+        let json5 = r#"{
+            peppy_schema: "node/v1",
+            manifest: { name: "n", tag: "v1" },
+            interfaces: {},
+            execution: { language: "rust", build_cmd: ["true"], run_cmd: ["true"] }
+        }"#;
+        std::fs::write(&path, json5).unwrap();
+
+        let err = PeppyLauncherParser::from_path(&path)
+            .expect_err("node config must not parse as a launcher");
+        // The schema check fires before `deny_unknown_fields` does.
+        assert!(
+            err.to_string().contains("launcher/v1"),
+            "unexpected error: {err}"
+        );
+    }
+
+    /// A document whose shape is launcher-compatible but whose
+    /// `peppy_schema` claims to be a node must still be rejected — the
+    /// schema field is the source of truth, so `deny_unknown_fields`
+    /// alone isn't enough.
+    #[test]
+    fn test_from_content_rejects_non_launcher_schema() {
+        let json5 = r#"{ peppy_schema: "node/v1", deployments: [] }"#;
+        let err = PeppyLauncherParser::from_content(json5)
+            .expect_err("non-launcher schema must be rejected");
+        assert!(
+            err.to_string().contains("launcher/v1"),
+            "error should mention the expected schema, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_examples_peppy_launcher_parses() {
+        let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("examples")
+            .join("nodes_example_1")
+            .join("peppy_launcher.json5");
+        let cfg = PeppyLauncherParser::from_path(&path).expect("example launcher should parse");
+        assert!(
+            !cfg.deployments.is_empty(),
+            "example launcher should contain deployments"
+        );
+    }
+}

--- a/crates/daemon-config-internal/src/launcher/parse.rs
+++ b/crates/daemon-config-internal/src/launcher/parse.rs
@@ -28,7 +28,9 @@ impl PeppyLauncherParser {
 
 #[cfg(test)]
 mod tests {
-    use crate::{launcher::DeploymentSource, schema::PeppySchema};
+    use crate::error::{Error, ParsingError};
+    use crate::launcher::DeploymentSource;
+    use config::schema::PeppySchema;
     use tempfile::tempdir;
 
     use super::PeppyLauncherParser;
@@ -178,10 +180,29 @@ mod tests {
     }
 
     #[test]
+    fn test_invalid_deployment_source() {
+        let json5 = r#"{
+            peppy_schema: "launcher/v1",
+            deployments: [
+                {
+                    source: { local: "" },
+                    instances: []
+                }
+            ]
+        }"#;
+
+        let result = PeppyLauncherParser::from_content(json5);
+        let Error::Parsing(ParsingError::InvalidDeploymentSource(msg)) = result.unwrap_err() else {
+            panic!("expected InvalidDeploymentSource error");
+        };
+        assert_eq!(msg, "local path cannot be empty");
+    }
+
+    #[test]
     fn test_examples_peppy_launcher_parses() {
         let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-            .join("examples")
-            .join("nodes_example_1")
+            .join("tests")
+            .join("fixtures")
             .join("peppy_launcher.json5");
         let cfg = PeppyLauncherParser::from_path(&path).expect("example launcher should parse");
         assert!(

--- a/crates/daemon-config-internal/src/launcher/types.rs
+++ b/crates/daemon-config-internal/src/launcher/types.rs
@@ -1,0 +1,597 @@
+use crate::{
+    common::AnyType,
+    consts::DEFAULT_LINK_ID_SENTINEL,
+    error::{ParsingError, StructuredError},
+    internal::interface::validate_named_items,
+    schema::PeppySchema,
+};
+use serde::{
+    Deserialize, Serialize,
+    de::{self, Deserializer, MapAccess, Visitor},
+};
+use std::{
+    collections::{BTreeMap, HashSet},
+    convert::TryFrom,
+};
+
+pub use crate::source::{
+    DeploymentGitSource, DeploymentLocalSource, DeploymentRepoSource, DeploymentSource,
+    DeploymentUrlSource,
+};
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PeppyLauncher {
+    pub peppy_schema: PeppySchema,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub deployments: Vec<Deployment>,
+}
+
+/// Custom deserialization for [`PeppyLauncher`] that, after the default
+/// shape parse, cross-checks every `bindings` value against the
+/// set of `instance_id`s declared across all deployments. A binding that
+/// points at an unknown instance is rejected with a structured
+/// [`StructuredError::UnknownInstanceId`] so callers see a path-aware
+/// message instead of a generic serde error.
+impl<'de> Deserialize<'de> for PeppyLauncher {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct RawPeppyLauncher {
+            #[serde(deserialize_with = "deserialize_launcher_v1_schema")]
+            peppy_schema: PeppySchema,
+            #[serde(default)]
+            deployments: Vec<Deployment>,
+        }
+
+        let raw = RawPeppyLauncher::deserialize(deserializer)?;
+
+        let known_ids: HashSet<&str> = raw
+            .deployments
+            .iter()
+            .flat_map(|d| d.instances.iter())
+            .map(|i| i.instance_id.as_str())
+            .collect();
+
+        for deployment in &raw.deployments {
+            for instance in &deployment.instances {
+                for (binding, target) in &instance.bindings {
+                    if binding == DEFAULT_LINK_ID_SENTINEL {
+                        let err = StructuredError::BindingSentinelKey {
+                            owner_instance_id: instance.instance_id.to_string(),
+                            binding: binding.clone(),
+                        };
+                        return Err(de::Error::custom(err.json5_message()));
+                    }
+                    if !known_ids.contains(target.as_str()) {
+                        let err = StructuredError::UnknownInstanceId {
+                            owner_instance_id: instance.instance_id.to_string(),
+                            binding: binding.clone(),
+                            instance_id: target.clone(),
+                        };
+                        return Err(de::Error::custom(err.json5_message()));
+                    }
+                }
+            }
+        }
+
+        Ok(PeppyLauncher {
+            peppy_schema: raw.peppy_schema,
+            deployments: raw.deployments,
+        })
+    }
+}
+
+/// Reject any `peppy_schema` value other than `launcher/v1` so a node
+/// document that happens to share the launcher's deployment shape can't
+/// slip through `PeppyLauncherParser`.
+fn deserialize_launcher_v1_schema<'de, D>(deserializer: D) -> Result<PeppySchema, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    PeppySchema::deserialize_expecting(deserializer, PeppySchema::LauncherV1)
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Deployment {
+    pub source: DeploymentSource,
+    #[serde(deserialize_with = "deserialize_instances")]
+    pub instances: Vec<DeploymentInstance>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DeploymentInstance {
+    pub instance_id: Name,
+    #[serde(default)]
+    pub arguments: BTreeMap<String, AnyType>,
+    #[serde(default)]
+    pub env_vars: BTreeMap<String, String>,
+    #[serde(default)]
+    pub framework: FrameworkOverrides,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_bindings",
+        skip_serializing_if = "BTreeMap::is_empty"
+    )]
+    pub bindings: BTreeMap<String, String>,
+}
+
+/// Each key is a `link_id` literal declared by the deployed node's
+/// `depends_on.{nodes,interfaces}` and each value points at the producer
+/// `instance_id` defined elsewhere in the launcher. Keys and values are
+/// validated for non-emptiness and intra-collection duplicates via
+/// [`validate_named_items`]; the reserved producer-default sentinel
+/// ([`DEFAULT_LINK_ID_SENTINEL`]) is rejected as a key here so the
+/// launcher cannot redundantly "bind" to the default. The value's
+/// existence as an `instance_id` is checked later at the
+/// [`PeppyLauncher`] level once all deployments have been parsed; the
+/// key's existence in the deployed node's `depends_on` and the producer
+/// identity are checked at launch time, when both the launcher and the
+/// node manifests are loaded.
+fn deserialize_bindings<'de, D>(deserializer: D) -> Result<BTreeMap<String, String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    // Capture entries as a Vec to preserve duplicate keys: a direct
+    // BTreeMap::deserialize would silently overwrite, hiding the
+    // duplicate from `validate_named_items`. The sentinel-key check
+    // lives in `PeppyLauncher::deserialize` where the owning
+    // `instance_id` is in scope and can be attached to the structured
+    // error.
+    let entries = deserializer.deserialize_map(BindingEntriesVisitor)?;
+    validate_named_items(entries.iter().map(|(k, _)| k.as_str()), "binding")
+        .map_err(de::Error::custom)?;
+    // Duplicate binding values are intentionally permitted: a single
+    // producer may serve multiple `link_id` slots on the same consumer
+    // (or across consumers), which the launch-time wiring materializes
+    // as a producer with multiple `link_ids` advertised in parallel.
+    // Only non-emptiness is enforced here.
+    for (key, value) in &entries {
+        if value.trim().is_empty() {
+            return Err(de::Error::custom(format!(
+                "binding target for key `{key}` cannot be empty"
+            )));
+        }
+    }
+    Ok(entries.into_iter().collect())
+}
+
+struct BindingEntriesVisitor;
+
+impl<'de> Visitor<'de> for BindingEntriesVisitor {
+    type Value = Vec<(String, String)>;
+
+    fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("a map of binding link_id -> instance_id strings")
+    }
+
+    fn visit_map<A>(self, mut access: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let mut entries = Vec::with_capacity(access.size_hint().unwrap_or(0));
+        while let Some((key, value)) = access.next_entry::<String, String>()? {
+            entries.push((key, value));
+        }
+        Ok(entries)
+    }
+}
+
+/// Per-instance framework knobs. Distinct from `arguments`: those are
+/// declared by the node author and validated against a per-node parameter
+/// schema; framework knobs are owned by peppylib, fixed-shape, and applied
+/// uniformly to every node. Each field is optional so the daemon can fall
+/// through to its own default when the instance omits the override.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct FrameworkOverrides {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub use_sim_time: Option<bool>,
+}
+
+fn deserialize_instances<'de, D>(deserializer: D) -> Result<Vec<DeploymentInstance>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let instances = Vec::<DeploymentInstance>::deserialize(deserializer)?;
+    let mut seen = HashSet::with_capacity(instances.len());
+    for instance in &instances {
+        let id = instance.instance_id.to_string();
+        if !seen.insert(id.clone()) {
+            let err = crate::error::StructuredError::DuplicateName(id);
+            return Err(de::Error::custom(err.json5_message()));
+        }
+    }
+    Ok(instances)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+#[serde(into = "String")]
+pub struct Name(String);
+
+use crate::consts::ALLOWED_CONFIG_CHARS;
+
+impl Name {
+    pub fn new<S: Into<String>>(s: S) -> Result<Self, ParsingError> {
+        Self::try_from(s.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    fn is_valid_char(c: char) -> bool {
+        ALLOWED_CONFIG_CHARS.contains(c)
+    }
+}
+
+impl TryFrom<String> for Name {
+    type Error = ParsingError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        if value.is_empty() {
+            return Err(ParsingError::EmptyName);
+        }
+        if value.chars().all(Name::is_valid_char) {
+            return Ok(Name(value));
+        }
+        Err(ParsingError::InvalidName(
+            value,
+            ALLOWED_CONFIG_CHARS.to_string(),
+        ))
+    }
+}
+
+impl<'de> Deserialize<'de> for Name {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Name::try_from(s).map_err(|err| de::Error::custom(err.to_string()))
+    }
+}
+
+impl From<Name> for String {
+    fn from(v: Name) -> Self {
+        v.0
+    }
+}
+
+impl std::fmt::Display for Name {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl AsRef<str> for Name {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl PartialEq<&str> for Name {
+    fn eq(&self, other: &&str) -> bool {
+        self.0 == *other
+    }
+}
+
+impl PartialEq<Name> for &str {
+    fn eq(&self, other: &Name) -> bool {
+        *self == other.0
+    }
+}
+
+impl PartialEq<String> for Name {
+    fn eq(&self, other: &String) -> bool {
+        self.0 == *other
+    }
+}
+
+impl PartialEq<Name> for String {
+    fn eq(&self, other: &Name) -> bool {
+        *self == other.0
+    }
+}
+
+impl PartialOrd for Name {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Name {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.0.cmp(&other.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn name_validation() {
+        assert!(Name::new("robot").is_ok());
+        assert!(Name::new("camera_v1").is_ok());
+
+        assert!(Name::new("").is_err()); // empty not permitted
+        assert!(Name::new("/").is_err()); // slash not permitted
+        assert!(Name::new("/robot").is_err()); // slash not permitted
+        assert!(Name::new("Robot").is_ok()); // capital now allowed
+        assert!(Name::new("robot$cam").is_err()); // special
+    }
+
+    #[test]
+    fn name_error_message() {
+        let err = Name::new("Invalid!").unwrap_err();
+        if let ParsingError::InvalidName(_, msg) = err {
+            assert_eq!(msg, crate::consts::ALLOWED_CONFIG_CHARS);
+        } else {
+            panic!("Expected InvalidName error");
+        }
+    }
+
+    #[test]
+    fn duplicate_instance_ids_are_rejected() {
+        let duplicate_instances = r#"{
+            source: { local: "./uvc_camera" },
+            instances: [
+                { instance_id: "camera_front" },
+                { instance_id: "camera_front" }
+            ]
+        }"#;
+
+        let err = serde_json5::from_str::<Deployment>(duplicate_instances)
+            .expect_err("expected duplicate instance_id rejection");
+        let ParsingError::DuplicateName(duplicate) = ParsingError::from(err) else {
+            panic!("expected duplicate instance id error");
+        };
+        assert_eq!(duplicate, "camera_front");
+    }
+
+    /// Verifies that optional fields (`arguments`, `env_vars`, `framework`)
+    /// default to empty when omitted, and that partially specified instances
+    /// deserialize correctly.
+    #[test]
+    fn deployment_instance_defaults() {
+        let instance: DeploymentInstance =
+            serde_json5::from_str("{ instance_id: \"camera_front\" }").unwrap();
+        assert_eq!(instance.instance_id, "camera_front");
+        assert!(instance.arguments.is_empty());
+        assert!(instance.env_vars.is_empty());
+        assert_eq!(instance.framework.use_sim_time, None);
+
+        let with_env: DeploymentInstance = serde_json5::from_str(
+            "{ instance_id: \"esp32_1\", env_vars: { ESP32_DEVICE: \"/dev/ttyUSB0\" } }",
+        )
+        .unwrap();
+        assert_eq!(with_env.instance_id, "esp32_1");
+        assert_eq!(
+            with_env.env_vars.get("ESP32_DEVICE").map(String::as_str),
+            Some("/dev/ttyUSB0")
+        );
+    }
+
+    /// Per-instance framework overrides parse cleanly and round-trip back
+    /// to JSON5. Both the explicit-true and explicit-false cases must be
+    /// distinguishable from "absent" so the daemon's precedence (per-instance
+    /// > daemon CLI flag > default) has a value to gate on.
+    #[test]
+    fn deployment_instance_framework_overrides_round_trip() {
+        let with_sim: DeploymentInstance = serde_json5::from_str(
+            "{ instance_id: \"camera_front\", framework: { use_sim_time: true } }",
+        )
+        .unwrap();
+        assert_eq!(with_sim.framework.use_sim_time, Some(true));
+
+        let with_wall: DeploymentInstance = serde_json5::from_str(
+            "{ instance_id: \"camera_front\", framework: { use_sim_time: false } }",
+        )
+        .unwrap();
+        assert_eq!(with_wall.framework.use_sim_time, Some(false));
+
+        let serialized = serde_json5::to_string(&with_sim).unwrap();
+        let reparsed: DeploymentInstance = serde_json5::from_str(&serialized).unwrap();
+        assert_eq!(reparsed.framework.use_sim_time, Some(true));
+    }
+
+    /// A binding's value pointing at an `instance_id` defined in a sibling
+    /// deployment must resolve; the bindings on the consumer instance
+    /// round-trip with the exact keys/values that were written.
+    #[test]
+    fn bindings_resolve_against_siblings() {
+        let json5 = r#"{
+            peppy_schema: "launcher/v1",
+            deployments: [
+                {
+                    source: { local: "./left" },
+                    instances: [{ instance_id: "cam_wrist_left", arguments: {} }]
+                },
+                {
+                    source: { local: "./right" },
+                    instances: [{ instance_id: "cam_wrist_right", arguments: {} }]
+                },
+                {
+                    source: { local: "./torso" },
+                    instances: [{ instance_id: "cam_torso", arguments: {} }]
+                },
+                {
+                    source: { local: "./backbone" },
+                    instances: [{
+                        instance_id: "backbone",
+                        bindings: {
+                            wrist_left_camera: "cam_wrist_left",
+                            wrist_right_camera: "cam_wrist_right",
+                            torso_camera: "cam_torso",
+                        }
+                    }]
+                }
+            ]
+        }"#;
+        let launcher: PeppyLauncher = serde_json5::from_str(json5).expect("launcher should parse");
+        let backbone = &launcher.deployments[3].instances[0];
+        assert_eq!(backbone.instance_id, "backbone");
+        assert_eq!(backbone.bindings.len(), 3);
+        assert_eq!(
+            backbone.bindings.get("torso_camera").map(String::as_str),
+            Some("cam_torso")
+        );
+    }
+
+    #[test]
+    fn bindings_default_to_empty_when_omitted() {
+        let instance: DeploymentInstance =
+            serde_json5::from_str("{ instance_id: \"camera_front\" }").unwrap();
+        assert!(instance.bindings.is_empty());
+    }
+
+    /// A binding value that doesn't match any `instance_id` declared across
+    /// the launcher must surface as a structured `UnknownInstanceId` error,
+    /// not a generic serde message.
+    #[test]
+    fn bindings_reject_unknown_instance_id() {
+        let json5 = r#"{
+            peppy_schema: "launcher/v1",
+            deployments: [
+                {
+                    source: { local: "./backbone" },
+                    instances: [{
+                        instance_id: "backbone",
+                        bindings: {
+                            torso_camera: "does_not_exist"
+                        }
+                    }]
+                }
+            ]
+        }"#;
+        let err = serde_json5::from_str::<PeppyLauncher>(json5)
+            .expect_err("unknown instance_id must be rejected");
+        let parsing_err = ParsingError::from(err);
+        let ParsingError::UnknownInstanceId {
+            owner_instance_id,
+            binding,
+            instance_id,
+        } = parsing_err
+        else {
+            panic!("expected UnknownInstanceId, got {parsing_err:?}");
+        };
+        assert_eq!(owner_instance_id, "backbone");
+        assert_eq!(binding, "torso_camera");
+        assert_eq!(instance_id, "does_not_exist");
+    }
+
+    #[test]
+    fn bindings_reject_empty_key() {
+        let json5 = r#"{
+            instance_id: "backbone",
+            bindings: { "": "cam_torso" }
+        }"#;
+        let err = serde_json5::from_str::<DeploymentInstance>(json5)
+            .expect_err("empty binding key must be rejected");
+        assert!(err.to_string().contains("empty"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn bindings_reject_empty_value() {
+        let json5 = r#"{
+            instance_id: "backbone",
+            bindings: { torso_camera: "" }
+        }"#;
+        let err = serde_json5::from_str::<DeploymentInstance>(json5)
+            .expect_err("empty binding value must be rejected");
+        assert!(err.to_string().contains("empty"), "unexpected error: {err}");
+    }
+
+    /// Two binding keys may point at the same producer `instance_id`:
+    /// that is the "one producer serves multiple `link_id` slots" case
+    /// the wiring step materializes as a producer with multiple
+    /// concurrent `link_ids` on the wire. Duplicates on the value side
+    /// are therefore intentionally permitted.
+    #[test]
+    fn bindings_accept_duplicate_values() {
+        let json5 = r#"{
+            instance_id: "backbone",
+            bindings: {
+                a: "cam_torso",
+                b: "cam_torso"
+            }
+        }"#;
+        let instance: DeploymentInstance =
+            serde_json5::from_str(json5).expect("duplicate binding targets should now be accepted");
+        assert_eq!(
+            instance.bindings.get("a").map(String::as_str),
+            Some("cam_torso")
+        );
+        assert_eq!(
+            instance.bindings.get("b").map(String::as_str),
+            Some("cam_torso")
+        );
+    }
+
+    /// The launcher rejects unknown framework keys so a typo (e.g.
+    /// `use_simulation_time`) does not silently fall through to wall mode.
+    #[test]
+    fn deployment_instance_framework_rejects_unknown_keys() {
+        let err = serde_json5::from_str::<DeploymentInstance>(
+            "{ instance_id: \"camera_front\", framework: { unknown_knob: true } }",
+        )
+        .expect_err("unknown framework key should be rejected");
+        assert!(err.to_string().contains("unknown_knob"));
+    }
+
+    /// The reserved producer-default segment cannot appear as a binding
+    /// key. Using it would be a redundant no-op (the producer already
+    /// publishes under that segment when no binding is declared) and
+    /// likely indicates a misuse. The check runs at the launcher level
+    /// (rather than per-instance) so the structured error can carry the
+    /// owning `instance_id`.
+    #[test]
+    fn bindings_reject_underscore_key() {
+        let json5 = r#"{
+            peppy_schema: "launcher/v1",
+            deployments: [
+                {
+                    source: { local: "./backbone" },
+                    instances: [{
+                        instance_id: "backbone",
+                        bindings: { "_": "backbone" }
+                    }]
+                }
+            ]
+        }"#;
+        let err = serde_json5::from_str::<PeppyLauncher>(json5)
+            .expect_err("`_` binding key must be rejected");
+        let parsing_err = ParsingError::from(err);
+        let ParsingError::BindingSentinelKey {
+            owner_instance_id,
+            binding,
+        } = &parsing_err
+        else {
+            panic!("expected BindingSentinelKey, got {parsing_err:?}");
+        };
+        assert_eq!(owner_instance_id, "backbone");
+        assert_eq!(binding, "_");
+    }
+
+    /// Duplicate binding keys must be rejected. The raw map deserializer
+    /// must surface them before the BTreeMap collapses duplicates.
+    #[test]
+    fn bindings_reject_duplicate_keys() {
+        let json5 = r#"{
+            instance_id: "backbone",
+            bindings: { "main": "prod_a", "main": "prod_b" }
+        }"#;
+        let err = serde_json5::from_str::<DeploymentInstance>(json5)
+            .expect_err("duplicate binding key must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("duplicate") && msg.contains("main"),
+            "unexpected error: {msg}"
+        );
+    }
+}

--- a/crates/daemon-config-internal/src/launcher/types.rs
+++ b/crates/daemon-config-internal/src/launcher/types.rs
@@ -1,18 +1,11 @@
-use crate::{
-    common::AnyType,
-    consts::DEFAULT_LINK_ID_SENTINEL,
-    error::{ParsingError, StructuredError},
-    internal::interface::validate_named_items,
-    schema::PeppySchema,
-};
+use crate::error::StructuredError;
+use crate::internal::interface::validate_named_items;
+use config::{AnyType, consts::DEFAULT_LINK_ID_SENTINEL, runtime::Name, schema::PeppySchema};
 use serde::{
     Deserialize, Serialize,
     de::{self, Deserializer, MapAccess, Visitor},
 };
-use std::{
-    collections::{BTreeMap, HashSet},
-    convert::TryFrom,
-};
+use std::collections::{BTreeMap, HashSet};
 
 pub use crate::source::{
     DeploymentGitSource, DeploymentLocalSource, DeploymentRepoSource, DeploymentSource,
@@ -209,132 +202,10 @@ where
     Ok(instances)
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
-#[serde(into = "String")]
-pub struct Name(String);
-
-use crate::consts::ALLOWED_CONFIG_CHARS;
-
-impl Name {
-    pub fn new<S: Into<String>>(s: S) -> Result<Self, ParsingError> {
-        Self::try_from(s.into())
-    }
-
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
-
-    fn is_valid_char(c: char) -> bool {
-        ALLOWED_CONFIG_CHARS.contains(c)
-    }
-}
-
-impl TryFrom<String> for Name {
-    type Error = ParsingError;
-
-    fn try_from(value: String) -> Result<Self, Self::Error> {
-        if value.is_empty() {
-            return Err(ParsingError::EmptyName);
-        }
-        if value.chars().all(Name::is_valid_char) {
-            return Ok(Name(value));
-        }
-        Err(ParsingError::InvalidName(
-            value,
-            ALLOWED_CONFIG_CHARS.to_string(),
-        ))
-    }
-}
-
-impl<'de> Deserialize<'de> for Name {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let s = String::deserialize(deserializer)?;
-        Name::try_from(s).map_err(|err| de::Error::custom(err.to_string()))
-    }
-}
-
-impl From<Name> for String {
-    fn from(v: Name) -> Self {
-        v.0
-    }
-}
-
-impl std::fmt::Display for Name {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl AsRef<str> for Name {
-    fn as_ref(&self) -> &str {
-        &self.0
-    }
-}
-
-impl PartialEq<&str> for Name {
-    fn eq(&self, other: &&str) -> bool {
-        self.0 == *other
-    }
-}
-
-impl PartialEq<Name> for &str {
-    fn eq(&self, other: &Name) -> bool {
-        *self == other.0
-    }
-}
-
-impl PartialEq<String> for Name {
-    fn eq(&self, other: &String) -> bool {
-        self.0 == *other
-    }
-}
-
-impl PartialEq<Name> for String {
-    fn eq(&self, other: &Name) -> bool {
-        *self == other.0
-    }
-}
-
-impl PartialOrd for Name {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for Name {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.0.cmp(&other.0)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn name_validation() {
-        assert!(Name::new("robot").is_ok());
-        assert!(Name::new("camera_v1").is_ok());
-
-        assert!(Name::new("").is_err()); // empty not permitted
-        assert!(Name::new("/").is_err()); // slash not permitted
-        assert!(Name::new("/robot").is_err()); // slash not permitted
-        assert!(Name::new("Robot").is_ok()); // capital now allowed
-        assert!(Name::new("robot$cam").is_err()); // special
-    }
-
-    #[test]
-    fn name_error_message() {
-        let err = Name::new("Invalid!").unwrap_err();
-        if let ParsingError::InvalidName(_, msg) = err {
-            assert_eq!(msg, crate::consts::ALLOWED_CONFIG_CHARS);
-        } else {
-            panic!("Expected InvalidName error");
-        }
-    }
+    use crate::error::ParsingError;
 
     #[test]
     fn duplicate_instance_ids_are_rejected() {

--- a/crates/daemon-config-internal/src/lib.rs
+++ b/crates/daemon-config-internal/src/lib.rs
@@ -1,0 +1,5 @@
+#![forbid(unsafe_code)]
+
+//! Daemon-side Peppy configuration documents (module wiring lands in the
+//! adaptation commit; this commit only carries the verbatim file copies
+//! from `peppy-config-model` so copy fidelity can be diffed in isolation).

--- a/crates/daemon-config-internal/src/lib.rs
+++ b/crates/daemon-config-internal/src/lib.rs
@@ -1,5 +1,88 @@
 #![forbid(unsafe_code)]
 
-//! Daemon-side Peppy configuration documents (module wiring lands in the
-//! adaptation commit; this commit only carries the verbatim file copies
-//! from `peppy-config-model` so copy fidelity can be diffed in isolation).
+//! Parsing and validation of the daemon-side Peppy configuration documents.
+//!
+//! This crate owns the config formats only the peppy daemon and CLI read or
+//! write: launcher documents (`peppy_schema: "launcher/v1"`) and their
+//! deployment sources, interface documents (`interface/v1`), the global
+//! daemon config `peppy_config.json5` with its comment-preserving completion,
+//! the [`atomic_write::publish_atomic`] staging helper, and the
+//! [`consts::PeppyDirs`] filesystem-layout helper with the process-global
+//! [`consts::set_app_env`] dev/prod root switch (a set-once `OnceLock`).
+//!
+//! It builds on the shared `config` crate (`peppy-config-model`), which keeps
+//! the wire-facing tier consumed by nodes and `peppylib`: the `peppy.json5`
+//! node config model, runtime configs, fingerprints, org namespaces, and
+//! schema tags. Types crossing that boundary (`config::runtime::Name`,
+//! `config::node` manifest types, `config::peppy_config::PeerConfig`) are
+//! used directly from `config` so each has exactly one definition.
+
+mod error;
+mod parsing;
+
+/// Private module that contains all implementation modules.
+/// The `#[path = "."]` attribute tells Rust to resolve child modules from
+/// `src/`, the same directory as this file, so existing file paths are
+/// preserved.
+#[path = "."]
+mod internal {
+    pub mod atomic_write;
+    pub mod consts;
+    pub mod interface;
+    pub mod launcher;
+    pub mod peppy_config;
+    pub mod source;
+}
+
+// -- error --
+pub use error::{
+    BindingMissingForPinnedDep, BindingTargetMismatch, DuplicateInstanceIdAcrossStack,
+    Error as DaemonConfigError, ParsingError, SlotKind, format_bulleted,
+};
+
+// -- atomic_write --
+pub mod atomic_write {
+    pub use crate::internal::atomic_write::publish_atomic;
+}
+
+// -- consts --
+pub mod consts {
+    pub use crate::internal::consts::{
+        AppEnv, CREDENTIALS_FILE, DAEMON_STATE_FILE_ENV, DEFAULT_ALPINE_BASE_IMAGE,
+        DEFAULT_PYTHON_BASE_IMAGE, DEFAULT_RUST_BASE_IMAGE, PEPPY_MESSAGING_PORT_VAR_NAME,
+        PEPPY_OUTPUT_DIR, PEPPYLIB_OUTPUT_PATH, PeppyDirs, peppy_root_dir, set_app_env,
+    };
+}
+
+// -- peppy_config --
+pub mod peppy_config {
+    pub use crate::internal::peppy_config::{
+        DAEMON_HEARTBEAT_INTERVAL_SECS, DEFAULT_API_URL, DEFAULT_FEDERATION_CONNECT_TIMEOUT_SECS,
+        FederationConfig, LifecycleConfig, Mode, PeppyConfig, ResourceServers, load_or_create,
+    };
+}
+
+// -- launcher --
+pub mod launcher {
+    pub use crate::internal::launcher::{
+        BindingValidationItem, Deployment, DeploymentGitSource, DeploymentInstance,
+        DeploymentLocalSource, DeploymentRepoSource, DeploymentSource, DeploymentUrlSource,
+        FrameworkOverrides, PeppyLauncher, PeppyLauncherParser, ValidatedBindings,
+        validate_bindings,
+    };
+}
+
+// -- interface --
+pub mod interface {
+    pub use crate::internal::interface::{
+        Interfaces, Manifest, PeppyInterface, PeppyInterfaceParser,
+    };
+}
+
+// -- source --
+pub mod source {
+    pub use crate::internal::source::{
+        DeploymentGitSource, DeploymentLocalSource, DeploymentRepoSource, DeploymentSource,
+        DeploymentUrlSource,
+    };
+}

--- a/crates/daemon-config-internal/src/parsing.rs
+++ b/crates/daemon-config-internal/src/parsing.rs
@@ -1,0 +1,13 @@
+use crate::error::{ParsingError, Result};
+use std::{fs, path::Path};
+
+pub(crate) fn read_non_empty_file(path: &Path) -> Result<String> {
+    let content = fs::read_to_string(path)
+        .map_err(|e| ParsingError::CannotRead(path.display().to_string(), e.kind()))?;
+
+    if content.trim().is_empty() {
+        Err(ParsingError::EmptyContent(path.display().to_string()).into())
+    } else {
+        Ok(content)
+    }
+}

--- a/crates/daemon-config-internal/src/peppy_config.rs
+++ b/crates/daemon-config-internal/src/peppy_config.rs
@@ -23,6 +23,10 @@ mod completion;
 use crate::atomic_write::publish_atomic;
 use crate::consts::PeppyDirs;
 use crate::error::{Error, ParsingError, Result};
+use config::peppy_config::{
+    DEFAULT_DAEMON_GRACE_SECS, DEFAULT_HIGH_THROUGHPUT_BUFFER_SIZE, DEFAULT_SHUTDOWN_GRACE_SECS,
+    DEFAULT_STANDARD_BUFFER_SIZE, PeerConfig,
+};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
@@ -39,17 +43,6 @@ pub const DEFAULT_API_URL: &str = "http://127.0.0.1:3000";
 #[cfg(not(debug_assertions))]
 pub const DEFAULT_API_URL: &str = "https://api.peppy.bot";
 
-/// Default subscriber channel buffer for the `Standard` QoS tier (number of
-/// in-flight messages). Mirrors the historical hardcoded value.
-pub const DEFAULT_STANDARD_BUFFER_SIZE: usize = 128;
-/// Default subscriber channel buffer for the `HighThroughput` QoS tier (e.g.
-/// sensor-data streams). Mirrors the historical hardcoded value.
-pub const DEFAULT_HIGH_THROUGHPUT_BUFFER_SIZE: usize = 1024;
-
-/// Default daemon-liveness grace period, in seconds (180 = 3 minutes). A
-/// spawned node that sees no daemon heartbeat for this long shuts itself down
-/// to avoid lingering as an orphan after an uncatchable daemon death.
-pub const DEFAULT_DAEMON_GRACE_SECS: u64 = 180;
 /// Minimum accepted grace period, in seconds. Must comfortably exceed the
 /// heartbeat interval and the router-watchdog restart window so a brief daemon
 /// blip never trips a node's watchdog.
@@ -64,30 +57,11 @@ pub const DAEMON_HEARTBEAT_INTERVAL_SECS: u64 = 5;
 // beats must fit inside the smallest accepted grace period.
 const _: () = assert!(MIN_DAEMON_GRACE_SECS >= 3 * DAEMON_HEARTBEAT_INTERVAL_SECS);
 
-/// Default cooperative-shutdown grace period, in seconds. How long the daemon
-/// (on a clean ctrl+C / `systemctl stop`) and `peppy node stop` wait for a node
-/// to run its cleanup hooks before force-killing its process group. 5s gives a
-/// robot node room to park actuators and release hardware before it is killed.
-pub const DEFAULT_SHUTDOWN_GRACE_SECS: u64 = 5;
 /// Minimum accepted cooperative-shutdown grace period, in seconds. At least 1 so
 /// the cooperative shutdown signal is actually given a chance to land before the
 /// force-kill (a 0 would cancel the in-flight send and amount to an immediate
 /// SIGKILL).
 pub const MIN_SHUTDOWN_GRACE_SECS: u64 = 1;
-
-/// Worst-case time a node runtime needs to tear down its asyncio event-loop
-/// thread after its shutdown hooks finish, before the OS process can exit. A
-/// background task may be executing native code (pycapnp serialization, a pyo3
-/// future) that must be joined rather than killed mid-call, so this is a real
-/// floor the daemon must allow for. Read by `peppylib-py` to bound the loop-join
-/// and by the daemon to size its force-kill deadline above the node's real exit
-/// cost. Nodes with no asyncio loop (sync-setup Python, Rust) simply finish well
-/// inside it.
-pub const EVENT_LOOP_JOIN_BUDGET_SECS: u64 = 5;
-/// Slack for interpreter finalize / `Drop` after the loop thread joins, before
-/// the OS process actually disappears. Added on top of the grace and join
-/// windows when the daemon computes how long to wait before force-killing.
-pub const RUNTIME_FINALIZE_MARGIN_SECS: u64 = 2;
 
 /// Default bound, in seconds, on resolving the caller's per-user cloud router
 /// when the daemon federates its local router to it: at startup (where it gates
@@ -103,10 +77,9 @@ pub const DEFAULT_FEDERATION_CONNECT_TIMEOUT_SECS: u64 = 30;
 pub const MIN_FEDERATION_CONNECT_TIMEOUT_SECS: u64 = 1;
 
 // The bundled default config, written verbatim on first create so its comments
-// survive. Kept inline (not `include_str!` from an asset file) because
-// `config` is vendored into every generated node as `src/` only, with
-// no sibling `assets/` directory, so an external include would fail to compile
-// inside a node build.
+// survive. Kept inline (not `include_str!` from an asset file) so the template
+// lives next to the completion logic that splices it and the crate needs no
+// sibling asset directory.
 //
 // The template is split into one snippet per entry so `completion` can splice a
 // missing section or field (comments included) into a user's existing file. The
@@ -267,28 +240,6 @@ impl Mode {
     /// Mode to gossip mapping: peer enables gossip, router disables it.
     pub fn gossip(self) -> bool {
         self.is_peer()
-    }
-}
-
-/// Peer-mode tuning knobs. Buffer sizes are the per-QoS subscriber channel
-/// capacities used when nodes peer directly (no router relay to absorb bursts).
-///
-/// `#[serde(default)]` fills any field a partial `peer` block omits from
-/// [`PeerConfig::default`], so every per-field default flows from the single
-/// `Default` impl below rather than parallel `default = "fn"` helpers.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(default)]
-pub struct PeerConfig {
-    pub standard_buffer_size: usize,
-    pub high_throughput_buffer_size: usize,
-}
-
-impl Default for PeerConfig {
-    fn default() -> Self {
-        Self {
-            standard_buffer_size: DEFAULT_STANDARD_BUFFER_SIZE,
-            high_throughput_buffer_size: DEFAULT_HIGH_THROUGHPUT_BUFFER_SIZE,
-        }
     }
 }
 

--- a/crates/daemon-config-internal/src/peppy_config.rs
+++ b/crates/daemon-config-internal/src/peppy_config.rs
@@ -1,0 +1,891 @@
+//! Global daemon configuration read from `~/.peppy/conf/peppy_config.json5`.
+//!
+//! This is the single user-facing switch for the messaging topology. The daemon
+//! reads it ONCE at startup (see `peppy serve`), creating the file from the
+//! bundled default template if it is missing, and applies the result to its own
+//! core-node session and to every node it spawns. Editing the file takes effect
+//! after a daemon restart.
+//!
+//! A well-formed file that omits settings (typically one written by an older
+//! peppy before a new knob existed) is completed in place: the missing entries
+//! are appended with their default values and explanatory comments, so the file
+//! on disk always lists every available knob. The user's own values, comments,
+//! and unknown keys are preserved byte-for-byte (see [`completion`]).
+//!
+//! Unlike `repositories.json5`, a malformed `peppy_config.json5` fails loud at
+//! startup ([`load_or_create`] returns `Err`) instead of falling back to
+//! defaults: the mode and buffer sizes determine the whole mesh's routing model
+//! and backpressure, so a hand-edited typo must surface immediately rather than
+//! silently reverting to peer mode. A malformed file is never rewritten.
+
+mod completion;
+
+use crate::atomic_write::publish_atomic;
+use crate::consts::PeppyDirs;
+use crate::error::{Error, ParsingError, Result};
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+/// File name of the global daemon config under `~/.peppy/conf`.
+pub const PEPPY_CONFIG_FILE: &str = "peppy_config.json5";
+
+/// The backend resource-server URL for this build: the local dev backend in
+/// debug builds, the prod backend in release builds. The single source of truth
+/// for both the seeded `resource_servers` block and the built-in fallback the
+/// `peppy auth login` / `whoami` / `logout` commands resolve when no `--api-url` /
+/// `PEPPY_API_URL` override is given.
+#[cfg(debug_assertions)]
+pub const DEFAULT_API_URL: &str = "http://127.0.0.1:3000";
+#[cfg(not(debug_assertions))]
+pub const DEFAULT_API_URL: &str = "https://api.peppy.bot";
+
+/// Default subscriber channel buffer for the `Standard` QoS tier (number of
+/// in-flight messages). Mirrors the historical hardcoded value.
+pub const DEFAULT_STANDARD_BUFFER_SIZE: usize = 128;
+/// Default subscriber channel buffer for the `HighThroughput` QoS tier (e.g.
+/// sensor-data streams). Mirrors the historical hardcoded value.
+pub const DEFAULT_HIGH_THROUGHPUT_BUFFER_SIZE: usize = 1024;
+
+/// Default daemon-liveness grace period, in seconds (180 = 3 minutes). A
+/// spawned node that sees no daemon heartbeat for this long shuts itself down
+/// to avoid lingering as an orphan after an uncatchable daemon death.
+pub const DEFAULT_DAEMON_GRACE_SECS: u64 = 180;
+/// Minimum accepted grace period, in seconds. Must comfortably exceed the
+/// heartbeat interval and the router-watchdog restart window so a brief daemon
+/// blip never trips a node's watchdog.
+pub const MIN_DAEMON_GRACE_SECS: u64 = 30;
+/// Cadence, in seconds, of the daemon-liveness heartbeat each spawned node's
+/// watchdog listens for (published by the daemon; see
+/// `core_node::services::clock::publish_daemon_heartbeat`). Defined next to
+/// `MIN_DAEMON_GRACE_SECS` so the invariant between them is enforced where
+/// both values live.
+pub const DAEMON_HEARTBEAT_INTERVAL_SECS: u64 = 5;
+// Compile-time guard on the watchdog's false-trip margin: even several missed
+// beats must fit inside the smallest accepted grace period.
+const _: () = assert!(MIN_DAEMON_GRACE_SECS >= 3 * DAEMON_HEARTBEAT_INTERVAL_SECS);
+
+/// Default cooperative-shutdown grace period, in seconds. How long the daemon
+/// (on a clean ctrl+C / `systemctl stop`) and `peppy node stop` wait for a node
+/// to run its cleanup hooks before force-killing its process group. 5s gives a
+/// robot node room to park actuators and release hardware before it is killed.
+pub const DEFAULT_SHUTDOWN_GRACE_SECS: u64 = 5;
+/// Minimum accepted cooperative-shutdown grace period, in seconds. At least 1 so
+/// the cooperative shutdown signal is actually given a chance to land before the
+/// force-kill (a 0 would cancel the in-flight send and amount to an immediate
+/// SIGKILL).
+pub const MIN_SHUTDOWN_GRACE_SECS: u64 = 1;
+
+/// Worst-case time a node runtime needs to tear down its asyncio event-loop
+/// thread after its shutdown hooks finish, before the OS process can exit. A
+/// background task may be executing native code (pycapnp serialization, a pyo3
+/// future) that must be joined rather than killed mid-call, so this is a real
+/// floor the daemon must allow for. Read by `peppylib-py` to bound the loop-join
+/// and by the daemon to size its force-kill deadline above the node's real exit
+/// cost. Nodes with no asyncio loop (sync-setup Python, Rust) simply finish well
+/// inside it.
+pub const EVENT_LOOP_JOIN_BUDGET_SECS: u64 = 5;
+/// Slack for interpreter finalize / `Drop` after the loop thread joins, before
+/// the OS process actually disappears. Added on top of the grace and join
+/// windows when the daemon computes how long to wait before force-killing.
+pub const RUNTIME_FINALIZE_MARGIN_SECS: u64 = 2;
+
+/// Default bound, in seconds, on resolving the caller's per-user cloud router
+/// when the daemon federates its local router to it: at startup (where it gates
+/// `serve` reporting ready) and again whenever `auth login`/`logout` pokes the
+/// daemon. A slow or unreachable backend must not stall federation past this, so
+/// the daemon falls back to standalone and retries in the background. 30 mirrors
+/// the historical hardcoded HTTP-client timeout, so behavior is unchanged until
+/// edited.
+pub const DEFAULT_FEDERATION_CONNECT_TIMEOUT_SECS: u64 = 30;
+/// Minimum accepted federation connect timeout, in seconds. At least 1 so a
+/// hand-edited 0 cannot collapse the bound to "give up immediately" (a 0 would
+/// also mean "no timeout" to the HTTP client, the opposite of the intent).
+pub const MIN_FEDERATION_CONNECT_TIMEOUT_SECS: u64 = 1;
+
+// The bundled default config, written verbatim on first create so its comments
+// survive. Kept inline (not `include_str!` from an asset file) because
+// `config` is vendored into every generated node as `src/` only, with
+// no sibling `assets/` directory, so an external include would fail to compile
+// inside a node build.
+//
+// The template is split into one snippet per entry so `completion` can splice a
+// missing section or field (comments included) into a user's existing file. The
+// numeric values are spliced in from the `DEFAULT_*` constants at compile time
+// via `concatcp!`, so neither the template nor a spliced snippet can drift from
+// the serde `Default` impls the parser falls back to when an entry is absent.
+
+/// Comment block at the top of the bundled config file.
+const TEMPLATE_HEADER: &str = r#"// Read once when the peppy daemon starts, so any edit below (mode or buffer
+// sizes) takes effect only after you restart the daemon.
+"#;
+
+/// The `mode` entry with its explanatory comment.
+const MODE_SECTION_SNIPPET: &str = r#"  //   "peer"   - Zenoh peer sessions with gossip: nodes form direct
+  //              peer-to-peer links and data stops relaying through the router.
+  //   "router" - gossip off: all traffic relays through the central zenohd
+  //              router.
+  // Container nodes in a separate network namespace (Lima on macOS) always use
+  // the router path regardless of this setting.
+  mode: "peer",
+"#;
+
+/// The `peer.standard_buffer_size` entry, indented for the `peer` block.
+const STANDARD_BUFFER_FIELD_SNIPPET: &str = const_format::concatcp!(
+    "    standard_buffer_size: ",
+    DEFAULT_STANDARD_BUFFER_SIZE,
+    ",\n"
+);
+
+/// The `peer.high_throughput_buffer_size` entry, indented for the `peer` block.
+const HIGH_THROUGHPUT_BUFFER_FIELD_SNIPPET: &str = const_format::concatcp!(
+    "    high_throughput_buffer_size: ",
+    DEFAULT_HIGH_THROUGHPUT_BUFFER_SIZE,
+    ",\n"
+);
+
+/// The whole `peer` block with its explanatory comment.
+const PEER_SECTION_SNIPPET: &str = const_format::concatcp!(
+    r#"  // Subscriber channel buffer sizes (number of in-flight messages) per QoS
+  // tier, used in peer mode where there is no router relay to buffer between a
+  // publisher and a subscriber. Defaults match peppy's built-in behavior; only
+  // edit to tune backpressure.
+  peer: {
+"#,
+    STANDARD_BUFFER_FIELD_SNIPPET,
+    HIGH_THROUGHPUT_BUFFER_FIELD_SNIPPET,
+    "  },\n"
+);
+
+/// The `lifecycle.daemon_grace_secs` entry with its comment, indented for the
+/// `lifecycle` block.
+const DAEMON_GRACE_FIELD_SNIPPET: &str = const_format::concatcp!(
+    r#"    // Node lifecycle knobs. `daemon_grace_secs` is the grace period a spawned node
+    // waits, after the daemon's heartbeat goes silent, before shutting itself down
+    // to avoid orphaning.
+    daemon_grace_secs: "#,
+    DEFAULT_DAEMON_GRACE_SECS,
+    ",\n"
+);
+
+/// The `lifecycle.shutdown_grace_secs` entry with its comment, indented for the
+/// `lifecycle` block.
+const SHUTDOWN_GRACE_FIELD_SNIPPET: &str = const_format::concatcp!(
+    r#"    // How long a clean shutdown (ctrl+C / `systemctl stop`) and `peppy node
+    // stop` wait for a node to exit cooperatively before force-killing its
+    // process group. Seconds; minimum 1. A robot node uses this window to park
+    // actuators and release hardware before it is killed.
+    shutdown_grace_secs: "#,
+    DEFAULT_SHUTDOWN_GRACE_SECS,
+    ",\n"
+);
+
+/// The whole `lifecycle` block.
+const LIFECYCLE_SECTION_SNIPPET: &str = const_format::concatcp!(
+    "  lifecycle: {\n",
+    DAEMON_GRACE_FIELD_SNIPPET,
+    "\n",
+    SHUTDOWN_GRACE_FIELD_SNIPPET,
+    "  },\n"
+);
+
+/// The `resource_servers.api` entry, indented for the `resource_servers` block.
+const API_FIELD_SNIPPET: &str = const_format::concatcp!("    api: \"", DEFAULT_API_URL, "\",\n");
+
+/// The whole `resource_servers` block with its explanatory comment. Only the
+/// CLI auth commands read this URL; the daemon ignores it but seeds and
+/// completes the block like every other knob.
+const RESOURCE_SERVERS_SECTION_SNIPPET: &str = const_format::concatcp!(
+    r#"  // Backend resource-server URL the `peppy auth login` / `whoami` / `logout`
+  // commands talk to. Baked in at compile time (the dev backend in debug
+  // builds, prod in release); --api-url / PEPPY_API_URL override it at runtime.
+  resource_servers: {
+"#,
+    API_FIELD_SNIPPET,
+    "  },\n"
+);
+
+/// The `federation.connect_timeout_secs` entry with its comment, indented for
+/// the `federation` block.
+const FEDERATION_TIMEOUT_FIELD_SNIPPET: &str = const_format::concatcp!(
+    r#"    // Seconds the daemon spends resolving your per-user cloud router before
+    // giving up for this attempt (it retries in the background). Bounds the
+    // federation done at startup and on each `peppy auth login`/`logout`;
+    // minimum 1. If the backend is unreachable within this window the daemon
+    // stays standalone rather than blocking.
+    connect_timeout_secs: "#,
+    DEFAULT_FEDERATION_CONNECT_TIMEOUT_SECS,
+    ",\n"
+);
+
+/// The whole `federation` block with its explanatory comment.
+const FEDERATION_SECTION_SNIPPET: &str = const_format::concatcp!(
+    r#"  // Per-user zenoh-router federation: how the daemon links its local router to
+  // your private cloud router. Only tuned to bound a slow/unreachable backend
+  // during the federation step.
+  federation: {
+"#,
+    FEDERATION_TIMEOUT_FIELD_SNIPPET,
+    "  },\n"
+);
+
+/// The full bundled default config, composed from the snippets above.
+const DEFAULT_PEPPY_CONFIG_TEMPLATE: &str = const_format::concatcp!(
+    TEMPLATE_HEADER,
+    "{\n",
+    MODE_SECTION_SNIPPET,
+    "\n",
+    PEER_SECTION_SNIPPET,
+    "\n",
+    LIFECYCLE_SECTION_SNIPPET,
+    "\n",
+    RESOURCE_SERVERS_SECTION_SNIPPET,
+    "\n",
+    FEDERATION_SECTION_SNIPPET,
+    "}\n"
+);
+
+/// The messaging topology the daemon runs in.
+///
+/// `Peer` keeps gossip on so nodes form direct peer-to-peer links; `Router`
+/// turns gossip off so every node routes through the central `zenohd`. The
+/// `gossip()` mapping is the single source of truth tying this user-facing
+/// choice to the `DiscoveryConfig.gossip` flag the sessions actually read.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Mode {
+    #[default]
+    Peer,
+    Router,
+}
+
+impl Mode {
+    /// Whether this is peer mode (direct peer-to-peer links).
+    pub fn is_peer(self) -> bool {
+        matches!(self, Mode::Peer)
+    }
+
+    /// Mode to gossip mapping: peer enables gossip, router disables it.
+    pub fn gossip(self) -> bool {
+        self.is_peer()
+    }
+}
+
+/// Peer-mode tuning knobs. Buffer sizes are the per-QoS subscriber channel
+/// capacities used when nodes peer directly (no router relay to absorb bursts).
+///
+/// `#[serde(default)]` fills any field a partial `peer` block omits from
+/// [`PeerConfig::default`], so every per-field default flows from the single
+/// `Default` impl below rather than parallel `default = "fn"` helpers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct PeerConfig {
+    pub standard_buffer_size: usize,
+    pub high_throughput_buffer_size: usize,
+}
+
+impl Default for PeerConfig {
+    fn default() -> Self {
+        Self {
+            standard_buffer_size: DEFAULT_STANDARD_BUFFER_SIZE,
+            high_throughput_buffer_size: DEFAULT_HIGH_THROUGHPUT_BUFFER_SIZE,
+        }
+    }
+}
+
+/// Node lifecycle knobs. `daemon_grace_secs` is the grace period a spawned node
+/// waits, after the daemon's heartbeat goes silent, before shutting itself down
+/// to avoid orphaning. A clean ctrl+C / `systemctl stop` is immediate and does
+/// not consult this value; it only governs an uncatchable daemon death.
+///
+/// `#[serde(default)]` fills any field a partial `lifecycle` block omits from
+/// [`LifecycleConfig::default`], matching the `PeerConfig` pattern.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct LifecycleConfig {
+    pub daemon_grace_secs: u64,
+    /// Cooperative-shutdown grace period, in seconds: how long a clean daemon
+    /// shutdown and `peppy node stop` wait for a node to exit on its own before
+    /// force-killing its process group. Unlike `daemon_grace_secs` (the
+    /// uncatchable-death watchdog), this governs the catchable/explicit stop
+    /// paths.
+    pub shutdown_grace_secs: u64,
+}
+
+impl Default for LifecycleConfig {
+    fn default() -> Self {
+        Self {
+            daemon_grace_secs: DEFAULT_DAEMON_GRACE_SECS,
+            shutdown_grace_secs: DEFAULT_SHUTDOWN_GRACE_SECS,
+        }
+    }
+}
+
+/// The backend resource server the CLI auth commands talk to. The endpoint
+/// paths (`/cli-config`, `/me`, `/logout`) are appended by the caller; `api`
+/// holds only the base URL. A single URL, baked in per build: there is no
+/// dev/prod selection at runtime, so the file stores exactly the build's
+/// backend ([`DEFAULT_API_URL`]).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ResourceServers {
+    pub api: String,
+}
+
+impl Default for ResourceServers {
+    fn default() -> Self {
+        Self {
+            api: DEFAULT_API_URL.to_string(),
+        }
+    }
+}
+
+/// Per-user zenoh-router federation knobs. `connect_timeout_secs` bounds the
+/// backend round-trip the daemon makes to resolve the caller's cloud router so a
+/// slow or unreachable backend never stalls the federation step past it (read at
+/// startup, where it gates `serve` reporting ready, and on every login/logout
+/// poke).
+///
+/// `#[serde(default)]` fills any field a partial `federation` block omits from
+/// [`FederationConfig::default`], matching the `LifecycleConfig` pattern.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct FederationConfig {
+    pub connect_timeout_secs: u64,
+}
+
+impl Default for FederationConfig {
+    fn default() -> Self {
+        Self {
+            connect_timeout_secs: DEFAULT_FEDERATION_CONNECT_TIMEOUT_SECS,
+        }
+    }
+}
+
+/// The whole `peppy_config.json5` document. Every field is serde-defaulted so a
+/// partial or older file still parses; extra unknown keys are tolerated (this is
+/// a user-edited file, forward-compat beats strictness here).
+///
+/// Not `Copy`: `resource_servers` owns heap strings. The daemon reads this once
+/// and moves it into the core node, and the CLI clones it field-by-field, so the
+/// lost `Copy` costs nothing.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct PeppyConfig {
+    #[serde(default)]
+    pub mode: Mode,
+    #[serde(default)]
+    pub peer: PeerConfig,
+    #[serde(default)]
+    pub lifecycle: LifecycleConfig,
+    #[serde(default)]
+    pub resource_servers: ResourceServers,
+    #[serde(default)]
+    pub federation: FederationConfig,
+}
+
+impl PeppyConfig {
+    /// Rejects user-tunable numeric fields that serde cannot constrain.
+    ///
+    /// Buffer sizes feed bounded channel constructors downstream: a 0 capacity
+    /// panics `tokio::sync::mpsc::channel` and degrades `flume::bounded` into a
+    /// rendezvous channel that stalls every send. A hand-edited 0 must fail loud
+    /// at load time rather than crash or wedge a running mesh.
+    fn validate(&self) -> Result<()> {
+        let buffer_sizes = [
+            ("standard_buffer_size", self.peer.standard_buffer_size),
+            (
+                "high_throughput_buffer_size",
+                self.peer.high_throughput_buffer_size,
+            ),
+        ];
+        for (field, value) in buffer_sizes {
+            if value == 0 {
+                return Err(Error::Parsing(ParsingError::CannotParseConfig(format!(
+                    "invalid peer buffer size: {field} must be > 0"
+                ))));
+            }
+        }
+
+        // The grace period must comfortably exceed the heartbeat interval and a
+        // router restart, or a brief daemon blip would trip every node's
+        // watchdog. Reject a hand-edited too-small value loud at load time.
+        if self.lifecycle.daemon_grace_secs < MIN_DAEMON_GRACE_SECS {
+            return Err(Error::Parsing(ParsingError::CannotParseConfig(format!(
+                "invalid lifecycle.daemon_grace_secs: must be >= {MIN_DAEMON_GRACE_SECS}"
+            ))));
+        }
+        if self.lifecycle.shutdown_grace_secs < MIN_SHUTDOWN_GRACE_SECS {
+            return Err(Error::Parsing(ParsingError::CannotParseConfig(format!(
+                "invalid lifecycle.shutdown_grace_secs: must be >= {MIN_SHUTDOWN_GRACE_SECS}"
+            ))));
+        }
+        // A 0 bound would make the federation pull either give up instantly or
+        // (to the HTTP client) wait forever; reject a hand-edited too-small value
+        // loud at load time, same as the grace periods.
+        if self.federation.connect_timeout_secs < MIN_FEDERATION_CONNECT_TIMEOUT_SECS {
+            return Err(Error::Parsing(ParsingError::CannotParseConfig(format!(
+                "invalid federation.connect_timeout_secs: must be >= {MIN_FEDERATION_CONNECT_TIMEOUT_SECS}"
+            ))));
+        }
+        Ok(())
+    }
+}
+
+/// Reads the global config from `~/.peppy/conf/peppy_config.json5`, creating it
+/// from the bundled default template (verbatim, so comments survive) when it
+/// does not exist, and appending defaults for any setting an existing file
+/// omits so the file on disk always lists every available knob.
+///
+/// Read ONCE by the daemon at startup. A malformed existing file returns `Err`
+/// (fail loud) rather than defaulting, since mode and buffer sizes are
+/// load-bearing for the whole mesh. This intentionally differs from
+/// `ensure_default_repos`, which only warns on a bad repos file.
+pub fn load_or_create(peppy_dirs: &PeppyDirs) -> Result<PeppyConfig> {
+    let conf_dir = peppy_dirs.conf_dir();
+    std::fs::create_dir_all(&conf_dir)?;
+    let path = conf_dir.join(PEPPY_CONFIG_FILE);
+
+    if !path.exists() {
+        // Plain write: there is no user-authored content to protect yet, and
+        // it leaves the new file with normal umask-derived permissions.
+        std::fs::write(&path, DEFAULT_PEPPY_CONFIG_TEMPLATE)?;
+        // The bundled template is a compile-time invariant; a parse failure here
+        // means the shipped asset is broken, not the user's file.
+        let config: PeppyConfig =
+            serde_json5::from_str(DEFAULT_PEPPY_CONFIG_TEMPLATE).map_err(|e| {
+                Error::Serialize(format!("bundled default peppy_config is invalid: {e}"))
+            })?;
+        config.validate()?;
+        return Ok(config);
+    }
+
+    let content = std::fs::read_to_string(&path)?;
+    let config: PeppyConfig = serde_json5::from_str(&content).map_err(|e| {
+        Error::Parsing(ParsingError::CannotParseConfig(format!(
+            "{PEPPY_CONFIG_FILE}: {e}"
+        )))
+    })?;
+    // serde parses any numeric field, so a hand-edited 0 buffer size survives
+    // the parse above; reject it before it reaches a bounded channel downstream.
+    config.validate()?;
+    // Only a fully successful load may touch the user's file: a malformed or
+    // invalid config errors out above with the file left byte-for-byte intact.
+    complete_file_with_defaults(&path, &content, &config);
+    Ok(config)
+}
+
+/// Appends template defaults for every setting the user's file omits, so the
+/// on-disk file spells out all available knobs.
+///
+/// Best effort by design: `config` (parsed from `content`) is already complete
+/// in memory via the serde defaults, so this only improves the FILE. The result
+/// must pass [`completion::verify_completion`] before anything is written; a
+/// failure means a splicing bug, in which case the user's file is left
+/// untouched and a warning is logged instead of taking the daemon down over a
+/// cosmetic rewrite.
+fn complete_file_with_defaults(path: &Path, content: &str, config: &PeppyConfig) {
+    let Some(completed) = completion::complete_config_content(content) else {
+        return;
+    };
+    if !completion::verify_completion(content, &completed, config) {
+        tracing::warn!(
+            "adding missing defaults to {PEPPY_CONFIG_FILE} produced inconsistent \
+             content, leaving the file untouched"
+        );
+        return;
+    }
+    // Write through a symlink, not over it: a dotfiles-managed config stays a
+    // symlink and its real target receives the completed content. (The atomic
+    // rename below replaces the path entry itself, so it must point at the
+    // resolved file.)
+    let target = match std::fs::canonicalize(path) {
+        Ok(target) => target,
+        Err(e) => {
+            tracing::warn!("could not resolve {PEPPY_CONFIG_FILE} for completion: {e}");
+            return;
+        }
+    };
+    if let Err(e) = write_config_file(&target, &completed) {
+        tracing::warn!(
+            "could not add missing defaults to {PEPPY_CONFIG_FILE}, \
+             continuing with the in-memory defaults: {e}"
+        );
+    }
+}
+
+/// Replaces an existing config through a staged sibling tmp file and an atomic
+/// rename, so a crash mid-write can never truncate a user's hand-edited
+/// `peppy_config.json5`. The destination's permissions are carried onto the
+/// staged file first: `NamedTempFile` creates it as 0600 on unix, and the
+/// rename would otherwise silently tighten the user's file.
+fn write_config_file(path: &Path, content: &str) -> Result<()> {
+    let permissions = std::fs::metadata(path)?.permissions();
+    publish_atomic(path, |tmp| {
+        std::fs::write(tmp, content)?;
+        std::fs::set_permissions(tmp, permissions)
+    })?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use tempfile::tempdir;
+
+    /// Writes `content` as the config file in a fresh `~/.peppy`-style tempdir.
+    /// The tempdir guard is returned so callers keep it alive for the test.
+    fn dirs_with_config(content: &str) -> (tempfile::TempDir, PeppyDirs, PathBuf) {
+        let tmp = tempdir().unwrap();
+        let peppy_dirs = PeppyDirs::new(tmp.path());
+        let conf_dir = peppy_dirs.conf_dir();
+        std::fs::create_dir_all(&conf_dir).unwrap();
+        let path = conf_dir.join(PEPPY_CONFIG_FILE);
+        std::fs::write(&path, content).unwrap();
+        (tmp, peppy_dirs, path)
+    }
+
+    #[test]
+    fn default_mode_is_peer_and_buffers_match_constants() {
+        let cfg = PeppyConfig::default();
+        assert_eq!(cfg.mode, Mode::Peer);
+        assert!(cfg.mode.is_peer());
+        assert!(cfg.mode.gossip());
+        assert!(!Mode::Router.gossip());
+        assert_eq!(cfg.peer.standard_buffer_size, DEFAULT_STANDARD_BUFFER_SIZE);
+        assert_eq!(
+            cfg.peer.high_throughput_buffer_size,
+            DEFAULT_HIGH_THROUGHPUT_BUFFER_SIZE
+        );
+        assert_eq!(cfg.lifecycle.daemon_grace_secs, DEFAULT_DAEMON_GRACE_SECS);
+        assert_eq!(
+            cfg.lifecycle.shutdown_grace_secs,
+            DEFAULT_SHUTDOWN_GRACE_SECS
+        );
+        assert_eq!(cfg.resource_servers.api, DEFAULT_API_URL);
+        assert_eq!(
+            cfg.federation.connect_timeout_secs,
+            DEFAULT_FEDERATION_CONNECT_TIMEOUT_SECS
+        );
+    }
+
+    #[test]
+    fn federation_section_defaults_and_completes() {
+        // An existing file with no `federation` block parses with the default
+        // and is completed in place with the section (the auto-complete path
+        // older files rely on).
+        let (_tmp, peppy_dirs, path) = dirs_with_config(r#"{ mode: "router" }"#);
+        let cfg = load_or_create(&peppy_dirs).unwrap();
+        assert_eq!(
+            cfg.federation.connect_timeout_secs,
+            DEFAULT_FEDERATION_CONNECT_TIMEOUT_SECS
+        );
+        let completed = std::fs::read_to_string(&path).unwrap();
+        assert!(completed.contains("federation: {"));
+        assert!(completed.contains(&format!(
+            "connect_timeout_secs: {DEFAULT_FEDERATION_CONNECT_TIMEOUT_SECS},"
+        )));
+        // Idempotent: a second load parses to the same config and stops rewriting.
+        assert_eq!(load_or_create(&peppy_dirs).unwrap(), cfg);
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), completed);
+
+        // An explicit value is honored.
+        let (_tmp, peppy_dirs, _) =
+            dirs_with_config(r#"{ federation: { connect_timeout_secs: 5 } }"#);
+        let cfg = load_or_create(&peppy_dirs).unwrap();
+        assert_eq!(cfg.federation.connect_timeout_secs, 5);
+    }
+
+    #[test]
+    fn zero_federation_timeout_fails_loud() {
+        let (_tmp, peppy_dirs, _) =
+            dirs_with_config(r#"{ federation: { connect_timeout_secs: 0 } }"#);
+
+        let err = load_or_create(&peppy_dirs).unwrap_err();
+        assert!(
+            matches!(err, Error::Parsing(ParsingError::CannotParseConfig(ref m)) if m.contains("connect_timeout_secs")),
+            "expected a federation-timeout validation error, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn resource_servers_api_is_read_and_defaults() {
+        // An explicit api is honored.
+        let (_tmp, peppy_dirs, _) =
+            dirs_with_config(r#"{ resource_servers: { api: "http://localhost:9000" } }"#);
+        let cfg = load_or_create(&peppy_dirs).unwrap();
+        assert_eq!(cfg.resource_servers.api, "http://localhost:9000");
+        assert_eq!(cfg.mode, Mode::Peer);
+
+        // An empty block falls back to the build's default backend URL.
+        let (_tmp, peppy_dirs, _) = dirs_with_config(r#"{ resource_servers: {} }"#);
+        let cfg = load_or_create(&peppy_dirs).unwrap();
+        assert_eq!(cfg.resource_servers.api, DEFAULT_API_URL);
+    }
+
+    #[test]
+    fn parses_partial_lifecycle_block() {
+        let (_tmp, peppy_dirs, _) =
+            dirs_with_config(r#"{ lifecycle: { daemon_grace_secs: 600 } }"#);
+
+        let cfg = load_or_create(&peppy_dirs).unwrap();
+        assert_eq!(cfg.lifecycle.daemon_grace_secs, 600);
+        // A field omitted from a partial lifecycle block falls back to its default.
+        assert_eq!(
+            cfg.lifecycle.shutdown_grace_secs,
+            DEFAULT_SHUTDOWN_GRACE_SECS
+        );
+        // Omitted blocks still fall back to their defaults.
+        assert_eq!(cfg.mode, Mode::Peer);
+        assert_eq!(cfg.peer, PeerConfig::default());
+    }
+
+    #[test]
+    fn sub_minimum_shutdown_grace_fails_loud() {
+        let (_tmp, peppy_dirs, _) =
+            dirs_with_config(r#"{ lifecycle: { shutdown_grace_secs: 0 } }"#);
+
+        let err = load_or_create(&peppy_dirs).unwrap_err();
+        assert!(
+            matches!(err, Error::Parsing(ParsingError::CannotParseConfig(ref m)) if m.contains("shutdown_grace_secs")),
+            "expected a shutdown-grace validation error, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn sub_minimum_grace_fails_loud_and_leaves_file_untouched() {
+        let invalid = r#"{ lifecycle: { daemon_grace_secs: 5 } }"#;
+        let (_tmp, peppy_dirs, path) = dirs_with_config(invalid);
+
+        let err = load_or_create(&peppy_dirs).unwrap_err();
+        assert!(
+            matches!(err, Error::Parsing(ParsingError::CannotParseConfig(ref m)) if m.contains("daemon_grace_secs")),
+            "expected a grace-period validation error, got: {err:?}"
+        );
+        // Out-of-range values fail BEFORE completion: the file keeps omitting
+        // knobs and is not rewritten, same as the malformed case.
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), invalid);
+    }
+
+    #[test]
+    fn creates_file_verbatim_on_first_run() {
+        let tmp = tempdir().unwrap();
+        let peppy_dirs = PeppyDirs::new(tmp.path());
+        let path = peppy_dirs.conf_dir().join(PEPPY_CONFIG_FILE);
+        assert!(!path.exists());
+
+        let cfg = load_or_create(&peppy_dirs).unwrap();
+
+        assert!(path.exists());
+        // Verbatim write preserves the template's comments byte-for-byte.
+        let written = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(written, DEFAULT_PEPPY_CONFIG_TEMPLATE);
+        assert_eq!(cfg, PeppyConfig::default());
+    }
+
+    #[test]
+    fn load_is_idempotent_and_reads_existing_file() {
+        let tmp = tempdir().unwrap();
+        let peppy_dirs = PeppyDirs::new(tmp.path());
+        let first = load_or_create(&peppy_dirs).unwrap();
+        let second = load_or_create(&peppy_dirs).unwrap();
+        assert_eq!(first, second);
+        // A file that already spells out every knob is not rewritten.
+        let path = peppy_dirs.conf_dir().join(PEPPY_CONFIG_FILE);
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            DEFAULT_PEPPY_CONFIG_TEMPLATE
+        );
+    }
+
+    #[test]
+    fn completes_missing_fields_while_preserving_user_values() {
+        let (_tmp, peppy_dirs, path) =
+            dirs_with_config(r#"{ mode: "router", lifecycle: { daemon_grace_secs: 45 } }"#);
+
+        let cfg = load_or_create(&peppy_dirs).unwrap();
+        assert_eq!(cfg.mode, Mode::Router);
+        assert_eq!(cfg.lifecycle.daemon_grace_secs, 45);
+        assert_eq!(
+            cfg.lifecycle.shutdown_grace_secs,
+            DEFAULT_SHUTDOWN_GRACE_SECS
+        );
+        assert_eq!(cfg.peer, PeerConfig::default());
+
+        // The user's values survive in the file and the omitted knobs now
+        // appear in it with their defaults.
+        let completed = std::fs::read_to_string(&path).unwrap();
+        assert!(completed.contains(r#"mode: "router""#));
+        assert!(completed.contains("daemon_grace_secs: 45"));
+        assert!(completed.contains(&format!(
+            "standard_buffer_size: {DEFAULT_STANDARD_BUFFER_SIZE},"
+        )));
+        assert!(completed.contains(&format!(
+            "shutdown_grace_secs: {DEFAULT_SHUTDOWN_GRACE_SECS},"
+        )));
+
+        // A second load parses the completed file to the same config and no
+        // longer rewrites it.
+        assert_eq!(load_or_create(&peppy_dirs).unwrap(), cfg);
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), completed);
+    }
+
+    #[test]
+    fn parses_partial_file_filling_defaults() {
+        let (_tmp, peppy_dirs, _) = dirs_with_config(r#"{ mode: "router" }"#);
+
+        let cfg = load_or_create(&peppy_dirs).unwrap();
+        assert_eq!(cfg.mode, Mode::Router);
+        assert!(!cfg.mode.gossip());
+        // Missing peer block falls back to the built-in defaults.
+        assert_eq!(cfg.peer.standard_buffer_size, DEFAULT_STANDARD_BUFFER_SIZE);
+        assert_eq!(
+            cfg.peer.high_throughput_buffer_size,
+            DEFAULT_HIGH_THROUGHPUT_BUFFER_SIZE
+        );
+    }
+
+    #[test]
+    fn parses_empty_object_as_all_defaults() {
+        let (_tmp, peppy_dirs, _) = dirs_with_config("{}");
+
+        let cfg = load_or_create(&peppy_dirs).unwrap();
+        assert_eq!(cfg, PeppyConfig::default());
+    }
+
+    #[test]
+    fn round_trips_custom_config() {
+        let custom = PeppyConfig {
+            mode: Mode::Router,
+            peer: PeerConfig {
+                standard_buffer_size: 64,
+                high_throughput_buffer_size: 4096,
+            },
+            lifecycle: LifecycleConfig {
+                daemon_grace_secs: 240,
+                shutdown_grace_secs: 5,
+            },
+            resource_servers: ResourceServers {
+                api: "http://localhost:9000".to_string(),
+            },
+            federation: FederationConfig {
+                connect_timeout_secs: 45,
+            },
+        };
+        let serialized = serde_json5::to_string(&custom).unwrap();
+        let reparsed: PeppyConfig = serde_json5::from_str(&serialized).unwrap();
+        assert_eq!(reparsed, custom);
+    }
+
+    #[test]
+    fn mode_serializes_snake_case() {
+        assert_eq!(
+            serde_json::to_value(Mode::Router).unwrap(),
+            serde_json::json!("router")
+        );
+        assert_eq!(
+            serde_json::to_value(Mode::Peer).unwrap(),
+            serde_json::json!("peer")
+        );
+    }
+
+    #[test]
+    fn malformed_file_fails_loud_and_is_left_untouched() {
+        let malformed = r#"{ mode: "router", peer: { standard_buffer_size: "not a number" } }"#;
+        let (_tmp, peppy_dirs, path) = dirs_with_config(malformed);
+
+        let err = load_or_create(&peppy_dirs).unwrap_err();
+        assert!(
+            matches!(err, Error::Parsing(ParsingError::CannotParseConfig(_))),
+            "expected a parse error, got: {err:?}"
+        );
+        // A failed load never modifies the file, even though it omits knobs.
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), malformed);
+    }
+
+    #[test]
+    fn zero_standard_buffer_size_fails_loud() {
+        let (_tmp, peppy_dirs, _) = dirs_with_config(r#"{ peer: { standard_buffer_size: 0 } }"#);
+
+        let err = load_or_create(&peppy_dirs).unwrap_err();
+        assert!(
+            matches!(err, Error::Parsing(ParsingError::CannotParseConfig(ref m)) if m.contains("standard_buffer_size")),
+            "expected a buffer-size validation error, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn zero_high_throughput_buffer_size_fails_loud() {
+        let (_tmp, peppy_dirs, _) =
+            dirs_with_config(r#"{ peer: { high_throughput_buffer_size: 0 } }"#);
+
+        let err = load_or_create(&peppy_dirs).unwrap_err();
+        assert!(
+            matches!(err, Error::Parsing(ParsingError::CannotParseConfig(ref m)) if m.contains("high_throughput_buffer_size")),
+            "expected a buffer-size validation error, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn accepts_minimal_nonzero_buffer_sizes() {
+        let (_tmp, peppy_dirs, _) = dirs_with_config(
+            r#"{ peer: { standard_buffer_size: 1, high_throughput_buffer_size: 1 } }"#,
+        );
+
+        let cfg = load_or_create(&peppy_dirs).unwrap();
+        assert_eq!(cfg.peer.standard_buffer_size, 1);
+        assert_eq!(cfg.peer.high_throughput_buffer_size, 1);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn completion_preserves_file_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let (_tmp, peppy_dirs, path) = dirs_with_config(r#"{ mode: "router" }"#);
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o640)).unwrap();
+
+        load_or_create(&peppy_dirs).unwrap();
+
+        // The staged tmp file is born 0600; the completed file must come out
+        // with the user's permissions, not the tmp file's.
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert!(
+            std::fs::read_to_string(&path)
+                .unwrap()
+                .contains("lifecycle"),
+            "completion did not run"
+        );
+        assert_eq!(mode, 0o640);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn completion_writes_through_a_symlinked_config() {
+        let tmp = tempdir().unwrap();
+        let peppy_dirs = PeppyDirs::new(tmp.path());
+        let conf_dir = peppy_dirs.conf_dir();
+        std::fs::create_dir_all(&conf_dir).unwrap();
+        // A dotfiles-style setup: the file under conf/ is a symlink to a
+        // config managed elsewhere.
+        let real = tmp.path().join("dotfiles_peppy.json5");
+        std::fs::write(&real, r#"{ mode: "router" }"#).unwrap();
+        let link = conf_dir.join(PEPPY_CONFIG_FILE);
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        let cfg = load_or_create(&peppy_dirs).unwrap();
+        assert_eq!(cfg.mode, Mode::Router);
+
+        // The symlink survives and the completed content landed in its target.
+        assert!(
+            std::fs::symlink_metadata(&link)
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+        assert!(
+            std::fs::read_to_string(&real)
+                .unwrap()
+                .contains("lifecycle")
+        );
+    }
+}

--- a/crates/daemon-config-internal/src/peppy_config/completion.rs
+++ b/crates/daemon-config-internal/src/peppy_config/completion.rs
@@ -1,0 +1,704 @@
+//! Comment-preserving completion of a user's `peppy_config.json5`.
+//!
+//! [`complete_config_content`] splices every missing known section or nested
+//! field into the file content, copying the snippet (explanatory comments
+//! included) from the bundled template, so the file on disk always lists every
+//! available knob. Everything the user wrote survives byte-for-byte: their
+//! values, their comments, their formatting, and any unknown keys.
+//!
+//! Rewriting the file through serde would destroy comments, and no
+//! comment-preserving JSON5 editor crate exists, so this works directly on the
+//! text: a minimal JSON5-aware scanner (strings, comments, and brace nesting,
+//! nothing more) locates the insertion points, and the snippets are inserted
+//! before the relevant closing brace. Before anything is written, the caller
+//! gates the result through [`verify_completion`], so a splicing bug cannot
+//! drop or alter any value the user wrote, cannot change what the file parses
+//! to, and cannot splice again on the next start; a bad splice is discarded
+//! with a warning and the user's file stays untouched.
+
+use serde_json::Value;
+use std::collections::HashMap;
+
+use super::{
+    API_FIELD_SNIPPET, DAEMON_GRACE_FIELD_SNIPPET, FEDERATION_SECTION_SNIPPET,
+    FEDERATION_TIMEOUT_FIELD_SNIPPET, HIGH_THROUGHPUT_BUFFER_FIELD_SNIPPET,
+    LIFECYCLE_SECTION_SNIPPET, MODE_SECTION_SNIPPET, PEER_SECTION_SNIPPET,
+    RESOURCE_SERVERS_SECTION_SNIPPET, SHUTDOWN_GRACE_FIELD_SNIPPET, STANDARD_BUFFER_FIELD_SNIPPET,
+};
+
+/// A nested field of a top-level section, with the template snippet to splice
+/// into the section's block when the field is absent.
+struct FieldSpec {
+    key: &'static str,
+    snippet: &'static str,
+}
+
+/// A top-level entry of the bundled template: the snippet to splice into the
+/// root object when the whole entry is absent, and the nested fields to splice
+/// individually when the entry exists but is incomplete.
+struct SectionSpec {
+    key: &'static str,
+    snippet: &'static str,
+    fields: &'static [FieldSpec],
+}
+
+/// Every known config entry, in template order. New knobs must be added here
+/// (and to the template composition) to be auto-completed into user files;
+/// `template_matches_section_table` pins the two against each other.
+const SECTIONS: &[SectionSpec] = &[
+    SectionSpec {
+        key: "mode",
+        snippet: MODE_SECTION_SNIPPET,
+        fields: &[],
+    },
+    SectionSpec {
+        key: "peer",
+        snippet: PEER_SECTION_SNIPPET,
+        fields: &[
+            FieldSpec {
+                key: "standard_buffer_size",
+                snippet: STANDARD_BUFFER_FIELD_SNIPPET,
+            },
+            FieldSpec {
+                key: "high_throughput_buffer_size",
+                snippet: HIGH_THROUGHPUT_BUFFER_FIELD_SNIPPET,
+            },
+        ],
+    },
+    SectionSpec {
+        key: "lifecycle",
+        snippet: LIFECYCLE_SECTION_SNIPPET,
+        fields: &[
+            FieldSpec {
+                key: "daemon_grace_secs",
+                snippet: DAEMON_GRACE_FIELD_SNIPPET,
+            },
+            FieldSpec {
+                key: "shutdown_grace_secs",
+                snippet: SHUTDOWN_GRACE_FIELD_SNIPPET,
+            },
+        ],
+    },
+    SectionSpec {
+        key: "resource_servers",
+        snippet: RESOURCE_SERVERS_SECTION_SNIPPET,
+        fields: &[FieldSpec {
+            key: "api",
+            snippet: API_FIELD_SNIPPET,
+        }],
+    },
+    SectionSpec {
+        key: "federation",
+        snippet: FEDERATION_SECTION_SNIPPET,
+        fields: &[FieldSpec {
+            key: "connect_timeout_secs",
+            snippet: FEDERATION_TIMEOUT_FIELD_SNIPPET,
+        }],
+    },
+];
+
+/// Returns `content` with every missing known section or field appended from
+/// the bundled template, or `None` when the file already spells out all of them
+/// (or, defensively, when the content cannot be analyzed; the caller treats
+/// both as "leave the file alone").
+///
+/// Expects `content` to already have parsed successfully as a `PeppyConfig`;
+/// malformed input simply returns `None` rather than guessing at splice points.
+pub(super) fn complete_config_content(content: &str) -> Option<String> {
+    let doc: Value = serde_json5::from_str(content).ok()?;
+    let doc = doc.as_object()?;
+
+    let mut missing_sections: Vec<&SectionSpec> = Vec::new();
+    let mut incomplete_sections: Vec<(&SectionSpec, Vec<&FieldSpec>)> = Vec::new();
+    for section in SECTIONS {
+        match doc.get(section.key) {
+            None => missing_sections.push(section),
+            Some(value) => {
+                // A present-but-non-object section cannot have parsed as a
+                // `PeppyConfig`; covered here anyway so this function never
+                // relies on its caller's checks.
+                let Some(block) = value.as_object() else {
+                    continue;
+                };
+                let absent: Vec<&FieldSpec> = section
+                    .fields
+                    .iter()
+                    .filter(|field| !block.contains_key(field.key))
+                    .collect();
+                if !absent.is_empty() {
+                    incomplete_sections.push((section, absent));
+                }
+            }
+        }
+    }
+    if missing_sections.is_empty() && incomplete_sections.is_empty() {
+        return None;
+    }
+
+    let layout = scan_layout(content)?;
+
+    // Each entry is (byte offset in `content`, text to insert there). Applied
+    // in descending offset order so earlier offsets stay valid. When two
+    // insertions share an offset, the one applied later lands EARLIER in the
+    // output; every comma is therefore pushed after its snippet, so it always
+    // ends up immediately behind the existing last entry.
+    let mut insertions: Vec<(usize, String)> = Vec::new();
+
+    if !missing_sections.is_empty() {
+        let mut text = String::new();
+        for section in &missing_sections {
+            text.push('\n');
+            text.push_str(section.snippet);
+        }
+        insertions.push((layout.root.close, text));
+        if let Some(at) = layout.root.trailing_comma_insertion() {
+            insertions.push((at, ",".to_string()));
+        }
+    }
+
+    for (section, fields) in &incomplete_sections {
+        // A block the scanner could not pair with this key (say, a key spelled
+        // with string escapes) is skipped: the in-memory defaults still apply,
+        // the file just keeps omitting the field.
+        let Some(block) = layout.blocks.get(section.key) else {
+            continue;
+        };
+        let mut text = String::new();
+        for field in fields {
+            text.push('\n');
+            text.push_str(field.snippet);
+        }
+        insertions.push((block.close, text));
+        if let Some(at) = block.trailing_comma_insertion() {
+            insertions.push((at, ",".to_string()));
+        }
+    }
+    if insertions.is_empty() {
+        return None;
+    }
+
+    insertions.sort_by_key(|&(at, _)| std::cmp::Reverse(at));
+    let mut completed = content.to_string();
+    for (at, text) in insertions {
+        completed.insert_str(at, &text);
+    }
+    Some(completed)
+}
+
+/// Whether `completed` is a faithful completion of `original`, parsed as
+/// `config`: it must parse back to the same `PeppyConfig`, need no further
+/// completion (every known knob now spelled out, so the splice cannot repeat
+/// on the next start), and preserve every value the user wrote. Any `false`
+/// means a splicing bug; the caller then discards `completed` unwritten.
+pub(super) fn verify_completion(
+    original: &str,
+    completed: &str,
+    config: &super::PeppyConfig,
+) -> bool {
+    let Ok(reparsed) = serde_json5::from_str::<super::PeppyConfig>(completed) else {
+        return false;
+    };
+    if reparsed != *config {
+        return false;
+    }
+    if complete_config_content(completed).is_some() {
+        return false;
+    }
+    // The typed checks above ignore unknown keys, so also require every value
+    // of the original document to survive untouched in the completed one.
+    let Ok(original_doc) = serde_json5::from_str::<Value>(original) else {
+        return false;
+    };
+    let Ok(completed_doc) = serde_json5::from_str::<Value>(completed) else {
+        return false;
+    };
+    every_value_preserved(&original_doc, &completed_doc)
+}
+
+/// Every value in `original` must appear unchanged in `completed`. Objects may
+/// gain entries (the spliced defaults) but never lose or alter existing ones;
+/// anything else, arrays included, must be identical.
+fn every_value_preserved(original: &Value, completed: &Value) -> bool {
+    match (original, completed) {
+        (Value::Object(original), Value::Object(completed)) => {
+            original.iter().all(|(key, value)| {
+                completed
+                    .get(key)
+                    .is_some_and(|kept| every_value_preserved(value, kept))
+            })
+        }
+        _ => original == completed,
+    }
+}
+
+/// Where an object literal opens and closes in the source text, plus what the
+/// last significant (non-whitespace, non-comment) character inside it is, which
+/// decides whether appending an entry needs a separating comma first.
+struct BlockSpan {
+    /// Byte offset just past the opening `{`.
+    open_end: usize,
+    /// Byte offset of the closing `}`.
+    close: usize,
+    /// Byte offset just past the last significant character before the closing
+    /// brace. Equal to `open_end` when the object is empty.
+    last_significant_end: usize,
+    /// The last significant character itself (the `{` itself when empty).
+    last_significant_char: char,
+}
+
+impl BlockSpan {
+    /// Byte offset at which a `,` must be inserted before appending another
+    /// entry to this object, or `None` when the object is empty or its last
+    /// entry already has a trailing comma.
+    fn trailing_comma_insertion(&self) -> Option<usize> {
+        let is_empty = self.last_significant_end == self.open_end;
+        if is_empty || self.last_significant_char == ',' {
+            return None;
+        }
+        Some(self.last_significant_end)
+    }
+}
+
+/// The insertion points of a config document: the root object, and every
+/// top-level key whose value is an object literal (keyed by name, last
+/// occurrence winning to match serde's duplicate-key behavior).
+struct DocumentLayout {
+    root: BlockSpan,
+    blocks: HashMap<String, BlockSpan>,
+}
+
+/// Scanner state: inside code, a string literal, or a comment.
+enum ScanState {
+    Code,
+    Str { quote: char, escaped: bool },
+    LineComment,
+    BlockComment,
+}
+
+/// One unclosed `{` or `[`. `key` is set for an object that is the value of a
+/// top-level entry (and left `None` for the root, arrays, and deeper nesting).
+struct OpenDelimiter {
+    is_object: bool,
+    open_end: usize,
+    key: Option<String>,
+}
+
+/// Single-pass scan of JSON5 text for the structure [`complete_config_content`]
+/// needs. Tracks just enough of the grammar to never misread a brace: string
+/// literals (with escapes), line and block comments, and `{`/`[` nesting.
+/// Returns `None` on structurally broken input.
+fn scan_layout(content: &str) -> Option<DocumentLayout> {
+    let mut state = ScanState::Code;
+    let mut stack: Vec<OpenDelimiter> = Vec::new();
+    let mut root: Option<BlockSpan> = None;
+    let mut blocks: HashMap<String, BlockSpan> = HashMap::new();
+
+    // Last significant char seen anywhere (offset-just-past, char).
+    let mut last_significant: Option<(usize, char)> = None;
+    // An identifier-ish token currently being accumulated (start offset).
+    let mut word_start: Option<usize> = None;
+    // The most recent completed identifier or string token at root level; a
+    // following `:` turns it into `pending_key`.
+    let mut last_root_token: Option<String> = None;
+    // Set between `key:` and its value, at root level only.
+    let mut pending_key: Option<String> = None;
+    // Start offset of the string literal currently being scanned.
+    let mut string_start = 0usize;
+
+    let mut chars = content.char_indices().peekable();
+    while let Some((i, c)) = chars.next() {
+        match state {
+            ScanState::Str { quote, escaped } => {
+                if escaped {
+                    state = ScanState::Str {
+                        quote,
+                        escaped: false,
+                    };
+                } else if c == '\\' {
+                    state = ScanState::Str {
+                        quote,
+                        escaped: true,
+                    };
+                } else if c == quote {
+                    if stack.len() == 1 {
+                        last_root_token = Some(content[string_start + 1..i].to_string());
+                    }
+                    last_significant = Some((i + c.len_utf8(), quote));
+                    state = ScanState::Code;
+                }
+            }
+            ScanState::LineComment => {
+                // JSON5 terminates a line comment at any ECMAScript
+                // LineTerminator, not just LF; exiting only on '\n' would let
+                // code hide between a lone CR (or U+2028/U+2029) and the next
+                // LF, where serde_json5 sees it but this scanner would not.
+                if matches!(c, '\n' | '\r' | '\u{2028}' | '\u{2029}') {
+                    state = ScanState::Code;
+                }
+            }
+            ScanState::BlockComment => {
+                if c == '*' && matches!(chars.peek(), Some((_, '/'))) {
+                    chars.next();
+                    state = ScanState::Code;
+                }
+            }
+            ScanState::Code => {
+                // Word tokens end at whitespace, a structural char, a quote, or
+                // a comment; close the current one before handling `c`.
+                let ends_word = c.is_whitespace()
+                    || matches!(c, '{' | '}' | '[' | ']' | ',' | ':' | '"' | '\'')
+                    || (c == '/' && matches!(chars.peek(), Some((_, '/' | '*'))));
+                // `take()` must run for every word end so the word is cleared
+                // even outside root level; the `&&` chain keeps that order.
+                if ends_word
+                    && let Some(start) = word_start.take()
+                    && stack.len() == 1
+                {
+                    last_root_token = Some(content[start..i].to_string());
+                }
+
+                if c == '/' && matches!(chars.peek(), Some((_, '/'))) {
+                    chars.next();
+                    state = ScanState::LineComment;
+                    continue;
+                }
+                if c == '/' && matches!(chars.peek(), Some((_, '*'))) {
+                    chars.next();
+                    state = ScanState::BlockComment;
+                    continue;
+                }
+                if c == '"' || c == '\'' {
+                    string_start = i;
+                    state = ScanState::Str {
+                        quote: c,
+                        escaped: false,
+                    };
+                    continue;
+                }
+                if c.is_whitespace() {
+                    continue;
+                }
+
+                match c {
+                    '{' => {
+                        let key = if stack.len() == 1 {
+                            pending_key.take()
+                        } else {
+                            pending_key = None;
+                            None
+                        };
+                        stack.push(OpenDelimiter {
+                            is_object: true,
+                            open_end: i + 1,
+                            key,
+                        });
+                    }
+                    '[' => {
+                        pending_key = None;
+                        stack.push(OpenDelimiter {
+                            is_object: false,
+                            open_end: i + 1,
+                            key: None,
+                        });
+                    }
+                    '}' => {
+                        let frame = stack.pop()?;
+                        if !frame.is_object {
+                            return None;
+                        }
+                        // `last_significant` still predates this brace, which
+                        // is exactly the "last entry" info the span needs.
+                        let (last_significant_end, last_significant_char) = last_significant?;
+                        let span = BlockSpan {
+                            open_end: frame.open_end,
+                            close: i,
+                            last_significant_end,
+                            last_significant_char,
+                        };
+                        if stack.is_empty() {
+                            root = Some(span);
+                        } else if stack.len() == 1
+                            && let Some(key) = frame.key
+                        {
+                            blocks.insert(key, span);
+                        }
+                    }
+                    ']' => {
+                        let frame = stack.pop()?;
+                        if frame.is_object {
+                            return None;
+                        }
+                    }
+                    ',' => {
+                        if stack.len() == 1 {
+                            last_root_token = None;
+                            pending_key = None;
+                        }
+                    }
+                    ':' => {
+                        if stack.len() == 1 {
+                            pending_key = last_root_token.take();
+                        }
+                    }
+                    _ => {
+                        if word_start.is_none() {
+                            word_start = Some(i);
+                        }
+                    }
+                }
+                last_significant = Some((i + c.len_utf8(), c));
+            }
+        }
+    }
+
+    if !stack.is_empty() {
+        return None;
+    }
+    Some(DocumentLayout {
+        root: root?,
+        blocks,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{
+        DEFAULT_DAEMON_GRACE_SECS, DEFAULT_HIGH_THROUGHPUT_BUFFER_SIZE,
+        DEFAULT_PEPPY_CONFIG_TEMPLATE, DEFAULT_SHUTDOWN_GRACE_SECS, PeppyConfig, TEMPLATE_HEADER,
+    };
+    use super::*;
+
+    /// Parses completed content the way `load_or_create` would, so every test
+    /// proves its splice result is real loadable config, not just plausible text.
+    fn parse(content: &str) -> PeppyConfig {
+        serde_json5::from_str(content).expect("completed content must stay valid json5")
+    }
+
+    /// The template must be exactly the section table in order, or splices
+    /// would diverge from what a fresh file gets.
+    #[test]
+    fn template_matches_section_table() {
+        let mut composed = String::from(TEMPLATE_HEADER);
+        composed.push_str("{\n");
+        for section in SECTIONS {
+            composed.push('\n');
+            composed.push_str(section.snippet);
+        }
+        // The first section follows the opening brace directly, without the
+        // blank-line separator the splice path adds between sections.
+        composed = composed.replacen("{\n\n", "{\n", 1);
+        composed.push_str("}\n");
+        assert_eq!(composed, DEFAULT_PEPPY_CONFIG_TEMPLATE);
+    }
+
+    #[test]
+    fn complete_template_needs_no_completion() {
+        assert_eq!(complete_config_content(DEFAULT_PEPPY_CONFIG_TEMPLATE), None);
+    }
+
+    #[test]
+    fn empty_object_gains_every_section() {
+        let completed = complete_config_content("{}").expect("everything is missing");
+        assert_eq!(parse(&completed), PeppyConfig::default());
+        for key in [
+            "mode:",
+            "peer:",
+            "lifecycle:",
+            "resource_servers:",
+            "federation:",
+        ] {
+            assert!(completed.contains(key), "expected {key} in:\n{completed}");
+        }
+        // A completed file needs no further completion.
+        assert_eq!(complete_config_content(&completed), None);
+    }
+
+    #[test]
+    fn missing_trailing_comma_gets_one_before_appending() {
+        let completed =
+            complete_config_content(r#"{ mode: "router" }"#).expect("peer and lifecycle missing");
+        let config = parse(&completed);
+        assert_eq!(config.mode, super::super::Mode::Router);
+        assert_eq!(
+            config.lifecycle.daemon_grace_secs,
+            DEFAULT_DAEMON_GRACE_SECS
+        );
+        assert!(completed.contains(r#"mode: "router","#));
+    }
+
+    #[test]
+    fn partial_peer_block_gains_missing_field() {
+        let completed = complete_config_content(r#"{ peer: { standard_buffer_size: 64 } }"#)
+            .expect("high_throughput_buffer_size missing");
+        let config = parse(&completed);
+        assert_eq!(config.peer.standard_buffer_size, 64);
+        assert_eq!(
+            config.peer.high_throughput_buffer_size,
+            DEFAULT_HIGH_THROUGHPUT_BUFFER_SIZE
+        );
+        assert_eq!(complete_config_content(&completed), None);
+    }
+
+    #[test]
+    fn partial_lifecycle_block_gains_field_with_its_comment() {
+        let completed = complete_config_content(r#"{ lifecycle: { daemon_grace_secs: 600, } }"#)
+            .expect("shutdown_grace_secs missing");
+        let config = parse(&completed);
+        assert_eq!(config.lifecycle.daemon_grace_secs, 600);
+        assert_eq!(
+            config.lifecycle.shutdown_grace_secs,
+            DEFAULT_SHUTDOWN_GRACE_SECS
+        );
+        // The spliced field brings its explanatory comment along.
+        assert!(completed.contains("// How long a clean shutdown"));
+    }
+
+    #[test]
+    fn empty_nested_blocks_gain_their_fields() {
+        let completed =
+            complete_config_content("{ peer: {}, lifecycle: {} }").expect("fields missing");
+        assert_eq!(parse(&completed), PeppyConfig::default());
+        assert_eq!(complete_config_content(&completed), None);
+    }
+
+    #[test]
+    fn user_content_survives_byte_for_byte() {
+        let content = r#"// my own note about why router mode
+{
+  mode: "router", // pinned during the lab demo
+  future_knob: { nested: "}{" },
+  /* braces in comments: } { */
+}
+// trailing remark
+"#;
+        let completed = complete_config_content(content)
+            .expect("peer, lifecycle, resource_servers, federation missing");
+        parse(&completed);
+
+        // Pin the exact splice: the missing sections go in front of the root's
+        // closing brace (its last '}'; the trailing remark contains none), with
+        // no comma added since the last entry already has one, and every other
+        // byte of the user's file untouched.
+        let close = content.rfind('}').unwrap();
+        let expected = format!(
+            "{}\n{}\n{}\n{}\n{}{}",
+            &content[..close],
+            super::super::PEER_SECTION_SNIPPET,
+            super::super::LIFECYCLE_SECTION_SNIPPET,
+            super::super::RESOURCE_SERVERS_SECTION_SNIPPET,
+            super::super::FEDERATION_SECTION_SNIPPET,
+            &content[close..]
+        );
+        assert_eq!(completed, expected);
+    }
+
+    #[test]
+    fn comma_lands_before_a_trailing_comment() {
+        // Also covers JSON5 single-quoted strings.
+        let completed = complete_config_content("{ mode: 'router' // why router\n}")
+            .expect("peer and lifecycle missing");
+        let config = parse(&completed);
+        assert_eq!(config.mode, super::super::Mode::Router);
+        // The separating comma goes right after the value, not after the
+        // comment that trails it.
+        assert!(
+            completed.contains("mode: 'router', // why router"),
+            "comma landed elsewhere in:\n{completed}"
+        );
+    }
+
+    /// JSON5 ends a `//` comment at any LineTerminator (LF, CR, U+2028,
+    /// U+2029). A scanner that only honors LF reads code that hides between a
+    /// lone CR and the next LF differently from serde_json5; two such comments
+    /// used to rotate brace pairings and splice into the wrong user object.
+    #[test]
+    fn lone_cr_terminates_line_comments_like_serde() {
+        let content = "{\npeer: { standard_buffer_size: 1 // X\r },\njunk: // Y\r {\nb: 2 },\nmode: \"router\"\n}\n";
+        let completed = complete_config_content(content).expect("fields missing");
+        let config = parse(&completed);
+        assert_eq!(config.peer.standard_buffer_size, 1);
+        assert_eq!(
+            config.peer.high_throughput_buffer_size,
+            DEFAULT_HIGH_THROUGHPUT_BUFFER_SIZE
+        );
+
+        // The buffer field belongs inside `peer`, not inside the unknown
+        // `junk` object whose braces sit behind the CR-terminated comments.
+        let junk_block =
+            &completed[completed.find("junk").unwrap()..completed.find("mode").unwrap()];
+        assert!(
+            !junk_block.contains("high_throughput_buffer_size"),
+            "spliced into junk:\n{completed}"
+        );
+        assert!(verify_completion(content, &completed, &config));
+        assert_eq!(complete_config_content(&completed), None);
+    }
+
+    #[test]
+    fn u2028_terminates_line_comments_like_serde() {
+        let content = "{ mode: \"peer\" // note\u{2028}}";
+        let completed = complete_config_content(content).expect("peer and lifecycle missing");
+        assert_eq!(parse(&completed), PeppyConfig::default());
+        assert_eq!(complete_config_content(&completed), None);
+    }
+
+    #[test]
+    fn verify_completion_rejects_unfaithful_results() {
+        let original = r#"{ note: "keep me" }"#;
+        let config: PeppyConfig = serde_json5::from_str(original).unwrap();
+        let completed = complete_config_content(original).expect("everything missing");
+        assert!(verify_completion(original, &completed, &config));
+
+        // Still missing knobs: would splice again on every start.
+        assert!(!verify_completion(
+            original,
+            r#"{ note: "keep me", mode: "peer" }"#,
+            &config
+        ));
+        // An altered unknown-key value is corruption even though the typed
+        // config parses identically.
+        let tampered = completed.replace("keep me", "lost");
+        assert!(!verify_completion(original, &tampered, &config));
+        // A different parsed config is rejected outright.
+        let mode_flipped = completed.replace(r#"mode: "peer""#, r#"mode: "router""#);
+        assert!(!verify_completion(original, &mode_flipped, &config));
+    }
+
+    #[test]
+    fn quoted_keys_are_recognized() {
+        let completed = complete_config_content(r#"{ "lifecycle": { "daemon_grace_secs": 60 } }"#)
+            .expect("shutdown_grace_secs missing");
+        let config = parse(&completed);
+        assert_eq!(config.lifecycle.daemon_grace_secs, 60);
+        assert_eq!(
+            config.lifecycle.shutdown_grace_secs,
+            DEFAULT_SHUTDOWN_GRACE_SECS
+        );
+        // The existing quoted block was completed in place, not duplicated.
+        assert_eq!(completed.matches("lifecycle").count(), 1);
+    }
+
+    #[test]
+    fn adjacent_closing_braces_get_comma_between_entries() {
+        // Worst-case offsets: the block close, the root's comma insertion, and
+        // the root's section insertion all touch neighboring bytes.
+        let completed = complete_config_content("{peer:{}}").expect("everything else missing");
+        assert_eq!(parse(&completed), PeppyConfig::default());
+        assert_eq!(complete_config_content(&completed), None);
+    }
+
+    #[test]
+    fn arrays_in_unknown_keys_do_not_confuse_the_scanner() {
+        let completed = complete_config_content(r#"{ tags: ["a", "b", { x: 1 }], mode: "peer" }"#)
+            .expect("peer and lifecycle missing");
+        assert_eq!(parse(&completed), PeppyConfig::default());
+        assert!(completed.contains(r#"tags: ["a", "b", { x: 1 }]"#));
+    }
+
+    #[test]
+    fn malformed_content_is_left_alone() {
+        assert_eq!(complete_config_content("{ mode: "), None);
+        assert_eq!(complete_config_content(""), None);
+        assert_eq!(complete_config_content("[1, 2]"), None);
+    }
+}

--- a/crates/daemon-config-internal/src/source.rs
+++ b/crates/daemon-config-internal/src/source.rs
@@ -1,0 +1,521 @@
+use serde::{
+    Deserialize, Serialize,
+    de::{self, Deserializer},
+};
+use std::path::{Component, Path, PathBuf};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(untagged)]
+pub enum DeploymentSource {
+    Local(DeploymentLocalSource),
+    Git(DeploymentGitSource),
+    Url(DeploymentUrlSource),
+    Repo(DeploymentRepoSource),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct DeploymentLocalSource {
+    pub local: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct DeploymentGitSource {
+    pub repo: String,
+    pub path: String,
+    #[serde(rename = "ref")]
+    pub ref_: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct DeploymentUrlSource {
+    pub url: String,
+    pub sha256: String,
+}
+
+/// Deployment source that resolves a node through the user's repo cache
+/// (`~/.peppy/cache/nodes.json5`). Accepts `{ name, tag }` or the
+/// combined `{ name: "<name>:<tag>" }` shorthand.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct DeploymentRepoSource {
+    pub name: String,
+    pub tag: String,
+}
+
+fn invalid_deployment_source<E>(detail: impl Into<String>) -> E
+where
+    E: de::Error,
+{
+    let err = crate::error::StructuredError::InvalidDeploymentSource(detail.into());
+    de::Error::custom(err.json5_message())
+}
+
+fn trim_non_empty<E>(value: String, empty_error: &'static str) -> Result<String, E>
+where
+    E: de::Error,
+{
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(invalid_deployment_source::<E>(empty_error));
+    }
+    Ok(trimmed.to_owned())
+}
+
+fn normalize_git_path<E>(value: String) -> Result<String, E>
+where
+    E: de::Error,
+{
+    let pre_trim = value.trim();
+    // Reject absolute paths (including leading-slash form) and parent-dir
+    // components *before* stripping leading slashes — otherwise `/foo/bar`
+    // would be silently coerced to a valid relative path.
+    let original_path = Path::new(pre_trim);
+    if original_path.is_absolute()
+        || original_path
+            .components()
+            .any(|c| matches!(c, Component::ParentDir | Component::Prefix(_)))
+    {
+        return Err(invalid_deployment_source::<E>(
+            "git path cannot be absolute or contain parent-dir components",
+        ));
+    }
+    let trimmed = pre_trim.trim_start_matches('/');
+    if trimmed.is_empty() {
+        return Err(invalid_deployment_source::<E>("git path cannot be empty"));
+    }
+    Ok(trimmed.to_owned())
+}
+
+fn normalize_http_url<E>(value: String) -> Result<String, E>
+where
+    E: de::Error,
+{
+    let trimmed = trim_non_empty::<E>(value, "url cannot be empty")?;
+
+    if trimmed.contains(' ') {
+        return Err(invalid_deployment_source::<E>(
+            "url must not contain spaces",
+        ));
+    }
+
+    let (scheme, rest) = if let Some(rest) = trimmed.strip_prefix("https://") {
+        ("https", rest)
+    } else if let Some(rest) = trimmed.strip_prefix("http://") {
+        ("http", rest)
+    } else {
+        return Err(invalid_deployment_source::<E>(
+            "url must start with http:// or https://",
+        ));
+    };
+    _ = scheme;
+
+    // rest must have a non-empty host followed by a non-empty path
+    let (host_part, path_part) = match rest.find('/') {
+        Some(idx) => (&rest[..idx], &rest[idx..]),
+        None => {
+            return Err(invalid_deployment_source::<E>(
+                "url must have a non-empty path",
+            ));
+        }
+    };
+
+    if host_part.is_empty() {
+        return Err(invalid_deployment_source::<E>("url must have a host"));
+    }
+
+    // path_part starts with '/', so a path of just "/" means no meaningful path
+    if path_part == "/" || path_part.is_empty() {
+        return Err(invalid_deployment_source::<E>(
+            "url must have a non-empty path",
+        ));
+    }
+
+    Ok(trimmed)
+}
+
+fn normalize_sha256_hex<E>(value: String) -> Result<String, E>
+where
+    E: de::Error,
+{
+    let trimmed = trim_non_empty::<E>(value, "sha256 cannot be empty")?;
+    if trimmed.len() != 64 || !trimmed.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(invalid_deployment_source::<E>(
+            "sha256 must be a 64-character hexadecimal string",
+        ));
+    }
+    Ok(trimmed.to_ascii_lowercase())
+}
+
+fn split_repo_name_and_tag<E>(
+    raw_name: String,
+    raw_tag: Option<&str>,
+) -> Result<(String, String), E>
+where
+    E: de::Error,
+{
+    let name_trimmed = raw_name.trim();
+    if name_trimmed.is_empty() {
+        return Err(invalid_deployment_source::<E>(
+            "repo source name cannot be empty",
+        ));
+    }
+
+    let (name, tag) = if let Some((n, t)) = name_trimmed.split_once(':') {
+        if raw_tag.is_some() {
+            return Err(invalid_deployment_source::<E>(
+                "repo source cannot combine `name: \"<name>:<tag>\"` with a separate `tag` field",
+            ));
+        }
+        if t.contains(':') {
+            return Err(invalid_deployment_source::<E>(
+                "repo source `name` must contain at most one ':' separating name and tag",
+            ));
+        }
+        (n.trim().to_owned(), t.trim().to_owned())
+    } else {
+        let tag = raw_tag.map(str::trim).unwrap_or("");
+        if tag.is_empty() {
+            return Err(invalid_deployment_source::<E>(
+                "repo source requires a non-empty `tag` (or the combined `name: \"<name>:<tag>\"` form)",
+            ));
+        }
+        (name_trimmed.to_owned(), tag.to_owned())
+    };
+
+    crate::internal::repo_node_id::validate_repo_node_name(&name, "repo source name")
+        .map_err(invalid_deployment_source::<E>)?;
+    crate::internal::repo_node_id::validate_repo_node_tag(&tag, "repo source tag")
+        .map_err(invalid_deployment_source::<E>)?;
+
+    Ok((name, tag))
+}
+
+impl<'de> Deserialize<'de> for DeploymentSource {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Debug, Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct RawDeploymentSource {
+            #[serde(default)]
+            local: Option<String>,
+            #[serde(default)]
+            repo: Option<String>,
+            #[serde(default)]
+            path: Option<String>,
+            #[serde(rename = "ref", default)]
+            ref_: Option<String>,
+            #[serde(default)]
+            url: Option<String>,
+            #[serde(default)]
+            sha256: Option<String>,
+            #[serde(default)]
+            name: Option<String>,
+            #[serde(default)]
+            tag: Option<String>,
+        }
+
+        let raw = RawDeploymentSource::deserialize(deserializer)?;
+        let has_local = raw.local.is_some();
+        let has_git = raw.repo.is_some() || raw.path.is_some() || raw.ref_.is_some();
+        let has_url = raw.url.is_some() || raw.sha256.is_some();
+        let has_repo = raw.name.is_some() || raw.tag.is_some();
+
+        match (has_local, has_git, has_url, has_repo) {
+            (false, false, false, true) => {
+                let name_raw = raw.name.ok_or_else(|| {
+                    invalid_deployment_source::<D::Error>("repo source requires `name`")
+                })?;
+                let (name, tag) =
+                    split_repo_name_and_tag::<D::Error>(name_raw, raw.tag.as_deref())?;
+                Ok(DeploymentSource::Repo(DeploymentRepoSource { name, tag }))
+            }
+            (true, false, false, false) => {
+                let local = trim_non_empty::<D::Error>(
+                    raw.local.expect("local is present"),
+                    "local path cannot be empty",
+                )?;
+                let local: PathBuf = Path::new(&local)
+                    .components()
+                    .filter(|c| !matches!(c, Component::CurDir))
+                    .collect();
+                Ok(DeploymentSource::Local(DeploymentLocalSource { local }))
+            }
+            (false, true, false, false) => {
+                let repo = raw.repo.ok_or_else(|| {
+                    invalid_deployment_source::<D::Error>("git source requires `repo`")
+                })?;
+                let path = raw.path.ok_or_else(|| {
+                    invalid_deployment_source::<D::Error>("git source requires `path`")
+                })?;
+                let ref_ = raw.ref_.ok_or_else(|| {
+                    invalid_deployment_source::<D::Error>("git source requires `ref`")
+                })?;
+
+                let repo = trim_non_empty::<D::Error>(repo, "git repo cannot be empty")?;
+                let path = normalize_git_path::<D::Error>(path)?;
+                let ref_ = trim_non_empty::<D::Error>(ref_, "git ref cannot be empty")?;
+
+                Ok(DeploymentSource::Git(DeploymentGitSource {
+                    repo,
+                    path,
+                    ref_,
+                }))
+            }
+            (false, false, true, false) => {
+                let url = raw.url.ok_or_else(|| {
+                    invalid_deployment_source::<D::Error>("url source requires `url`")
+                })?;
+                let sha256 = raw.sha256.ok_or_else(|| {
+                    invalid_deployment_source::<D::Error>("url source requires `sha256`")
+                })?;
+
+                let url = normalize_http_url::<D::Error>(url)?;
+                let sha256 = normalize_sha256_hex::<D::Error>(sha256)?;
+
+                Ok(DeploymentSource::Url(DeploymentUrlSource { url, sha256 }))
+            }
+            _ => {
+                if has_git && has_repo {
+                    Err(invalid_deployment_source::<D::Error>(
+                        "cannot mix git fields (`repo`, `path`, `ref`) with repo-source fields (`name`, `tag`); use one source type per deployment",
+                    ))
+                } else {
+                    Err(invalid_deployment_source::<D::Error>(
+                        "source must be one of: { local }, { repo, path, ref }, { url, sha256 }, { name, tag }",
+                    ))
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::ParsingError;
+
+    #[test]
+    fn deployment_source_parses_all_variants() {
+        let local: DeploymentSource = serde_json5::from_str("{ local: \"./uvc_camera\" }").unwrap();
+        let DeploymentSource::Local(local) = local else {
+            panic!("expected local source");
+        };
+        assert_eq!(local.local, PathBuf::from("uvc_camera"));
+
+        let git: DeploymentSource = serde_json5::from_str(
+            "{ repo: \"https://github.com/Peppy-bot/nodes_hub.git\", path: \"fake_openarm01_controller\", ref: \"0.1.0\" }",
+        )
+        .unwrap();
+        let DeploymentSource::Git(git) = git else {
+            panic!("expected git source");
+        };
+        assert_eq!(git.repo, "https://github.com/Peppy-bot/nodes_hub.git");
+        assert_eq!(git.path, "fake_openarm01_controller");
+        assert_eq!(git.ref_, "0.1.0");
+
+        let url: DeploymentSource = serde_json5::from_str(
+            "{ url: \"https://example.com/fake_robot_brain.tar.zst\", sha256: \"33e83da60a54e3bb487a9a3b67705918602143b30f158143b6909acaf017a36a\" }",
+        )
+        .unwrap();
+        let DeploymentSource::Url(url) = url else {
+            panic!("expected url source");
+        };
+        assert_eq!(url.url, "https://example.com/fake_robot_brain.tar.zst");
+        assert_eq!(
+            url.sha256,
+            "33e83da60a54e3bb487a9a3b67705918602143b30f158143b6909acaf017a36a"
+        );
+    }
+
+    #[test]
+    fn deployment_source_validation_errors_are_structured() {
+        let empty_local: Result<DeploymentSource, _> = serde_json5::from_str("{ local: \"\" }");
+        let err = empty_local.expect_err("empty local should fail");
+        let ParsingError::InvalidDeploymentSource(msg) = err.into() else {
+            panic!("expected invalid deployment source error");
+        };
+        assert_eq!(msg, "local path cannot be empty");
+
+        let bad_url: Result<DeploymentSource, _> = serde_json5::from_str(
+            "{ url: \"ftp://example.com/node.tar.zst\", sha256: \"33e83da60a54e3bb487a9a3b67705918602143b30f158143b6909acaf017a36a\" }",
+        );
+        let err = bad_url.expect_err("non-http url should fail");
+        let ParsingError::InvalidDeploymentSource(msg) = err.into() else {
+            panic!("expected invalid deployment source error");
+        };
+        assert_eq!(msg, "url must start with http:// or https://");
+
+        let bad_sha: Result<DeploymentSource, _> = serde_json5::from_str(
+            "{ url: \"https://example.com/node.tar.zst\", sha256: \"not-a-sha\" }",
+        );
+        let err = bad_sha.expect_err("bad sha256 should fail");
+        let ParsingError::InvalidDeploymentSource(msg) = err.into() else {
+            panic!("expected invalid deployment source error");
+        };
+        assert_eq!(msg, "sha256 must be a 64-character hexadecimal string");
+    }
+
+    #[test]
+    fn deployment_source_rejects_malformed_urls() {
+        let valid_sha = "33e83da60a54e3bb487a9a3b67705918602143b30f158143b6909acaf017a36a";
+
+        let cases = [
+            (
+                format!("{{ url: \"https://\", sha256: \"{valid_sha}\" }}"),
+                "url must have a non-empty path",
+            ),
+            (
+                format!("{{ url: \"https:// /node.tar.zst\", sha256: \"{valid_sha}\" }}"),
+                "url must not contain spaces",
+            ),
+            (
+                format!("{{ url: \"https://example.com\", sha256: \"{valid_sha}\" }}"),
+                "url must have a non-empty path",
+            ),
+            (
+                format!("{{ url: \"https://example.com/\", sha256: \"{valid_sha}\" }}"),
+                "url must have a non-empty path",
+            ),
+        ];
+
+        for (input, expected_msg) in cases {
+            let result: Result<DeploymentSource, _> = serde_json5::from_str(&input);
+            let err = result.expect_err(&format!("expected failure for: {input}"));
+            let ParsingError::InvalidDeploymentSource(msg) = err.into() else {
+                panic!("expected InvalidDeploymentSource for: {input}");
+            };
+            assert_eq!(msg, expected_msg, "wrong message for: {input}");
+        }
+    }
+
+    // -- DeploymentRepoSource tests --
+
+    #[test]
+    fn repo_source_parses_name_and_tag_fields() {
+        let src: DeploymentSource =
+            serde_json5::from_str("{ name: \"robot_brain\", tag: \"v1\" }").unwrap();
+        let DeploymentSource::Repo(repo) = src else {
+            panic!("expected repo source");
+        };
+        assert_eq!(repo.name, "robot_brain");
+        assert_eq!(repo.tag, "v1");
+    }
+
+    #[test]
+    fn repo_source_parses_combined_name_tag() {
+        let src: DeploymentSource = serde_json5::from_str("{ name: \"robot_brain:v1\" }").unwrap();
+        let DeploymentSource::Repo(repo) = src else {
+            panic!("expected repo source");
+        };
+        assert_eq!(repo.name, "robot_brain");
+        assert_eq!(repo.tag, "v1");
+    }
+
+    #[test]
+    fn repo_source_rejects_name_without_tag() {
+        let err: serde_json5::Error =
+            serde_json5::from_str::<DeploymentSource>("{ name: \"foo\" }").unwrap_err();
+        let ParsingError::InvalidDeploymentSource(msg) = err.into() else {
+            panic!("expected InvalidDeploymentSource");
+        };
+        assert!(msg.contains("non-empty `tag`"), "unexpected: {msg}");
+    }
+
+    #[test]
+    fn repo_source_rejects_empty_name() {
+        let err: serde_json5::Error =
+            serde_json5::from_str::<DeploymentSource>("{ name: \"\", tag: \"v1\" }").unwrap_err();
+        let ParsingError::InvalidDeploymentSource(msg) = err.into() else {
+            panic!("expected InvalidDeploymentSource");
+        };
+        assert_eq!(msg, "repo source name cannot be empty");
+    }
+
+    #[test]
+    fn repo_source_rejects_combined_with_separate_tag() {
+        let err: serde_json5::Error =
+            serde_json5::from_str::<DeploymentSource>("{ name: \"foo:v1\", tag: \"v1\" }")
+                .unwrap_err();
+        let ParsingError::InvalidDeploymentSource(msg) = err.into() else {
+            panic!("expected InvalidDeploymentSource");
+        };
+        assert!(msg.contains("cannot combine"), "unexpected: {msg}");
+    }
+
+    #[test]
+    fn repo_source_rejects_multiple_colons() {
+        let err: serde_json5::Error =
+            serde_json5::from_str::<DeploymentSource>("{ name: \"foo:v1:extra\" }").unwrap_err();
+        let ParsingError::InvalidDeploymentSource(msg) = err.into() else {
+            panic!("expected InvalidDeploymentSource");
+        };
+        assert!(msg.contains("at most one ':'"), "unexpected: {msg}");
+    }
+
+    #[test]
+    fn repo_source_rejects_dot_in_tag() {
+        let err: serde_json5::Error =
+            serde_json5::from_str::<DeploymentSource>("{ name: \"foo\", tag: \"v1.2\" }")
+                .unwrap_err();
+        let ParsingError::InvalidDeploymentSource(msg) = err.into() else {
+            panic!("expected InvalidDeploymentSource");
+        };
+        assert!(
+            msg.contains("disallowed character") && msg.contains("'.'"),
+            "unexpected: {msg}"
+        );
+    }
+
+    #[test]
+    fn repo_source_rejects_tag_not_starting_with_letter() {
+        let err: serde_json5::Error =
+            serde_json5::from_str::<DeploymentSource>("{ name: \"foo\", tag: \"0.1.0\" }")
+                .unwrap_err();
+        let ParsingError::InvalidDeploymentSource(msg) = err.into() else {
+            panic!("expected InvalidDeploymentSource");
+        };
+        assert!(
+            msg.contains("must start with an ASCII letter"),
+            "unexpected: {msg}"
+        );
+    }
+
+    #[test]
+    fn repo_source_rejects_invalid_name_char() {
+        let err: serde_json5::Error =
+            serde_json5::from_str::<DeploymentSource>("{ name: \"foo/bar\", tag: \"v1\" }")
+                .unwrap_err();
+        let ParsingError::InvalidDeploymentSource(msg) = err.into() else {
+            panic!("expected InvalidDeploymentSource");
+        };
+        assert!(
+            msg.contains("invalid repo source name"),
+            "unexpected: {msg}"
+        );
+    }
+
+    #[test]
+    fn repo_source_rejects_mixed_with_local() {
+        let err: serde_json5::Error = serde_json5::from_str::<DeploymentSource>(
+            "{ name: \"foo\", tag: \"v1\", local: \"./x\" }",
+        )
+        .unwrap_err();
+        let ParsingError::InvalidDeploymentSource(msg) = err.into() else {
+            panic!("expected InvalidDeploymentSource");
+        };
+        assert!(msg.contains("source must be one of"), "unexpected: {msg}");
+    }
+
+    #[test]
+    fn repo_source_rejects_mixed_with_git_fields() {
+        let err: serde_json5::Error = serde_json5::from_str::<DeploymentSource>(
+            "{ repo: \"https://github.com/org/repo.git\", name: \"foo\", tag: \"v1\" }",
+        )
+        .unwrap_err();
+        let ParsingError::InvalidDeploymentSource(msg) = err.into() else {
+            panic!("expected InvalidDeploymentSource");
+        };
+        assert!(msg.contains("cannot mix git fields"), "unexpected: {msg}");
+    }
+}

--- a/crates/daemon-config-internal/src/source.rs
+++ b/crates/daemon-config-internal/src/source.rs
@@ -181,9 +181,9 @@ where
         (name_trimmed.to_owned(), tag.to_owned())
     };
 
-    crate::internal::repo_node_id::validate_repo_node_name(&name, "repo source name")
+    config::repo_node_id::validate_repo_node_name(&name, "repo source name")
         .map_err(invalid_deployment_source::<E>)?;
-    crate::internal::repo_node_id::validate_repo_node_tag(&tag, "repo source tag")
+    config::repo_node_id::validate_repo_node_tag(&tag, "repo source tag")
         .map_err(invalid_deployment_source::<E>)?;
 
     Ok((name, tag))

--- a/crates/daemon-config-internal/tests/fixtures/peppy_launcher.json5
+++ b/crates/daemon-config-internal/tests/fixtures/peppy_launcher.json5
@@ -1,0 +1,105 @@
+// PeppyOS Configuration
+// This is the main configuration file that defines the deployments on the current machine.
+{
+  peppy_schema: "launcher/v1",
+  deployments: [
+    {
+      // Example of a node being pulled from an url
+      source: {
+        url: "https://example.com/fake_robot_brain.tar.zst",
+        sha256: "33e83da60a54e3bb487a9a3b67705918602143b30f158143b6909acaf017a36a"
+      },
+      instances: [
+        {
+          instance_id: "the_brain",
+          arguments: {}
+        }
+      ],
+    },
+    {
+      // the source property is mandatory
+      source: {
+        repo: "https://github.com/Peppy-bot/nodes_hub.git",
+        path: "rust/fake_openarm01_controller",
+        ref: "main",
+      },
+      instances: [
+        {
+          instance_id: "the_nervous_system",
+          arguments: {}
+        }
+      ]
+    },
+    {
+      source: {
+        local: "./uvc_camera"
+      },
+      instances: [
+        {
+          instance_id: "camera_front",
+          arguments: {
+            device: {
+              physical: "/dev/video_right",
+              sim: "mujoco:camera_right",
+              priority: "physical" // "physical" or "sim". If the physical path is not accessible, the sim path is attempted
+            },
+            video: {
+              frame_rate: 30,
+              resolution: {
+                width: 1920,
+                height: 1080,
+              },
+              encoding: "yuyv", // "rgb8", "bgr8", "yuyv", "mjpeg"
+            },
+          }
+        },
+        {
+          instance_id: "camera_rear",
+          arguments: {
+            device: {
+              physical: "/dev/video_left",
+              sim: "mujoco:camera_left",
+              priority: "physical" // "physical" or "sim". If the physical path is not accessible, the sim path is attempted
+            },
+            video: {
+              frame_rate: 30,
+              resolution: {
+                width: 1920,
+                height: 1080,
+              },
+              encoding: "yuyv", // "rgb8", "bgr8", "yuyv", "mjpeg"
+            },
+          }
+        }
+      ]
+    },
+    {
+      source: {
+        local: "./video_reconstruction"
+      },
+      instances: [
+        {
+          instance_id: "video_reconstruction_1",
+          arguments: {
+            video_duration_seconds: 5
+          }
+        }
+      ]
+    },
+    {
+      source: {
+        local: "./esp32_board"
+      },
+      instances: [
+        {
+          instance_id: "esp32_1",
+          // This env var becomes available during the execution of `build_cmd` and `run_cmd`
+          env_vars: {
+            ESP32_DEVICE: "/dev/tty.usbmodem585A0076841"
+          },
+          // No arguments given for this node, no_std env cannot accept dynamic parameters after compilation
+        }
+      ]
+    },
+  ]
+}

--- a/crates/encoding-internal/Cargo.toml
+++ b/crates/encoding-internal/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 
 [dependencies]
 config = { workspace = true }
+daemon-config = { workspace = true }
 capnp = "0.26"
 capnpc = "0.26"
 proc-macro2 = "1.0"

--- a/crates/encoding-internal/src/facade.rs
+++ b/crates/encoding-internal/src/facade.rs
@@ -177,7 +177,7 @@ impl CapnpFacade {
         let binary_path = temp_dir.join("peppy_capnp_binary");
 
         if !binary_path.exists() {
-            let result = config::atomic_write::publish_atomic(&binary_path, |tmp_path| {
+            let result = daemon_config::atomic_write::publish_atomic(&binary_path, |tmp_path| {
                 std::fs::write(tmp_path, binary_bytes)?;
                 #[cfg(unix)]
                 {

--- a/crates/generator-internal/Cargo.toml
+++ b/crates/generator-internal/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 [dependencies]
 pmi = { workspace = true }
 config = { workspace = true }
+daemon-config = { workspace = true }
 encoding = { workspace = true }
 quote = "1.0"
 proc-macro2 = "1.0"

--- a/crates/generator-internal/src/generator.rs
+++ b/crates/generator-internal/src/generator.rs
@@ -11,9 +11,10 @@ pub mod types;
 use crate::error::{Error, Result};
 use config::node::{EmittedTopic, ExposedAction, ExposedService};
 use config::{
-    consts::{NODE_CONFIG_FILE, PeppyDirs},
+    consts::NODE_CONFIG_FILE,
     node::{NodeConfigParser, PeppygenLanguage},
 };
+use daemon_config::consts::PeppyDirs;
 use python::PythonGenerator;
 use rust::RustGenerator;
 use std::{fs, io::ErrorKind, path::Path};
@@ -73,7 +74,7 @@ pub fn generate_peppygen_lib(
         .map(|p| p.to_path_buf())
         .unwrap_or_else(|| node_dir.join(NODE_CONFIG_FILE));
 
-    let peppy_dir = node_dir.join(config::consts::PEPPY_OUTPUT_DIR);
+    let peppy_dir = node_dir.join(daemon_config::consts::PEPPY_OUTPUT_DIR);
     std::fs::create_dir_all(&peppy_dir)?;
     if !node_config_path.exists() {
         return Err(Error::NodeNotFound(node_config_path.display().to_string()));
@@ -281,7 +282,7 @@ fn ensure_node_cargo_toml(node_dir: &Path, node_name: &str) -> Result<()> {
         set_path_dependency(
             dependencies,
             "peppylib",
-            config::consts::PEPPYLIB_OUTPUT_PATH,
+            daemon_config::consts::PEPPYLIB_OUTPUT_PATH,
         );
     }
 
@@ -354,7 +355,7 @@ mod tests {
             .and_then(|p| p.get("path"))
             .and_then(|p| p.as_str())
             .expect("should have peppylib dependency with path");
-        assert_eq!(peppylib_path, config::consts::PEPPYLIB_OUTPUT_PATH);
+        assert_eq!(peppylib_path, daemon_config::consts::PEPPYLIB_OUTPUT_PATH);
     }
 
     #[test]
@@ -407,7 +408,7 @@ mod tests {
             .and_then(|p| p.get("path"))
             .and_then(|p| p.as_str())
             .expect("should have peppylib dependency with path");
-        assert_eq!(peppylib_path, config::consts::PEPPYLIB_OUTPUT_PATH);
+        assert_eq!(peppylib_path, daemon_config::consts::PEPPYLIB_OUTPUT_PATH);
     }
 
     #[test]
@@ -479,7 +480,7 @@ mod tests {
             .expect("should have peppylib dependency with path");
         assert_eq!(
             peppylib_path,
-            config::consts::PEPPYLIB_OUTPUT_PATH,
+            daemon_config::consts::PEPPYLIB_OUTPUT_PATH,
             "stale peppylib path should be overwritten"
         );
     }
@@ -507,7 +508,7 @@ mod tests {
         let custom_path = temp_dir.path().join("custom_peppy.json5");
         fs::write(&custom_path, custom_config).unwrap();
 
-        let peppy_dirs = config::consts::PeppyDirs::default();
+        let peppy_dirs = daemon_config::consts::PeppyDirs::default();
         generate_peppygen_lib(
             config::node::PeppygenLanguage::Rust,
             &node_dir,
@@ -541,7 +542,7 @@ mod tests {
         );
 
         let git_hash_path = node_dir
-            .join(config::consts::PEPPY_OUTPUT_DIR)
+            .join(daemon_config::consts::PEPPY_OUTPUT_DIR)
             .join("git.hash");
         let written_hash = fs::read_to_string(&git_hash_path)
             .expect("git.hash file should exist after successful generation");
@@ -558,7 +559,7 @@ mod tests {
         fs::create_dir_all(&node_dir).unwrap();
 
         // Do NOT write any peppy.json5 — generation should fail with NodeNotFound
-        let peppy_dirs = config::consts::PeppyDirs::default();
+        let peppy_dirs = daemon_config::consts::PeppyDirs::default();
         let result = generate_peppygen_lib(
             config::node::PeppygenLanguage::Rust,
             &node_dir,
@@ -583,7 +584,7 @@ mod tests {
         );
 
         let git_hash_path = node_dir
-            .join(config::consts::PEPPY_OUTPUT_DIR)
+            .join(daemon_config::consts::PEPPY_OUTPUT_DIR)
             .join("git.hash");
         assert!(
             !git_hash_path.exists(),

--- a/crates/generator-internal/src/generator/python.rs
+++ b/crates/generator-internal/src/generator/python.rs
@@ -354,7 +354,7 @@ impl LanguageGenerator for PythonGenerator {
     fn build(
         self,
         to_path: impl AsRef<Path>,
-        peppy_dirs: &config::consts::PeppyDirs,
+        peppy_dirs: &daemon_config::consts::PeppyDirs,
         _deploy_mode: crate::generator::common::CrateDeployMode,
     ) -> Result<()> {
         let to_path = to_path.as_ref();

--- a/crates/generator-internal/src/generator/python/ruff/facade.rs
+++ b/crates/generator-internal/src/generator/python/ruff/facade.rs
@@ -134,7 +134,7 @@ impl RuffFacade {
         let binary_path = temp_dir.join(format!("peppy_ruff_binary_{}", env!("RUFF_VERSION")));
 
         if !binary_path.exists() {
-            let result = config::atomic_write::publish_atomic(&binary_path, |tmp_path| {
+            let result = daemon_config::atomic_write::publish_atomic(&binary_path, |tmp_path| {
                 std::fs::write(tmp_path, binary_bytes)?;
                 #[cfg(unix)]
                 {

--- a/crates/generator-internal/src/generator/python/scaffold.rs
+++ b/crates/generator-internal/src/generator/python/scaffold.rs
@@ -60,7 +60,7 @@ fn target_platform_suffix(is_container: bool) -> String {
 
 pub fn add_peppylib_dependencies(
     to_path: &Path,
-    peppy_dirs: &config::consts::PeppyDirs,
+    peppy_dirs: &daemon_config::consts::PeppyDirs,
     is_container: bool,
 ) -> Result<()> {
     // Copy Python project templates (pyproject.toml, peppygen/__init__.py)

--- a/crates/generator-internal/src/generator/python/tests/parameters.rs
+++ b/crates/generator-internal/src/generator/python/tests/parameters.rs
@@ -192,7 +192,7 @@ fn generate_parameters_struct() {
     generator
         .build(
             &output_dir,
-            &config::consts::PeppyDirs::default(),
+            &daemon_config::consts::PeppyDirs::default(),
             Default::default(),
         )
         .unwrap();
@@ -261,7 +261,7 @@ fn generate_parameters_struct_avoids_nested_class_name_collisions() {
     generator
         .build(
             &output_dir,
-            &config::consts::PeppyDirs::default(),
+            &daemon_config::consts::PeppyDirs::default(),
             Default::default(),
         )
         .unwrap();
@@ -307,7 +307,7 @@ fn generate_empty_parameters_struct() {
     generator
         .build(
             &output_dir,
-            &config::consts::PeppyDirs::default(),
+            &daemon_config::consts::PeppyDirs::default(),
             Default::default(),
         )
         .unwrap();

--- a/crates/generator-internal/src/generator/rust.rs
+++ b/crates/generator-internal/src/generator/rust.rs
@@ -1527,7 +1527,7 @@ impl LanguageGenerator for RustGenerator {
     fn build(
         self,
         to_path: impl AsRef<Path>,
-        peppy_dirs: &config::consts::PeppyDirs,
+        peppy_dirs: &daemon_config::consts::PeppyDirs,
         deploy_mode: crate::generator::common::CrateDeployMode,
     ) -> Result<()> {
         scaffold::add_peppylib_dependencies(&to_path, peppy_dirs, deploy_mode)?;

--- a/crates/generator-internal/src/generator/rust/scaffold.rs
+++ b/crates/generator-internal/src/generator/rust/scaffold.rs
@@ -34,7 +34,7 @@ use toml_edit::{DocumentMut, value};
 
 pub fn add_peppylib_dependencies(
     to_path: impl AsRef<Path>,
-    peppy_dirs: &config::consts::PeppyDirs,
+    peppy_dirs: &daemon_config::consts::PeppyDirs,
     deploy_mode: CrateDeployMode,
 ) -> Result<()> {
     let to_path = to_path.as_ref();
@@ -348,7 +348,7 @@ fn vendored_crates_cache_key() -> String {
 /// staging directory for concurrent-safe deployment.
 fn deploy_rust_crates_to_shared_cache(
     node_libs_dir: &Path,
-    peppy_dirs: &config::consts::PeppyDirs,
+    peppy_dirs: &daemon_config::consts::PeppyDirs,
     deploy_mode: CrateDeployMode,
 ) -> Result<()> {
     let cache_key = vendored_crates_cache_key();

--- a/crates/generator-internal/src/generator/rust/tests/actions.rs
+++ b/crates/generator-internal/src/generator/rust/tests/actions.rs
@@ -1006,7 +1006,7 @@ fn clippy_single_exposed_action_empty_goal_request() {
     generator
         .build(
             &output_dir,
-            &config::consts::PeppyDirs::default(),
+            &daemon_config::consts::PeppyDirs::default(),
             Default::default(),
         )
         .unwrap();
@@ -1093,7 +1093,7 @@ fn compile_lib_with_exposed_and_consumed_actions() {
     generator
         .build(
             &output_dir,
-            &config::consts::PeppyDirs::default(),
+            &daemon_config::consts::PeppyDirs::default(),
             Default::default(),
         )
         .unwrap();
@@ -1199,7 +1199,7 @@ fn clippy_consumed_action_empty_goal_request() {
     generator
         .build(
             &output_dir,
-            &config::consts::PeppyDirs::default(),
+            &daemon_config::consts::PeppyDirs::default(),
             Default::default(),
         )
         .unwrap();

--- a/crates/generator-internal/src/generator/rust/tests/parameters.rs
+++ b/crates/generator-internal/src/generator/rust/tests/parameters.rs
@@ -191,7 +191,7 @@ fn generate_parameters_struct() {
     generator
         .build(
             &output_dir,
-            &config::consts::PeppyDirs::default(),
+            &daemon_config::consts::PeppyDirs::default(),
             Default::default(),
         )
         .unwrap();
@@ -250,7 +250,7 @@ fn generate_empty_parameters_struct() {
     generator
         .build(
             &output_dir,
-            &config::consts::PeppyDirs::default(),
+            &daemon_config::consts::PeppyDirs::default(),
             Default::default(),
         )
         .unwrap();
@@ -284,7 +284,7 @@ fn generate_parameters_struct_avoids_nested_struct_name_collisions() {
     generator
         .build(
             &output_dir,
-            &config::consts::PeppyDirs::default(),
+            &daemon_config::consts::PeppyDirs::default(),
             Default::default(),
         )
         .unwrap();

--- a/crates/generator-internal/src/generator/rust/tests/services.rs
+++ b/crates/generator-internal/src/generator/rust/tests/services.rs
@@ -546,7 +546,7 @@ fn clippy_single_exposed_service_without_request_body() {
     generator
         .build(
             &output_dir,
-            &config::consts::PeppyDirs::default(),
+            &daemon_config::consts::PeppyDirs::default(),
             Default::default(),
         )
         .unwrap();
@@ -621,7 +621,7 @@ fn compile_lib_with_exposed_and_consumed_services() {
     generator
         .build(
             &output_dir,
-            &config::consts::PeppyDirs::default(),
+            &daemon_config::consts::PeppyDirs::default(),
             Default::default(),
         )
         .unwrap();
@@ -704,7 +704,7 @@ fn clippy_consumed_service_empty_request_format() {
     generator
         .build(
             &output_dir,
-            &config::consts::PeppyDirs::default(),
+            &daemon_config::consts::PeppyDirs::default(),
             Default::default(),
         )
         .unwrap();
@@ -743,7 +743,7 @@ fn clippy_consumed_service_empty_response_format() {
     generator
         .build(
             &output_dir,
-            &config::consts::PeppyDirs::default(),
+            &daemon_config::consts::PeppyDirs::default(),
             Default::default(),
         )
         .unwrap();

--- a/crates/generator-internal/src/generator/rust/tests/topics.rs
+++ b/crates/generator-internal/src/generator/rust/tests/topics.rs
@@ -635,7 +635,7 @@ fn clippy_single_emitted_topic_empty_format() {
     generator
         .build(
             &output_dir,
-            &config::consts::PeppyDirs::default(),
+            &daemon_config::consts::PeppyDirs::default(),
             Default::default(),
         )
         .unwrap();
@@ -691,7 +691,7 @@ fn compile_lib_with_emitted_and_consumed_topics() {
     generator
         .build(
             &output_dir,
-            &config::consts::PeppyDirs::default(),
+            &daemon_config::consts::PeppyDirs::default(),
             Default::default(),
         )
         .unwrap();

--- a/crates/generator-internal/src/generator/types.rs
+++ b/crates/generator-internal/src/generator/types.rs
@@ -1,7 +1,7 @@
 use crate::error::{Error, Result};
 use crate::generator::common::CrateDeployMode;
 use crate::generator::naming::{array_item_type_name, to_camel_case};
-use config::consts::PeppyDirs;
+use daemon_config::consts::PeppyDirs;
 use config::node::{
     ConsumedAction, ConsumedService, ConsumedTopic, EmittedTopic, ExposedAction, ExposedService,
     MessageFormat, PrimitiveSchema, SchemaType, TypeToken,

--- a/crates/generator-internal/tests/helpers.rs
+++ b/crates/generator-internal/tests/helpers.rs
@@ -1,9 +1,9 @@
 #![allow(dead_code)]
 
 use config::consts::{
-    NODE_CONFIG_FILE, PEPPYGEN_OUTPUT_PATH, PEPPYLIB_OUTPUT_PATH, PYTHON_MAX_VERSION,
-    PYTHON_MIN_VERSION, PeppyDirs,
+    NODE_CONFIG_FILE, PEPPYGEN_OUTPUT_PATH, PYTHON_MAX_VERSION, PYTHON_MIN_VERSION,
 };
+use daemon_config::consts::{PEPPYLIB_OUTPUT_PATH, PeppyDirs};
 use config::node::PeppygenLanguage;
 use generator::generate_peppygen_lib;
 use peppylib::messaging::SenderTarget;
@@ -43,7 +43,7 @@ pub const TEST_NODE_TAG: &str = "v1";
 
 /// Re-exported so the communication test files can name the messaging mode for
 /// their `#[case]` parameterization without reaching into the internal path.
-pub use config::peppy_config::Mode;
+pub use daemon_config::peppy_config::Mode;
 
 /// Applies a messaging mode to a node's runtime config before it is written and
 /// handed to a spawned node. This is the single seam the dual-mode communication
@@ -605,7 +605,7 @@ pub fn run_generate_peppygen_lib_test(
 
     // Check that the git.hash was created
     let git_hash_path = node_dir
-        .join(config::consts::PEPPY_OUTPUT_DIR)
+        .join(daemon_config::consts::PEPPY_OUTPUT_DIR)
         .join("git.hash");
     let git_hash_content =
         fs::read_to_string(&git_hash_path).expect("git.hash file should exist in .peppy directory");

--- a/crates/generator-internal/tests/python/actions_communication.rs
+++ b/crates/generator-internal/tests/python/actions_communication.rs
@@ -8,9 +8,8 @@ use crate::helpers::{
 use config::consts::{PEPPYGEN_OUTPUT_PATH, RUNTIME_CONFIG_VAR_NAME};
 use config::runtime::NodeInstanceConfig;
 use config::{
-    launcher::Name,
     node::{ConsumedAction, ExposedAction, ExposedService, MessageFormat},
-    runtime::RuntimeConfig,
+    runtime::{Name, RuntimeConfig},
 };
 use generator::{ConsumedActionMessage, LanguageGenerator};
 use std::path::Path;

--- a/crates/generator-internal/tests/python/generate_lib.rs
+++ b/crates/generator-internal/tests/python/generate_lib.rs
@@ -1,8 +1,9 @@
 use crate::helpers;
 use config::{
-    consts::{NODE_CONFIG_FILE, PEPPYGEN_OUTPUT_PATH, PEPPYLIB_OUTPUT_PATH},
+    consts::{NODE_CONFIG_FILE, PEPPYGEN_OUTPUT_PATH},
     node::{ConsumedAction, ConsumedService, ConsumedTopic, MessageFormat, PeppygenLanguage},
 };
+use daemon_config::consts::PEPPYLIB_OUTPUT_PATH;
 use generator::generate_peppygen_lib;
 use generator::{ConsumedActionMessage, DeploymentInterface, InterfaceVariant};
 use std::fs;

--- a/crates/generator-internal/tests/python/services_communication.rs
+++ b/crates/generator-internal/tests/python/services_communication.rs
@@ -7,9 +7,8 @@ use crate::helpers::{
 use config::consts::{PEPPYGEN_OUTPUT_PATH, RUNTIME_CONFIG_VAR_NAME};
 use config::runtime::NodeInstanceConfig;
 use config::{
-    launcher::Name,
     node::{ConsumedService, ExposedService, MessageFormat},
-    runtime::RuntimeConfig,
+    runtime::{Name, RuntimeConfig},
 };
 use generator::LanguageGenerator;
 use std::path::Path;

--- a/crates/generator-internal/tests/python/topics_communication.rs
+++ b/crates/generator-internal/tests/python/topics_communication.rs
@@ -7,9 +7,8 @@ use crate::helpers::{
 use config::consts::{PEPPYGEN_OUTPUT_PATH, RUNTIME_CONFIG_VAR_NAME};
 use config::runtime::NodeInstanceConfig;
 use config::{
-    launcher::Name,
     node::{ConsumedTopic, EmittedTopic, ExposedService, MessageFormat},
-    runtime::RuntimeConfig,
+    runtime::{Name, RuntimeConfig},
 };
 use generator::LanguageGenerator;
 use std::path::Path;

--- a/crates/generator-internal/tests/python/wire_compat.rs
+++ b/crates/generator-internal/tests/python/wire_compat.rs
@@ -34,7 +34,7 @@ use crate::helpers::{
     wait_for_child, wait_for_health_service_reachable_or_exit, wait_for_service_reachable_or_exit,
 };
 use config::consts::{NODE_CONFIG_FILE, RUNTIME_CONFIG_VAR_NAME};
-use config::launcher::Name;
+use config::runtime::Name;
 use config::node::{
     ConsumedAction, ConsumedService, ConsumedTopic, NodeConfigParser, PeppygenLanguage,
 };

--- a/crates/generator-internal/tests/rust/actions_communication.rs
+++ b/crates/generator-internal/tests/rust/actions_communication.rs
@@ -7,9 +7,8 @@ use crate::helpers::{
 use config::consts::{PEPPYGEN_OUTPUT_PATH, RUNTIME_CONFIG_VAR_NAME};
 use config::runtime::NodeInstanceConfig;
 use config::{
-    launcher::Name,
     node::{ConsumedAction, ExposedAction, MessageFormat},
-    runtime::RuntimeConfig,
+    runtime::{Name, RuntimeConfig},
 };
 use generator::{ConsumedActionMessage, LanguageGenerator};
 use std::path::Path;

--- a/crates/generator-internal/tests/rust/generate_lib.rs
+++ b/crates/generator-internal/tests/rust/generate_lib.rs
@@ -1,7 +1,8 @@
 use config::{
-    consts::{NODE_CONFIG_FILE, PEPPYGEN_OUTPUT_PATH, PEPPYLIB_OUTPUT_PATH},
+    consts::{NODE_CONFIG_FILE, PEPPYGEN_OUTPUT_PATH},
     node::{ConsumedAction, ConsumedService, ConsumedTopic, MessageFormat, PeppygenLanguage},
 };
+use daemon_config::consts::PEPPYLIB_OUTPUT_PATH;
 use generator::generate_peppygen_lib;
 use generator::{ConsumedActionMessage, DeploymentInterface, InterfaceVariant};
 use std::fs;

--- a/crates/generator-internal/tests/rust/services_communication.rs
+++ b/crates/generator-internal/tests/rust/services_communication.rs
@@ -7,9 +7,8 @@ use crate::helpers::{
 use config::consts::{PEPPYGEN_OUTPUT_PATH, RUNTIME_CONFIG_VAR_NAME};
 use config::runtime::NodeInstanceConfig;
 use config::{
-    launcher::Name,
     node::{ConsumedService, ExposedService, MessageFormat},
-    runtime::RuntimeConfig,
+    runtime::{Name, RuntimeConfig},
 };
 use generator::LanguageGenerator;
 use std::path::Path;

--- a/crates/generator-internal/tests/rust/topics_communication.rs
+++ b/crates/generator-internal/tests/rust/topics_communication.rs
@@ -6,9 +6,8 @@ use crate::helpers::{
 use config::consts::{PEPPYGEN_OUTPUT_PATH, RUNTIME_CONFIG_VAR_NAME};
 use config::runtime::NodeInstanceConfig;
 use config::{
-    launcher::Name,
     node::{ConsumedTopic, EmittedTopic, MessageFormat},
-    runtime::RuntimeConfig,
+    runtime::{Name, RuntimeConfig},
 };
 use generator::LanguageGenerator;
 use std::path::Path;

--- a/crates/node-stack-internal/Cargo.toml
+++ b/crates/node-stack-internal/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 
 [dependencies]
 config = { workspace = true }
+daemon-config = { workspace = true }
 containers = { workspace = true }
 core-node-api = { workspace = true }
 petgraph = "0.8.3"

--- a/crates/node-stack-internal/src/node_stack/add_steps.rs
+++ b/crates/node-stack-internal/src/node_stack/add_steps.rs
@@ -5,7 +5,7 @@
 
 use std::path::{Path, PathBuf};
 
-use config::consts::PEPPY_OUTPUT_DIR;
+use daemon_config::consts::PEPPY_OUTPUT_DIR;
 use tracing::debug;
 
 /// Directories excluded from node snapshot copies.

--- a/crates/node-stack-internal/src/node_stack/build_steps.rs
+++ b/crates/node-stack-internal/src/node_stack/build_steps.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::Arc;
 
-use config::consts::PeppyDirs;
+use daemon_config::consts::PeppyDirs;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use tracing::debug;
@@ -38,7 +38,7 @@ pub(super) fn archive_dir_to_storage(
     validate_node_tag(node_tag)?;
     let storage_dir = peppy_dirs.built_nodes_dir();
     let archive_name = format!("{}_{}.tar.zst", node_name, node_tag);
-    config::atomic_write::publish_atomic(&storage_dir.join(&archive_name), |tmp_path| {
+    daemon_config::atomic_write::publish_atomic(&storage_dir.join(&archive_name), |tmp_path| {
         let file = File::create(tmp_path)?;
         let encoder = ZstdEncoder::new(file, 1)?;
         let mut tar_builder = tar::Builder::new(encoder);
@@ -71,7 +71,7 @@ pub(super) fn move_sif_to_storage(
 
     // Copy + rename (not rename alone) because the working dir may be on a
     // different filesystem than storage.
-    config::atomic_write::publish_atomic(&storage_dir.join(&sif_name), |tmp_path| {
+    daemon_config::atomic_write::publish_atomic(&storage_dir.join(&sif_name), |tmp_path| {
         std::fs::copy(&sif_source, tmp_path)
             .map(|_| ())
             .map_err(|e| {

--- a/crates/node-stack-internal/src/node_stack/entity.rs
+++ b/crates/node-stack-internal/src/node_stack/entity.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
-use config::consts::PeppyDirs;
+use daemon_config::consts::PeppyDirs;
 use config::node::{Name, NodeConfig};
 use core_node_api::{
     InstanceState, NodeStage as SerializedNodeStage, SerializedInstance, SerializedNode,

--- a/crates/node-stack-internal/src/node_stack/run_steps.rs
+++ b/crates/node-stack-internal/src/node_stack/run_steps.rs
@@ -12,7 +12,8 @@ use std::process::Stdio;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use config::consts::{PeppyDirs, RUNTIME_CONFIG_VAR_NAME};
+use config::consts::RUNTIME_CONFIG_VAR_NAME;
+use daemon_config::consts::PeppyDirs;
 use config::node::{NodeConfig, PeppygenLanguage};
 use tokio::process::{Child, Command};
 use tokio::task::JoinHandle;

--- a/crates/node-stack-internal/tests/helpers/real_lifecycle.rs
+++ b/crates/node-stack-internal/tests/helpers/real_lifecycle.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
-use config::consts::PeppyDirs;
+use daemon_config::consts::PeppyDirs;
 use config::node::{Name, NodeConfig};
 use core_node_api::NodeStage as SerializedNodeStage;
 use node_stack::{

--- a/crates/node-stack-internal/tests/tests_modules/lifecycle_transitions.rs
+++ b/crates/node-stack-internal/tests/tests_modules/lifecycle_transitions.rs
@@ -390,7 +390,7 @@ async fn concurrent_builds_are_rejected_immediately() {
 
     // Isolated peppy_dirs root for this test.
     let peppy_root = tempfile::tempdir().expect("tempdir peppy_root");
-    let peppy_dirs = config::consts::PeppyDirs::new(peppy_root.path().to_path_buf());
+    let peppy_dirs = daemon_config::consts::PeppyDirs::new(peppy_root.path().to_path_buf());
 
     // The winning build blocks in Phase 2 on a build_cmd that waits for this
     // proceed file, holding the entity in `Building` until the test explicitly
@@ -533,7 +533,7 @@ fn sensor_config_with_build_cmd(build_cmd_shell: &str) -> config::node::NodeConf
 struct BuildHarness {
     working_dir: tempfile::TempDir,
     peppy_root: tempfile::TempDir,
-    peppy_dirs: config::consts::PeppyDirs,
+    peppy_dirs: daemon_config::consts::PeppyDirs,
     log_file: Arc<StdMutex<std::fs::File>>,
     feedback_tx: tokio::sync::mpsc::UnboundedSender<node_stack::build_io::FeedbackLine>,
     _feedback_rx: tokio::sync::mpsc::UnboundedReceiver<node_stack::build_io::FeedbackLine>,
@@ -542,7 +542,7 @@ struct BuildHarness {
 fn build_harness() -> BuildHarness {
     let working_dir = tempfile::tempdir().expect("tempdir working_dir");
     let peppy_root = tempfile::tempdir().expect("tempdir peppy_root");
-    let peppy_dirs = config::consts::PeppyDirs::new(peppy_root.path().to_path_buf());
+    let peppy_dirs = daemon_config::consts::PeppyDirs::new(peppy_root.path().to_path_buf());
     let log_path = peppy_root.path().join("build.log");
     let log_file = Arc::new(StdMutex::new(
         std::fs::File::create(&log_path).expect("create log"),

--- a/crates/peppy/Cargo.toml
+++ b/crates/peppy/Cargo.toml
@@ -7,6 +7,7 @@ autotests = false
 [dependencies]
 pmi = { workspace = true, features = ["zenoh", "build_zenoh"] }
 config = { workspace = true }
+daemon-config = { workspace = true }
 containers = { workspace = true }
 peppylib = { workspace = true }
 core-node = { workspace = true }

--- a/crates/peppy/src/auth/profile.rs
+++ b/crates/peppy/src/auth/profile.rs
@@ -6,7 +6,7 @@
 //! default) and can be overridden at runtime via `--api-url` / `PEPPY_API_URL`.
 
 use crate::error::{Error, Result};
-use config::peppy_config::ResourceServers;
+use daemon_config::peppy_config::ResourceServers;
 
 /// Resolves the backend base URL in precedence order: the `--api-url` flag,
 /// then `PEPPY_API_URL`, then the build's URL from the `resource_servers`
@@ -83,7 +83,7 @@ fn is_local(host: Option<&str>) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use config::peppy_config::DEFAULT_API_URL;
+    use daemon_config::peppy_config::DEFAULT_API_URL;
 
     /// The default `resource_servers` block, the built-in fallback every test
     /// resolves against unless it overrides the URL explicitly.

--- a/crates/peppy/src/auth/router.rs
+++ b/crates/peppy/src/auth/router.rs
@@ -84,7 +84,7 @@ pub struct RouterEndpoint {
 pub fn resolve_router_ca() -> Option<PathBuf> {
     resolve_router_ca_from(
         EMBEDDED_DEV_CA,
-        &config::consts::PeppyDirs::default().cache_dir(),
+        &daemon_config::consts::PeppyDirs::default().cache_dir(),
     )
 }
 
@@ -108,7 +108,7 @@ pub fn resolve_router_client_identity() -> Option<(PathBuf, PathBuf)> {
     resolve_router_client_identity_from(
         EMBEDDED_DEV_CLIENT_CERT,
         EMBEDDED_DEV_CLIENT_KEY,
-        &config::consts::PeppyDirs::default().cache_dir(),
+        &daemon_config::consts::PeppyDirs::default().cache_dir(),
     )
 }
 

--- a/crates/peppy/src/auth/storage.rs
+++ b/crates/peppy/src/auth/storage.rs
@@ -184,15 +184,15 @@ fn wrap<'de, D: Deserializer<'de>>(de: D) -> std::result::Result<SecretString, D
 /// Credentials path under a given peppy root: `<root>/conf/credentials.json5`.
 /// Pairs with `peppy_config.json5` in the same `conf/` dir so a caller derives
 /// both auth files from one [`PeppyDirs`].
-pub fn credentials_path(dirs: &config::consts::PeppyDirs) -> PathBuf {
-    dirs.conf_dir().join(config::consts::CREDENTIALS_FILE)
+pub fn credentials_path(dirs: &daemon_config::consts::PeppyDirs) -> PathBuf {
+    dirs.conf_dir().join(daemon_config::consts::CREDENTIALS_FILE)
 }
 
 /// Default credentials path: `<peppy root>/conf/credentials.json5`, honouring
 /// `PEPPY_HOME`. The root is the global peppy data dir, never the cwd.
 pub fn default_path() -> PathBuf {
-    credentials_path(&config::consts::PeppyDirs::new(
-        config::consts::peppy_root_dir(),
+    credentials_path(&daemon_config::consts::PeppyDirs::new(
+        daemon_config::consts::peppy_root_dir(),
     ))
 }
 
@@ -233,7 +233,7 @@ pub fn save(path: &Path, creds: &Credentials) -> Result<()> {
         restrict_dir(parent)?;
     }
 
-    config::atomic_write::publish_atomic(path, |tmp| {
+    daemon_config::atomic_write::publish_atomic(path, |tmp| {
         std::fs::write(tmp, &content)?;
         restrict_file(tmp)
     })?;

--- a/crates/peppy/src/commands/auth.rs
+++ b/crates/peppy/src/commands/auth.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use clap::Subcommand;
-use config::consts::PeppyDirs;
+use daemon_config::consts::PeppyDirs;
 use core_node_api::encoding::StackListRequest;
 use core_node_api::{NodeStage, SerializedNodeGraph};
 use peppylib::core_node::transport::poll_stack_list;

--- a/crates/peppy/src/commands/auth/login.rs
+++ b/crates/peppy/src/commands/auth/login.rs
@@ -6,7 +6,7 @@
 
 use std::sync::Arc;
 
-use config::consts::PeppyDirs;
+use daemon_config::consts::PeppyDirs;
 
 use crate::auth::device::DeviceFlowOptions;
 use crate::auth::{
@@ -37,7 +37,7 @@ impl Command for LoginCommand {
         // Loads (and seeds/completes) peppy_config.json5 with the same strict,
         // fail-loud semantics the daemon uses; resource_servers supplies the
         // per-profile URL fallback.
-        let config = config::peppy_config::load_or_create(&dirs).map_err(Error::PeppyConfig)?;
+        let config = daemon_config::peppy_config::load_or_create(&dirs).map_err(Error::DaemonConfig)?;
         let api_url = profile::resolve_api_url(self.api_url.as_deref(), &config.resource_servers)?;
         let creds_path = storage::credentials_path(&dirs);
         let http = HttpClient::new();

--- a/crates/peppy/src/commands/auth/logout.rs
+++ b/crates/peppy/src/commands/auth/logout.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use secrecy::ExposeSecret;
 
-use config::consts::PeppyDirs;
+use daemon_config::consts::PeppyDirs;
 
 use crate::auth::{client, http::HttpClient, profile, storage};
 use crate::commands::Command;
@@ -26,7 +26,7 @@ pub struct LogoutCommand {
 impl Command for LogoutCommand {
     fn execute(self, ctx: &Arc<AppContext>) -> Result<()> {
         let dirs = self.peppy_dirs.unwrap_or_default();
-        let config = config::peppy_config::load_or_create(&dirs).map_err(Error::PeppyConfig)?;
+        let config = daemon_config::peppy_config::load_or_create(&dirs).map_err(Error::DaemonConfig)?;
         let api_url = profile::resolve_api_url(self.api_url.as_deref(), &config.resource_servers)?;
         let creds_path = storage::credentials_path(&dirs);
         let http = HttpClient::new();

--- a/crates/peppy/src/commands/auth/whoami.rs
+++ b/crates/peppy/src/commands/auth/whoami.rs
@@ -5,7 +5,7 @@
 use std::path::Path;
 use std::sync::Arc;
 
-use config::consts::PeppyDirs;
+use daemon_config::consts::PeppyDirs;
 
 use crate::auth::client::Principal;
 use crate::auth::{client, http::HttpClient, profile, resolver, storage};
@@ -25,7 +25,7 @@ pub struct WhoamiCommand {
 impl Command for WhoamiCommand {
     fn execute(self, _ctx: &Arc<AppContext>) -> Result<()> {
         let dirs = self.peppy_dirs.unwrap_or_default();
-        let config = config::peppy_config::load_or_create(&dirs).map_err(Error::PeppyConfig)?;
+        let config = daemon_config::peppy_config::load_or_create(&dirs).map_err(Error::DaemonConfig)?;
         let api_url = profile::resolve_api_url(self.api_url.as_deref(), &config.resource_servers)?;
         let creds_path = storage::credentials_path(&dirs);
         let http = HttpClient::new();

--- a/crates/peppy/src/commands/node/run.rs
+++ b/crates/peppy/src/commands/node/run.rs
@@ -1,7 +1,7 @@
 use config::AnyType;
-use config::launcher::{BindingValidationItem, DeploymentInstance, Name, validate_bindings};
 use config::node::ConformsToItem;
-use config::runtime::{NodeInstanceConfig, RuntimeConfig, SlotBinding};
+use config::runtime::{Name, NodeInstanceConfig, RuntimeConfig, SlotBinding};
+use daemon_config::launcher::{BindingValidationItem, DeploymentInstance, validate_bindings};
 use core_node_api::NodeStage;
 use core_node_api::encoding::{
     NodeInfoRequest, NodeInfoResponse, NodeRunFeedback, NodeRunGoal, NodeRunGoalResponse,
@@ -59,7 +59,7 @@ fn empty_deployment_instance(instance_id: Name) -> DeploymentInstance {
         instance_id,
         arguments: BTreeMap::new(),
         env_vars: BTreeMap::new(),
-        framework: config::launcher::FrameworkOverrides::default(),
+        framework: daemon_config::launcher::FrameworkOverrides::default(),
         bindings: BTreeMap::new(),
     }
 }
@@ -485,7 +485,7 @@ async fn validate_binds_against_stack(
     // daemon's own materialization agree on every producer address.
     let mut validated = validate_bindings(&items, core_node_name);
     if !validated.errors.is_empty() {
-        let msg = config::format_bulleted(&validated.errors);
+        let msg = daemon_config::format_bulleted(&validated.errors);
         return Err(Error::ExecutionFailed(msg));
     }
     Ok(Some(

--- a/crates/peppy/src/commands/node/runtime_config.rs
+++ b/crates/peppy/src/commands/node/runtime_config.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
-use config::launcher::Name;
+use config::runtime::Name;
 use config::node::NodeConfigParser;
 use config::runtime::{NodeInstanceConfig, RuntimeConfig};
 use core_node_api::encoding::StackListRequest;

--- a/crates/peppy/src/commands/repo/init.rs
+++ b/crates/peppy/src/commands/repo/init.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use config::consts::PeppyDirs;
+use daemon_config::consts::PeppyDirs;
 use core_node::{InitOutcome, ensure_default_repos, repositories_list_path};
 use tracing::info;
 

--- a/crates/peppy/src/commands/service/builder.rs
+++ b/crates/peppy/src/commands/service/builder.rs
@@ -5,7 +5,7 @@ use super::router_federation::RouterFederation;
 use super::serve::{CompositeCommand, Serve};
 use crate::daemon_state::DaemonState;
 use crate::error::{Error, Result};
-use config::peppy_config::PeppyConfig;
+use daemon_config::peppy_config::PeppyConfig;
 use pmi::Messenger;
 use pmi::MessengerAdapter;
 use pmi::MockAdapter;
@@ -81,7 +81,7 @@ impl ServeCommandBuilder {
             peppy_config: PeppyConfig::default(),
             federation_api_url: None,
             federation_connect_timeout: Duration::from_secs(
-                config::peppy_config::DEFAULT_FEDERATION_CONNECT_TIMEOUT_SECS,
+                daemon_config::peppy_config::DEFAULT_FEDERATION_CONNECT_TIMEOUT_SECS,
             ),
             // Default for the mock/other engines that never resolve a namespace;
             // the zenoh path overwrites this in `with_messaging_router`.
@@ -309,7 +309,7 @@ impl ServeCommandBuilder {
             // Control socket the CLI pokes. Derived from the same `PeppyDirs` the
             // CLI resolves, so the two agree without a discovery handshake.
             let socket_path = crate::daemon_control::federation_control_socket_path(
-                &config::consts::PeppyDirs::default(),
+                &daemon_config::consts::PeppyDirs::default(),
             );
             self.composite_command =
                 self.composite_command
@@ -336,7 +336,7 @@ impl ServeCommandBuilder {
 
 /// Extracts the messaging port from the environment variable, falling back to the default port.
 pub(super) fn extract_messaging_port() -> u16 {
-    std::env::var(config::consts::PEPPY_MESSAGING_PORT_VAR_NAME)
+    std::env::var(daemon_config::consts::PEPPY_MESSAGING_PORT_VAR_NAME)
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(config::consts::DEFAULT_MESSAGING_PORT)

--- a/crates/peppy/src/commands/service/core_node.rs
+++ b/crates/peppy/src/commands/service/core_node.rs
@@ -1,6 +1,6 @@
 use super::serve::{ServeAsyncCommand, ServeAsyncHandle};
 use crate::error::Error;
-use config::consts::PeppyDirs;
+use daemon_config::consts::PeppyDirs;
 use core_node::{CoreNode, CoreNodeArguments, CoreNodeConfig};
 use pmi::Messenger;
 use std::path::PathBuf;
@@ -28,7 +28,7 @@ pub(crate) const HEALTH_MONITOR_TIMEOUT: Duration = Duration::from_secs(3);
 /// defined next to the grace-period floor in `config::peppy_config`, where a
 /// compile-time assert enforces that margin.
 pub(crate) const DAEMON_HEARTBEAT_INTERVAL: Duration =
-    Duration::from_secs(config::peppy_config::DAEMON_HEARTBEAT_INTERVAL_SECS);
+    Duration::from_secs(daemon_config::peppy_config::DAEMON_HEARTBEAT_INTERVAL_SECS);
 
 pub struct CoreNodeRunner {
     core_node: CoreNode,
@@ -58,7 +58,7 @@ impl CoreNodeRunner {
         root_dir: PathBuf,
         messaging_ready: Option<watch::Receiver<bool>>,
         clock_source: super::ClockSource,
-        peppy_config: config::peppy_config::PeppyConfig,
+        peppy_config: daemon_config::peppy_config::PeppyConfig,
         organization_namespace: String,
         serve_teardown_token: CancellationToken,
         core_node_done: watch::Sender<bool>,

--- a/crates/peppy/src/commands/service/install.rs
+++ b/crates/peppy/src/commands/service/install.rs
@@ -140,7 +140,7 @@ fn make_install_context(
 ///
 /// Kept pure (inputs passed in rather than read from the process env) so the
 /// `PEPPY_HOME` precedence can be unit-tested without mutating global state,
-/// mirroring `config::consts::resolve_root`.
+/// mirroring `daemon_config::consts::resolve_root`.
 fn service_environment(
     path: Option<String>,
     peppy_home: Option<OsString>,
@@ -158,7 +158,7 @@ fn service_environment(
     // `~/.peppy` while a caller that set PEPPY_HOME (CI per-run isolation or a
     // custom install prefix) reads daemon state from the override path — the two
     // never find each other and the install's readiness probe times out. Empty
-    // is treated as unset, matching `config::consts::peppy_root_dir`.
+    // is treated as unset, matching `daemon_config::consts::peppy_root_dir`.
     if let Some(home) = peppy_home.filter(|value| !value.is_empty()) {
         environment.push((
             config::consts::PEPPY_HOME_ENV.to_string(),

--- a/crates/peppy/src/commands/service/serve.rs
+++ b/crates/peppy/src/commands/service/serve.rs
@@ -330,8 +330,8 @@ impl ServeCommand {
         // Read the daemon-global config, creating it with defaults if missing.
         // Resolved from `PeppyDirs::default()` (the same ~/.peppy the core node
         // uses), applied to the daemon's own session and every spawned node.
-        let peppy_dirs = config::consts::PeppyDirs::default();
-        let peppy_config = config::peppy_config::load_or_create(&peppy_dirs).map_err(|e| {
+        let peppy_dirs = daemon_config::consts::PeppyDirs::default();
+        let peppy_config = daemon_config::peppy_config::load_or_create(&peppy_dirs).map_err(|e| {
             Error::ExecutionFailed(format!("Failed to load peppy_config.json5: {e}"))
         })?;
 

--- a/crates/peppy/src/commands/stack/launch.rs
+++ b/crates/peppy/src/commands/stack/launch.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
-use config::launcher::PeppyLauncherParser;
+use daemon_config::launcher::PeppyLauncherParser;
 use core_node_api::encoding::{
     LaunchFeedback, LaunchFeedbackStep, LaunchGoal, LaunchGoalResponse, LaunchResult,
     LauncherOrigin, NodeAddLogEntry, NodeBuildLogEntry, NodeRunLogEntry,
@@ -217,7 +217,7 @@ async fn launch_async(
     // error before the daemon round-trip. `Repository` resolution lives daemon-side, so we
     // skip the local check rather than duplicate the lookup here.
     if let LauncherOrigin::Fs(path) = &launcher_origin {
-        PeppyLauncherParser::from_path(path).map_err(Error::PeppyConfig)?;
+        PeppyLauncherParser::from_path(path).map_err(Error::DaemonConfig)?;
     }
 
     let conn = ctx.connect_to_daemon().await?;

--- a/crates/peppy/src/daemon_control.rs
+++ b/crates/peppy/src/daemon_control.rs
@@ -24,7 +24,7 @@ use std::os::unix::net::UnixStream;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use config::consts::PeppyDirs;
+use daemon_config::consts::PeppyDirs;
 use serde::{Deserialize, Serialize};
 
 /// File name of the daemon's federation control socket under the runtime dir.

--- a/crates/peppy/src/daemon_state.rs
+++ b/crates/peppy/src/daemon_state.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use config::consts::PeppyDirs;
+use daemon_config::consts::PeppyDirs;
 use serde::{Deserialize, Serialize};
 use std::fs::{self};
 use std::io;
@@ -154,7 +154,7 @@ impl DaemonState {
     }
 
     fn env_state_file_path() -> Option<PathBuf> {
-        std::env::var_os(config::consts::DAEMON_STATE_FILE_ENV).map(PathBuf::from)
+        std::env::var_os(daemon_config::consts::DAEMON_STATE_FILE_ENV).map(PathBuf::from)
     }
 
     fn default_state_file_path() -> PathBuf {
@@ -222,7 +222,7 @@ impl DaemonState {
             _ => {
                 return Err(io::Error::other(format!(
                     "Multiple running peppy daemons detected. Set {} to select one.",
-                    config::consts::DAEMON_STATE_FILE_ENV
+                    daemon_config::consts::DAEMON_STATE_FILE_ENV
                 )));
             }
         }

--- a/crates/peppy/src/error.rs
+++ b/crates/peppy/src/error.rs
@@ -29,8 +29,10 @@ pub enum Error {
     #[from]
     PeppyMessagingInterface(pmi::PeppyMessagingInterfaceError),
 
-    // -- config
+    // -- config: shared document model (node configs, runtime configs)
     PeppyConfig(config::ConfigError),
+    // -- config: daemon-side documents (launcher files, peppy_config.json5)
+    DaemonConfig(daemon_config::DaemonConfigError),
 
     // -- auth: transport/HTTP failures (unreachable backend, unexpected status)
     Http(String),
@@ -62,6 +64,7 @@ impl Display for Error {
             Error::NodeWatcher(msg) => write!(fmt, "Node watcher error: {msg}"),
             Error::PeppyMessagingInterface(e) => write!(fmt, "Messaging interface error: {e}"),
             Error::PeppyConfig(e) => write!(fmt, "Config error: {e}"),
+            Error::DaemonConfig(e) => write!(fmt, "Config error: {e}"),
             Error::Http(msg) => write!(fmt, "{msg}"),
             Error::Auth(msg) => write!(fmt, "{msg}"),
             Error::NotAuthenticated => write!(

--- a/crates/peppy/src/main.rs
+++ b/crates/peppy/src/main.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use clap::{Parser, Subcommand};
 use tracing::error;
 
-use config::consts::AppEnv;
+use daemon_config::consts::AppEnv;
 use peppy::{
     commands::{Command, auth, container, info, node, repo, service, stack},
     context::AppContext,
@@ -67,7 +67,7 @@ fn main() {
     } else {
         AppEnv::Prod
     };
-    config::consts::set_app_env(env);
+    daemon_config::consts::set_app_env(env);
 
     let cli = Cli::parse();
     let log_style = if cfg!(debug_assertions)

--- a/crates/peppy/src/test_support.rs
+++ b/crates/peppy/src/test_support.rs
@@ -1,5 +1,6 @@
 use crate::daemon_state::DaemonState;
-use config::consts::{PEPPYGEN_OUTPUT_PATH, PeppyDirs};
+use config::consts::PEPPYGEN_OUTPUT_PATH;
+use daemon_config::consts::PeppyDirs;
 use config::node::NodeConfigParser;
 use core_node::{CoreNode, CoreNodeArguments, CoreNodeConfig};
 use pmi::{Messenger, MessengerBackend, MockAdapter, MockInstance, ZenohAdapter, ZenohdInstance};
@@ -205,7 +206,7 @@ impl ServeCommandEmulation {
             },
             root_dir: temp_dir.path().to_path_buf(),
             peppy_dirs,
-            peppy_config: config::peppy_config::PeppyConfig::default(),
+            peppy_config: daemon_config::peppy_config::PeppyConfig::default(),
             organization_namespace: "local".to_string(),
             shutdown_token: tokio_util::sync::CancellationToken::new(),
         });

--- a/crates/peppy/tests/auth_flow.rs
+++ b/crates/peppy/tests/auth_flow.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
-use config::consts::PeppyDirs;
+use daemon_config::consts::PeppyDirs;
 use httpmock::prelude::*;
 use secrecy::ExposeSecret;
 use serde_json::json;

--- a/crates/peppy/tests/node_add.rs
+++ b/crates/peppy/tests/node_add.rs
@@ -1,4 +1,5 @@
-use config::consts::{PEPPY_OUTPUT_DIR, PEPPYGEN_OUTPUT_PATH};
+use config::consts::PEPPYGEN_OUTPUT_PATH;
+use daemon_config::consts::PEPPY_OUTPUT_DIR;
 use config::node::Toolchain;
 use core_node_api::SerializedNodeGraph;
 use core_node_api::encoding::StackListRequest;

--- a/crates/peppy/tests/node_sync.rs
+++ b/crates/peppy/tests/node_sync.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
-use config::consts::PeppyDirs;
+use daemon_config::consts::PeppyDirs;
 use config::node::{EmittedTopic, MessageFormat, NodeConfigParser, QoSProfile, Toolchain};
 use core_node::nodes_repo_cache_path;
 use peppy::commands::Command;

--- a/crates/peppy/tests/repo_init.rs
+++ b/crates/peppy/tests/repo_init.rs
@@ -1,4 +1,4 @@
-use config::consts::PeppyDirs;
+use daemon_config::consts::PeppyDirs;
 use core_node::repositories_list_path;
 use peppy::commands::repo::repo_init_with_dirs;
 use serde_json::Value;

--- a/crates/peppy/tests/repo_list.rs
+++ b/crates/peppy/tests/repo_list.rs
@@ -1,5 +1,6 @@
 use super::common::setup;
-use config::consts::{NODE_CONFIG_FILE, PeppyDirs};
+use config::consts::NODE_CONFIG_FILE;
+use daemon_config::consts::PeppyDirs;
 use core_node::nodes_repo_cache_path;
 use peppy::commands::Command;
 use peppy::commands::repo::{RepoCommand, RepoCommands};

--- a/crates/peppy/tests/service_reset.rs
+++ b/crates/peppy/tests/service_reset.rs
@@ -4,7 +4,8 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
-use config::consts::{NODE_CONFIG_FILE, PEPPY_OUTPUT_DIR, PEPPYGEN_OUTPUT_PATH};
+use config::consts::{NODE_CONFIG_FILE, PEPPYGEN_OUTPUT_PATH};
+use daemon_config::consts::PEPPY_OUTPUT_DIR;
 use core_node_api::SerializedNodeGraph;
 use core_node_api::encoding::StackListRequest;
 use peppy::commands::Command;

--- a/crates/peppy/tests/stack_launch.rs
+++ b/crates/peppy/tests/stack_launch.rs
@@ -8,7 +8,8 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use config::consts::{NODE_CONFIG_FILE, PEPPY_OUTPUT_DIR, PEPPYGEN_OUTPUT_PATH};
+use config::consts::{NODE_CONFIG_FILE, PEPPYGEN_OUTPUT_PATH};
+use daemon_config::consts::PEPPY_OUTPUT_DIR;
 use core_node_api::SerializedNodeGraph;
 use core_node_api::encoding::StackListRequest;
 use peppy::commands::Command;

--- a/docs/tests/integration/Cargo.toml
+++ b/docs/tests/integration/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 [dependencies]
 peppy = { path = "../../../crates/peppy", features = ["test-support"] }
 config = { workspace = true }
+daemon-config = { workspace = true }
 tokio = { version = "1", features = ["full"] }
 tokio-util = "0.7"
 tempfile = "3"

--- a/docs/tests/integration/tests/snippet_configs.rs
+++ b/docs/tests/integration/tests/snippet_configs.rs
@@ -10,7 +10,7 @@
 //! snippets — either the code or the snippets need updating.
 
 use config::consts::NODE_CONFIG_FILE;
-use config::interface::PeppyInterfaceParser;
+use daemon_config::interface::PeppyInterfaceParser;
 use config::node::NodeConfigParser;
 use config::schema::PeppySchema;
 use docs_integration_tests::workspace_root;


### PR DESCRIPTION
## Summary

PR 1 of 3 in the daemon-config extraction. Adds `crates/daemon-config-internal` (package `daemon-config`, lib `daemon_config`, mirroring the `containers-internal`/`containers` convention) holding the daemon-side config document models that nothing outside peppyos consumes (~5k LOC out of `peppy-config-model`'s ~13k):

- launcher documents (`launcher/v1`): types, parser, binding validator
- interface documents (`interface/v1`)
- deployment `source` forms
- `peppy_config.json5`: model, `load_or_create`, bundled template, comment-preserving completion
- `atomic_write::publish_atomic`
- daemon-side `consts` (`PeppyDirs`, `AppEnv`/`set_app_env`, output dirs, credentials file, base images)
- daemon-domain error tier (`SlotKind`, binding payload structs, 10 `ParsingError` variants, `format_bulleted`)

## Commit structure

1. **Verbatim copies** from `public-peppy-libs@a17a3ca` (the rev pinned in Cargo.lock before this PR): `diff -r` against the source shows byte-identical files.
2. **Adaptations only**: module wiring, `crate::...` to `config::...` path flips for staying types, residue trims (`PeerConfig` and the buffer/grace defaults stay shared; pmi/peppylib-py/runtime.rs consume them), the private serde-bridge copy (~45 LOC bounded duplication, chosen over widening the shared crate's public surface), fixture relocation.
3. **Consumer flips**: direct `daemon_config::` imports across ~100 files, no shims. `config::launcher::Name` becomes `config::runtime::Name` (the type stays shared). `peppy::Error` gains a `DaemonConfig` variant next to `PeppyConfig` since both error families now exist.

## Lock pin

Cargo.lock moves the single shared git rev to Peppy-bot/public-peppy-libs#21 (`f3b3ea36`), which provides `config::runtime::Name` and the public `deserialize_expecting`. **If #21 lands as a squash or rebase merge**, re-run `cargo update -p peppy-config-model` here afterwards so the lock points at a rev on `main` (with a fast-forward/merge-commit it already does).

## Verification (macOS; container/e2e suites stay on Linux CI)

- `scripts/local-libs.sh status`: OFF (no local patching; the pinned remote rev is what built)
- `cargo check --workspace --all-targets`: clean, zero warnings
- `cargo test`: all green, including the 127 moved tests in `daemon-config`
- `cargo test -p docs-integration-tests`: green
- Grep proofs: zero references to any moved `config::` path outside the new crate; staying paths (`config::schema`, `config::node`, residue consts) untouched

## Landing order

Peppy-bot/public-peppy-libs#21 first, then this, then the public-peppy-libs removal PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a dedicated daemon-side configuration system, including shared paths, defaults, and config file creation on first run.
  * Added parsing support for launcher and interface configuration files with stronger validation.

* **Bug Fixes**
  * Improved handling of configuration and cache file writes to reduce partial-write issues.
  * Updated node, service, and authentication flows to use the new configuration source consistently.

* **Documentation**
  * Added example configuration fixtures and updated related test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->