### PR TITLE
Rename organization/org-id concept to workspace/namespace acro…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,7 +573,7 @@ dependencies = [
 [[package]]
 name = "build-helpers"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#a9d0514fdc99448ff48d277b84f9788d8e8c6993"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#e19618a8de805b26045ec592dbf26c18e005690f"
 dependencies = [
  "sha2",
 ]
@@ -774,7 +774,7 @@ dependencies = [
 [[package]]
 name = "config-test-support"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#a9d0514fdc99448ff48d277b84f9788d8e8c6993"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#e19618a8de805b26045ec592dbf26c18e005690f"
 dependencies = [
  "askama",
  "git2",
@@ -918,7 +918,7 @@ dependencies = [
 [[package]]
 name = "core-node-api"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#a9d0514fdc99448ff48d277b84f9788d8e8c6993"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#e19618a8de805b26045ec592dbf26c18e005690f"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -2577,7 +2577,7 @@ dependencies = [
 [[package]]
 name = "json5-pretty"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#a9d0514fdc99448ff48d277b84f9788d8e8c6993"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#e19618a8de805b26045ec592dbf26c18e005690f"
 dependencies = [
  "serde",
  "serde_json",
@@ -2585,9 +2585,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.47.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "281c43ff06dcb331e9356d30e38853d559ce3d0a3f693e0b0e102667dec14fb1"
+checksum = "39d785c0683d1027839f1ac6a43b6d07c63d58ecd363d8146dda4531d53465a1"
 dependencies = [
  "ahash",
  "bytecount",
@@ -2608,15 +2608,16 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
+ "strum",
  "unicode-general-category",
  "uuid-simd",
 ]
 
 [[package]]
 name = "jsonschema-regex"
-version = "0.47.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee0b351864e7ffbc5db9273daf7fa1b4d5177b0946713d667ca571b83c0b4045"
+checksum = "917b3be16b2662538aafb55201790561e1f1ad1a0454baf42f33bd9de343778b"
 dependencies = [
  "regex-syntax",
 ]
@@ -2669,9 +2670,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.187"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "a7743783ea728ef5c31194c6590797eed286449b4a4e87d626d8a51f0a94e732"
 
 [[package]]
 name = "libgit2-sys"
@@ -3350,7 +3351,7 @@ dependencies = [
 [[package]]
 name = "peppy-config-model"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#a9d0514fdc99448ff48d277b84f9788d8e8c6993"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#e19618a8de805b26045ec592dbf26c18e005690f"
 dependencies = [
  "capnp",
  "clap",
@@ -3373,7 +3374,7 @@ version = "0.0.1"
 [[package]]
 name = "peppylib-rs"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#a9d0514fdc99448ff48d277b84f9788d8e8c6993"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#e19618a8de805b26045ec592dbf26c18e005690f"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -3568,7 +3569,7 @@ dependencies = [
 [[package]]
 name = "pmi"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#a9d0514fdc99448ff48d277b84f9788d8e8c6993"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#e19618a8de805b26045ec592dbf26c18e005690f"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -3961,9 +3962,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.47.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "348e860aeb0b7bd035778fd11dd9cd5290d32e4aed3b8f2274a00287a9fd362b"
+checksum = "2d2b21a85c07fcf1cb95ff7ab8a687fcd37fa70db59975b5a032abdaadfdf42e"
 dependencies = [
  "ahash",
  "fluent-uri",
@@ -4903,6 +4904,27 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
 dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.119",

--- a/crates/auth-internal/src/client.rs
+++ b/crates/auth-internal/src/client.rs
@@ -5,6 +5,7 @@
 //! on a PAT is a hard error (a PAT cannot be refreshed). `502`/`503` map to
 //! distinct messages so an ops problem isn't mistaken for a bad token.
 
+use config::namespace::Namespace;
 use secrecy::ExposeSecret;
 use serde::{Deserialize, de::DeserializeOwned};
 
@@ -67,12 +68,11 @@ pub struct ZenohRouterConfig {
     /// still-fresh config (rather than re-pulling) never risks the router being torn
     /// down.
     pub reconnect_after_secs: u64,
-    /// The caller's organization id (the platform's stable per-user `Uuid`, as a
-    /// string). Becomes the daemon's session namespace so robots of the same org
-    /// interoperate across the federation while different orgs stay routing-isolated.
-    /// Required: a backend that predates this field fails to parse, which is the
-    /// intended clean break (re-run `peppy platform login`).
-    pub organization_id: String,
+    /// The daemon's session namespace, deserialized directly from the backend's
+    /// `workspace_id`. Typed at the HTTP boundary: an invalid workspace id fails
+    /// the pull before anything can be cached or reach a live session.
+    #[serde(rename = "workspace_id")]
+    pub namespace: Namespace,
 }
 
 impl ZenohRouterConfig {
@@ -281,7 +281,7 @@ mod tests {
             endpoint: endpoint.to_string(),
             protocol: "tls".to_string(),
             reconnect_after_secs: 3000,
-            organization_id: "550e8400-e29b-41d4-a716-446655440000".to_string(),
+            namespace: Namespace::parse("550e8400-e29b-41d4-a716-446655440000").unwrap(),
         }
     }
 
@@ -326,16 +326,30 @@ mod tests {
             "protocol": "tls",
             "mode": "client",
             "reconnect_after_secs": 3000,
-            "organization_id": "550e8400-e29b-41d4-a716-446655440000",
+            "workspace_id": "550e8400-e29b-41d4-a716-446655440000",
             "some_future_field": "ignored"
         }"#;
         let cfg: ZenohRouterConfig = serde_json::from_str(json).expect("tolerant parse");
         assert_eq!(cfg.protocol, "tls");
         assert_eq!(cfg.reconnect_after_secs, 3000);
-        assert_eq!(cfg.organization_id, "550e8400-e29b-41d4-a716-446655440000");
+        assert_eq!(
+            cfg.namespace.as_str(),
+            "550e8400-e29b-41d4-a716-446655440000"
+        );
         assert_eq!(
             cfg.host_port().unwrap(),
             ("abc.zenoh.localhost".to_string(), 7443)
         );
+    }
+
+    #[test]
+    fn router_config_rejects_an_invalid_workspace_id() {
+        let json = r#"{
+            "endpoint": "tls/abc.zenoh.localhost:7443",
+            "protocol": "tls",
+            "reconnect_after_secs": 3000,
+            "workspace_id": "**"
+        }"#;
+        assert!(serde_json::from_str::<ZenohRouterConfig>(json).is_err());
     }
 }

--- a/crates/auth-internal/src/lib.rs
+++ b/crates/auth-internal/src/lib.rs
@@ -20,7 +20,7 @@
 //!
 //! This crate owns everything non-interactive: credential storage and
 //! resolution, the blocking HTTP client, the device-flow *protocol* (start and
-//! poll), backend URL resolution, org-id and federation-target resolution, and
+//! poll), backend URL resolution, workspace-id and federation-target resolution, and
 //! the router-config cache (plus the debug-only embedded dev-CA/client-cert
 //! material). Consumers (the `peppy` CLI and the daemon) own every interactive
 //! or process-level concern: the user-facing command structs, printing the

--- a/crates/auth-internal/src/router.rs
+++ b/crates/auth-internal/src/router.rs
@@ -71,10 +71,10 @@ pub struct RouterEndpoint {
     pub host: String,
     pub port: u16,
     pub tls: pmi::TlsConfig,
-    /// The organization id this endpoint was resolved for, carried out of the
-    /// same pull so the caller derives the federation gate and the session
-    /// namespace from one source.
-    pub organization_id: String,
+    /// The namespace this endpoint was resolved for, carried out of the same
+    /// pull so the caller derives the federation gate and session namespace
+    /// from one validated value.
+    pub namespace: config::namespace::Namespace,
 }
 
 /// The router trust anchor, resolved client-side with zero configuration. In a
@@ -188,10 +188,10 @@ pub fn resolve_router_endpoint(
         .unwrap_or_default();
     // The cache is identity-bound two ways: `login`/`logout` clear it with the
     // session, AND `RouterSession.subject` tags it with the backend identity it was
-    // pulled for. Reuse the cached endpoint (and its `organization_id`) only for a
+    // pulled for. Reuse the cached endpoint (and its `namespace`) only for a
     // *session* resolve (no active PAT) whose non-empty subject still matches the
     // cache, so a config pulled under one identity is never replayed under another
-    // (e.g. a PAT-pulled org leaking onto the on-disk session once the PAT is gone).
+    // (e.g. a PAT-pulled workspace leaking onto the on-disk session once the PAT is gone).
     // An active PAT always re-pulls: a PAT is bound to its own backend subject at
     // pull time (see `pull_and_cache`), which the session-derived `active_subject`
     // cannot match on this fast path, and re-pulling is cheap (federation resolves
@@ -204,14 +204,14 @@ pub fn resolve_router_endpoint(
     // thereby register its new name — instead of reusing a still-fresh cache and
     // staying absent from the registry until the cache goes stale.
     let reuse_cache = pat.is_none() && !active_subject.is_empty();
-    let (endpoint, organization_id) = match creds.router {
+    let (endpoint, namespace) = match creds.router {
         Some(rs)
             if reuse_cache
                 && !rs.is_stale(now, REPULL_SKEW_SECS)
                 && rs.subject == active_subject
                 && rs.core_node_name == core_node_name =>
         {
-            (rs.endpoint, rs.organization_id)
+            (rs.endpoint, rs.namespace)
         }
         _ => pull_and_cache(creds_path, http, api_url, pat, now, core_node_name)?,
     };
@@ -221,7 +221,7 @@ pub fn resolve_router_endpoint(
         host,
         port,
         tls: client_tls(ca_certificate, client_identity),
-        organization_id,
+        namespace,
     })
 }
 
@@ -239,11 +239,11 @@ fn pull_and_cache(
     pat: Option<String>,
     now: i64,
     core_node_name: &str,
-) -> Result<(String, String)> {
+) -> Result<(String, config::namespace::Namespace)> {
     let mut cred = resolver::resolve(creds_path, http, pat)?;
     // The identity this pull is actually authenticated as drives the cache tag
     // below. A PAT is not the on-disk session, so it must not be tagged with the
-    // session subject; doing so would let the session reuse the PAT's org once the
+    // session subject; doing so would let the session reuse the PAT's workspace once the
     // PAT is gone (a cross-identity leak).
     let is_pat = matches!(cred.kind, resolver::CredentialKind::Pat);
     let cfg = client::establish_federation(http, api_url, &mut cred, core_node_name)?;
@@ -287,14 +287,14 @@ fn pull_and_cache(
         endpoint: cfg.endpoint.clone(),
         protocol: cfg.protocol.clone(),
         repull_after: now.saturating_add(saturating_secs_to_i64(cfg.reconnect_after_secs)),
-        organization_id: cfg.organization_id.clone(),
+        namespace: cfg.namespace.clone(),
         subject,
         // Tag the cache with the name this pull registered, so a rename forces
         // a re-pull (and re-registration) even while the cache is still fresh.
         core_node_name: core_node_name.to_string(),
     });
     storage::save(creds_path, &creds)?;
-    Ok((cfg.endpoint, cfg.organization_id))
+    Ok((cfg.endpoint, cfg.namespace))
 }
 
 /// Best-effort federation target for the daemon's *local* router: the upstream
@@ -381,19 +381,15 @@ pub fn resolve_federation_target_at(
         client_identity,
         core_node_name,
     ) {
-        // Fail-closed gate, single source: federate only when the resolved org id
-        // is a valid namespace. The daemon's session namespace is resolved from
-        // the same cached `organization_id`, so a config that cannot federate also
-        // cannot carry a federating namespace -- an unprefixed/`local` session can
-        // never reach the shared multi-tenant router.
-        Ok(ep) if config::org::should_federate(Some(&ep.organization_id)) => {
+        // Fail-closed gate, single source: only a validated, non-local namespace
+        // federates. The daemon session is resolved from the same cached value.
+        Ok(ep) if !ep.namespace.is_local() => {
             Some((format!("tls/{}:{}", ep.host, ep.port), ep.tls))
         }
         Ok(ep) => {
             tracing::warn!(
-                organization_id = %ep.organization_id,
-                "router federation: resolved organization id is not a valid namespace; \
-                 local router stays standalone (fail closed)"
+                namespace = %ep.namespace,
+                "router federation: local namespace keeps the router standalone"
             );
             None
         }
@@ -407,17 +403,15 @@ pub fn resolve_federation_target_at(
     }
 }
 
-/// The cached organization id the daemon resolves its session namespace from, or
-/// `None` when there is no fresh router cache (logged out, or not yet pulled). An
-/// empty cached value is treated as absent. Pairs with
-/// [`config::org::resolve_session_namespace`] (absent -> `local`) and
-/// [`config::org::should_federate`] (absent -> standalone).
-pub fn cached_organization_id(creds_path: &Path) -> Option<String> {
-    storage::load(creds_path)
-        .ok()?
+/// Resolve the daemon's session namespace from credentials. A missing file or a
+/// valid document without a router session is legitimate standalone operation
+/// and resolves to `local`; malformed, rejected, unreadable, or invalid state
+/// propagates as an error.
+pub fn session_namespace(creds_path: &Path) -> Result<config::namespace::Namespace> {
+    Ok(storage::load(creds_path)?
         .router
-        .map(|r| r.organization_id)
-        .filter(|s| !s.is_empty())
+        .map(|router| router.namespace)
+        .unwrap_or_else(config::namespace::Namespace::local))
 }
 
 /// Client TLS material for dialing the shared router: validate it against the

--- a/crates/auth-internal/src/storage.rs
+++ b/crates/auth-internal/src/storage.rs
@@ -70,17 +70,15 @@ pub struct RouterSession {
     /// next poke instead of reusing this cached config. A cache-freshness deadline
     /// only; derived at pull time from the server's `reconnect_after_secs`.
     pub repull_after: i64,
-    /// The organization id this config was pulled for (the platform's stable
-    /// per-user `Uuid`, as a string). Drives the daemon's session namespace, so
-    /// it is cached alongside the endpoint. Required: a pre-`organization_id`
-    /// file fails to parse with [`Error::Auth`], the intended clean break (the
-    /// load-resilient `auth login`/`logout` then start fresh).
-    pub organization_id: String,
+    /// The namespace this config was pulled for (the backend's `workspace_id`,
+    /// already validated at the HTTP boundary). It is cached alongside the
+    /// endpoint and fails loudly if an invalid value is read from disk.
+    pub namespace: config::namespace::Namespace,
     /// The OAuth subject the config was pulled for, tagging the cache to one
     /// identity. On reuse the daemon re-pulls when this no longer matches the
     /// active session, so a cache that survives an identity change can never be
-    /// reused under the wrong org. Empty for a PAT pull (no session). Required
-    /// for the same clean-break reason as `organization_id`.
+    /// reused under the wrong workspace. Empty for a PAT pull (no session). Required
+    /// for the same clean-break reason as `namespace`.
     pub subject: String,
     /// The core-node name the config was pulled under (the pull's POST body,
     /// which registers the daemon in the backend's core-node registry). Tags
@@ -89,7 +87,7 @@ pub struct RouterSession {
     /// `CoreNodeNameTaken` collision fix) re-pulls — and re-registers — on its
     /// next resolve instead of staying absent from the registry until the
     /// cache goes stale. Required for the same clean-break reason as
-    /// `organization_id`.
+    /// `namespace`.
     pub core_node_name: String,
 }
 
@@ -326,7 +324,10 @@ mod tests {
                 endpoint: "tls/cap.zenoh.localhost:7443".into(),
                 protocol: "tls".into(),
                 repull_after: 1_700_000_000,
-                organization_id: "550e8400-e29b-41d4-a716-446655440000".into(),
+                namespace: config::namespace::Namespace::parse(
+                    "550e8400-e29b-41d4-a716-446655440000",
+                )
+                .unwrap(),
                 subject: "auth0|alice".into(),
                 core_node_name: "core-node-alice-1".into(),
             }),
@@ -339,14 +340,17 @@ mod tests {
         assert_eq!(rs.endpoint, "tls/cap.zenoh.localhost:7443");
         assert_eq!(rs.protocol, "tls");
         assert_eq!(rs.repull_after, 1_700_000_000);
-        assert_eq!(rs.organization_id, "550e8400-e29b-41d4-a716-446655440000");
+        assert_eq!(
+            rs.namespace.as_str(),
+            "550e8400-e29b-41d4-a716-446655440000"
+        );
         assert_eq!(rs.subject, "auth0|alice");
         assert_eq!(rs.core_node_name, "core-node-alice-1");
     }
 
     /// A cached router session missing the `core_node_name` tag is rejected
     /// outright (no back-compat default), the same clean break as
-    /// `organization_id`: `auth login`/`logout` start fresh.
+    /// `namespace`: `auth login`/`logout` start fresh.
     #[test]
     fn rejects_a_router_session_missing_the_core_node_name() {
         let dir = tempfile::tempdir().expect("temp dir");
@@ -357,7 +361,7 @@ mod tests {
             format!(
                 r#"{{ version: {CREDENTIALS_VERSION}, router: {{
                     endpoint: "tls/cap:7443", protocol: "tls", repull_after: 1,
-                    organization_id: "550e8400-e29b-41d4-a716-446655440000",
+                    namespace: "550e8400-e29b-41d4-a716-446655440000",
                     subject: "auth0|alice" }} }}"#
             ),
         )
@@ -403,7 +407,8 @@ mod tests {
             endpoint: "tls/cap:7443".into(),
             protocol: "tls".into(),
             repull_after: 1_000,
-            organization_id: "550e8400-e29b-41d4-a716-446655440000".into(),
+            namespace: config::namespace::Namespace::parse("550e8400-e29b-41d4-a716-446655440000")
+                .unwrap(),
             subject: "auth0|alice".into(),
             core_node_name: "core-node-alice-1".into(),
         };

--- a/crates/auth-internal/tests/auth_flow.rs
+++ b/crates/auth-internal/tests/auth_flow.rs
@@ -39,6 +39,49 @@ fn creds_path(dir: &tempfile::TempDir) -> PathBuf {
 }
 
 #[test]
+fn session_namespace_resolves_legitimate_absence_to_local() {
+    let missing_dir = tempfile::tempdir().expect("temp dir");
+    let missing = creds_path(&missing_dir);
+    assert_eq!(
+        router::session_namespace(&missing).expect("a missing file is logged-out state"),
+        config::namespace::Namespace::local()
+    );
+
+    let unstamped_dir = tempfile::tempdir().expect("temp dir");
+    let unstamped = creds_path(&unstamped_dir);
+    storage::save(&unstamped, &Credentials::default()).expect("save valid unstamped credentials");
+    assert_eq!(
+        router::session_namespace(&unstamped).expect("router absence is standalone state"),
+        config::namespace::Namespace::local()
+    );
+}
+
+#[test]
+fn session_namespace_propagates_malformed_and_version_rejected_credentials() {
+    let malformed_dir = tempfile::tempdir().expect("temp dir");
+    let malformed = creds_path(&malformed_dir);
+    std::fs::create_dir_all(malformed.parent().unwrap()).expect("create credentials dir");
+    std::fs::write(&malformed, "{ this is not valid json5").expect("write malformed credentials");
+    assert!(
+        router::session_namespace(&malformed).is_err(),
+        "malformed credentials must not become the local namespace"
+    );
+
+    let rejected_dir = tempfile::tempdir().expect("temp dir");
+    let rejected = creds_path(&rejected_dir);
+    std::fs::create_dir_all(rejected.parent().unwrap()).expect("create credentials dir");
+    std::fs::write(
+        &rejected,
+        format!("{{ version: {} }}", storage::CREDENTIALS_VERSION + 1),
+    )
+    .expect("write version-rejected credentials");
+    assert!(
+        router::session_namespace(&rejected).is_err(),
+        "version-rejected credentials must not become the local namespace"
+    );
+}
+
+#[test]
 fn resolver_prefers_pat_env_over_files() {
     let http = HttpClient::new();
 
@@ -126,6 +169,10 @@ fn get_me_parses_principal_with_unknown_fields() {
 /// drops or malforms the body gets no mock response and fails its test.
 const CORE_NODE: &str = "core-node-test-1";
 
+fn workspace_namespace() -> config::namespace::Namespace {
+    config::namespace::Namespace::parse("550e8400-e29b-41d4-a716-446655440000").unwrap()
+}
+
 #[test]
 fn establish_federation_parses_the_contract() {
     let server = MockServer::start();
@@ -141,7 +188,7 @@ fn establish_federation_parses_the_contract() {
             "protocol": "tls",
             "mode": "client",
             "reconnect_after_secs": 3000,
-            "organization_id": "550e8400-e29b-41d4-a716-446655440000",
+            "workspace_id": "550e8400-e29b-41d4-a716-446655440000",
             "some_future_field": "ignored by a tolerant client",
         }));
     });
@@ -156,7 +203,7 @@ fn establish_federation_parses_the_contract() {
         .expect("fetch shared router config");
     assert_eq!(cfg.protocol, "tls");
     assert_eq!(cfg.reconnect_after_secs, 3000);
-    assert_eq!(cfg.organization_id, "550e8400-e29b-41d4-a716-446655440000");
+    assert_eq!(cfg.namespace, workspace_namespace());
     assert_eq!(
         cfg.host_port().expect("parse endpoint"),
         ("localhost".to_string(), 7447)
@@ -209,7 +256,7 @@ fn router_config_pull_refreshes_on_401_then_re_pulls() {
             "protocol": "tls",
             "mode": "client",
             "reconnect_after_secs": 3000,
-            "organization_id": "550e8400-e29b-41d4-a716-446655440000",
+            "workspace_id": "550e8400-e29b-41d4-a716-446655440000",
         }));
     });
 
@@ -278,7 +325,7 @@ fn resolve_router_endpoint_reuses_a_fresh_cache_without_pulling() {
             protocol: "tls".into(),
             // Far in the future ⇒ fresh ⇒ reuse.
             repull_after: storage::now_unix() + 100_000,
-            organization_id: "550e8400-e29b-41d4-a716-446655440000".into(),
+            namespace: workspace_namespace(),
             // Matches `seeded_creds`'s subject so the identity tag agrees and the
             // fresh cache is reused (a mismatch would force a re-pull).
             subject: "user-123".into(),
@@ -323,7 +370,7 @@ fn resolve_federation_target_derives_the_upstream_tls_locator() {
             "endpoint": "tls/cap.zenoh.localhost:7443",
             "protocol": "tls",
             "reconnect_after_secs": 3000,
-            "organization_id": "550e8400-e29b-41d4-a716-446655440000",
+            "workspace_id": "550e8400-e29b-41d4-a716-446655440000",
         }));
     });
 
