### PR TITLE
docs: sync with PR #288

### DIFF
--- a/crates/daemon-config-internal/src/peppy_config.rs
+++ b/crates/daemon-config-internal/src/peppy_config.rs
@@ -1,7 +1,7 @@
 //! Global daemon configuration read from `~/.peppy/conf/peppy_config.json5`.
 //!
 //! This is the single user-facing switch for the messaging topology. The daemon
-//! reads it ONCE at startup (see `peppy serve`), creating the file from the
+//! reads it ONCE at startup (see `peppy service serve`), creating the file from the
 //! bundled default template if it is missing, and applies the result to its own
 //! core-node session and to every node it spawns. Editing the file takes effect
 //! after a daemon restart.

--- a/docs/src/content/docs/advanced_guides/daemon_config.mdx
+++ b/docs/src/content/docs/advanced_guides/daemon_config.mdx
@@ -5,10 +5,10 @@ sidebar:
   order: 9
 ---
 
-The peppy daemon reads one global configuration file, `~/.peppy/conf/peppy_config.json5`. It controls the messaging topology of the whole stack, the subscriber channel buffer sizes, the grace periods that govern node lifecycle, and the timeout for federating to your organization's cloud router. The daemon applies it to its own core-node session and to every node it spawns. The same file also records the backend resource-server URL the `peppy auth login` / `whoami` / `logout` commands talk to; that block is read by the CLI, not the daemon.
+The peppy daemon reads one global configuration file, `~/.peppy/conf/peppy_config.json5`. It sets the daemon's core-node name, controls the messaging topology of the whole stack, the subscriber channel buffer sizes, the grace periods that govern node lifecycle, and the timeout for federating to your organization's cloud router. The daemon applies it to its own core-node session and to every node it spawns. The same file also records the backend resource-server URL the `peppy auth login` / `whoami` / `logout` commands talk to; that block is read by the CLI, not the daemon.
 
 :::note
-The daemon reads its settings (`mode`, `peer`, `lifecycle`, `federation`) **once, at daemon startup**. Editing them has no effect on a running stack; restart the daemon (`peppy serve`, or `systemctl restart` your service) to apply changes. The `resource_servers` block is read fresh by each CLI auth command, so an edit there takes effect on the next `peppy auth login` without a daemon restart.
+The daemon reads its settings (`core_node_name`, `mode`, `peer`, `lifecycle`, `federation`) **once, at daemon startup**. Editing them has no effect on a running stack; restart the daemon (`peppy serve`, or `systemctl restart` your service) to apply changes. The `resource_servers` block is read fresh by each CLI auth command, so an edit there takes effect on the next `peppy auth login` without a daemon restart.
 :::
 
 ## How the file is managed
