### PR TITLE
Add PEPPY_CONFIG daemon config override

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,7 +418,7 @@ dependencies = [
 [[package]]
 name = "build-helpers"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#cde897f7e20125c12cca21f1ed07b4ca06f27420"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#b1eca97987cd37e672a6bca8e610033800406613"
 dependencies = [
  "sha2",
 ]
@@ -613,7 +613,7 @@ dependencies = [
 [[package]]
 name = "config-test-support"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#cde897f7e20125c12cca21f1ed07b4ca06f27420"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#b1eca97987cd37e672a6bca8e610033800406613"
 dependencies = [
  "askama",
  "git2",
@@ -756,7 +756,7 @@ dependencies = [
 [[package]]
 name = "core-node-api"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#cde897f7e20125c12cca21f1ed07b4ca06f27420"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#b1eca97987cd37e672a6bca8e610033800406613"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -2316,7 +2316,7 @@ dependencies = [
 [[package]]
 name = "json5-pretty"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#cde897f7e20125c12cca21f1ed07b4ca06f27420"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#b1eca97987cd37e672a6bca8e610033800406613"
 dependencies = [
  "serde",
  "serde_json",
@@ -3058,7 +3058,7 @@ dependencies = [
 [[package]]
 name = "peppy-config-model"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#cde897f7e20125c12cca21f1ed07b4ca06f27420"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#b1eca97987cd37e672a6bca8e610033800406613"
 dependencies = [
  "capnp",
  "clap",
@@ -3081,7 +3081,7 @@ version = "0.0.1"
 [[package]]
 name = "peppylib-rs"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#cde897f7e20125c12cca21f1ed07b4ca06f27420"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#b1eca97987cd37e672a6bca8e610033800406613"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -3256,7 +3256,7 @@ dependencies = [
 [[package]]
 name = "pmi"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#cde897f7e20125c12cca21f1ed07b4ca06f27420"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#b1eca97987cd37e672a6bca8e610033800406613"
 dependencies = [
  "build-helpers",
  "bytes",

--- a/Claude.md
+++ b/Claude.md
@@ -14,6 +14,7 @@ Review this plan thoroughly before making any code changes. For every issue or r
 - Do not leave legacy code behind or code that is meant to support previous version of the code.
 - When you write comments or documentation, stop using em-dash `—`, this is a recurring pattern that you make and immediately jumps at users as being your coding style.
 - Push back hard against design implementation that you think are fundamentally wrong and explain your reasoning
+- Never open or merge PRs in the remote repository without my consent
 
 ---
 

--- a/crates/daemon-config-internal/src/peppy_config.rs
+++ b/crates/daemon-config-internal/src/peppy_config.rs
@@ -7,14 +7,21 @@
 //! after a daemon restart.
 //!
 //! A well-formed file that omits settings (typically one written by an older
-//! peppy before a new knob existed) is completed in place: the missing entries
-//! are appended with their default values and explanatory comments, so the file
-//! on disk always lists every available knob. The user's own values, comments,
-//! and unknown root-level keys are otherwise preserved byte-for-byte (see
-//! [`completion`]); when appending defaults, completion may add a structural
-//! separator comma after the prior final entry. Each setting added this way is
-//! logged at info level, so the first start after a peppy upgrade shows exactly
-//! which new settings appeared in the file.
+//! peppy before a new knob existed) is completed in place where the text
+//! scanner can safely locate the insertion point. Missing entries are appended
+//! with their default values and explanatory comments. Any omission the scanner
+//! cannot safely splice is named in a warning and remains defaulted in memory.
+//! The user's own values, comments, and unknown root-level keys are otherwise
+//! preserved byte-for-byte (see [`completion`]); when appending defaults,
+//! completion may add a structural separator comma after the prior final entry.
+//! Each setting added this way is logged at info level, so the first start after
+//! a peppy upgrade shows exactly which new settings appeared in the file.
+//!
+//! A non-empty `PEPPY_CONFIG` environment variable bypasses that on-disk flow.
+//! Its value is tried first as a config file path and then, if the file cannot
+//! be read, as an inline JSON5 document. An override is read-only: peppy never
+//! creates, completes, or rewrites either source, and any invalid or incomplete
+//! source fails loud.
 //!
 //! Unlike `repositories.json5`, a malformed `peppy_config.json5` fails loud at
 //! startup ([`load_or_create`] returns `Err`) instead of falling back to
@@ -28,7 +35,7 @@ mod completion;
 use crate::atomic_write::publish_atomic;
 use crate::consts::PeppyDirs;
 use crate::error::{Error, ParsingError, Result};
-use config::consts::ALLOWED_CONFIG_CHARS;
+use config::consts::{ALLOWED_CONFIG_CHARS, PEPPY_CONFIG_ENV};
 use config::peppy_config::{
     DEFAULT_DAEMON_GRACE_SECS, DEFAULT_HIGH_THROUGHPUT_BUFFER_SIZE, DEFAULT_SHUTDOWN_GRACE_SECS,
     DEFAULT_STANDARD_BUFFER_SIZE, PeerConfig,
@@ -36,8 +43,10 @@ use config::peppy_config::{
 use config::runtime::Name;
 use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::BTreeMap;
+use std::ffi::OsString;
+use std::fs;
 use std::net::{Ipv4Addr, Ipv6Addr};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 /// File name of the global daemon config under `~/.peppy/conf`.
 pub const PEPPY_CONFIG_FILE: &str = "peppy_config.json5";
@@ -733,14 +742,29 @@ impl PeppyConfig {
 
 /// Reads the global config from `~/.peppy/conf/peppy_config.json5`, creating it
 /// from the bundled default template (verbatim, so comments survive) when it
-/// does not exist, and appending defaults for any setting an existing file
-/// omits so the file on disk always lists every available knob.
+/// does not exist, and appending defaults for settings an existing file omits.
+///
+/// A non-empty [`PEPPY_CONFIG_ENV`] value bypasses the normal file completely.
+/// The override is loaded read-only and is never created, completed, rewritten,
+/// or used as a reason to touch the normal on-disk config. Invalid, incomplete,
+/// or unreadable overrides return `Err`.
 ///
 /// Read ONCE by the daemon at startup. A malformed existing file returns `Err`
 /// (fail loud) rather than defaulting, since mode and buffer sizes are
 /// load-bearing for the whole mesh. This intentionally differs from
 /// `ensure_default_repos`, which only warns on a bad repos file.
 pub fn load_or_create(peppy_dirs: &PeppyDirs) -> Result<PeppyConfig> {
+    load_or_create_with_override(peppy_dirs, std::env::var_os(PEPPY_CONFIG_ENV))
+}
+
+fn load_or_create_with_override(
+    peppy_dirs: &PeppyDirs,
+    env_value: Option<OsString>,
+) -> Result<PeppyConfig> {
+    if let Some(value) = env_override_source(env_value)? {
+        return load_override_config(&value);
+    }
+
     let conf_dir = peppy_dirs.conf_dir();
     std::fs::create_dir_all(&conf_dir)?;
     let path = conf_dir.join(PEPPY_CONFIG_FILE);
@@ -775,9 +799,105 @@ pub fn load_or_create(peppy_dirs: &PeppyDirs) -> Result<PeppyConfig> {
     Ok(config)
 }
 
-/// Appends template defaults for every setting the user's file omits, so the
-/// on-disk file spells out all available knobs, and logs at info level which
-/// settings were added so a release upgrade leaves a visible trace.
+fn env_override_source(value: Option<OsString>) -> Result<Option<String>> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    if value.is_empty() {
+        return Ok(None);
+    }
+    value.into_string().map(Some).map_err(|_| {
+        cannot_parse_config(format!(
+            "{PEPPY_CONFIG_ENV} is set but its value is not valid UTF-8; use a UTF-8 file path or inline JSON5 document"
+        ))
+    })
+}
+
+fn load_override_config(value: &str) -> Result<PeppyConfig> {
+    let file_attempt = match expand_tilde(value) {
+        Ok(path) => fs::read_to_string(&path)
+            .map(|content| (path.clone(), content))
+            .map_err(|error| format!("{}: {error}", path.display())),
+        Err(error) => Err(format!("{value}: {error}")),
+    };
+
+    let (content, origin, config) = match file_attempt {
+        Ok((path, content)) => {
+            let origin = format!("file {}", path.display());
+            tracing::info!(
+                "using {PEPPY_CONFIG_ENV} ({origin}); bypassing on-disk {PEPPY_CONFIG_FILE}"
+            );
+            let config = serde_json5::from_str::<PeppyConfig>(&content).map_err(|error| {
+                cannot_parse_config(format!("{PEPPY_CONFIG_ENV} ({origin}): {error}"))
+            })?;
+            (content, origin, config)
+        }
+        Err(file_error) => match serde_json5::from_str::<PeppyConfig>(value) {
+            Ok(config) => {
+                let origin = "inline document".to_string();
+                tracing::info!(
+                    "using {PEPPY_CONFIG_ENV} ({origin}); bypassing on-disk {PEPPY_CONFIG_FILE}"
+                );
+                (value.to_string(), origin, config)
+            }
+            Err(inline_error) => {
+                return Err(cannot_parse_config(format!(
+                    "{PEPPY_CONFIG_ENV} is neither a readable config file ({file_error}) nor an inline JSON5 config ({inline_error})"
+                )));
+            }
+        },
+    };
+
+    config
+        .validate()
+        .map_err(|error| prefix_override_error(error, &origin))?;
+    ensure_override_spells_out_every_setting(&content, &origin)?;
+    Ok(config)
+}
+
+fn cannot_parse_config(message: String) -> Error {
+    Error::Parsing(ParsingError::CannotParseConfig(message))
+}
+
+fn prefix_override_error(error: Error, origin: &str) -> Error {
+    match error {
+        Error::Parsing(ParsingError::CannotParseConfig(message)) => {
+            cannot_parse_config(format!("{PEPPY_CONFIG_ENV} ({origin}): {message}"))
+        }
+        other => other,
+    }
+}
+
+fn ensure_override_spells_out_every_setting(content: &str, origin: &str) -> Result<()> {
+    let Some(completion) = completion::complete_config_content(content) else {
+        return Ok(());
+    };
+    let missing_paths = completion::missing_paths_in_template_order(&completion);
+    Err(cannot_parse_config(format!(
+        "{PEPPY_CONFIG_ENV} ({origin}): missing settings this peppy release defines: {}; {PEPPY_CONFIG_ENV} sources are never completed with defaults, so every setting must be spelled out",
+        missing_paths.join(", ")
+    )))
+}
+
+fn expand_tilde(path: &str) -> std::result::Result<PathBuf, String> {
+    if path == "~" {
+        return dirs::home_dir()
+            .ok_or_else(|| "cannot resolve ~ because the home directory is unavailable".into());
+    }
+    if let Some(rest) = path.strip_prefix("~/") {
+        return dirs::home_dir()
+            .map(|home| home.join(rest))
+            .ok_or_else(|| "cannot resolve ~/ because the home directory is unavailable".into());
+    }
+    if path.starts_with('~') {
+        return Err("~user paths are not supported; use an absolute path or ~/...".into());
+    }
+    Ok(PathBuf::from(path))
+}
+
+/// Appends template defaults for every omitted setting whose insertion point
+/// can be safely located, warns about any omission it cannot splice, and logs
+/// which settings were added so a release upgrade leaves a visible trace.
 ///
 /// Best effort by design: `config` (parsed from `content`) is already complete
 /// in memory via the serde defaults, so this only improves the FILE. The result
@@ -789,6 +909,16 @@ fn complete_file_with_defaults(path: &Path, content: &str, config: &PeppyConfig)
     let Some(completion) = completion::complete_config_content(content) else {
         return;
     };
+    if !completion.unspliceable_paths.is_empty() {
+        tracing::warn!(
+            "{PEPPY_CONFIG_FILE}: could not add missing settings to the file: {}; \
+             continuing with the in-memory defaults",
+            completion.unspliceable_paths.join(", ")
+        );
+    }
+    if completion.added_paths.is_empty() {
+        return;
+    }
     if !completion::verify_completion(content, &completion.content, config) {
         tracing::warn!(
             "adding missing defaults to {PEPPY_CONFIG_FILE} produced inconsistent \
@@ -850,6 +980,243 @@ mod tests {
         let path = conf_dir.join(PEPPY_CONFIG_FILE);
         std::fs::write(&path, content).unwrap();
         (tmp, peppy_dirs, path)
+    }
+
+    fn error_message(error: Error) -> String {
+        match error {
+            Error::Parsing(ParsingError::CannotParseConfig(message)) => message,
+            other => panic!("expected CannotParseConfig, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn env_override_source_unset_and_empty_are_none() {
+        assert_eq!(env_override_source(None).unwrap(), None);
+        assert_eq!(env_override_source(Some(OsString::new())).unwrap(), None);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn env_override_source_non_utf8_fails_loud() {
+        use std::os::unix::ffi::OsStringExt;
+
+        let error = env_override_source(Some(OsString::from_vec(vec![0xff]))).unwrap_err();
+        let message = error_message(error);
+        assert!(message.contains(PEPPY_CONFIG_ENV));
+        assert!(message.contains("not valid UTF-8"));
+    }
+
+    #[test]
+    fn inline_override_accepts_the_full_template_with_comments() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path().join("never-created");
+        let peppy_dirs = PeppyDirs::new(&root);
+
+        let config =
+            load_or_create_with_override(&peppy_dirs, Some(DEFAULT_PEPPY_CONFIG_TEMPLATE.into()))
+                .unwrap();
+
+        assert_eq!(config, PeppyConfig::default());
+        assert!(!root.exists());
+    }
+
+    #[test]
+    fn file_override_loads_a_complete_config_file() {
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("override.json5");
+        let content = DEFAULT_PEPPY_CONFIG_TEMPLATE.replacen(
+            "local_nodes_topology: \"peer\"",
+            "local_nodes_topology: \"router\"",
+            1,
+        );
+        std::fs::write(&path, &content).unwrap();
+        let before = std::fs::read(&path).unwrap();
+
+        let config = load_override_config(path.to_str().unwrap()).unwrap();
+
+        assert_eq!(
+            config.zenoh.local_nodes_topology,
+            LocalNodesTopology::Router
+        );
+        assert_eq!(std::fs::read(&path).unwrap(), before);
+    }
+
+    #[test]
+    fn file_form_errors_do_not_fall_back_to_inline() {
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("malformed.json5");
+        std::fs::write(&path, "{ not json5").unwrap();
+
+        let message = error_message(load_override_config(path.to_str().unwrap()).unwrap_err());
+
+        assert!(message.contains(PEPPY_CONFIG_ENV));
+        assert!(message.contains(&format!("file {}", path.display())));
+        assert!(!message.contains("neither a readable config file"));
+    }
+
+    #[test]
+    fn neither_file_nor_inline_lists_both_reasons() {
+        let value = "definitely/missing.json5";
+
+        let message = error_message(load_override_config(value).unwrap_err());
+
+        assert!(message.contains(PEPPY_CONFIG_ENV));
+        assert!(message.contains(value));
+        assert!(message.contains("readable config file"));
+        assert!(message.contains("inline JSON5 config"));
+    }
+
+    #[test]
+    fn whitespace_only_value_fails_with_both_reasons() {
+        let message = error_message(load_override_config("   ").unwrap_err());
+
+        assert!(message.contains(PEPPY_CONFIG_ENV));
+        assert!(message.contains("readable config file"));
+        assert!(message.contains("inline JSON5 config"));
+    }
+
+    #[test]
+    fn file_override_expands_tilde() {
+        let relative = format!(
+            "definitely-missing-peppy-config-env-{}-{}",
+            std::process::id(),
+            line!()
+        );
+        let value = format!("~/{relative}/x.json5");
+        let expanded = dirs::home_dir().unwrap().join(relative).join("x.json5");
+
+        let message = error_message(load_override_config(&value).unwrap_err());
+
+        assert!(message.contains(&expanded.display().to_string()));
+        assert!(message.contains("inline JSON5 config"));
+    }
+
+    #[test]
+    fn inline_override_failing_validation_names_the_env_var() {
+        let content = DEFAULT_PEPPY_CONFIG_TEMPLATE.replacen(
+            &format!("standard_buffer_size: {DEFAULT_STANDARD_BUFFER_SIZE}"),
+            "standard_buffer_size: 0",
+            1,
+        );
+
+        let message = error_message(load_override_config(&content).unwrap_err());
+
+        assert!(message.contains("PEPPY_CONFIG (inline document)"));
+        assert!(message.contains("standard_buffer_size"));
+    }
+
+    #[test]
+    fn override_outdated_lists_missing_paths() {
+        let message = error_message(load_override_config(r#"{ mode: "peer" }"#).unwrap_err());
+
+        assert!(message.contains("PEPPY_CONFIG (inline document)"));
+        assert!(message.contains("core_node_name"));
+        assert!(message.contains("zenoh"));
+        assert!(message.contains("lifecycle"));
+        assert!(message.contains("resource_servers"));
+        assert!(message.contains("never completed with defaults"));
+        assert!(message.contains("every setting must be spelled out"));
+    }
+
+    #[test]
+    fn outdated_check_runs_after_validation() {
+        let content = r#"{ zenoh: { peer: { standard_buffer_size: 0 } } }"#;
+
+        let message = error_message(load_override_config(content).unwrap_err());
+
+        assert!(message.contains("PEPPY_CONFIG (inline document)"));
+        assert!(message.contains("standard_buffer_size"));
+        assert!(!message.contains("missing settings this peppy release defines"));
+    }
+
+    #[test]
+    fn file_override_outdated_stays_untouched() {
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("outdated.json5");
+        let content = b"{ mode: \"peer\" }\n";
+        std::fs::write(&path, content).unwrap();
+
+        let message = error_message(load_override_config(path.to_str().unwrap()).unwrap_err());
+
+        assert!(message.contains(&format!("file {}", path.display())));
+        assert!(message.contains("core_node_name"));
+        assert_eq!(std::fs::read(&path).unwrap(), content);
+    }
+
+    #[test]
+    fn override_takes_precedence_over_dirs_without_touching_disk() {
+        let (_tmp, peppy_dirs, path) = dirs_with_config("{ not json5");
+        let before = std::fs::read(&path).unwrap();
+
+        let config =
+            load_or_create_with_override(&peppy_dirs, Some(DEFAULT_PEPPY_CONFIG_TEMPLATE.into()))
+                .unwrap();
+
+        assert_eq!(config, PeppyConfig::default());
+        assert_eq!(std::fs::read(&path).unwrap(), before);
+
+        let tmp = tempdir().unwrap();
+        let root = tmp.path().join("never-created");
+        let peppy_dirs = PeppyDirs::new(&root);
+        load_or_create_with_override(&peppy_dirs, Some(DEFAULT_PEPPY_CONFIG_TEMPLATE.into()))
+            .unwrap();
+        assert!(!root.exists());
+    }
+
+    #[test]
+    fn no_override_falls_through_to_disk_flow() {
+        let tmp = tempdir().unwrap();
+        let peppy_dirs = PeppyDirs::new(tmp.path());
+        let config = load_or_create_with_override(&peppy_dirs, None).unwrap();
+        let path = peppy_dirs.conf_dir().join(PEPPY_CONFIG_FILE);
+
+        assert_eq!(config, PeppyConfig::default());
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            DEFAULT_PEPPY_CONFIG_TEMPLATE
+        );
+
+        let (_tmp, peppy_dirs, path) = dirs_with_config("{}");
+        load_or_create_with_override(&peppy_dirs, None).unwrap();
+        let completed = std::fs::read_to_string(path).unwrap();
+        assert_eq!(
+            serde_json5::from_str::<PeppyConfig>(&completed).unwrap(),
+            PeppyConfig::default()
+        );
+        assert!(completion::complete_config_content(&completed).is_none());
+    }
+
+    #[test]
+    fn partial_splice_survives_unspliceable_remainder() {
+        let content = DEFAULT_PEPPY_CONFIG_TEMPLATE
+            .replacen("  lifecycle: {", r#"  "life\u0063ycle": {"#, 1)
+            .replacen(SHUTDOWN_GRACE_FIELD_SNIPPET, "", 1)
+            .replacen(API_FIELD_SNIPPET, "", 1);
+        let (_tmp, peppy_dirs, path) = dirs_with_config(&content);
+
+        let config = load_or_create(&peppy_dirs).unwrap();
+        let completed = std::fs::read_to_string(&path).unwrap();
+
+        assert_eq!(config, PeppyConfig::default());
+        assert_ne!(completed, content);
+        assert!(completed.contains(API_FIELD_SNIPPET));
+        assert!(!completed.contains(SHUTDOWN_GRACE_FIELD_SNIPPET));
+        assert!(completed.contains(r#""life\u0063ycle""#));
+        assert_eq!(load_or_create(&peppy_dirs).unwrap(), config);
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), completed);
+    }
+
+    #[test]
+    fn override_with_escaped_key_outdated_doc_crashes() {
+        let content = DEFAULT_PEPPY_CONFIG_TEMPLATE
+            .replacen("  lifecycle: {", r#"  "life\u0063ycle": {"#, 1)
+            .replacen(SHUTDOWN_GRACE_FIELD_SNIPPET, "", 1);
+
+        let message = error_message(load_override_config(&content).unwrap_err());
+
+        assert!(message.contains("PEPPY_CONFIG (inline document)"));
+        assert!(message.contains("lifecycle.shutdown_grace_secs"));
+        assert!(message.contains("never completed with defaults"));
     }
 
     #[test]

--- a/crates/daemon-config-internal/src/peppy_config/completion.rs
+++ b/crates/daemon-config-internal/src/peppy_config/completion.rs
@@ -1,11 +1,12 @@
 //! Comment-preserving completion of a user's `peppy_config.json5`.
 //!
-//! [`complete_config_content`] splices every missing known entry, at any
-//! nesting depth, into the file content, copying the snippet (explanatory
-//! comments included) from the bundled template, so the file on disk always
-//! lists every available knob. Everything the user wrote survives
+//! [`complete_config_content`] detects every missing known entry and splices
+//! each one whose parent block it can safely locate, at any nesting depth,
+//! into the file content. It copies the snippet (explanatory comments
+//! included) from the bundled template. Everything the user wrote survives
 //! byte-for-byte: their values, their comments, their formatting, and any
-//! unknown keys.
+//! unknown keys. Omissions whose source spelling the scanner cannot pair with
+//! a block are reported separately instead of being silently skipped.
 //!
 //! Rewriting the file through serde would destroy comments, and no
 //! comment-preserving JSON5 editor crate exists, so this works directly on the
@@ -14,8 +15,8 @@
 //! before the relevant closing brace. Before anything is written, the caller
 //! gates the result through [`verify_completion`], so a splicing bug cannot
 //! drop or alter any value the user wrote, cannot change what the file parses
-//! to, and cannot splice again on the next start; a bad splice is discarded
-//! with a warning and the user's file stays untouched.
+//! to, and cannot leave another splice possible on the next start; a bad
+//! splice is discarded with a warning and the user's file stays untouched.
 
 use serde_json::Value;
 use std::collections::HashMap;
@@ -132,13 +133,16 @@ const SECTIONS: &[EntrySpec] = &[
 /// ("federation" spelled "zenoh.federation", a nested field
 /// "lifecycle.shutdown_grace_secs"), grouped by the block it was spliced into
 /// (outer blocks first) and in template order within a block. It reflects what
-/// was actually inserted, not merely what was absent: an entry whose parent
-/// block the scanner could not locate is skipped by the splice and therefore
-/// not listed.
+/// was actually inserted, not merely what was absent.
+///
+/// `unspliceable_paths` names settings that were detected as absent but whose
+/// parent block the scanner could not safely locate. Those settings remain
+/// absent from `content` and are never included in `added_paths`.
 #[derive(Debug)]
 pub(super) struct Completion {
     pub(super) content: String,
     pub(super) added_paths: Vec<String>,
+    pub(super) unspliceable_paths: Vec<String>,
 }
 
 /// A known entry absent from the document: the path of the block it splices
@@ -193,10 +197,43 @@ fn collect_missing(
     }
 }
 
-/// Returns `content` with every missing known entry appended from the bundled
-/// template (plus the paths that were appended), or `None` when the file
-/// already spells out all of them (or, defensively, when the content cannot be
-/// analyzed; the caller treats both as "leave the file alone").
+/// Returns every omitted path in the order its entry appears in the bundled
+/// template, regardless of whether the path was spliceable.
+pub(super) fn missing_paths_in_template_order(completion: &Completion) -> Vec<String> {
+    fn collect_known_paths(specs: &[EntrySpec], parent: &str, paths: &mut Vec<String>) {
+        for spec in specs {
+            let path = if parent.is_empty() {
+                spec.key.to_string()
+            } else {
+                format!("{parent}.{}", spec.key)
+            };
+            paths.push(path.clone());
+            collect_known_paths(spec.children, &path, paths);
+        }
+    }
+
+    let mut known_paths = Vec::new();
+    collect_known_paths(SECTIONS, "", &mut known_paths);
+
+    let mut missing_paths: Vec<String> = completion
+        .added_paths
+        .iter()
+        .chain(&completion.unspliceable_paths)
+        .cloned()
+        .collect();
+    missing_paths.sort_by_key(|path| {
+        known_paths
+            .iter()
+            .position(|known| known == path)
+            .unwrap_or(usize::MAX)
+    });
+    missing_paths
+}
+
+/// Returns `content` with every safely placeable missing known entry appended
+/// from the bundled template, plus the paths that were appended and the paths
+/// that could not be placed. Returns `None` when the file already spells out
+/// every known setting or, defensively, when the content cannot be analyzed.
 ///
 /// Expects `content` to already have parsed successfully as a `PeppyConfig`;
 /// malformed input simply returns `None` rather than guessing at splice points.
@@ -210,7 +247,16 @@ pub(super) fn complete_config_content(content: &str) -> Option<Completion> {
         return None;
     }
 
-    let layout = scan_layout(content)?;
+    let layout = match scan_layout(content) {
+        Some(layout) => layout,
+        None => {
+            return Some(Completion {
+                content: content.to_string(),
+                added_paths: Vec::new(),
+                unspliceable_paths: missing.into_iter().map(|entry| entry.path).collect(),
+            });
+        }
+    };
 
     // One insertion per target block: group the missing entries by their
     // parent path, preserving first-encounter order, so siblings share a
@@ -235,12 +281,14 @@ pub(super) fn complete_config_content(content: &str) -> Option<Completion> {
     // Collected alongside the insertions, not from the classification above,
     // so a skipped splice (unlocatable block) is never reported as added.
     let mut added_paths: Vec<String> = Vec::new();
+    let mut unspliceable_paths: Vec<String> = Vec::new();
 
     for (parent_path, entries) in groups {
         // A block the scanner could not pair with its key chain (say, a key
-        // spelled with string escapes) is skipped: the in-memory defaults
-        // still apply, the file just keeps omitting the entry.
+        // spelled with string escapes) cannot be safely changed. The in-memory
+        // defaults still apply, and every affected path is reported.
         let Some(block) = layout.block_at(&parent_path) else {
+            unspliceable_paths.extend(entries.into_iter().map(|entry| entry.path));
             continue;
         };
         let mut text = String::new();
@@ -254,10 +302,6 @@ pub(super) fn complete_config_content(content: &str) -> Option<Completion> {
             insertions.push((at, ",".to_string()));
         }
     }
-    if insertions.is_empty() {
-        return None;
-    }
-
     insertions.sort_by_key(|&(at, _)| std::cmp::Reverse(at));
     let mut completed = content.to_string();
     for (at, text) in insertions {
@@ -266,14 +310,16 @@ pub(super) fn complete_config_content(content: &str) -> Option<Completion> {
     Some(Completion {
         content: completed,
         added_paths,
+        unspliceable_paths,
     })
 }
 
 /// Whether `completed` is a faithful completion of `original`, parsed as
-/// `config`: it must parse back to the same `PeppyConfig`, need no further
-/// completion (every known knob now spelled out, so the splice cannot repeat
-/// on the next start), and preserve every value the user wrote. Any `false`
-/// means a splicing bug; the caller then discards `completed` unwritten.
+/// `config`: it must parse back to the same `PeppyConfig`, leave no further
+/// splice possible on the next start, and preserve every value the user wrote.
+/// An omission that remains unspliceable is acceptable because another pass
+/// cannot make progress on it. Any `false` means a splicing bug; the caller
+/// then discards `completed` unwritten.
 pub(super) fn verify_completion(
     original: &str,
     completed: &str,
@@ -285,7 +331,9 @@ pub(super) fn verify_completion(
     if reparsed != *config {
         return false;
     }
-    if complete_config_content(completed).is_some() {
+    if complete_config_content(completed)
+        .is_some_and(|completion| !completion.added_paths.is_empty())
+    {
         return false;
     }
     // The typed checks above ignore unknown keys, so also require every value
@@ -605,7 +653,7 @@ mod tests {
     use super::super::{
         DEFAULT_DAEMON_GRACE_SECS, DEFAULT_HIGH_THROUGHPUT_BUFFER_SIZE,
         DEFAULT_PEPPY_CONFIG_TEMPLATE, DEFAULT_SHUTDOWN_GRACE_SECS, PEPPY_CONFIG_FILE, PeppyConfig,
-        TEMPLATE_HEADER,
+        SHUTDOWN_GRACE_FIELD_SNIPPET, TEMPLATE_HEADER,
     };
     use super::*;
 
@@ -1023,6 +1071,24 @@ mod tests {
         assert_eq!(completed.matches("standard_buffer_size").count(), 1);
         assert_eq!(completed.matches("high_throughput_buffer_size").count(), 1);
         assert!(complete_config_content(&completed).is_none());
+    }
+
+    #[test]
+    fn escaped_section_key_reports_unspliceable_paths() {
+        let content = DEFAULT_PEPPY_CONFIG_TEMPLATE
+            .replacen("  lifecycle: {", r#"  "life\u0063ycle": {"#, 1)
+            .replacen(SHUTDOWN_GRACE_FIELD_SNIPPET, "", 1);
+
+        let completion =
+            complete_config_content(&content).expect("lifecycle.shutdown_grace_secs is missing");
+
+        assert_eq!(parse(&content), PeppyConfig::default());
+        assert_eq!(completion.content, content);
+        assert!(completion.added_paths.is_empty());
+        assert_eq!(
+            completion.unspliceable_paths,
+            ["lifecycle.shutdown_grace_secs"]
+        );
     }
 
     #[test]

--- a/crates/peppy/tests/main.rs
+++ b/crates/peppy/tests/main.rs
@@ -12,6 +12,7 @@ mod node_run;
 mod node_runtime_config;
 mod node_stop;
 mod node_sync;
+mod peppy_config_env;
 mod repo_add;
 mod repo_exclude;
 mod repo_init;

--- a/crates/peppy/tests/peppy_config_env.rs
+++ b/crates/peppy/tests/peppy_config_env.rs
@@ -1,0 +1,90 @@
+//! Real-binary coverage for the daemon-config environment override.
+
+use std::path::Path;
+use std::process::{Command, Output, Stdio};
+use std::time::{Duration, Instant};
+
+const INVALID_CONFIG: &str = "{ not json5";
+const PROCESS_TIMEOUT: Duration = Duration::from_secs(30);
+
+fn run_with_invalid_override(home: &Path, args: &[&str]) -> Output {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_peppy"))
+        .args(args)
+        .current_dir(home)
+        .env(config::consts::PEPPY_HOME_ENV, home)
+        .env(config::consts::PEPPY_CONFIG_ENV, INVALID_CONFIG)
+        .env("RUST_LOG", "error")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn peppy");
+
+    let start = Instant::now();
+    loop {
+        if child.try_wait().expect("failed to poll peppy").is_some() {
+            return child
+                .wait_with_output()
+                .expect("failed to collect peppy output");
+        }
+        if start.elapsed() >= PROCESS_TIMEOUT {
+            child.kill().expect("failed to kill timed-out peppy");
+            let output = child
+                .wait_with_output()
+                .expect("failed to collect timed-out peppy output");
+            panic!(
+                "peppy did not exit within {PROCESS_TIMEOUT:?}; {}",
+                combined_output(&output)
+            );
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+}
+
+fn combined_output(output: &Output) -> String {
+    format!(
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    )
+}
+
+#[test]
+fn serve_with_invalid_peppy_config_env_exits_one_naming_the_var() {
+    let home = tempfile::tempdir().expect("temp home");
+    let output = run_with_invalid_override(
+        home.path(),
+        &["service", "serve", "--messaging-engine", "mock"],
+    );
+    let combined = combined_output(&output);
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "unexpected status; {combined}"
+    );
+    assert!(
+        combined.contains(config::consts::PEPPY_CONFIG_ENV),
+        "error did not name PEPPY_CONFIG; {combined}"
+    );
+    assert!(
+        !home.path().join("conf/peppy_config.json5").exists(),
+        "override mode created the normal config file"
+    );
+}
+
+#[test]
+fn auth_whoami_with_invalid_peppy_config_env_exits_one() {
+    let home = tempfile::tempdir().expect("temp home");
+    let output = run_with_invalid_override(home.path(), &["auth", "whoami"]);
+    let combined = combined_output(&output);
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "unexpected status; {combined}"
+    );
+    assert!(
+        combined.contains(config::consts::PEPPY_CONFIG_ENV),
+        "error did not name PEPPY_CONFIG; {combined}"
+    );
+}

--- a/docs/src/content/docs/advanced_guides/daemon_config.mdx
+++ b/docs/src/content/docs/advanced_guides/daemon_config.mdx
@@ -5,21 +5,38 @@ sidebar:
   order: 9
 ---
 
-The peppy daemon reads one global configuration file, `~/.peppy/conf/peppy_config.json5`. It sets the daemon's core-node name, controls the messaging topology and router ownership of the whole stack, the subscriber channel buffer sizes, the grace periods that govern node lifecycle, and the timeout for federating to your organization's cloud router. The daemon applies it to its own core-node session and to every node it spawns. The same file also records the backend resource-server URL the `peppy auth login` / `whoami` / `logout` commands talk to; that block is read by the CLI, not the daemon.
+By default, the peppy daemon reads one global configuration file, `~/.peppy/conf/peppy_config.json5`. It sets the daemon's core-node name, controls the messaging topology and router ownership of the whole stack, the subscriber channel buffer sizes, the grace periods that govern node lifecycle, and the timeout for federating to your organization's cloud router. The daemon applies it to its own core-node session and to every node it spawns. The same file also records the backend resource-server URL the `peppy auth login` / `whoami` / `logout` commands talk to; that block is read by the CLI, not the daemon. [`PEPPY_CONFIG`](#override-with-peppy_config) can supply a read-only alternative source.
 
 :::note
-The daemon reads its settings (`core_node_name`, `zenoh`, `lifecycle`) **once, at daemon startup**. Editing them has no effect on a running stack; restart the daemon (`peppy service serve`, or `systemctl restart` your service) to apply changes. The `resource_servers` block is read fresh by each CLI auth command, so an edit there takes effect on the next `peppy auth login` without a daemon restart.
+The daemon reads its settings (`core_node_name`, `zenoh`, `lifecycle`) from the active source **once, at daemon startup**. Editing them has no effect on a running stack; restart the daemon (`peppy service serve`, or `systemctl restart` your service) to apply changes. The `resource_servers` block in the active source is read fresh by each CLI auth command, so an edit there takes effect on the next `peppy auth login` without a daemon restart.
 :::
 
 ## How the file is managed
 
-You never need to create or migrate this file by hand:
+In the normal on-disk flow, you never need to create or migrate this file by hand:
 
 - **First load.** If the file does not exist, peppy creates it with every setting at its default value, annotated with explanatory comments.
-- **Missing settings.** If the file exists but omits settings (typically a file written by an older peppy, before a newer knob existed), peppy appends each missing defaulted setting with its default value and comments. Your own values, comments, formatting, and any unrecognized top-level keys are otherwise preserved exactly as you wrote them; when appending defaults, completion may add a structural separator comma after the prior final entry. Every defaulted setting a peppy release understands is guaranteed to be covered by this mechanism (enforced by tests), so the file is brought up to the running release's full set of defaults the next time peppy loads the configuration, and peppy logs each setting it added. Fields required only by a non-default choice are not invented: for example, selecting `zenoh.zenohd.ownership: "external"` requires you to supply its `endpoint`.
+- **Missing settings.** If the file exists but omits settings (typically a file written by an older peppy, before a newer knob existed), peppy detects every omission and appends each setting it can safely place, together with its default value and comments. Your own values, comments, formatting, and any unrecognized top-level keys are otherwise preserved exactly as you wrote them; when appending defaults, completion may add a structural separator comma after the prior final entry. Peppy logs each setting it added. An unusual JSON5 spelling or layout, such as an escaped section key that the text scanner cannot safely pair with its block, produces a warning naming every setting that could not be inserted; the daemon continues with those defaults in memory. Fields required only by a non-default choice are not invented: for example, selecting `zenoh.zenohd.ownership: "external"` requires you to supply its `endpoint`.
 - **Malformed file.** If the file cannot be parsed, or a value is out of range, peppy refuses to continue and reports the error instead of silently falling back to defaults. A file that fails to load is never modified.
 
-A defaulted setting you delete from the file therefore comes back with its default the next time peppy loads the configuration. To change one, edit its value instead of removing it. Removing an ownership-specific required field instead makes the file invalid and leaves it untouched.
+In a normally spelled section, a defaulted setting you delete from the file therefore comes back with its default the next time peppy loads the configuration. To change one, edit its value instead of removing it. If peppy warns that an unusual spelling or layout prevented insertion, add the named setting manually if you want it written; the daemon already uses its default in memory. Removing an ownership-specific required field instead makes the file invalid and leaves it untouched.
+
+### Override with `PEPPY_CONFIG`
+
+Set `PEPPY_CONFIG` to inject the complete daemon configuration at launch. A non-empty value has two forms: a path to a JSON5 config file, or an inline JSON5 document. Peppy expands `~` and `~/` in path form, and resolves relative paths from the command's current working directory, which is the daemon's working directory for `peppy service serve`.
+
+Classification always tries the value as a file first. If the file can be read, file form is committed, so a later parse, validation, or completeness error does not fall back to interpreting the path text as inline JSON5. Only a file read or path-expansion failure triggers the inline parse. If both attempts fail, the error reports both reasons. An empty value is treated as unset and uses the normal file flow; whitespace alone is not empty and fails if it is neither a readable path nor valid inline JSON5.
+
+An override is read-only. Peppy ignores `$PEPPY_HOME/conf/peppy_config.json5` and never creates, completes, or rewrites either that file or the override source. The override must parse, pass validation, and explicitly spell out every setting the running release defines. Missing settings are a startup error that names their paths and explains that override sources are never completed with defaults. This differs from the normal on-disk flow, which appends safe defaults and warns when an unusual source spelling prevents an insertion.
+
+The override applies to `peppy service serve` and to every auth command that reads daemon configuration: `peppy auth login`, `logout`, and `whoami`. `PEPPY_HOME` still controls credentials, repositories, and all other peppy state. Edits to a file-form override take effect on the daemon's next restart, just like edits to the default file.
+
+Both examples below use the same complete config file. The second passes its full contents inline, including any leading JSON5 comments:
+
+```sh
+PEPPY_CONFIG=./deploy/peppy_config.json5 peppy service serve
+PEPPY_CONFIG="$(cat ./deploy/peppy_config.json5)" peppy service serve
+```
 
 ## The default file
 


### PR DESCRIPTION
## What changed

- add a read-only `PEPPY_CONFIG` override accepted as a file path or inline JSON5 by every daemon-config reader
- keep file-first classification deterministic, validate committed sources, and reject overrides that omit release-defined settings
- track completion gaps that cannot be safely spliced, warn for the normal on-disk flow, and fail loud for overrides
- add the full unit matrix plus real-binary serve and auth acceptance tests
- document override precedence, scope, lifecycle, path expansion, and read-only behavior
- pin all seven shared crates to merged public-peppy-libs PR #50

## Why

Orchestrated deployments need to inject daemon configuration at launch without pre-seeding `~/.peppy/conf/peppy_config.json5`. The existing completion scanner also silently dropped detected omissions when exotic source spelling prevented a safe text insertion; that gap would have allowed an incomplete override to pass.

## User impact

`peppy service serve` and `peppy auth login/logout/whoami` now honor `PEPPY_CONFIG`. Override sources are never created, completed, or rewritten. Invalid, outdated, or unreadable inputs exit through the existing config error path, while the default on-disk flow remains best-effort and warns when a setting cannot be inserted.

## Validation

Run both with local shared sources and again with the merged `b1eca979` shared pins:

- `cargo test -p daemon-config` (217 passed)
- `cargo test -p peppy --test integration peppy_config_env` (2 passed)
- `cargo test -p peppy --test integration service_serve` (1 passed)
- `cargo build --workspace`
- `cargo clippy --workspace`
- `cargo fmt --all -- --check`
- manual incomplete-inline, complete-file, and complete-inline smoke checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `PEPPY_CONFIG` support for loading configuration from a file path or inline JSON5.
  * Override configurations are read-only and require all settings to be explicitly provided.
  * Added tilde expansion and clearer configuration error messages.

* **Bug Fixes**
  * Improved handling and warnings for configuration settings that cannot be automatically added.
  * Preserved normal on-disk configuration behavior when no override is supplied.

* **Documentation**
  * Updated daemon configuration guidance with override usage, lifecycle details, and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->