@@ -394,11 +441,11 @@ fn resolve_federation_target_is_none_when_not_logged_in() {
 }
 
 #[test]
-fn resolve_federation_target_fails_closed_on_an_invalid_org_namespace() {
-    // Fail closed: a logged-in pull whose `organization_id` cannot be a zenoh
+fn resolve_federation_target_fails_closed_on_an_invalid_workspace_namespace() {
+    // Fail closed: a logged-in pull whose `namespace` cannot be a zenoh
     // namespace (here a wildcard) must NOT federate. The local router stays
     // standalone rather than dialing the shared router under a bogus namespace.
-    // The daemon resolves its session namespace from the same org id, so a value
+    // The daemon resolves its session namespace from the same workspace id, so a value
     // that cannot federate also cannot carry a federating namespace.
     let server = MockServer::start();
     let pull = server.mock(|when, then| {
@@ -407,7 +454,7 @@ fn resolve_federation_target_fails_closed_on_an_invalid_org_namespace() {
             "endpoint": "tls/cap.zenoh.localhost:7443",
             "protocol": "tls",
             "reconnect_after_secs": 3000,
-            "organization_id": "**",
+            "workspace_id": "**",
         }));
     });
 
@@ -430,7 +477,7 @@ fn resolve_federation_target_fails_closed_on_an_invalid_org_namespace() {
     );
     assert!(
         target.is_none(),
-        "an org id that is not a valid namespace must fail closed (no federation)"
+        "an invalid workspace namespace must fail closed (no federation)"
     );
     assert!(
         pull.calls() >= 1,
@@ -456,7 +503,7 @@ fn resolve_federation_target_honors_a_short_connect_timeout() {
                 "endpoint": "tls/cap.zenoh.localhost:7443",
                 "protocol": "tls",
                 "reconnect_after_secs": 3000,
-                "organization_id": "550e8400-e29b-41d4-a716-446655440000",
+                "workspace_id": "550e8400-e29b-41d4-a716-446655440000",
             }));
     });
 
