### PR TITLE
docs: sync with PR #299

### DIFF
--- a/docs/src/content/docs/advanced_guides/communication_patterns.mdx
+++ b/docs/src/content/docs/advanced_guides/communication_patterns.mdx
@@ -41,8 +41,8 @@ The shape says nothing about which node sits on the other end. A consumer couple
 
 | | Declared under | Who can fill the slot | Instances per slot |
 |---|---|---|---|
-| Direct node dependency | `depends_on.nodes` | Instances of that exact producer node | The one instance the launcher binds to the slot |
-| [Contract dependency](/advanced_guides/contract_implementation/) | `depends_on.contracts` | Any node whose `manifest.implements` names the contract | The one implementing instance the launcher binds to the slot |
+| Direct node dependency | `depends_on.nodes` | Instances of that exact producer node | The producer instance(s) bound to the slot, sized by its cardinality (one by default) |
+| [Contract dependency](/advanced_guides/contract_implementation/) | `depends_on.contracts` | Any node whose `manifest.implements` names the contract | The implementing instance(s) bound to the slot, sized by its cardinality (one by default) |
 | [Pairing slot](/advanced_guides/pairing/) | `depends_on.pairings` | One instance playing the complementary role of the pairing | Exactly one peer at a time, exclusive, both directions |
 
 :::note

--- a/docs/src/content/docs/guides/communication.mdx
+++ b/docs/src/content/docs/guides/communication.mdx
@@ -225,7 +225,7 @@ Log file: /Users/tuatini/.peppy/logs/run/vigorous-buck-8117.log
 Started node instance 'vigorous-buck-8117' (pid: 77190)
 ```
 
-A slot left without a `--bind` is an error: every declared slot must be bound, and the run is rejected before the node spawns.
+A slot left without a `--bind` is an error: every declared slot must be bound (unless its cardinality is `zero_or_more`), and the run is rejected before the node spawns.
 
 When you start the node, you can see a path to the logs. In my case: `/Users/tuatini/.peppy/logs/run/vigorous-buck-8117.log`.
 If we open it up:


### PR DESCRIPTION
Automated doc update generated by `scripts/docs/update_docs.py`
in response to code changes in #299.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how node and contract dependencies bind to producer instances based on declared cardinality.
  * Documented that all required startup binding slots must be assigned, or the run is rejected before the node starts.
  * Noted that only slots with `zero_or_more` cardinality may remain unbound.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->