### PR TITLE
Rename the `peppy auth` command group to `peppy platform`

### DIFF
--- a/crates/auth-internal/src/client.rs
+++ b/crates/auth-internal/src/client.rs
@@ -71,7 +71,7 @@ pub struct ZenohRouterConfig {
     /// string). Becomes the daemon's session namespace so robots of the same org
     /// interoperate across the federation while different orgs stay routing-isolated.
     /// Required: a backend that predates this field fails to parse, which is the
-    /// intended clean break (re-run `peppy auth login`).
+    /// intended clean break (re-run `peppy platform login`).
     pub organization_id: String,
 }
 

--- a/crates/auth-internal/src/device.rs
+++ b/crates/auth-internal/src/device.rs
@@ -1,7 +1,7 @@
 //! RFC 8628 device-authorization grant, protocol only: [`start`] the flow, then
 //! [`poll`] the token endpoint until the user approves in the browser. The CLI
 //! never sees the user's Google/passkey credentials. Showing/opening the
-//! verification URL and any waiting UX are the caller's job (the `peppy auth
+//! verification URL and any waiting UX are the caller's job (the `peppy platform
 //! login` command).
 
 use std::time::Duration;
@@ -107,7 +107,7 @@ fn classify(error: &str) -> PollOutcome {
             "authorization denied in the browser".to_string(),
         )),
         "expired_token" => PollOutcome::Fatal(Error::Auth(
-            "login timed out, run `peppy auth login` again".to_string(),
+            "login timed out, run `peppy platform login` again".to_string(),
         )),
         other => PollOutcome::Fatal(Error::Auth(format!("device login failed: {other}"))),
     }