@@ -517,7 +564,7 @@ fn resolve_router_endpoint_re_pulls_and_caches_when_stale() {
             "protocol": "tls",
             "mode": "client",
             "reconnect_after_secs": 3000,
-            "organization_id": "550e8400-e29b-41d4-a716-446655440000",
+            "workspace_id": "550e8400-e29b-41d4-a716-446655440000",
         }));
     });
 
@@ -529,7 +576,7 @@ fn resolve_router_endpoint_re_pulls_and_caches_when_stale() {
             endpoint: "tls/stale.zenoh.localhost:7443".into(),
             protocol: "tls".into(),
             repull_after: 1, // long past ⇒ stale ⇒ re-pull
-            organization_id: "550e8400-e29b-41d4-a716-446655440000".into(),
+            namespace: workspace_namespace(),
             subject: "user-123".into(),
             core_node_name: CORE_NODE.into(),
         }),
@@ -586,7 +633,7 @@ fn resolve_router_endpoint_re_pulls_when_the_core_node_name_changed() {
             "endpoint": "tls/cap.zenoh.localhost:7443",
             "protocol": "tls",
             "reconnect_after_secs": 3000,
-            "organization_id": "550e8400-e29b-41d4-a716-446655440000",
+            "workspace_id": "550e8400-e29b-41d4-a716-446655440000",
         }));
     });
 
@@ -599,7 +646,7 @@ fn resolve_router_endpoint_re_pulls_when_the_core_node_name_changed() {
             protocol: "tls".into(),
             // Far in the future ⇒ fresh; only the name tag differs.
             repull_after: storage::now_unix() + 100_000,
-            organization_id: "550e8400-e29b-41d4-a716-446655440000".into(),
+            namespace: workspace_namespace(),
             subject: "user-123".into(),
             core_node_name: "the-old-name".into(),
         }),