@@ -27,6 +27,14 @@ A setting you delete from the file therefore comes back with its default on the 
 // Read once when the peppy daemon starts, so any edit below (mode or buffer
 // sizes) takes effect only after you restart the daemon.
 {
+  // Fixed name for this daemon's core node, or null to derive a
+  // machine-specific default (core-node-...). Names must be unique across all
+  // daemons reachable over the same router/federation: a daemon whose name is
+  // already in use refuses to boot. At most 63 characters from the node-name
+  // character set (start with a letter; letters, digits, `_`, `-`).
+  // `peppy service serve --core-node-name` overrides this for one run.
+  core_node_name: null,
+
   //   "peer"   - Zenoh peer sessions with gossip: nodes form direct
   //              peer-to-peer links and data stops relaying through the router.
   //   "router" - gossip off: all traffic relays through the central zenohd
@@ -78,6 +86,14 @@ A setting you delete from the file therefore comes back with its default on the 
 }
 ```
 
+## `core_node_name`: the daemon's core-node name
+
+`core_node_name` fixes the name of this daemon's [core node](/reference/concepts/#the-core-node). Leave it `null` (the default) and the daemon derives a stable, machine-specific name of the form `core-node-...`; set a string to pin an explicit one.
+
+Core-node names must be **unique across every daemon reachable over the same router or federation**. On boot the daemon probes its own name and, if another daemon already answers under it, refuses to start rather than break the name-based routing that every core-node call relies on. If two daemons end up sharing a name, give one of them a unique `core_node_name` (or pass `peppy service serve --core-node-name <name>` for a single run) and restart it. This most commonly matters when logging in federates several machines together, or when cloning a disk image reuses another machine's derived name.
+
+The value must be non-empty, at most **63 characters**, and use only the node-name character set (start with a letter; letters, digits, `_`, `-`). An invalid value stops the daemon at startup with an error instead of failing later when the core node boots. `peppy service serve --core-node-name <name>` overrides the config for one run (the flag wins over the file); both absent falls back to the derived default.
+
 ## `mode`: messaging topology
 
 `mode` selects how nodes exchange data:
@@ -125,6 +141,7 @@ When you are logged in, the daemon links ("federates") its local messaging route
 
 | Setting | Default | Constraint | Effect |
 |---|---|---|---|
+| `core_node_name` | `null` (derived `core-node-...`) | Non-empty, ≤ 63 chars, node-name charset | Fixed name for this daemon's core node; must be unique across all daemons on the same router/federation or the daemon refuses to boot. Overridable per run with `--core-node-name`. |
 | `mode` | `"peer"` | `"peer"` or `"router"` | Messaging topology: direct peer links with gossip, or relay everything through the central router. |
 | `peer.standard_buffer_size` | `128` | `> 0` | Subscriber channel capacity (messages) for standard-QoS topics; also sizes service request/reply channels. |
 | `peer.high_throughput_buffer_size` | `1024` | `> 0` | Subscriber channel capacity (messages) for high-throughput-QoS topics such as sensor-data streams. |

--- a/docs/src/content/docs/advanced_guides/daemon_config.mdx
+++ b/docs/src/content/docs/advanced_guides/daemon_config.mdx
@@ -8,7 +8,7 @@ sidebar:
 The peppy daemon reads one global configuration file, `~/.peppy/conf/peppy_config.json5`. It sets the daemon's core-node name, controls the messaging topology of the whole stack, the subscriber channel buffer sizes, the grace periods that govern node lifecycle, and the timeout for federating to your organization's cloud router. The daemon applies it to its own core-node session and to every node it spawns. The same file also records the backend resource-server URL the `peppy auth login` / `whoami` / `logout` commands talk to; that block is read by the CLI, not the daemon.
 
 :::note
-The daemon reads its settings (`core_node_name`, `mode`, `peer`, `lifecycle`, `federation`) **once, at daemon startup**. Editing them has no effect on a running stack; restart the daemon (`peppy serve`, or `systemctl restart` your service) to apply changes. The `resource_servers` block is read fresh by each CLI auth command, so an edit there takes effect on the next `peppy auth login` without a daemon restart.
+The daemon reads its settings (`core_node_name`, `mode`, `peer`, `lifecycle`, `federation`) **once, at daemon startup**. Editing them has no effect on a running stack; restart the daemon (`peppy service serve`, or `systemctl restart` your service) to apply changes. The `resource_servers` block is read fresh by each CLI auth command, so an edit there takes effect on the next `peppy auth login` without a daemon restart.
 :::
 
 ## How the file is managed

--- a/docs/src/content/docs/reference/concepts.mdx
+++ b/docs/src/content/docs/reference/concepts.mdx
@@ -113,6 +113,8 @@ In a distributed deployment, multiple runtimes (each with their own core node) c
 The core nodes operate independently, managing their local node stacks without a centralized controller. 
 Nodes communicate across runtimes through the shared messaging layer, enabling a fully decentralized system where each core node is responsible only for its own set of nodes.
 
+Because core nodes are addressed by name over the messaging layer, every core node reachable over the same router or federation must have a **unique name**. Each daemon derives a stable, machine-specific name by default, or you can pin one with [`core_node_name`](/advanced_guides/daemon_config/#core_node_name-the-daemons-core-node-name); a daemon whose name is already taken refuses to boot.
+
 ## Summary
 
 ```


### PR DESCRIPTION
Automated doc update generated by `scripts/docs/update_docs.py`
in response to code changes in #288.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded daemon configuration documentation with `core_node_name`, including default behavior, validation constraints, uniqueness requirements across reachable core nodes, and the note that it’s read once at startup.
  * Clarified that `resource_servers` are refreshed per CLI auth command, applying changes to the next login.
  * Added/updated examples and a reference entry describing derived vs pinned naming and one-run override via `--core-node-name`.
  * Updated core node concept guidance on name-based addressing and startup refusal on conflicts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->