@@ -174,7 +174,7 @@ pub fn poll(
 
         if now_unix() >= deadline {
             break Err(Error::Auth(
-                "login timed out, run `peppy auth login` again".to_string(),
+                "login timed out, run `peppy platform login` again".to_string(),
             ));
         }
         std::thread::sleep(Duration::from_secs(interval));

--- a/crates/auth-internal/src/error.rs
+++ b/crates/auth-internal/src/error.rs
@@ -15,6 +15,6 @@ pub enum Error {
     Auth(String),
 
     // -- no usable credential and not on an interactive terminal
-    #[error("Not authenticated. Run `peppy auth login` or set PEPPY_API_KEY.")]
+    #[error("Not authenticated. Run `peppy platform login` or set PEPPY_API_KEY.")]
     NotAuthenticated,
 }

--- a/crates/auth-internal/src/lib.rs
+++ b/crates/auth-internal/src/lib.rs
@@ -1,4 +1,4 @@
-//! Authentication engine for `peppy auth login` / `logout` / `whoami` and the
+//! Authentication engine for `peppy platform login` / `logout` / `whoami` and the
 //! daemon's router federation.
 //!
 //! `peppy` is a public OAuth client of the project's Zitadel instance and a

--- a/crates/auth-internal/src/resolver.rs
+++ b/crates/auth-internal/src/resolver.rs
@@ -70,7 +70,7 @@ pub fn resolve(creds_path: &Path, http: &HttpClient, pat: Option<String>) -> Res
     // Expired: refresh proactively and persist the rotation.
     let updated = refresh_and_persist(http, creds_path, &pc).map_err(|e| {
         Error::Auth(format!(
-            "{e}\nYour session may have expired, run `peppy auth login`."
+            "{e}\nYour session may have expired, run `peppy platform login`."
         ))
     })?;
     Ok(session_credential(creds_path, &updated))
@@ -87,7 +87,7 @@ pub fn pat_from_env() -> Option<String> {
 }
 
 /// Builds a refreshable session [`Credential`] from the cached `pc`. Public
-/// for the one caller outside the resolver: `peppy auth login`, which builds
+/// for the one caller outside the resolver: `peppy platform login`, which builds
 /// the credential from tokens it minted seconds ago instead of re-resolving.
 pub fn session_credential(creds_path: &Path, pc: &ProfileCreds) -> Credential {
     Credential {

--- a/crates/auth-internal/src/storage.rs
+++ b/crates/auth-internal/src/storage.rs
@@ -21,7 +21,7 @@ use crate::error::{Error, Result};
 /// On-disk schema version of `credentials.json5`. Bumped on any shape change;
 /// there is intentionally **no reader for an older version**. A clean break: a
 /// pre-Phase-F file has no `version`, deserializes to `0`, and is rejected by
-/// [`load`], so dev users simply re-run `peppy auth login` (acceptable pre-GA).
+/// [`load`], so dev users simply re-run `peppy platform login` (acceptable pre-GA).
 pub const CREDENTIALS_VERSION: u32 = 1;
 
 /// Whole `credentials.json5` document: the schema version, a single cached OAuth
@@ -214,7 +214,7 @@ pub fn load(path: &Path) -> Result<Credentials> {
             if creds.version != CREDENTIALS_VERSION {
                 return Err(Error::Auth(format!(
                     "credentials file {} is an unsupported format (v{}, expected v{}); \
-                     run `peppy auth login` again",
+                     run `peppy platform login` again",
                     path.display(),
                     creds.version,
                     CREDENTIALS_VERSION
@@ -392,7 +392,7 @@ mod tests {
         let err = load(&path).expect_err("old format must be rejected");
         let msg = err.to_string();
         assert!(
-            msg.contains("unsupported format") && msg.contains("peppy auth login"),
+            msg.contains("unsupported format") && msg.contains("peppy platform login"),
             "rejection should be actionable: {msg}"
         );
     }

--- a/crates/auth-internal/tests/auth_flow.rs
+++ b/crates/auth-internal/tests/auth_flow.rs
@@ -2,7 +2,7 @@
 //! discovery, the Zitadel token endpoint, and the backend `/me` +
 //! `/me/cli/federation`. All auth state is isolated per test via an
 //! explicit credentials path under a tempdir (no `PEPPY_HOME` mutation, so
-//! tests run in parallel). The command-level flows (`peppy auth login` /
+//! tests run in parallel). The command-level flows (`peppy platform login` /
 //! `logout` / `whoami`) are covered by the `peppy` crate's own auth tests.
 
 use std::path::PathBuf;

--- a/crates/daemon-config-internal/src/peppy_config.rs
+++ b/crates/daemon-config-internal/src/peppy_config.rs
@@ -54,7 +54,7 @@ pub const PEPPY_CONFIG_FILE: &str = "peppy_config.json5";
 /// The backend resource-server URL for this build: the local dev backend in
 /// debug builds, the prod backend in release builds. The single source of truth
 /// for both the seeded `resource_servers` block and the built-in fallback the
-/// `peppy auth login` / `whoami` / `logout` commands resolve when no `--api-url` /
+/// `peppy platform login` / `whoami` / `logout` commands resolve when no `--api-url` /
 /// `PEPPY_API_URL` override is given.
 #[cfg(debug_assertions)]
 pub const DEFAULT_API_URL: &str = "http://127.0.0.1:3000";
@@ -221,7 +221,7 @@ const API_FIELD_SNIPPET: &str = const_format::concatcp!("    api: \"", DEFAULT_A
 /// CLI auth commands read this URL; the daemon ignores it but seeds and
 /// completes the block like every other knob.
 const RESOURCE_SERVERS_SECTION_SNIPPET: &str = const_format::concatcp!(
-    r#"  // Backend resource-server URL the `peppy auth login` / `whoami` / `logout`
+    r#"  // Backend resource-server URL the `peppy platform login` / `whoami` / `logout`
   // commands talk to. Baked in at compile time (the dev backend in debug
   // builds, prod in release); --api-url / PEPPY_API_URL override it at runtime.
   resource_servers: {
@@ -235,7 +235,7 @@ const RESOURCE_SERVERS_SECTION_SNIPPET: &str = const_format::concatcp!(
 const FEDERATION_TIMEOUT_FIELD_SNIPPET: &str = const_format::concatcp!(
     r#"        // Seconds the daemon spends resolving your per-user cloud router before
         // giving up for this attempt (it retries in the background). Bounds the
-        // federation done at startup and on each `peppy auth login`/`logout`;
+        // federation done at startup and on each `peppy platform login`/`logout`;
         // minimum 1. If the backend is unreachable within this window the daemon
         // stays standalone rather than blocking.
         connect_timeout_secs: "#,

--- a/crates/daemon-internal/src/control.rs
+++ b/crates/daemon-internal/src/control.rs
@@ -1,6 +1,6 @@
 //! Client and wire protocol for the daemon's *federation control socket*.
 //!
-//! `peppy auth login`/`logout` run in a separate, short-lived process from the
+//! `peppy platform login`/`logout` run in a separate, short-lived process from the
 //! `serve` daemon; their only shared state is the on-disk credentials file, which
 //! the daemon would otherwise only re-read on its periodic poll (so federation
 //! would lag a login by up to that interval). To apply it immediately, the

--- a/crates/daemon-internal/src/federation_control.rs
+++ b/crates/daemon-internal/src/federation_control.rs
@@ -1,4 +1,4 @@
-//! Daemon control socket that turns a `peppy auth login`/`logout` poke into an
+//! Daemon control socket that turns a `peppy platform login`/`logout` poke into an
 //! *immediate* router (de)federation.
 //!
 //! A [`ServeAsyncCommand`] that binds the per-user Unix-domain socket

--- a/crates/daemon-internal/src/lib.rs
+++ b/crates/daemon-internal/src/lib.rs
@@ -7,7 +7,7 @@
 //! CLI<->daemon shared surfaces: the on-disk [`state::DaemonState`] handoff
 //! file (the daemon writes it once per generation; client commands read it)
 //! and the [`control`] socket protocol plus its blocking client
-//! ([`control::poke_refederate`], used by `peppy auth login`/`logout`).
+//! ([`control::poke_refederate`], used by `peppy platform login`/`logout`).
 //!
 //! Consumers (the `peppy` CLI) own everything user-facing and process-level:
 //! clap dispatch, service install/uninstall, the device-flow UX, logging

--- a/crates/daemon-internal/src/router_federation.rs
+++ b/crates/daemon-internal/src/router_federation.rs
@@ -18,7 +18,7 @@
 //!   so the check sees the federated mesh (a same-name daemon reachable only
 //!   through the cloud router refuses boot) rather than the always-standalone
 //!   just-started local router.
-//! * **Immediate (re)federation on login/logout.** `peppy auth login`/`logout`
+//! * **Immediate (re)federation on login/logout.** `peppy platform login`/`logout`
 //!   poke the daemon over the control socket
 //!   ([`FederationControl`](super::federation_control)); the poke is delivered
 //!   here as a [`RefederateRequest`] that runs a poll *now* (not on the next

--- a/crates/daemon-internal/src/state.rs
+++ b/crates/daemon-internal/src/state.rs
@@ -50,7 +50,7 @@ pub struct DaemonState {
     /// the daemon's `zenoh.managed.federation.connect_timeout_secs` at startup);
     /// `None` when it runs an operator-run external router (or no router), so
     /// there is no federation control socket to poke and no restart to warn
-    /// about. `peppy auth login`/`logout` read this so they follow the RUNNING
+    /// about. `peppy platform login`/`logout` read this so they follow the RUNNING
     /// daemon's mode, not a config edited on disk after it started.
     pub federation_connect_timeout_secs: Option<u64>,
 }

--- a/crates/peppy/src/commands.rs
+++ b/crates/peppy/src/commands.rs
@@ -1,9 +1,9 @@
 mod action_poll;
-pub mod auth;
 mod confirm;
 pub mod container;
 pub mod info;
 pub mod node;
+pub mod platform;
 pub mod repo;
 pub mod service;
 pub mod stack;

--- a/crates/peppy/src/commands/platform.rs
+++ b/crates/peppy/src/commands/platform.rs
@@ -1,7 +1,11 @@
-//! The `peppy auth` command group: `login`, `logout`, and `whoami`. Each
+//! The `peppy platform` command group: `login`, `logout`, and `whoami`. Each
 //! variant maps to a handler in this module's directory; the OAuth device flow,
 //! token storage, and credential resolution they share live in the separate
-//! `auth` engine crate.
+//! `auth` engine crate. The group is named for the platform account rather than
+//! for auth because signing in does more than obtain a token: it stamps this
+//! machine's organization namespace and pokes the running daemon to refederate
+//! its messaging router, and a login whose federation link cannot be
+//! established fails.
 
 pub mod login;
 pub mod logout;
@@ -274,7 +278,7 @@ fn await_restart(
         if Instant::now() >= deadline {
             break Err(Error::Auth(format!(
                 "the daemon did not come back under namespace `{expected}` within the timeout; \
-                 check the `peppy service serve` logs and re-run `peppy auth {subcommand}`"
+                 check the `peppy service serve` logs and re-run `peppy platform {subcommand}`"
             )));
         }
         std::thread::sleep(RESTART_POLL_INTERVAL);
@@ -283,7 +287,7 @@ fn await_restart(
         // daemon will not come back under what we wrote.
         if current_creds_namespace(dirs) != expected {
             break Err(Error::Auth(format!(
-                "credentials changed during restart; re-run `peppy auth {subcommand}`"
+                "credentials changed during restart; re-run `peppy platform {subcommand}`"
             )));
         }
 
@@ -347,31 +351,31 @@ fn report_login(outcome: PokeOutcome) -> Result<()> {
             "logged in, but federation with the platform could not be established: {reason}. \
              The per-user cloud router is unreachable or its certificate is not trusted; in \
              dev, ensure the router cert is signed by the committed dev CA (re-run \
-             gen_dev_certs), then run `peppy auth login` again."
+             gen_dev_certs), then run `peppy platform login` again."
         ))),
         PokeOutcome::DaemonError(msg) => Err(Error::Auth(format!(
             "logged in, but the daemon could not apply federation: {msg}. Check the \
-             `peppy service serve` logs and run `peppy auth login` again."
+             `peppy service serve` logs and run `peppy platform login` again."
         ))),
         PokeOutcome::TimedOut => Err(Error::Auth(
             "logged in, but the daemon did not apply federation within the timeout. Check the \
-             `peppy service serve` logs and run `peppy auth login` again."
+             `peppy service serve` logs and run `peppy platform login` again."
                 .to_string(),
         )),
         PokeOutcome::DaemonNotRunning => Err(Error::Auth(
             "logged in, but no running peppy daemon was found to establish federation. Start it \
-             with `peppy service serve`, then run `peppy auth login` again."
+             with `peppy service serve`, then run `peppy platform login` again."
                 .to_string(),
         )),
         PokeOutcome::Applied(None) => Err(Error::Auth(
             "logged in, but no cloud router resolved to federate to. Confirm the backend is \
-             reachable and your account is provisioned, then run `peppy auth login` again."
+             reachable and your account is provisioned, then run `peppy platform login` again."
                 .to_string(),
         )),
         // `Restarting` is intercepted by `poke_federation_and_report` (it drives
         // the restart poll), so it should not reach here; treat defensively.
         PokeOutcome::Restarting => Err(Error::Auth(
-            "the daemon is restarting to apply the new namespace; re-run `peppy auth login` \
+            "the daemon is restarting to apply the new namespace; re-run `peppy platform login` \
              once it is back."
                 .to_string(),
         )),
@@ -402,7 +406,7 @@ fn report_logout(outcome: PokeOutcome) {
 }
 
 #[derive(Subcommand)]
-pub enum AuthCommands {
+pub enum PlatformCommands {
     /// Log in to Peppy via the browser (OAuth device flow)
     Login {
         /// Override the backend base URL (else the build default / PEPPY_API_URL).
@@ -434,14 +438,14 @@ pub enum AuthCommands {
     },
 }
 
-pub struct AuthCommand {
-    pub command: AuthCommands,
+pub struct PlatformCommand {
+    pub command: PlatformCommands,
 }
 
-impl Command for AuthCommand {
+impl Command for PlatformCommand {
     fn execute(self, app_ctx: &Arc<AppContext>) -> Result<()> {
         match self.command {
-            AuthCommands::Login {
+            PlatformCommands::Login {
                 api_url,
                 no_browser,
                 yes,
@@ -452,13 +456,13 @@ impl Command for AuthCommand {
                 peppy_dirs: None,
             }
             .execute(app_ctx),
-            AuthCommands::Logout { api_url, yes } => logout::LogoutCommand {
+            PlatformCommands::Logout { api_url, yes } => logout::LogoutCommand {
                 api_url,
                 yes,
                 peppy_dirs: None,
             }
             .execute(app_ctx),
-            AuthCommands::Whoami { api_url, json } => whoami::WhoamiCommand {
+            PlatformCommands::Whoami { api_url, json } => whoami::WhoamiCommand {
                 api_url,
                 json,
                 peppy_dirs: None,

--- a/crates/peppy/src/commands/platform/login.rs
+++ b/crates/peppy/src/commands/platform/login.rs
@@ -1,4 +1,4 @@
-//! `peppy auth login`: OAuth 2.0 device-authorization login (RFC 8628).
+//! `peppy platform login`: OAuth 2.0 device-authorization login (RFC 8628).
 //!
 //! Fetches the public `/cli/auth-config`, runs OIDC discovery against the returned
 //! issuer, performs the device flow (opening the browser on a TTY), caches the

--- a/crates/peppy/src/commands/platform/logout.rs
+++ b/crates/peppy/src/commands/platform/logout.rs
@@ -1,4 +1,4 @@
-//! `peppy auth logout`: kill the access token on the backend (cross-replica) and
+//! `peppy platform logout`: kill the access token on the backend (cross-replica) and
 //! delete the local session credentials. Does not revoke the refresh token at
 //! Zitadel (out of scope for v1); a backend that's unreachable or returns
 //! 401/503 still results in the local credentials being cleared.

--- a/crates/peppy/src/commands/platform/whoami.rs
+++ b/crates/peppy/src/commands/platform/whoami.rs
@@ -1,4 +1,4 @@
-//! `peppy auth whoami` (alias `status`): resolve the cached credential, call
+//! `peppy platform whoami` (alias `status`): resolve the cached credential, call
 //! `GET /me`, and print the identity, backend, and token validity. `--json`
 //! emits a machine-readable object (never including raw tokens).
 
@@ -54,7 +54,7 @@ impl Command for WhoamiCommand {
                     println!("{doc}");
                 } else {
                     println!(
-                        "Not authenticated ({}). Run `peppy auth login`.",
+                        "Not authenticated ({}). Run `peppy platform login`.",
                         profile::build_env_name()
                     );
                 }

--- a/crates/peppy/src/lib.rs
+++ b/crates/peppy/src/lib.rs
@@ -7,7 +7,7 @@
 //! The supported surface is intentionally small:
 //! - [`commands`]: the [`commands::Command`] trait plus the per-group command
 //!   and subcommand types that `main.rs` dispatches to. The OAuth engine behind
-//!   the [`commands::auth`] group (device flow, token storage, credential
+//!   the [`commands::platform`] group (device flow, token storage, credential
 //!   resolution, authenticated backend client) lives in the separate `auth`
 //!   workspace crate; this crate keeps only the interactive residue (browser
 //!   open, spinners, prompts).

--- a/crates/peppy/src/main.rs
+++ b/crates/peppy/src/main.rs
@@ -7,7 +7,7 @@ use tracing::error;
 
 use daemon_config::consts::AppEnv;
 use peppy::{
-    commands::{Command, auth, container, info, node, repo, service, stack},
+    commands::{Command, container, info, node, platform, repo, service, stack},
     context::AppContext,
 };
 
@@ -74,10 +74,10 @@ enum Commands {
         #[command(subcommand)]
         command: repo::RepoCommands,
     },
-    /// Authentication: log in, log out, and show the current identity
-    Auth {
+    /// Platform account: log in, log out, and show the current identity
+    Platform {
         #[command(subcommand)]
-        command: auth::AuthCommands,
+        command: platform::PlatformCommands,
     },
     /// Display peppy version information
     Info {},
@@ -122,7 +122,7 @@ fn main() {
             container::ContainerCommand { command }.execute(&app_ctx)
         }
         Commands::Repo { command } => repo::RepoCommand { command }.execute(&app_ctx),
-        Commands::Auth { command } => auth::AuthCommand { command }.execute(&app_ctx),
+        Commands::Platform { command } => platform::PlatformCommand { command }.execute(&app_ctx),
         Commands::Info {} => info::InfoCommand.execute(&app_ctx),
     };
 
@@ -177,5 +177,41 @@ mod tests {
                 "--core-node {bad:?} should be rejected"
             );
         }
+    }
+
+    /// The group is spelled `platform`, and only `platform`. The negative half
+    /// is the point: `auth` is gone outright, with no alias, hidden command, or
+    /// compatibility parser to fall back on, so it must fail to parse.
+    #[test]
+    fn platform_subcommands_parse() {
+        for args in [
+            vec!["peppy", "platform", "login", "--no-browser", "--yes"],
+            vec!["peppy", "platform", "login", "--api-url", "http://x:3000"],
+            vec!["peppy", "platform", "logout", "-y"],
+            vec!["peppy", "platform", "logout", "--api-url", "http://x:3000"],
+            vec!["peppy", "platform", "whoami", "--json"],
+            vec!["peppy", "platform", "whoami", "--api-url", "http://x:3000"],
+        ] {
+            assert!(
+                Cli::try_parse_from(args.clone()).is_ok(),
+                "{args:?} should parse"
+            );
+        }
+
+        assert!(Cli::try_parse_from(["peppy", "auth", "whoami"]).is_err());
+        assert!(Cli::try_parse_from(["peppy", "auth", "login"]).is_err());
+        assert!(Cli::try_parse_from(["peppy", "auth", "logout"]).is_err());
+    }
+
+    #[test]
+    fn platform_status_is_an_alias_for_whoami() {
+        let cli = Cli::try_parse_from(["peppy", "platform", "status"])
+            .expect("the status alias should parse");
+        assert!(matches!(
+            cli.command,
+            Commands::Platform {
+                command: platform::PlatformCommands::Whoami { .. }
+            }
+        ));
     }
 }

--- a/crates/peppy/tests/main.rs
+++ b/crates/peppy/tests/main.rs
@@ -1,4 +1,3 @@
-mod auth_flow;
 mod common;
 mod container;
 mod daemon_lifecycle_e2e;
@@ -14,6 +13,7 @@ mod node_runtime_config;
 mod node_stop;
 mod node_sync;
 mod peppy_config_env;
+mod platform_flow;
 mod repo_add;
 mod repo_exclude;
 mod repo_init;

--- a/crates/peppy/tests/peppy_config_env.rs
+++ b/crates/peppy/tests/peppy_config_env.rs
@@ -73,9 +73,9 @@ fn serve_with_invalid_peppy_config_env_exits_one_naming_the_var() {
 }
 
 #[test]
-fn auth_whoami_with_invalid_peppy_config_env_exits_one() {
+fn platform_whoami_with_invalid_peppy_config_env_exits_one() {
     let home = tempfile::tempdir().expect("temp home");
-    let output = run_with_invalid_override(home.path(), &["auth", "whoami"]);
+    let output = run_with_invalid_override(home.path(), &["platform", "whoami"]);
     let combined = combined_output(&output);
 
     assert_eq!(

--- a/crates/peppy/tests/platform_flow.rs
+++ b/crates/peppy/tests/platform_flow.rs
@@ -1,4 +1,4 @@
-//! Command-level auth tests (`peppy auth login` / `logout` / `whoami`) with
+//! Command-level platform tests (`peppy platform login` / `logout` / `whoami`) with
 //! every HTTP endpoint mocked (`httpmock`): the public `/cli/auth-config`, OIDC
 //! discovery, the Zitadel device/token endpoints, and the backend `/me` +
 //! `/logout`. All auth state is isolated per test via the `peppy_dirs` seam
@@ -17,9 +17,9 @@ use serde_json::json;
 
 use auth::storage::{self, Credentials, ProfileCreds};
 use peppy::commands::Command;
-use peppy::commands::auth::login::LoginCommand;
-use peppy::commands::auth::logout::LogoutCommand;
-use peppy::commands::auth::whoami::WhoamiCommand;
+use peppy::commands::platform::login::LoginCommand;
+use peppy::commands::platform::logout::LogoutCommand;
+use peppy::commands::platform::whoami::WhoamiCommand;
 use peppy::context::AppContext;
 
 /// Builds the cli/auth-config + OIDC discovery + device-authorization + token mocks

--- a/docs/src/content/docs/advanced_guides/daemon_config.mdx
+++ b/docs/src/content/docs/advanced_guides/daemon_config.mdx
@@ -5,10 +5,10 @@ sidebar:
   order: 9
 ---
 
-By default, the peppy daemon reads one global configuration file, `~/.peppy/conf/peppy_config.json5`. It sets the daemon's core-node name, selects either a peppy-managed or operator-run Zenoh router, controls the managed router's messaging behavior, and defines the grace periods that govern node lifecycle. The daemon applies it to its own core-node session and to every node it spawns. The same file also records the backend resource-server URL the `peppy auth login` / `whoami` / `logout` commands talk to; that block is read by the CLI, not the daemon. [`PEPPY_CONFIG`](#override-with-peppy_config) can supply a read-only alternative source.
+By default, the peppy daemon reads one global configuration file, `~/.peppy/conf/peppy_config.json5`. It sets the daemon's core-node name, selects either a peppy-managed or operator-run Zenoh router, controls the managed router's messaging behavior, and defines the grace periods that govern node lifecycle. The daemon applies it to its own core-node session and to every node it spawns. The same file also records the backend resource-server URL the `peppy platform login` / `whoami` / `logout` commands talk to; that block is read by the CLI, not the daemon. [`PEPPY_CONFIG`](#override-with-peppy_config) can supply a read-only alternative source.
 
 :::note
-The daemon reads its settings (`core_node_name`, `zenoh`, `lifecycle`) from the active source **once, at daemon startup**. Editing them has no effect on a running stack; restart the daemon (`peppy service serve`, or `systemctl restart` your service) to apply changes. The `resource_servers` block in the active source is read fresh by each CLI auth command, so an edit there takes effect on the next `peppy auth login` without a daemon restart.
+The daemon reads its settings (`core_node_name`, `zenoh`, `lifecycle`) from the active source **once, at daemon startup**. Editing them has no effect on a running stack; restart the daemon (`peppy service serve`, or `systemctl restart` your service) to apply changes. The `resource_servers` block in the active source is read fresh by each CLI auth command, so an edit there takes effect on the next `peppy platform login` without a daemon restart.
 :::
 
 ## How the file is managed
@@ -29,7 +29,7 @@ Classification always tries the value as a file first. If the file can be read, 
 
 An override is read-only. Peppy ignores `$PEPPY_HOME/conf/peppy_config.json5` and never creates, completes, or rewrites either that file or the override source. The override must parse, pass validation, and explicitly spell out every setting the running release defines. Missing settings are a startup error that names their paths and explains that override sources are never completed with defaults. This differs from the normal on-disk flow, which appends safe defaults and warns when an unusual source spelling prevents an insertion.
 
-The override applies to `peppy service serve` and to every auth command that reads daemon configuration: `peppy auth login`, `logout`, and `whoami`. `PEPPY_HOME` still controls credentials, repositories, and all other peppy state. Edits to a file-form override take effect on the daemon's next restart, just like edits to the default file.
+The override applies to `peppy service serve` and to every auth command that reads daemon configuration: `peppy platform login`, `logout`, and `whoami`. `PEPPY_HOME` still controls credentials, repositories, and all other peppy state. Edits to a file-form override take effect on the daemon's next restart, just like edits to the default file.
 
 Both examples below use the same complete config file. The second passes its full contents inline, including any leading JSON5 comments:
 
@@ -92,7 +92,7 @@ PEPPY_CONFIG="$(cat ./deploy/peppy_config.json5)" peppy service serve
       federation: {
         // Seconds the daemon spends resolving your per-user cloud router before
         // giving up for this attempt (it retries in the background). Bounds the
-        // federation done at startup and on each `peppy auth login`/`logout`;
+        // federation done at startup and on each `peppy platform login`/`logout`;
         // minimum 1. If the backend is unreachable within this window the daemon
         // stays standalone rather than blocking.
         connect_timeout_secs: 30,
@@ -113,7 +113,7 @@ PEPPY_CONFIG="$(cat ./deploy/peppy_config.json5)" peppy service serve
     shutdown_grace_secs: 5,
   },
 
-  // Backend resource-server URL the `peppy auth login` / `whoami` / `logout`
+  // Backend resource-server URL the `peppy platform login` / `whoami` / `logout`
   // commands talk to. Baked in at compile time (the dev backend in debug
   // builds, prod in release); --api-url / PEPPY_API_URL override it at runtime.
   resource_servers: {
@@ -189,9 +189,9 @@ Both values must be greater than `0`; the daemon rejects a zero buffer size at s
 
 ## `zenoh.managed.federation`: cloud-router timeout
 
-When you are logged in under `zenoh.managed`, the daemon links ("federates") its local messaging router to your organization's private cloud router so that robots signed in to the same organization interoperate across the federation (see [Authentication](/advanced_guides/authentication/#organization-federation)). Resolving that cloud router involves a backend round-trip, and this block bounds it.
+When you are logged in under `zenoh.managed`, the daemon links ("federates") its local messaging router to your organization's private cloud router so that robots signed in to the same organization interoperate across the federation (see [Platform](/advanced_guides/platform/#organization-federation)). Resolving that cloud router involves a backend round-trip, and this block bounds it.
 
-- **`connect_timeout_secs`** (default `30`, minimum `1`): how long the daemon spends resolving the cloud router (once at startup, and again each time `peppy auth login` / `logout` pokes the daemon) before giving up for that attempt. If the backend is unreachable within the window, the daemon leaves its router **standalone** and retries federation in the background rather than blocking startup. A logged-out daemon never federates, so this timeout does not apply to it.
+- **`connect_timeout_secs`** (default `30`, minimum `1`): how long the daemon spends resolving the cloud router (once at startup, and again each time `peppy platform login` / `logout` pokes the daemon) before giving up for that attempt. If the backend is unreachable within the window, the daemon leaves its router **standalone** and retries federation in the background rather than blocking startup. A logged-out daemon never federates, so this timeout does not apply to it.
 
 ## `zenoh.external`: use an operator-run router
 
@@ -217,7 +217,7 @@ zenohd -l tcp/0.0.0.0:7448
 
 At startup, peppy requires a responsive Zenoh router at the configured endpoint. Nothing listening is a startup error; a non-Zenoh service at the address is a distinct startup error. Peppy observes a responsive router's health but never kills it on daemon exit, restarts it after a failure, or changes its configuration to federate it to the cloud router. The operator controls the router's lifecycle and federation. If it becomes unresponsive while the daemon is running, the watchdog logs a prominent warning but leaves it alone; sessions reconnect automatically after the operator restores it.
 
-`peppy auth login` and `logout` leave external federation untouched and print a note instead of poking the daemon. They do not restart the daemon; a sign-in change reaches its sessions on the next manual daemon restart. `PEPPY_MESSAGING_PORT` configures the listener for peppy's managed router, while external mode uses the port written in `zenoh.external.endpoint`.
+`peppy platform login` and `logout` leave external federation untouched and print a note instead of poking the daemon. They do not restart the daemon; a sign-in change reaches its sessions on the next manual daemon restart. `PEPPY_MESSAGING_PORT` configures the listener for peppy's managed router, while external mode uses the port written in `zenoh.external.endpoint`.
 
 ## `lifecycle`: grace periods
 
@@ -228,7 +228,7 @@ The `lifecycle` block tunes the two windows peppy uses to guarantee that no node
 
 ## `resource_servers`: backend URL
 
-This block holds the platform-backend base URL the CLI auth commands talk to. The daemon ignores it; the `peppy auth login` / `whoami` / `logout` commands read it. See [Authentication](/advanced_guides/authentication/) for the full login flow.
+This block holds the platform-backend base URL the CLI auth commands talk to. The daemon ignores it; the `peppy platform login` / `whoami` / `logout` commands read it. See [Platform](/advanced_guides/platform/) for the full login flow.
 
 - **`api`** (default `https://api.peppy.bot` in release builds, `http://127.0.0.1:3000` in debug): the backend the auth commands talk to. There is no dev/prod selection at runtime; the file stores exactly the build's backend.
 

--- a/docs/src/content/docs/advanced_guides/platform.mdx
+++ b/docs/src/content/docs/advanced_guides/platform.mdx
@@ -1,11 +1,11 @@
 ---
-title: Authentication
-description: Log in to the Peppy backend with peppy auth login (OAuth device flow), stay logged in across runs, and authenticate CI with a PEPPY_API_KEY.
+title: Platform
+description: Log in to the Peppy platform account with peppy platform login (OAuth device flow), stay logged in across runs, and authenticate CI with a PEPPY_API_KEY.
 sidebar:
   order: 15
 ---
 
-`peppy auth login` authenticates the CLI against the Peppy backend. Peppy is a public
+`peppy platform login` authenticates the CLI against the Peppy backend. Peppy is a public
 OAuth client of the project's identity provider (Zitadel): the CLI obtains a
 bearer token through the browser and sends it to the backend, which validates it.
 The CLI never sees your Google/passkey credentials. Those stay in the browser.
@@ -14,9 +14,9 @@ The CLI never sees your Google/passkey credentials. Those stay in the browser.
 
 | Command | What it does |
 |---------|--------------|
-| `peppy auth login [--api-url <url>] [--no-browser] [--yes]` | Logs in via the OAuth 2.0 Device Authorization Grant, caches the tokens, and federates a managed router to your organization's cloud router. |
-| `peppy auth whoami` (alias `status`) | Shows the current identity, backend, and token validity. `--json` for machine-readable output. |
-| `peppy auth logout [--yes]` | Revokes the access token on the backend (across replicas), deletes the local credentials, and de-federates a managed router. |
+| `peppy platform login [--api-url <url>] [--no-browser] [--yes]` | Logs in via the OAuth 2.0 Device Authorization Grant, caches the tokens, and federates a managed router to your organization's cloud router. |
+| `peppy platform whoami` (alias `status`) | Shows the current identity, backend, and token validity. `--json` for machine-readable output. |
+| `peppy platform logout [--yes]` | Revokes the access token on the backend (across replicas), deletes the local credentials, and de-federates a managed router. |
 
 `--yes` (`-y`) skips the daemon-restart confirmation prompt described under
 [Organization federation](#organization-federation).
@@ -24,7 +24,7 @@ The CLI never sees your Google/passkey credentials. Those stay in the browser.
 ## Logging in
 
 ```
-peppy auth login
+peppy platform login
 ```
 
 On a terminal this prints a verification URL and a user code, then opens your
@@ -37,7 +37,7 @@ Over SSH or anywhere without a browser, use `--no-browser`: the CLI prints the
 URL and code and waits for you to approve them on another device.
 
 ```
-peppy auth login --no-browser
+peppy platform login --no-browser
 ```
 
 ### How it works
@@ -107,7 +107,7 @@ access token (PAT). It is used directly as the bearer: no browser, no refresh,
 and it is never written to disk. A PAT short-circuits every other credential
 source, so CI never opens a browser. If the PAT is revoked, requests start
 failing with 401 and you must rotate it. A PAT principal shows up as
-`kind: "machine"` under `peppy auth whoami`.
+`kind: "machine"` under `peppy platform whoami`.
 
 ## Credential storage
 
@@ -120,7 +120,7 @@ output.
 ## Logging out
 
 ```
-peppy auth logout
+peppy platform logout
 ```
 
 This calls `POST {api_url}/logout`, which denylists the presented access token


### PR DESCRIPTION
`auth` stopped describing the group once login began stamping the machine's organization namespace, poking the running daemon to refederate its messaging router, and failing the command when that federation link cannot be established. Rename it now, alone, before the remaining federation work widens the group further and the rename hides inside a feature branch where a reviewer can no longer separate "this changed behavior" from "this changed a name".

`peppy platform login|logout|whoami|status` is the only spelling. `peppy auth` is not a recognized subcommand and exits with a clap parse error: no alias, no hidden command, no compatibility parser, no warning period, no deprecated re-export, and no Astro redirect for the moved documentation route.

Behavior, exit codes, prompts, flags, output, credential locations, HTTP requests, and environment and config resolution are unchanged. The nine platform_flow test bodies are identical to their auth_flow originals; only the import paths moved. `login.rs` and `logout.rs` move with their existing bodies at 173 and 107 lines, which git scores as 98 percent renames.

Deliberately not in this commit: no `federations` subcommand, no `Cargo.toml` change, no daemon-control or enrollment behavior, and no organization to workspace vocabulary change. The `auth` engine crate keeps its directory, its package name, and its own `tests/auth_flow.rs` filename; only the CLI command group is renamed. The three `peppy auth` mentions in `docs/src/content/releases/v0.13.0.html` stay: they are historical release notes describing the CLI that shipped at the time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Renamed the authentication command group from `peppy auth` to `peppy platform`.
  * Updated login, logout, and identity-check commands, including the `status` alias for `platform whoami`.
  * Improved guidance for authentication timeouts, expired sessions, and credential issues.

* **Documentation**
  * Updated platform and daemon configuration guides with the new command names and examples.

* **Tests**
  * Updated command parsing and authentication flow coverage for the `platform` command group.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->