@@ -638,16 +685,16 @@ fn resolve_router_endpoint_re_pulls_when_the_core_node_name_changed() {
 fn router_cache_is_bound_to_the_pull_identity_not_the_on_disk_session() {
     // A PAT-authenticated pull must tag the cache with the PAT owner's stable
     // backend subject (`/me`), NOT the on-disk session subject. Otherwise, once the
-    // PAT is gone, a session resolve would reuse the PAT's org, a cross-identity
+    // PAT is gone, a session resolve would reuse the PAT's workspace, a cross-identity
     // (cross-tenant) leak.
     let server = MockServer::start();
     let pull = server.mock(|when, then| {
         when.method(POST).path("/me/cli/federation");
         then.status(200).json_body(json!({
-            "endpoint": "tls/pat-org.zenoh.localhost:7443",
+            "endpoint": "tls/pat-workspace.zenoh.localhost:7443",
             "protocol": "tls",
             "reconnect_after_secs": 3000,
-            "organization_id": "550e8400-e29b-41d4-a716-446655440000",
+            "workspace_id": "550e8400-e29b-41d4-a716-446655440000",
         }));
     });
     // Only a PAT pull resolves `/me` (to learn the PAT owner's stable subject).
@@ -679,7 +726,7 @@ fn router_cache_is_bound_to_the_pull_identity_not_the_on_disk_session() {
         CORE_NODE,
     )
     .expect("PAT pull resolves");
-    assert_eq!(ep.host, "pat-org.zenoh.localhost");
+    assert_eq!(ep.host, "pat-workspace.zenoh.localhost");
     assert_eq!(pull.calls(), 1, "the PAT pull hit the backend once");
     assert_eq!(
         me.calls(),
@@ -698,7 +745,7 @@ fn router_cache_is_bound_to_the_pull_identity_not_the_on_disk_session() {
     );
 
     // With the PAT gone, a session resolve must NOT reuse the PAT's cache: the
-    // subjects differ, so it re-pulls rather than leaking the PAT's org.
+    // subjects differ, so it re-pulls rather than leaking the PAT's workspace.
     let _ = router::resolve_router_endpoint(
         &path,
         &http,

--- a/crates/containers-internal/build.rs
+++ b/crates/containers-internal/build.rs
@@ -1537,6 +1537,14 @@ echo "=== Apptainer build complete ==="
         let cache_sentinel = apptainer_cache_sentinel_path(&cache_dir, APPTAINER_VERSION);
         println!("cargo:rerun-if-changed={}", cache_sentinel.display());
 
+        // Export the sentinel path so the cache-consistency test asserts on the
+        // name this build actually wrote. Only `apptainer_cache_sentinel_path`
+        // knows the naming scheme, so changing it cannot desync the test.
+        println!(
+            "cargo:rustc-env=APPTAINER_CACHE_SENTINEL={}",
+            cache_sentinel.display()
+        );
+
         // Step 3: Copy apptainer installation to OUT_DIR for release packaging.
         // Use a sentinel to skip the copy when the source hasn't changed,
         // avoiding mtime bumps that trigger unnecessary recompilation.

--- a/crates/containers-internal/src/apptainer/tests.rs
+++ b/crates/containers-internal/src/apptainer/tests.rs
@@ -843,7 +843,10 @@ fn shell_escape_single_quoted_survives_embedded_quotes() {
 // ---------------------------------------------------------------------------
 
 /// Verifies that the compile-time `APPTAINER_INSTALL_DIR` injected by build.rs
-/// points to a valid cache directory with the expected sentinel and binary.
+/// points to a valid cache directory with the expected sentinel and binary. The
+/// sentinel path comes from build.rs too, via `APPTAINER_CACHE_SENTINEL`: the
+/// name is version and recipe keyed, so re-deriving it here would go stale the
+/// next time the cache key changes.
 ///
 /// If this test fails after deleting `~/.peppy`, it means the build cache is
 /// stale and `cargo build` needs to re-run build.rs (which the
@@ -863,7 +866,10 @@ fn compile_time_apptainer_dir_exists_with_sentinel() {
         install_dir
     );
 
-    let sentinel = path.join(format!(".peppy-version-{}", env!("APPTAINER_VERSION")));
+    let sentinel = Path::new(env!(
+        "APPTAINER_CACHE_SENTINEL",
+        "APPTAINER_CACHE_SENTINEL should be set by build.rs at compile time"
+    ));
     assert!(
         sentinel.exists(),
         "Cache sentinel {:?} is missing; the apptainer cache may be corrupt",

--- a/crates/core-node-internal/src/services.rs
+++ b/crates/core-node-internal/src/services.rs
@@ -139,11 +139,11 @@ pub struct CoreNodeConfig {
     /// Daemon-global messaging mode + subscriber buffer sizes, injected into every
     /// spawned node's runtime config (see `node::run`).
     pub peppy_config: daemon_config::peppy_config::PeppyConfig,
-    /// The daemon's organization namespace for this generation (`"local"` when
-    /// logged out, else the org id). Stamped onto every spawned node's
-    /// `discovery.organization_id` so the node opens its session under the same
+    /// The daemon's workspace namespace for this generation (`local` when
+    /// logged out, else the workspace id). Stamped onto every spawned node's
+    /// `discovery.namespace` so the node opens its session under the same
     /// namespace as the daemon.
-    pub organization_namespace: String,
+    pub namespace: config::namespace::Namespace,
     /// Cancelled at the start of daemon shutdown to stop the core node's own
     /// clock + heartbeat publishers before the messaging session is closed, so
     /// they do not spin against a closed session logging a failed publish on
@@ -171,9 +171,9 @@ pub struct CoreNode {
     /// Daemon-global messaging mode + subscriber buffer sizes, read once at startup.
     /// Injected into every spawned node's runtime config (see `node::run`).
     peppy_config: daemon_config::peppy_config::PeppyConfig,
-    /// The daemon's organization namespace for this generation, stamped onto
+    /// The daemon's workspace namespace for this generation, stamped onto
     /// every spawned node so it opens its session under the daemon's namespace.
-    organization_namespace: String,
+    namespace: config::namespace::Namespace,
     /// Cancelled on shutdown to stop the clock + heartbeat publishers cleanly.
     /// Cloned into each publisher task in [`CoreNode::start_with_ready`].
     shutdown_token: CancellationToken,
@@ -303,7 +303,7 @@ impl CoreNode {
             root_dir,
             peppy_dirs,
             peppy_config,
-            organization_namespace,
+            namespace,
             shutdown_token,
         } = config;
 
@@ -365,7 +365,7 @@ impl CoreNode {
             daemon_use_sim_time,
             name_claim_settle,
             peppy_config,
-            organization_namespace,
+            namespace,
             shutdown_token,
             presence_token: std::sync::Mutex::new(None),
             started: AtomicBool::new(false),
@@ -614,7 +614,7 @@ impl CoreNode {
                     use_sim_time: self.daemon_use_sim_time,
                     daemon_defaults: node::DaemonDefaults::from_peppy_config(
                         &self.peppy_config,
-                        self.organization_namespace.clone(),
+                        self.namespace.clone(),
                     ),
                     shutdown_token: self.shutdown_token.clone(),
                 },
@@ -663,7 +663,7 @@ impl CoreNode {
                     health_monitor_timeout: self.health_monitor_timeout,
                     daemon_defaults: node::DaemonDefaults::from_peppy_config(
                         &self.peppy_config,
-                        self.organization_namespace.clone(),
+                        self.namespace.clone(),
                     ),
                     shutdown_token: self.shutdown_token.clone(),
                     pairing: Arc::clone(&ctx.pairing),

--- a/crates/core-node-internal/src/services/node/run.rs
+++ b/crates/core-node-internal/src/services/node/run.rs
@@ -103,27 +103,30 @@ pub struct DaemonDefaults {
     /// node so its runtime bounds registered shutdown hooks by the same window
     /// the daemon waits before force-killing a stopping node.
     pub shutdown_grace_secs: u64,
-    /// The daemon's organization namespace (`"local"` when logged out, else the
-    /// org id), stamped onto every spawned node's `discovery.organization_id` so
+    /// The daemon's workspace namespace (`local` when logged out, else the
+    /// workspace id), stamped onto every spawned node's `discovery.namespace` so
     /// the node opens its session under exactly the daemon's namespace and stays
     /// routing-isolated across the federation. Resolved per daemon generation
     /// from the cached credentials, not from `peppy_config`, so it is threaded in
     /// rather than derived in `from_peppy_config`.
-    pub organization_namespace: String,
+    pub namespace: config::namespace::Namespace,
 }
 
 impl DaemonDefaults {
     /// Resolves the per-node defaults from the daemon's loaded `peppy_config`
     /// (the single place that knows which of its fields are shipped to
-    /// spawned nodes) plus the daemon's resolved `organization_namespace`
+    /// spawned nodes) plus the daemon's resolved `namespace`
     /// (which comes from the credentials, not `peppy_config`).
-    pub fn from_peppy_config(config: &PeppyConfig, organization_namespace: String) -> Self {
+    pub fn from_peppy_config(
+        config: &PeppyConfig,
+        namespace: config::namespace::Namespace,
+    ) -> Self {
         Self {
             gossip: config.zenoh.gossip(),
             subscriber_buffers: config.zenoh.subscriber_buffers(),
             daemon_grace_secs: config.lifecycle.daemon_grace_secs,
             shutdown_grace_secs: config.lifecycle.shutdown_grace_secs,
-            organization_namespace,
+            namespace,
         }
     }
 }
@@ -179,10 +182,9 @@ fn apply_daemon_defaults(
         defaults.subscriber_buffers.high_throughput_buffer_size;
     cfg.lifecycle.daemon_grace_secs = defaults.daemon_grace_secs;
     cfg.lifecycle.shutdown_grace_secs = defaults.shutdown_grace_secs;
-    // Stamp the daemon's organization namespace so the spawned node opens its
-    // session under it (`peppylib` resolves `discovery.organization_id` through
-    // `resolve_session_namespace`). Always set: `"local"` when logged out.
-    cfg.discovery.organization_id = Some(defaults.organization_namespace.clone());
+    // Stamp the daemon's validated workspace namespace so the spawned node opens
+    // under it. Always set: `local` when logged out.
+    cfg.discovery.namespace = Some(defaults.namespace.clone());
 }
 
 struct ProcessNodeRunContext {
@@ -1847,7 +1849,7 @@ mod tests {
             subscriber_buffers,
             daemon_grace_secs: 123,
             shutdown_grace_secs: 17,
-            organization_namespace: "local".to_string(),
+            namespace: config::namespace::Namespace::local(),
         }
     }
 
@@ -1894,7 +1896,7 @@ mod tests {
         );
     }
 
-    /// Subscriber buffer sizes, both grace periods, and the organization
+    /// Subscriber buffer sizes, both grace periods, and the workspace
     /// namespace are applied regardless of topology or container placement.
     #[test]
     fn apply_daemon_defaults_always_applies_subscriber_buffers_and_grace() {
@@ -1915,7 +1917,13 @@ mod tests {
             assert_eq!(cfg.lifecycle.shutdown_grace_secs, 17);
             // The node is stamped with the daemon's namespace, so it opens its
             // session under the same routing-isolation prefix as the daemon.
-            assert_eq!(cfg.discovery.organization_id.as_deref(), Some("local"));
+            assert_eq!(
+                cfg.discovery
+                    .namespace
+                    .as_ref()
+                    .map(|namespace| namespace.as_str()),
+                Some("local")
+            );
         }
     }
 
@@ -1930,7 +1938,8 @@ mod tests {
             ..PeppyConfig::default()
         };
 
-        let defaults = DaemonDefaults::from_peppy_config(&config, "local".to_string());
+        let defaults =
+            DaemonDefaults::from_peppy_config(&config, config::namespace::Namespace::local());
 
         assert!(!defaults.gossip);
         assert_eq!(
@@ -1939,15 +1948,19 @@ mod tests {
         );
     }
 
-    /// A logged-in daemon stamps the org id (not `local`) onto every node.
+    /// A logged-in daemon stamps the workspace namespace onto every node.
     #[test]
-    fn apply_daemon_defaults_stamps_the_org_namespace() {
+    fn apply_daemon_defaults_stamps_the_workspace_namespace() {
         let mut defaults = daemon_defaults(true, SubscriberBufferConfig::default());
-        defaults.organization_namespace = "550e8400-e29b-41d4-a716-446655440000".to_string();
+        defaults.namespace =
+            config::namespace::Namespace::parse("550e8400-e29b-41d4-a716-446655440000").unwrap();
         let mut cfg = runtime_config_for_test();
         apply_daemon_defaults(&mut cfg, defaults, false);
         assert_eq!(
-            cfg.discovery.organization_id.as_deref(),
+            cfg.discovery
+                .namespace
+                .as_ref()
+                .map(|namespace| namespace.as_str()),
             Some("550e8400-e29b-41d4-a716-446655440000")
         );
     }

--- a/crates/core-node-internal/src/services/presence.rs
+++ b/crates/core-node-internal/src/services/presence.rs
@@ -322,7 +322,7 @@ mod tests {
         )
         .expect("build a router-topology daemon session")
         .with_session_reconnect()
-        .with_namespace(Some(config::org::OrgNamespace::local()));
+        .with_namespace(Some(config::namespace::Namespace::local()));
         let mut client = Messenger::new(MessengerAdapter::Zenoh(adapter));
         client
             .start_session()

--- a/crates/core-node-internal/src/services/tests.rs
+++ b/crates/core-node-internal/src/services/tests.rs
@@ -127,7 +127,7 @@ fn test_core_node_config(
         root_dir: std::env::temp_dir(),
         peppy_dirs,
         peppy_config: daemon_config::peppy_config::PeppyConfig::default(),
-        organization_namespace: "local".to_string(),
+        namespace: config::namespace::Namespace::local(),
         shutdown_token: tokio_util::sync::CancellationToken::new(),
     }
 }

--- a/crates/core-node-internal/tests/common/daemon.rs
+++ b/crates/core-node-internal/tests/common/daemon.rs
@@ -193,12 +193,12 @@ pub async fn start_core_node_with_real_messenger_in_topology(
         None,
         topology.gossip(),
         pmi::SubscriberBufferSizes::default(),
-        // The core node stamps the `local` org namespace onto every node it
-        // spawns (see `organization_namespace` below); its own session must open
+        // The core node stamps the `local` workspace namespace onto every node it
+        // spawns (see `namespace` below); its own session must open
         // under the same namespace or it cannot reach a spawned node's
         // node_ready/health services. Mirrors the daemon's
         // `with_router(...).with_namespace(...)` pairing in production.
-        Some(config::org::OrgNamespace::local()),
+        Some(config::namespace::Namespace::local()),
     )
     .await
     .expect("failed to start zenoh router for test");
@@ -301,7 +301,7 @@ async fn start_core_node_with_messenger(
         root_dir,
         peppy_dirs: peppy_dirs.clone(),
         peppy_config,
-        organization_namespace: "local".to_string(),
+        namespace: config::namespace::Namespace::local(),
         shutdown_token: shutdown_token.clone(),
     });
     let core_node_name = core_node.node_name().to_string();

--- a/crates/daemon-config-internal/src/lib.rs
+++ b/crates/daemon-config-internal/src/lib.rs
@@ -12,7 +12,7 @@
 //!
 //! It builds on the shared `config` crate (`peppy-config-model`), which keeps
 //! the wire-facing tier consumed by nodes and `peppylib`: the `peppy.json5`
-//! node config model, runtime configs, fingerprints, org namespaces, and
+//! node config model, runtime configs, fingerprints, workspace namespaces, and
 //! schema tags. Types crossing that boundary (`config::runtime::Name`,
 //! `config::node` manifest types, `config::peppy_config::SubscriberBufferConfig`) are
 //! used directly from `config` so each has exactly one definition.

--- a/crates/daemon-internal/src/builder.rs
+++ b/crates/daemon-internal/src/builder.rs
@@ -61,14 +61,14 @@ pub struct ServeCommandBuilder {
     /// moved into the core node, and shared by [`RouterFederation`] and
     /// [`FederationControl`].
     federation_connect_timeout: Duration,
-    /// The organization namespace resolved once for this daemon generation
-    /// (`"local"` when logged out, else the org id). Resolved in
+    /// The workspace namespace resolved once for this daemon generation
+    /// (`local` when logged out, else the workspace id). Resolved in
     /// [`with_messaging_router`](Self::with_messaging_router) from the cached
     /// credentials and applied to the daemon's own session there; also threaded
     /// into [`DaemonState`], the core node (and thus every spawned node), and the
     /// [`RouterFederation`] task (which compares against it to decide restart vs
     /// live re-federate). A single source for the whole generation.
-    organization_namespace: String,
+    namespace: config::namespace::Namespace,
     /// The shared coordinator token for this generation: cloned into every serve
     /// task (so a restart/stop unparks them for graceful teardown) and handed to
     /// [`Serve`] (which cancels it on its way out). Created per generation.
@@ -100,7 +100,7 @@ impl ServeCommandBuilder {
             ),
             // Default for the mock/other engines that never resolve a namespace;
             // the zenoh path overwrites this in `with_messaging_router`.
-            organization_namespace: config::org::LOCAL_NAMESPACE.to_string(),
+            namespace: config::namespace::Namespace::local(),
             teardown_token: CancellationToken::new(),
         })
     }
@@ -161,20 +161,22 @@ impl ServeCommandBuilder {
                         Duration::from_secs(federation.connect_timeout_secs);
                 }
 
-                // Resolve this generation's organization namespace once, from the
-                // credentials cached under this run's data root: `"local"` when
-                // logged out, else the org id. It is the single source threaded
+                // Resolve this generation's workspace namespace once, from the
+                // credentials cached under this run's data root: `local` when
+                // logged out, else the workspace id. It is the single source threaded
                 // into the daemon's own session (here), `DaemonState`, every
                 // spawned node, and the federation task. The router itself is
                 // never namespaced (it only forwards), so the namespace rides
                 // only on application sessions.
-                let namespace = config::org::resolve_session_namespace(
-                    auth::router::cached_organization_id(&auth::storage::credentials_path(
-                        &self.peppy_dirs,
+                let namespace = auth::router::session_namespace(&auth::storage::credentials_path(
+                    &self.peppy_dirs,
+                ))
+                .map_err(|error| {
+                    Error::ExecutionFailed(format!(
+                        "failed to resolve the workspace namespace from credentials: {error}"
                     ))
-                    .as_deref(),
-                );
-                self.organization_namespace = namespace.as_str().to_string();
+                })?;
+                self.namespace = namespace.clone();
 
                 let gossip = self.peppy_config.zenoh.gossip();
                 let adapter = match self.peppy_config.zenoh.external_endpoint() {
@@ -307,14 +309,14 @@ impl ServeCommandBuilder {
                     federation_settled_rx,
                     self.clock_source,
                     self.peppy_config,
-                    self.organization_namespace.clone(),
+                    self.namespace.clone(),
                     name_claim_settle,
                     self.teardown_token.clone(),
                     core_node_done_tx,
                 );
 
                 // Write the daemon state file with the core node name. The
-                // organization namespace is recorded here, before the control
+                // workspace namespace is recorded here, before the control
                 // socket binds (below), so a CLI control session that reads it
                 // never sees a half-set generation.
                 let core_node_name = core_node.node_name().to_string();
@@ -325,7 +327,7 @@ impl ServeCommandBuilder {
                         &core_node_name,
                         &self.git_hash,
                         shutdown_grace_secs,
-                        &self.organization_namespace,
+                        self.namespace.clone(),
                         // `Some` exactly when this generation arms managed-router
                         // federation below (a control socket will exist), so the
                         // auth commands can follow the running daemon's mode.
@@ -403,7 +405,7 @@ impl ServeCommandBuilder {
                         // This generation's namespace: the federation loop compares
                         // the namespace it re-resolves from fresh creds against this
                         // to decide live re-federate (unchanged) vs restart (changed).
-                        self.organization_namespace.clone(),
+                        self.namespace.clone(),
                         // The startup poll raises this if it resolves a namespace
                         // that differs from this generation's (the steady-state
                         // poke path leaves the restart to the control handler).
@@ -451,7 +453,7 @@ fn daemon_state_for_messenger(
     core_node_name: &str,
     git_hash: &str,
     shutdown_grace_secs: u64,
-    organization_namespace: &str,
+    namespace: config::namespace::Namespace,
     federation_connect_timeout_secs: Option<u64>,
 ) -> DaemonState {
     let (messaging_host, messaging_port) = messenger
@@ -469,7 +471,7 @@ fn daemon_state_for_messenger(
         messaging_port,
         git_hash,
         shutdown_grace_secs,
-        organization_namespace,
+        namespace,
         federation_connect_timeout_secs,
     )
 }
@@ -628,7 +630,7 @@ mod tests {
             "regression-core",
             "regression-git-hash",
             42,
-            config::org::LOCAL_NAMESPACE,
+            config::namespace::Namespace::local(),
             builder
                 .federation_api_url
                 .as_ref()

--- a/crates/daemon-internal/src/control.rs
+++ b/crates/daemon-internal/src/control.rs
@@ -69,7 +69,7 @@ pub enum ControlResponse {
     /// The daemon attempted the apply and it failed (e.g. backend unreachable
     /// within the federation timeout).
     Error { message: String },
-    /// The credentials changed the daemon's *organization namespace*, which is
+    /// The credentials changed the daemon's *workspace namespace*, which is
     /// immutable for a live session, so the daemon is restarting its whole
     /// generation to re-open every session under the new namespace. The daemon
     /// flushes this ack and only then tears down; the CLI polls the (path-stable)
@@ -103,7 +103,7 @@ pub enum PokeOutcome {
     DaemonNotRunning,
     /// Connected, but the daemon did not ack within the read deadline.
     TimedOut,
-    /// The credentials changed the daemon's organization namespace, so the daemon
+    /// The credentials changed the daemon's workspace namespace, so the daemon
     /// acked and is restarting its whole generation. The caller then polls until
     /// the daemon is back under the expected namespace.
     Restarting,

--- a/crates/daemon-internal/src/core_node.rs
+++ b/crates/daemon-internal/src/core_node.rs
@@ -87,7 +87,7 @@ impl CoreNodeRunner {
         federation_settled: Option<watch::Receiver<bool>>,
         clock_source: crate::ClockSource,
         peppy_config: daemon_config::peppy_config::PeppyConfig,
-        organization_namespace: String,
+        namespace: config::namespace::Namespace,
         name_claim_settle: Duration,
         serve_teardown_token: CancellationToken,
         core_node_done: watch::Sender<bool>,
@@ -121,7 +121,7 @@ impl CoreNodeRunner {
             root_dir,
             peppy_dirs,
             peppy_config,
-            organization_namespace,
+            namespace,
             shutdown_token: shutdown_token.clone(),
         });
         Self {

--- a/crates/daemon-internal/src/router_federation.rs
+++ b/crates/daemon-internal/src/router_federation.rs
@@ -130,7 +130,7 @@ pub(crate) enum FederationOutcome {
     /// federation with platform-backend is NOT actually in effect (e.g. an
     /// UnknownCA handshake loop). Only a verifying poke produces this.
     Unreachable(String),
-    /// The credentials changed the daemon's *organization namespace*. A session's
+    /// The credentials changed the daemon's *workspace namespace*. A session's
     /// namespace is immutable after open and the core node holds long-lived
     /// declarations, so the change cannot be applied to the live session by a
     /// zenohd bounce; it needs a full daemon-generation restart. This poll does
@@ -141,25 +141,17 @@ pub(crate) enum FederationOutcome {
     Restart,
 }
 
-/// Resolves the daemon's *current* organization namespace from the credentials
+/// Resolves the daemon's current workspace namespace from the credentials
 /// (after a federation pull has warmed the cache), so the federation loop can
 /// compare it to the generation's startup namespace. A boxed closure so tests can
 /// inject a deterministic value in place of the real credentials read.
-type NamespaceResolver = Arc<dyn Fn() -> String + Send + Sync>;
+type NamespaceResolver = Arc<dyn Fn() -> auth::Result<config::namespace::Namespace> + Send + Sync>;
 
-/// The real namespace resolver: read the cached organization id from the
-/// generation's credentials file and resolve it to a namespace (absent ->
-/// `local`), matching exactly how the daemon generation resolved its own
-/// namespace at startup (the same [`auth::storage::credentials_path`] derived
-/// from the same `PeppyDirs`).
+/// The real namespace resolver reads the generation's credentials file with the
+/// same fallible policy as startup. Legitimate absence resolves to `local`, while
+/// malformed or unreadable credentials propagate instead of synthesizing it.
 fn real_namespace_resolver(creds_path: PathBuf) -> NamespaceResolver {
-    Arc::new(move || {
-        config::org::resolve_session_namespace(
-            auth::router::cached_organization_id(&creds_path).as_deref(),
-        )
-        .as_str()
-        .to_string()
-    })
+    Arc::new(move || auth::router::session_namespace(&creds_path))
 }
 
 /// A "refederate now" request from the control socket: run a poll immediately and
@@ -188,10 +180,10 @@ pub(crate) struct RouterFederation {
     /// Bound on the initial federation (the startup gate) and on each resolve, so
     /// a slow/unreachable backend can't stall startup or a poll past it.
     connect_timeout: Duration,
-    /// This generation's organization namespace, resolved once at startup. A poll
+    /// This generation's workspace namespace, resolved once at startup. A poll
     /// that re-resolves a *different* namespace from fresh creds requests a
     /// restart instead of a live re-federation.
-    startup_namespace: String,
+    startup_namespace: config::namespace::Namespace,
     /// Resolves the current namespace from the credentials (post-pull), compared
     /// against `startup_namespace` to detect a namespace change.
     namespace_resolver: NamespaceResolver,
@@ -224,7 +216,7 @@ impl RouterFederation {
         messaging_ready: watch::Receiver<bool>,
         trigger_rx: TriggerReceiver,
         connect_timeout: Duration,
-        startup_namespace: String,
+        startup_namespace: config::namespace::Namespace,
         restart_tx: watch::Sender<bool>,
         presence_gate_tx: Option<watch::Sender<bool>>,
         teardown_token: CancellationToken,
@@ -345,7 +337,7 @@ async fn manage_federation(
     mut trigger_rx: TriggerReceiver,
     ready_tx: oneshot::Sender<()>,
     connect_timeout: Duration,
-    startup_namespace: String,
+    startup_namespace: config::namespace::Namespace,
     namespace_resolver: NamespaceResolver,
     restart_tx: watch::Sender<bool>,
     presence_gate_tx: Option<watch::Sender<bool>>,
@@ -407,10 +399,10 @@ async fn manage_federation(
     fire_gate(&mut ready_tx, &presence_gate_tx);
 
     // The initial poll re-pulled the federation config, so the credentials now
-    // reflect the current org. If that resolves to a *different* namespace than
+    // reflect the current workspace. If that resolves to a *different* namespace than
     // this generation started under (e.g. the daemon started logged-in but with a
     // cleared/stale router cache, so `startup_namespace` was `local` before the
-    // pull discovered the real org), the live session can't be re-namespaced.
+    // pull discovered the real workspace), the live session can't be re-namespaced.
     // Request a generation restart now; otherwise the daemon would run
     // un-federated under the wrong namespace until the next login/logout poke. The
     // steady-state poke path leaves the actual restart to the control handler
@@ -472,7 +464,7 @@ async fn poll_and_apply(
     connect_timeout: Duration,
     applied: &mut AppliedState,
     verify: bool,
-    startup_namespace: &str,
+    startup_namespace: &config::namespace::Namespace,
     namespace_resolver: &NamespaceResolver,
 ) -> FederationOutcome {
     // The resolver is blocking (HTTP + file I/O); keep it off the async worker. It
@@ -500,12 +492,12 @@ async fn poll_and_apply(
     };
 
     // Namespace-change gate. The resolve above re-pulled (and re-cached) the
-    // federation config, so the credentials now reflect the current org id. A
+    // federation config, so the credentials now reflect the current workspace id. A
     // session's namespace is immutable after open, so if the re-resolved namespace
     // differs from this generation's startup namespace the change cannot be applied
     // by a live zenodh bounce: request a full restart instead, WITHOUT federating
-    // (federating under a namespace that differs from the live session's would leak
-    // across tenants). The control handler flushes the ack before triggering the
+    // (federating under a namespace that differs from the live session's would use
+    // the wrong workspace routing context). The control handler flushes the ack before triggering the
     // restart; the initial (non-poke) poll discards this outcome but, crucially,
     // also does not federate, so it stays fail-closed until the next generation.
     // Like the resolve above, the namespace re-resolve is blocking (a file-backed
@@ -513,17 +505,21 @@ async fn poll_and_apply(
     // local read, not a network pull.
     let namespace_resolver = namespace_resolver.clone();
     let current_namespace = match tokio::task::spawn_blocking(move || namespace_resolver()).await {
-        Ok(ns) => ns,
+        Ok(Ok(namespace)) => namespace,
+        Ok(Err(error)) => {
+            warn!(error = %error, "router federation: namespace resolve failed; will retry");
+            return FederationOutcome::Failed(format!("namespace resolve failed: {error}"));
+        }
         Err(e) => {
             warn!(error = %e, "router federation: namespace resolve task panicked; will retry");
             return FederationOutcome::Failed(format!("namespace resolve task panicked: {e}"));
         }
     };
-    if current_namespace != startup_namespace {
+    if &current_namespace != startup_namespace {
         info!(
             from = %startup_namespace,
             to = %current_namespace,
-            "router federation: organization namespace changed; requesting a daemon restart \
+            "router federation: workspace namespace changed; requesting a daemon restart \
              (a namespace change cannot be applied to a live session)"
         );
         return FederationOutcome::Restart;
@@ -760,7 +756,7 @@ mod tests {
     /// startup namespace these tests pass, so no namespace change is detected and
     /// the existing federation behavior (Applied/Pinned/...) is exercised.
     fn local_ns_resolver() -> NamespaceResolver {
-        Arc::new(|| "local".to_string())
+        Arc::new(|| Ok(config::namespace::Namespace::local()))
     }
 
     /// A namespace resolver returning a fixed value and counting its calls, for a
@@ -768,10 +764,10 @@ mod tests {
     fn counting_ns_resolver(value: &str) -> (NamespaceResolver, Arc<AtomicUsize>) {
         let calls = Arc::new(AtomicUsize::new(0));
         let counter = calls.clone();
-        let value = value.to_string();
+        let value = config::namespace::Namespace::parse(value).unwrap();
         let resolver: NamespaceResolver = Arc::new(move || {
             counter.fetch_add(1, Ordering::SeqCst);
-            value.clone()
+            Ok(value.clone())
         });
         (resolver, calls)
     }
@@ -782,13 +778,13 @@ mod tests {
     /// `Restart` ack distinctly from the startup restart path.
     fn switching_ns_resolver(first: &str, rest: &str) -> NamespaceResolver {
         let calls = AtomicUsize::new(0);
-        let first = first.to_string();
-        let rest = rest.to_string();
+        let first = config::namespace::Namespace::parse(first).unwrap();
+        let rest = config::namespace::Namespace::parse(rest).unwrap();
         Arc::new(move || {
             if calls.fetch_add(1, Ordering::SeqCst) == 0 {
-                first.clone()
+                Ok(first.clone())
             } else {
-                rest.clone()
+                Ok(rest.clone())
             }
         })
     }
@@ -811,7 +807,7 @@ mod tests {
             Duration::from_millis(50),
             &mut applied,
             true,
-            "local",
+            &config::namespace::Namespace::local(),
             &local_ns_resolver(),
         )
         .await;
@@ -853,7 +849,7 @@ mod tests {
             trigger_rx,
             ready_tx,
             Duration::from_secs(5),
-            "local".to_string(),
+            config::namespace::Namespace::local(),
             local_ns_resolver(),
             watch::channel(false).0,
             None,
@@ -928,7 +924,7 @@ mod tests {
             ready_tx,
             // A deliberately large connect_timeout: the probe must NOT inherit it.
             Duration::from_secs(45),
-            "local".to_string(),
+            config::namespace::Namespace::local(),
             local_ns_resolver(),
             watch::channel(false).0,
             None,
@@ -978,7 +974,7 @@ mod tests {
             trigger_rx,
             ready_tx,
             Duration::from_secs(5),
-            "local".to_string(),
+            config::namespace::Namespace::local(),
             local_ns_resolver(),
             watch::channel(false).0,
             None,
@@ -1035,7 +1031,7 @@ mod tests {
             trigger_rx,
             ready_tx,
             Duration::from_secs(5),
-            "local".to_string(),
+            config::namespace::Namespace::local(),
             local_ns_resolver(),
             watch::channel(false).0,
             None,
@@ -1099,7 +1095,7 @@ mod tests {
             trigger_rx,
             ready_tx,
             Duration::from_millis(100),
-            "local".to_string(),
+            config::namespace::Namespace::local(),
             local_ns_resolver(),
             watch::channel(false).0,
             Some(presence_gate_tx),
@@ -1142,7 +1138,7 @@ mod tests {
             trigger_rx,
             ready_tx,
             Duration::from_secs(5),
-            "local".to_string(),
+            config::namespace::Namespace::local(),
             local_ns_resolver(),
             watch::channel(false).0,
             Some(presence_gate_tx),
@@ -1188,7 +1184,7 @@ mod tests {
             trigger_rx,
             ready_tx,
             Duration::from_secs(5),
-            "local".to_string(),
+            config::namespace::Namespace::local(),
             local_ns_resolver(),
             watch::channel(false).0,
             None,
@@ -1219,7 +1215,7 @@ mod tests {
         let (resolver, _calls) = counting_resolver(upstream());
         let (prober, probe_calls) = counting_prober(Ok(()));
         // Startup resolves `local` (matches the startup namespace ⇒ no startup
-        // restart); the poke resolves the changed org id ⇒ a steady-state Restart.
+        // restart); the poke resolves the changed workspace id, producing a steady-state Restart.
         let ns_resolver = switching_ns_resolver("local", "550e8400-e29b-41d4-a716-446655440000");
         let (messaging_tx, messaging_rx) = watch::channel(true);
         let (trigger_tx, trigger_rx) = mpsc::channel(8);
@@ -1235,7 +1231,7 @@ mod tests {
             trigger_rx,
             ready_tx,
             Duration::from_secs(5),
-            "local".to_string(),
+            config::namespace::Namespace::local(),
             ns_resolver,
             restart_tx,
             None,
@@ -1285,7 +1281,7 @@ mod tests {
     async fn startup_poll_requests_restart_on_namespace_drift() {
         let (resolver, _calls) = counting_resolver(upstream());
         let (prober, probe_calls) = counting_prober(Ok(()));
-        // Every resolve returns an org id that differs from the `local` startup
+        // Every resolve returns a workspace id that differs from the `local` startup
         // namespace, so the very first (startup) poll detects the drift.
         let (ns_resolver, ns_calls) = counting_ns_resolver("550e8400-e29b-41d4-a716-446655440000");
         let (messaging_tx, messaging_rx) = watch::channel(true);
@@ -1301,7 +1297,7 @@ mod tests {
             trigger_rx,
             ready_tx,
             Duration::from_secs(5),
-            "local".to_string(),
+            config::namespace::Namespace::local(),
             ns_resolver,
             restart_tx,
             None,

--- a/crates/daemon-internal/src/state.rs
+++ b/crates/daemon-internal/src/state.rs
@@ -20,31 +20,22 @@ pub struct DaemonState {
     pub core_node_name: String,
     pub daemon_pid: Option<u32>,
     /// The dial host the daemon, CLI, and spawned nodes use for the messaging
-    /// router. Older state files predate this field and therefore resolve to the
-    /// historical loopback host.
-    #[serde(default = "default_messaging_host")]
+    /// router.
     pub messaging_host: String,
     /// The dial port the messaging router is serving.
-    #[serde(default = "default_messaging_port")]
     pub messaging_port: u16,
     /// The git hash of the peppy binary at compile time.
-    #[serde(default)]
     pub git_hash: String,
     /// Cooperative-shutdown grace period the daemon resolved from
     /// `peppy_config.lifecycle.shutdown_grace_secs`. Surfaced here so a client
     /// command (`peppy node stop`) can size its request timeout to exceed the
-    /// daemon's grace + reap window. Defaulted on read so a state file written
-    /// by a daemon predating this field still parses.
-    #[serde(default = "default_shutdown_grace_secs")]
+    /// daemon's grace + reap window.
     pub shutdown_grace_secs: u64,
-    /// The organization namespace this daemon generation resolved at startup
-    /// (`"local"` when logged out, else the org id). A CLI control session reads
-    /// it so it opens its session under exactly the daemon's namespace; it is
-    /// written before the control socket binds, so a reader never sees a half-set
-    /// generation. Defaulted to `"local"` on read so a state file written before
-    /// this field still parses.
-    #[serde(default = "default_organization_namespace")]
-    pub organization_namespace: String,
+    /// The workspace namespace this daemon generation resolved at startup
+    /// (`local` when logged out, else the workspace id). A CLI control session
+    /// reads it so it opens under exactly the daemon's namespace. The field is
+    /// required and typed: missing or invalid persisted state fails at read.
+    pub namespace: config::namespace::Namespace,
     /// `Some(secs)` when this daemon generation armed managed-router federation
     /// (a control socket exists and login/logout pokes apply within this bound,
     /// the daemon's `zenoh.managed.federation.connect_timeout_secs` at startup);
@@ -55,22 +46,6 @@ pub struct DaemonState {
     pub federation_connect_timeout_secs: Option<u64>,
 }
 
-fn default_organization_namespace() -> String {
-    config::org::LOCAL_NAMESPACE.to_string()
-}
-
-fn default_messaging_port() -> u16 {
-    config::consts::DEFAULT_MESSAGING_PORT
-}
-
-fn default_messaging_host() -> String {
-    config::consts::DEFAULT_MESSAGING_HOST.to_string()
-}
-
-fn default_shutdown_grace_secs() -> u64 {
-    config::peppy_config::DEFAULT_SHUTDOWN_GRACE_SECS
-}
-
 impl DaemonState {
     pub fn new(
         core_node_name: impl Into<String>,
@@ -78,7 +53,7 @@ impl DaemonState {
         messaging_port: u16,
         git_hash: impl Into<String>,
         shutdown_grace_secs: u64,
-        organization_namespace: impl Into<String>,
+        namespace: config::namespace::Namespace,
         federation_connect_timeout_secs: Option<u64>,
     ) -> Self {
         Self {
@@ -88,7 +63,7 @@ impl DaemonState {
             messaging_port,
             git_hash: git_hash.into(),
             shutdown_grace_secs,
-            organization_namespace: organization_namespace.into(),
+            namespace,
             federation_connect_timeout_secs,
         }
     }
@@ -177,7 +152,7 @@ mod tests {
             messaging_port: 7447,
             git_hash: "test".to_string(),
             shutdown_grace_secs: 5,
-            organization_namespace: "local".to_string(),
+            namespace: config::namespace::Namespace::local(),
             federation_connect_timeout_secs: Some(30),
         };
         DaemonState::write_to(&path, &original).expect("write");
@@ -189,7 +164,7 @@ mod tests {
         assert_eq!(read.messaging_port, 7447);
         assert_eq!(read.git_hash, "test");
         assert_eq!(read.shutdown_grace_secs, 5);
-        assert_eq!(read.organization_namespace, "local");
+        assert_eq!(read.namespace, config::namespace::Namespace::local());
         assert_eq!(read.federation_connect_timeout_secs, Some(30));
     }
 
@@ -199,15 +174,47 @@ mod tests {
         let path = dir.path().join("daemon_state.json5");
         std::fs::write(
             &path,
-            r#"{ "core_node_name": "old", "daemon_pid": null, "written_at_ms": 1234 }"#,
+            r#"{
+                "core_node_name": "old",
+                "daemon_pid": null,
+                "messaging_host": "127.0.0.1",
+                "messaging_port": 7448,
+                "git_hash": "old",
+                "shutdown_grace_secs": 5,
+                "namespace": "local",
+                "federation_connect_timeout_secs": null,
+                "written_at_ms": 1234
+            }"#,
         )
         .expect("write file with unknown field");
 
         let read = DaemonState::read_from(&path).expect("read");
         assert_eq!(read.core_node_name, "old");
         assert_eq!(read.daemon_pid, None);
-        assert_eq!(read.messaging_host, config::consts::DEFAULT_MESSAGING_HOST);
-        assert_eq!(read.messaging_port, config::consts::DEFAULT_MESSAGING_PORT);
+        assert_eq!(read.messaging_host, "127.0.0.1");
+        assert_eq!(read.messaging_port, 7448);
+    }
+
+    #[test]
+    fn an_invalid_namespace_fails_the_read() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("daemon_state.json5");
+        std::fs::write(
+            &path,
+            r#"{
+                "core_node_name": "bad",
+                "daemon_pid": null,
+                "messaging_host": "127.0.0.1",
+                "messaging_port": 7448,
+                "git_hash": "test",
+                "shutdown_grace_secs": 5,
+                "namespace": "**",
+                "federation_connect_timeout_secs": null
+            }"#,
+        )
+        .expect("write invalid state");
+
+        assert!(DaemonState::read_from(&path).is_err());
     }
 
     #[cfg(unix)]

--- a/crates/peppy/src/commands.rs
+++ b/crates/peppy/src/commands.rs
@@ -207,7 +207,7 @@ mod tests {
                 target_is_override: target != "local-daemon",
                 git_hash: "test-git-hash".to_string(),
                 shutdown_grace_secs: 5,
-                organization_namespace: "local".to_string(),
+                namespace: config::namespace::Namespace::local(),
             };
 
             // Target == local (the no-override shape): allowed.

--- a/crates/peppy/src/commands/node/runtime_config.rs
+++ b/crates/peppy/src/commands/node/runtime_config.rs
@@ -120,14 +120,14 @@ async fn print_runtime_config_async(
     )
     .map_err(Error::PeppyConfig)?;
 
-    // Reflect the daemon's organization namespace, exactly as `apply_daemon_defaults`
+    // Reflect the daemon's workspace namespace, exactly as `apply_daemon_defaults`
     // stamps it onto a launched node, so this inspection output matches the session
     // namespace a real node would open under. Reuse the namespace captured when the
     // connection was established (above) rather than reading the state again, which
     // could race a restart and pair this generation's stack lookup with another
     // generation's namespace.
     let mut runtime_config = runtime_config;
-    runtime_config.discovery.organization_id = Some(conn.organization_namespace);
+    runtime_config.discovery.namespace = Some(conn.namespace);
 
     let runtime_config_json = serde_json::to_string(&runtime_config).map_err(|e| {
         Error::ExecutionFailed(format!("Failed to serialize runtime config: {}", e))

--- a/crates/peppy/src/commands/platform.rs
+++ b/crates/peppy/src/commands/platform.rs
@@ -3,7 +3,7 @@
 //! token storage, and credential resolution they share live in the separate
 //! `auth` engine crate. The group is named for the platform account rather than
 //! for auth because signing in does more than obtain a token: it stamps this
-//! machine's organization namespace and pokes the running daemon to refederate
+//! machine's workspace namespace and pokes the running daemon to refederate
 //! its messaging router, and a login whose federation link cannot be
 //! established fails.
 
@@ -51,16 +51,13 @@ const RESTART_POLL_DEADLINE: Duration = Duration::from_secs(60);
 const STACK_PROBE_TIMEOUT: Duration = Duration::from_secs(3);
 
 /// The namespace the on-disk credentials under `dirs` resolve to (`local` when
-/// logged out, else the org id). The same resolution the daemon does at startup,
+/// logged out, else the workspace id). The same resolution the daemon does at startup,
 /// so the CLI can confirm the daemon came back under exactly what it just wrote.
 /// Reads the credentials from the same `dirs` the command resolved, so a test
 /// seam isolates it.
-fn current_creds_namespace(dirs: &PeppyDirs) -> String {
-    config::org::resolve_session_namespace(
-        auth::router::cached_organization_id(&auth::storage::credentials_path(dirs)).as_deref(),
-    )
-    .as_str()
-    .to_string()
+fn current_creds_namespace(dirs: &PeppyDirs) -> Result<config::namespace::Namespace> {
+    auth::router::session_namespace(&auth::storage::credentials_path(dirs))
+        .map_err(|error| Error::Auth(error.to_string()))
 }
 
 /// Whether a federation poke follows a login (federate) or a logout
@@ -133,7 +130,7 @@ pub(crate) fn confirm_restart(
         FederationPokeAction::Logout => "Logging out",
     };
     eprintln!(
-        "{verb} changes this machine's organization namespace, which restarts the messaging \
+        "{verb} changes this machine's workspace namespace, which restarts the messaging \
          daemon and wipes the running node stack."
     );
     eprint!("Continue? [y/N] ");
@@ -264,7 +261,7 @@ fn await_restart(
     action: &FederationPokeAction,
 ) -> Result<()> {
     // The namespace the daemon must come back under (what we just wrote).
-    let expected = current_creds_namespace(dirs);
+    let expected = current_creds_namespace(dirs)?;
     // This helper is shared by both flows, so the recovery guidance must name the
     // caller's own subcommand rather than always saying `login`.
     let subcommand = match action {
@@ -285,7 +282,7 @@ fn await_restart(
 
         // A concurrent login/logout rewrote the credentials mid-restart, so the
         // daemon will not come back under what we wrote.
-        if current_creds_namespace(dirs) != expected {
+        if current_creds_namespace(dirs)? != expected {
             break Err(Error::Auth(format!(
                 "credentials changed during restart; re-run `peppy platform {subcommand}`"
             )));
@@ -297,7 +294,7 @@ fn await_restart(
         // Read from the same `dirs` the command resolved, like the socket path.
         let back_under_expected = matches!(
             DaemonState::read_from(&DaemonState::state_file_in(dirs.root())),
-            Ok(state) if state.organization_namespace == expected
+            Ok(state) if state.namespace == expected
         );
         if !back_under_expected {
             continue;
@@ -505,7 +502,15 @@ mod tests {
     /// Writes a daemon state file under `dirs` whose recorded pid is this test
     /// process (so `is_running` holds) and whose federation field is `timeout`.
     fn write_running_state(dirs: &PeppyDirs, timeout: Option<u64>) {
-        let state = DaemonState::new("cn-test", "127.0.0.1", 7447, "test", 5, "local", timeout);
+        let state = DaemonState::new(
+            "cn-test",
+            "127.0.0.1",
+            7447,
+            "test",
+            5,
+            config::namespace::Namespace::local(),
+            timeout,
+        );
         DaemonState::write_to(&DaemonState::state_file_in(dirs.root()), &state)
             .expect("write daemon state");
     }
@@ -555,7 +560,15 @@ mod tests {
     fn a_stale_state_file_from_a_dead_daemon_falls_back_to_the_disk_config() {
         let dir = tempfile::tempdir().expect("tempdir");
         let dirs = PeppyDirs::new(dir.path());
-        let mut state = DaemonState::new("cn-test", "127.0.0.1", 7447, "test", 5, "local", None);
+        let mut state = DaemonState::new(
+            "cn-test",
+            "127.0.0.1",
+            7447,
+            "test",
+            5,
+            config::namespace::Namespace::local(),
+            None,
+        );
         // A pid outside the valid range names no live process, so the state is
         // stale and the disk config decides again.
         state.daemon_pid = Some(u32::MAX);

--- a/crates/peppy/src/commands/platform/login.rs
+++ b/crates/peppy/src/commands/platform/login.rs
@@ -47,7 +47,7 @@ impl Command for LoginCommand {
         let http = HttpClient::new();
 
         // With a managed router, warn (before authentication begins) that a login
-        // changing the organization namespace restarts the daemon and wipes the
+        // changing the workspace namespace restarts the daemon and wipes the
         // running node stack. Bypassed by `--yes`, and skipped when no daemon is
         // running or its node stack holds no user nodes (so the restart wipes
         // nothing). External mode never pokes or restarts the daemon.
@@ -69,7 +69,7 @@ impl Command for LoginCommand {
         )?;
 
         // Persist immediately so a transient `/me` failure can't lose a good login.
-        // Load-resilient: a malformed / pre-`organization_id` / version-mismatched
+        // Load-resilient: a malformed / pre-`workspace_id` / version-mismatched
         // file fails to parse with `Error::Auth`; start fresh rather than wedge
         // login on it (the stale file self-heals on this save).
         let mut creds = match storage::load(&creds_path) {

--- a/crates/peppy/src/commands/platform/logout.rs
+++ b/crates/peppy/src/commands/platform/logout.rs
@@ -36,7 +36,7 @@ impl Command for LogoutCommand {
         let creds_path = storage::credentials_path(&dirs);
         let http = HttpClient::new();
 
-        // Load-resilient: a malformed / pre-`organization_id` file fails to parse
+        // Load-resilient: a malformed / pre-`workspace_id` file fails to parse
         // with `Error::Auth`; treat it as "already effectively logged out" rather
         // than wedging logout. A default has no session, so the early return below
         // would otherwise leave the bad file on disk; overwrite it with a clean

--- a/crates/peppy/src/context.rs
+++ b/crates/peppy/src/context.rs
@@ -93,13 +93,10 @@ impl AppContext {
         &self,
         messaging_host: &str,
         messaging_port: u16,
-        organization_namespace: &str,
+        namespace: config::namespace::Namespace,
     ) -> crate::error::Result<()> {
-        // Open the control session under the daemon's namespace so the CLI reaches
-        // the daemon/node services that run under it. The daemon recorded the
-        // namespace in `DaemonState` before binding the control socket, so it is a
-        // valid value; resolve defensively (a bad value falls back to `local`).
-        let namespace = config::org::resolve_session_namespace(Some(organization_namespace));
+        // Open the control session under the typed namespace recorded by the
+        // daemon generation so the CLI reaches its daemon and node services.
         self.messenger_handle
             .get_or_try_init(|| async {
                 MessengerHandle::connect(messaging_host, messaging_port)
@@ -136,12 +133,12 @@ pub(crate) struct DaemonConnection<'a> {
     /// node, from its `peppy_config`. Lets `node stop` size its request timeout
     /// to outlast the daemon's grace + reap window.
     pub shutdown_grace_secs: u64,
-    /// The organization namespace recorded by the generation this connection was
+    /// The workspace namespace recorded by the generation this connection was
     /// established against, captured from the *same* `DaemonState` read the
     /// connection used. Callers reuse this instead of reading the state again,
     /// which could race a restart and pair this connection's data with a different
     /// generation's namespace.
-    pub organization_namespace: String,
+    pub namespace: config::namespace::Namespace,
 }
 
 impl AppContext {
@@ -150,7 +147,7 @@ impl AppContext {
         self.connect_with_endpoint(
             &daemon_state.messaging_host,
             daemon_state.messaging_port,
-            &daemon_state.organization_namespace,
+            daemon_state.namespace.clone(),
         )
         .await?;
         let messenger = self
@@ -168,7 +165,7 @@ impl AppContext {
             target_is_override,
             git_hash: daemon_state.git_hash,
             shutdown_grace_secs: daemon_state.shutdown_grace_secs,
-            organization_namespace: daemon_state.organization_namespace,
+            namespace: daemon_state.namespace,
         })
     }
 }
@@ -200,7 +197,7 @@ mod tests {
             0,
             "test-git-hash",
             config::peppy_config::DEFAULT_SHUTDOWN_GRACE_SECS,
-            "local",
+            config::namespace::Namespace::local(),
             None,
         );
         DaemonState::write_to(&state_path, &state).expect("daemon state should write");

--- a/crates/peppy/src/main.rs
+++ b/crates/peppy/src/main.rs
@@ -24,7 +24,7 @@ struct Cli {
     /// Core-node name of the daemon to target (see `peppy info`). Defaults
     /// to the local daemon. The local daemon must be running either way (its
     /// router and federation carry the traffic), and a remote daemon must
-    /// belong to the same organization.
+    /// use the same workspace namespace.
     #[arg(long = "core-node", global = true, value_name = "NAME", value_parser = parse_core_node_target)]
     core_node: Option<String>,
 }

--- a/crates/peppy/src/test_support.rs
+++ b/crates/peppy/src/test_support.rs
@@ -152,7 +152,7 @@ impl ServeCommandEmulation {
             None,
             true,
             pmi::SubscriberBufferSizes::default(),
-            Some(pmi::OrgNamespace::local()),
+            Some(pmi::Namespace::local()),
         )
         .await?;
         instance.messenger().start_session().await?;
@@ -205,7 +205,7 @@ impl ServeCommandEmulation {
             root_dir: temp_dir.path().to_path_buf(),
             peppy_dirs,
             peppy_config: daemon_config::peppy_config::PeppyConfig::default(),
-            organization_namespace: "local".to_string(),
+            namespace: config::namespace::Namespace::local(),
             shutdown_token: shutdown_token.clone(),
         });
         let core_node_name = core_node.node_name().to_string();
@@ -236,7 +236,7 @@ impl ServeCommandEmulation {
             port,
             "test-git-hash",
             config::peppy_config::DEFAULT_SHUTDOWN_GRACE_SECS,
-            "local",
+            config::namespace::Namespace::local(),
             None,
         );
         DaemonState::write_to(&daemon_state_path, &daemon_state)

--- a/crates/peppy/tests/platform_flow.rs
+++ b/crates/peppy/tests/platform_flow.rs
@@ -402,7 +402,7 @@ fn external_logout_does_not_poke_federation_control() {
 
 #[test]
 fn logout_heals_a_malformed_credentials_file() {
-    // A malformed (e.g. pre-`organization_id`/unversioned) credentials file fails
+    // A malformed (e.g. pre-`workspace_id`/unversioned) credentials file fails
     // to parse with `AuthError::Auth`. Logout treats that as "already logged out",
     // but it must still rewrite the file to a clean default so the bad file does
     // not linger on disk (the early "Not logged in" return used to skip the save).

--- a/docs/src/content/docs/advanced_guides/daemon_config.mdx
+++ b/docs/src/content/docs/advanced_guides/daemon_config.mdx
@@ -189,7 +189,7 @@ Both values must be greater than `0`; the daemon rejects a zero buffer size at s
 
 ## `zenoh.managed.federation`: cloud-router timeout
 
-When you are logged in under `zenoh.managed`, the daemon links ("federates") its local messaging router to your organization's private cloud router so that robots signed in to the same organization interoperate across the federation (see [Platform](/advanced_guides/platform/#organization-federation)). Resolving that cloud router involves a backend round-trip, and this block bounds it.
+When you are logged in under `zenoh.managed`, the daemon links ("federates") its local messaging router to your workspace's private cloud router so that sessions using the same workspace namespace can interoperate across the federation (see [Platform](/advanced_guides/platform/#workspace-federation)). The namespace is routing context only, not proof of membership, a tenant-isolation boundary, or an authorization policy. Resolving that cloud router involves a backend round-trip, and this block bounds it.
 
 - **`connect_timeout_secs`** (default `30`, minimum `1`): how long the daemon spends resolving the cloud router (once at startup, and again each time `peppy platform login` / `logout` pokes the daemon) before giving up for that attempt. If the backend is unreachable within the window, the daemon leaves its router **standalone** and retries federation in the background rather than blocking startup. A logged-out daemon never federates, so this timeout does not apply to it.
 
@@ -245,7 +245,7 @@ The URL is resolved in precedence order: `--api-url`, then `PEPPY_API_URL`, then
 | `lifecycle.daemon_grace_secs` | `180` | `>= 30` | Seconds without a daemon heartbeat before a spawned node self-terminates (unclean daemon death only). |
 | `lifecycle.shutdown_grace_secs` | `5` | `>= 1` | Seconds a clean shutdown and `peppy node stop` wait for cooperative exit (plus a fixed runtime-teardown allowance) before force-killing. |
 | `resource_servers.api` | `https://api.peppy.bot` (release), `http://127.0.0.1:3000` (debug) | `https`, or `http` for local hosts | Backend the CLI auth commands talk to. Read by the CLI, not the daemon. |
-| `zenoh.managed.federation.connect_timeout_secs` | `30` | `>= 1` | Seconds the daemon spends resolving your organization's cloud router (at startup and on each auth login/logout) before falling back to a standalone router. |
+| `zenoh.managed.federation.connect_timeout_secs` | `30` | `>= 1` | Seconds the daemon spends resolving your workspace's cloud router (at startup and on each auth login/logout) before falling back to a standalone router. |
 | `zenoh.external.endpoint` | No default | Required inside `external`; `tcp/<dial-host>:<port>`; no wildcard host | Network endpoint of the operator-run router. Peppy dials it without changing its federation or managing its lifecycle. |
 
 Both Zenoh variants at once, a value outside its constraint, an unsupported `zenoh.external.endpoint`, an unknown `zenoh.managed.local_nodes_topology` value, an unknown key inside `zenoh` or either variant, or a syntax error all stop the operation that loaded the configuration with an error pointing at the problem. An out-of-range value names the offending field, and a parse error reports the bad value or its position, so a typo can never silently revert your stack to defaults. Unknown top-level keys remain accepted and preserved.

--- a/docs/src/content/docs/advanced_guides/platform.mdx
+++ b/docs/src/content/docs/advanced_guides/platform.mdx
@@ -14,12 +14,12 @@ The CLI never sees your Google/passkey credentials. Those stay in the browser.
 
 | Command | What it does |
 |---------|--------------|
-| `peppy platform login [--api-url <url>] [--no-browser] [--yes]` | Logs in via the OAuth 2.0 Device Authorization Grant, caches the tokens, and federates a managed router to your organization's cloud router. |
+| `peppy platform login [--api-url <url>] [--no-browser] [--yes]` | Logs in via the OAuth 2.0 Device Authorization Grant, caches the tokens, and federates a managed router to your workspace's cloud router. |
 | `peppy platform whoami` (alias `status`) | Shows the current identity, backend, and token validity. `--json` for machine-readable output. |
 | `peppy platform logout [--yes]` | Revokes the access token on the backend (across replicas), deletes the local credentials, and de-federates a managed router. |
 
 `--yes` (`-y`) skips the daemon-restart confirmation prompt described under
-[Organization federation](#organization-federation).
+[Workspace federation](#workspace-federation).
 
 ## Logging in
 
@@ -51,16 +51,18 @@ peppy platform login --no-browser
 4. It caches the tokens (and the `issuer`/`client_id`, so refresh works offline)
    under `~/.peppy/conf/credentials.json5`.
 
-## Organization federation
+## Workspace federation
 
 Logging in does more than cache a token: it stamps this machine with your
-**organization namespace** (your account's stable organization id). Under
-`zenoh.managed`, it also federates the peppy daemon's local messaging router to
-your organization's private cloud router. Robots signed in to the same
-organization then interoperate across that federation, while different
-organizations stay routing-isolated. Logged out, the machine falls back to the
-`local` namespace, which never reaches the cloud router; two logged-out machines
-on the same LAN still discover each other, but nothing leaves the local network.
+**workspace namespace**, using the stable `workspace_id` returned by the backend.
+The namespace is messaging routing context only. It is not proof of workspace
+membership, a tenant-isolation boundary, or an authorization policy, and it does
+not enforce ACLs. Under `zenoh.managed`, the daemon also federates its local
+messaging router to the workspace cloud router. Sessions using the same workspace
+namespace can interoperate across that federation, while different namespaces
+take separate routing paths. Logged out, the machine falls back to the `local`
+namespace, which never reaches the cloud router; two logged-out machines on the
+same LAN still discover each other, but nothing leaves the local network.
 
 A session's namespace is fixed once the daemon opens it. Under `zenoh.managed`,
 changing that namespace by logging in or out **restarts the messaging daemon and
@@ -68,7 +70,7 @@ wipes the running node stack**. When a managed daemon is running with user nodes
 `login` and `logout` confirm first:
 
 ```
-Logging in changes this machine's organization namespace, which restarts the messaging daemon and wipes the running node stack.
+Logging in changes this machine's workspace namespace, which restarts the messaging daemon and wipes the running node stack.
 Continue? [y/N]
 ```
 
@@ -131,7 +133,7 @@ token you presented; a session on another device keeps working.
 Logout also returns this machine to the `local` namespace. Under `zenoh.managed`,
 it de-federates the router, restarts the daemon, and wipes the running node stack,
 with the same confirmation prompt and `--yes` bypass (see
-[Organization federation](#organization-federation)). Under `zenoh.external`,
+[Workspace federation](#workspace-federation)). Under `zenoh.external`,
 the operator's federation is left untouched and the namespace changes on the
 next manual daemon restart.
 


### PR DESCRIPTION
…ss auth, daemon, and core-node crates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace namespaces are now used consistently across authentication, routing, federation, daemon state, and runtime configuration.
  * Added typed session-namespace resolution from credentials, with a local fallback when credentials are missing or unstamped.
  * Federation and router behavior now detect workspace namespace changes and trigger a daemon restart when needed.
* **Bug Fixes**
  * Invalid or malformed workspace identifiers are rejected safely during credential/session deserialization.
* **Documentation**
  * Updated CLI help and platform/daemon documentation to use workspace (instead of organization) terminology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->