### PR TITLE
Add a build-profile-aware transport policy for control-plane URLs, al…

### DIFF
--- a/crates/auth-internal/src/cli_config.rs
+++ b/crates/auth-internal/src/cli_config.rs
@@ -6,7 +6,7 @@
 use serde::Deserialize;
 
 use super::http::HttpClient;
-use super::profile;
+use super::profile::{self, TransportPolicy};
 use crate::error::{Error, Result};
 
 /// The three fields the backend serves to the CLI (no endpoint URLs; those come
@@ -20,7 +20,9 @@ pub struct CliConfig {
 
 /// Fetches `/cli/auth-config`. A `503` means the deployment hasn't provisioned the
 /// CLI client yet (`PEPPY_CLI_CLIENT_ID` / `PEPPY_INTROSPECT_AUDIENCE` unset).
-pub fn fetch(http: &HttpClient, api_url: &str) -> Result<CliConfig> {
+/// Callers pass [`profile::build_transport_policy`]; the parameter exists so the
+/// strict policy stays exercisable from tests in any build profile.
+pub fn fetch(http: &HttpClient, api_url: &str, policy: TransportPolicy) -> Result<CliConfig> {
     let url = format!("{}/cli/auth-config", api_url.trim_end_matches('/'));
     let resp = http.get(&url, None)?;
     match resp.status {
@@ -30,7 +32,7 @@ pub fn fetch(http: &HttpClient, api_url: &str) -> Result<CliConfig> {
             // flow, up to and including the token exchange, is aimed at
             // whatever it names. Apply the transport policy here, at the point
             // it enters the process, rather than at each of those steps.
-            profile::validate_https_or_local(&config.issuer, "OIDC issuer")?;
+            profile::validate_https_or_local_with(&config.issuer, "OIDC issuer", policy)?;
             Ok(config)
         }
         503 => Err(Error::Auth(
@@ -57,8 +59,12 @@ mod tests {
             }));
         });
 
-        let error = fetch(&HttpClient::new(), &server.base_url())
-            .expect_err("a remote plain http issuer must not reach discovery");
+        let error = fetch(
+            &HttpClient::new(),
+            &server.base_url(),
+            TransportPolicy::Strict,
+        )
+        .expect_err("a remote plain http issuer must not reach discovery");
         assert!(error.to_string().contains("plain http"), "{error}");
     }
 }

--- a/crates/auth-internal/src/device.rs
+++ b/crates/auth-internal/src/device.rs
@@ -10,7 +10,7 @@ use serde::Deserialize;
 
 use super::discovery::OidcEndpoints;
 use super::http::HttpClient;
-use super::profile;
+use super::profile::{self, TransportPolicy};
 use super::storage::now_unix;
 use crate::error::{Error, Result};
 
@@ -145,6 +145,7 @@ pub fn start(
     endpoints: &OidcEndpoints,
     client_id: &str,
     scopes: &str,
+    policy: TransportPolicy,
 ) -> Result<DeviceAuthorization> {
     let start = http.post_form(
         &endpoints.device_authorization_endpoint,
@@ -159,7 +160,7 @@ pub fn start(
         )));
     }
     let mut authorization: DeviceAuthorization = start.json("device authorization")?;
-    canonicalize_verification_urls(endpoints, &mut authorization)?;
+    canonicalize_verification_urls(endpoints, &mut authorization, policy)?;
     Ok(authorization)
 }
 
@@ -178,14 +179,17 @@ pub fn start(
 fn canonicalize_verification_urls(
     endpoints: &OidcEndpoints,
     authorization: &mut DeviceAuthorization,
+    policy: TransportPolicy,
 ) -> Result<()> {
-    let device_endpoint = profile::validate_https_or_local(
+    let device_endpoint = profile::validate_https_or_local_with(
         &endpoints.device_authorization_endpoint,
         "OIDC device authorization endpoint",
+        policy,
     )?;
-    let verification = profile::validate_https_or_local(
+    let verification = profile::validate_https_or_local_with(
         &authorization.verification_uri,
         "device verification URI",
+        policy,
     )?;
     if device_endpoint.scheme() == "https" && verification.scheme() != "https" {
         return Err(Error::Auth(
@@ -197,8 +201,11 @@ fn canonicalize_verification_urls(
         .verification_uri_complete
         .as_deref()
         .map(|complete| {
-            let parsed =
-                profile::validate_https_or_local(complete, "complete device verification URI")?;
+            let parsed = profile::validate_https_or_local_with(
+                complete,
+                "complete device verification URI",
+                policy,
+            )?;
             if device_endpoint.scheme() == "https" && parsed.scheme() != "https" {
                 return Err(Error::Auth(
                     "complete device verification URI attempts an HTTPS to HTTP downgrade".into(),
@@ -293,8 +300,14 @@ mod tests {
             revocation_endpoint: None,
         };
 
-        let error = start(&HttpClient::new(), &endpoints, "client", "openid")
-            .expect_err("a remote cleartext URL must never reach browser-opening code");
+        let error = start(
+            &HttpClient::new(),
+            &endpoints,
+            "client",
+            "openid",
+            TransportPolicy::Strict,
+        )
+        .expect_err("a remote cleartext URL must never reach browser-opening code");
         assert!(error.to_string().contains("plain http"), "{error}");
         assert_eq!(authorization.calls(), 1);
     }
@@ -318,8 +331,14 @@ mod tests {
             revocation_endpoint: None,
         };
 
-        let error = start(&HttpClient::new(), &endpoints, "client", "openid")
-            .expect_err("the primary remote cleartext URL must be rejected too");
+        let error = start(
+            &HttpClient::new(),
+            &endpoints,
+            "client",
+            "openid",
+            TransportPolicy::Strict,
+        )
+        .expect_err("the primary remote cleartext URL must be rejected too");
         assert!(error.to_string().contains("plain http"), "{error}");
     }
 
@@ -333,8 +352,9 @@ mod tests {
         let mut authorization = device_auth(5, 300);
         authorization.verification_uri = "http://127.0.0.1/device".into();
 
-        let error = canonicalize_verification_urls(&endpoints, &mut authorization)
-            .expect_err("an https issuer flow cannot downgrade even to loopback http");
+        let error =
+            canonicalize_verification_urls(&endpoints, &mut authorization, TransportPolicy::Strict)
+                .expect_err("an https issuer flow cannot downgrade even to loopback http");
         assert!(error.to_string().contains("downgrade"), "{error}");
     }
 

--- a/crates/auth-internal/src/discovery.rs
+++ b/crates/auth-internal/src/discovery.rs
@@ -6,7 +6,7 @@
 use serde::Deserialize;
 
 use super::http::HttpClient;
-use super::profile;
+use super::profile::{self, TransportPolicy};
 use crate::error::{Error, Result};
 
 /// The endpoints the device flow needs, plus the (optional) revocation endpoint.
@@ -48,9 +48,9 @@ impl OidcDiscoveryDocument {
 /// itself, or an endpoint that fails the transport policy, is a hard error
 /// instead: those are answers from the wrong realm or over the wrong transport,
 /// not an unavailable document.
-pub fn discover(http: &HttpClient, issuer: &str) -> Result<OidcEndpoints> {
+pub fn discover(http: &HttpClient, issuer: &str, policy: TransportPolicy) -> Result<OidcEndpoints> {
     let issuer = issuer.trim_end_matches('/');
-    let parsed_issuer = profile::validate_https_or_local(issuer, "OIDC issuer")?;
+    let parsed_issuer = profile::validate_https_or_local_with(issuer, "OIDC issuer", policy)?;
     if parsed_issuer.query().is_some() || parsed_issuer.fragment().is_some() {
         return Err(Error::Auth(format!(
             "invalid OIDC issuer `{issuer}`: a query string or fragment is not allowed"
@@ -62,18 +62,18 @@ pub fn discover(http: &HttpClient, issuer: &str) -> Result<OidcEndpoints> {
         && resp.status == 200
         && let Ok(document) = serde_json::from_str::<OidcDiscoveryDocument>(&resp.body)
     {
-        validate_discovered_issuer(&parsed_issuer, &document.issuer)?;
+        validate_discovered_issuer(&parsed_issuer, &document.issuer, policy)?;
         let endpoints = document.endpoints();
         if !endpoints.device_authorization_endpoint.is_empty()
             && !endpoints.token_endpoint.is_empty()
         {
-            validate_endpoints(&parsed_issuer, &endpoints)?;
+            validate_endpoints(&parsed_issuer, &endpoints, policy)?;
             return Ok(endpoints);
         }
     }
 
     let endpoints = fallback(issuer);
-    validate_endpoints(&parsed_issuer, &endpoints)?;
+    validate_endpoints(&parsed_issuer, &endpoints, policy)?;
     Ok(endpoints)
 }
 
@@ -82,9 +82,14 @@ pub fn discover(http: &HttpClient, issuer: &str) -> Result<OidcEndpoints> {
 /// issuer by its literal URL, so normalizing case or ports any further than
 /// `Url::parse` already does would accept a realm the operator did not
 /// configure.
-fn validate_discovered_issuer(configured: &url::Url, discovered: &str) -> Result<()> {
+fn validate_discovered_issuer(
+    configured: &url::Url,
+    discovered: &str,
+    policy: TransportPolicy,
+) -> Result<()> {
     let discovered = discovered.trim_end_matches('/');
-    let parsed = profile::validate_https_or_local(discovered, "discovered OIDC issuer")?;
+    let parsed =
+        profile::validate_https_or_local_with(discovered, "discovered OIDC issuer", policy)?;
     if parsed.query().is_some() || parsed.fragment().is_some() {
         return Err(Error::Auth(format!(
             "invalid discovered OIDC issuer `{discovered}`: a query string or fragment is not allowed"
@@ -106,7 +111,11 @@ fn validate_discovered_issuer(configured: &url::Url, discovered: &str) -> Result
 /// loopback, because the issuer that authorized the flow was reached over TLS.
 /// A local HTTP issuer may advertise local HTTP endpoints, which is what the
 /// hermetic development stack runs on.
-fn validate_endpoints(issuer: &url::Url, endpoints: &OidcEndpoints) -> Result<()> {
+fn validate_endpoints(
+    issuer: &url::Url,
+    endpoints: &OidcEndpoints,
+    policy: TransportPolicy,
+) -> Result<()> {
     let mut values = vec![
         (
             "OIDC device authorization endpoint",
@@ -119,7 +128,7 @@ fn validate_endpoints(issuer: &url::Url, endpoints: &OidcEndpoints) -> Result<()
     }
 
     for (what, endpoint) in values {
-        let parsed = profile::validate_https_or_local(endpoint, what)?;
+        let parsed = profile::validate_https_or_local_with(endpoint, what, policy)?;
         if issuer.scheme() == "https" && parsed.scheme() != "https" {
             return Err(Error::Auth(format!(
                 "{what} attempts an HTTPS to HTTP downgrade"
@@ -159,9 +168,25 @@ mod tests {
 
     #[test]
     fn rejects_a_non_local_plain_http_issuer() {
-        let error = discover(&HttpClient::new(), "http://auth.example.test")
-            .expect_err("a remote OIDC issuer must use https");
+        let error = discover(
+            &HttpClient::new(),
+            "http://auth.example.test",
+            TransportPolicy::Strict,
+        )
+        .expect_err("a remote OIDC issuer must use https");
         assert!(error.to_string().contains("plain http"), "{error}");
+    }
+
+    /// Debug builds relax the transport policy so the dev backend can hand out
+    /// a plain-http issuer on a trusted network (LAN name or Tailscale IP).
+    /// The address comes from `100.64.0.0/10`, the shared address space
+    /// Tailscale allocates from, standing in for a TS-mode dev stack.
+    #[test]
+    fn permissive_policy_admits_a_non_local_plain_http_issuer() {
+        let issuer = url::Url::parse("http://100.64.0.7:8080").unwrap();
+        let endpoints = fallback(issuer.as_str().trim_end_matches('/'));
+        validate_endpoints(&issuer, &endpoints, TransportPolicy::AllowInsecureHttp)
+            .expect("the dev policy admits a trusted-network http issuer");
     }
 
     #[test]
@@ -173,9 +198,12 @@ mod tests {
             revocation_endpoint: Some("https://auth.example.test/revoke".into()),
         };
 
-        let error = validate_endpoints(&issuer, &endpoints).expect_err(
-            "an https issuer cannot downgrade its token endpoint, not even to loopback",
-        );
+        // The downgrade guard holds under the permissive policy too: it is
+        // about the issuer's own transport, not about host locality.
+        let error = validate_endpoints(&issuer, &endpoints, TransportPolicy::AllowInsecureHttp)
+            .expect_err(
+                "an https issuer cannot downgrade its token endpoint, not even to loopback",
+            );
         assert!(error.to_string().contains("downgrade"), "{error}");
     }
 
@@ -183,7 +211,8 @@ mod tests {
     fn local_development_issuer_and_endpoints_are_allowed() {
         let issuer = url::Url::parse("http://auth.peppy.localhost:8080").unwrap();
         let endpoints = fallback(issuer.as_str().trim_end_matches('/'));
-        validate_endpoints(&issuer, &endpoints).expect("the local development policy is explicit");
+        validate_endpoints(&issuer, &endpoints, TransportPolicy::Strict)
+            .expect("the local development policy is explicit");
     }
 
     #[test]
@@ -199,7 +228,7 @@ mod tests {
             }));
         });
 
-        let error = discover(&HttpClient::new(), &base)
+        let error = discover(&HttpClient::new(), &base, TransportPolicy::Strict)
             .expect_err("endpoints from a different issuer realm must be rejected");
         assert!(error.to_string().contains("issuer mismatch"), "{error}");
         assert_eq!(discovery.calls(), 1);

--- a/crates/auth-internal/src/profile.rs
+++ b/crates/auth-internal/src/profile.rs
@@ -5,23 +5,55 @@
 //! the `resource_servers` block of `peppy_config.json5` (seeded with the build
 //! default) and can be overridden at runtime via `--api-url` / `PEPPY_API_URL`.
 
+use std::sync::Once;
+
 use crate::error::{Error, Result};
 use daemon_config::peppy_config::ResourceServers;
 use url::{Host, Url};
+
+/// Transport policy for server-supplied control-plane URLs, fixed by the build
+/// profile via [`build_transport_policy`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransportPolicy {
+    /// https required for any non-local host. Release builds always use this.
+    Strict,
+    /// Plain http admitted for non-local hosts too, with a one-time warning.
+    /// Debug builds use this: they talk to the dev backend, whose launcher may
+    /// hand out plain-http control-plane URLs on a trusted network (LAN mDNS
+    /// name or Tailscale IP), so only dev credentials are at stake.
+    AllowInsecureHttp,
+}
+
+/// The policy for this build: strict in release, permissive in debug. A
+/// runtime check rather than `#[cfg]` so both arms stay compiled and the
+/// policy-dependent behavior stays testable in either build profile.
+pub fn build_transport_policy() -> TransportPolicy {
+    if cfg!(debug_assertions) {
+        TransportPolicy::AllowInsecureHttp
+    } else {
+        TransportPolicy::Strict
+    }
+}
 
 /// Resolves the backend base URL in precedence order: the `--api-url` flag,
 /// then `PEPPY_API_URL`, then the build's URL from the `resource_servers`
 /// block. Reads process env directly; pass the flag through from clap.
 pub fn resolve_api_url(api_url_flag: Option<&str>, servers: &ResourceServers) -> Result<String> {
-    resolve_api_url_from(api_url_flag, env_nonempty("PEPPY_API_URL"), servers)
+    resolve_api_url_from(
+        api_url_flag,
+        env_nonempty("PEPPY_API_URL"),
+        build_transport_policy(),
+        servers,
+    )
 }
 
-/// Pure core of [`resolve_api_url`] with the env input made explicit, so
+/// Pure core of [`resolve_api_url`] with the env inputs made explicit, so
 /// precedence and the transport guard can be unit-tested without mutating
 /// process env.
 pub fn resolve_api_url_from(
     api_url_flag: Option<&str>,
     env_api_url: Option<String>,
+    policy: TransportPolicy,
     servers: &ResourceServers,
 ) -> Result<String> {
     let api_url = api_url_flag
@@ -30,7 +62,7 @@ pub fn resolve_api_url_from(
         .unwrap_or_else(|| servers.api.clone());
 
     let api_url = api_url.trim_end_matches('/').to_string();
-    let parsed = validate_https_or_local(&api_url, "platform API")?;
+    let parsed = validate_https_or_local_with(&api_url, "platform API", policy)?;
     if parsed.query().is_some() || parsed.fragment().is_some() {
         return Err(Error::Auth(format!(
             "invalid platform API `{api_url}`: a query string or fragment is not allowed"
@@ -54,15 +86,24 @@ fn env_nonempty(key: &str) -> Option<String> {
     std::env::var(key).ok().filter(|v| !v.is_empty())
 }
 
-/// Validates one server-supplied control-plane URL. Plain `http` is allowed
-/// only for an actual loopback address, `localhost`, or `*.localhost`; anything
-/// else must be `https` so tokens never travel in cleartext.
+/// Validates one server-supplied control-plane URL under this build's policy.
+/// Plain `http` is allowed only for an actual loopback address, `localhost`,
+/// or `*.localhost`; anything else must be `https` so tokens never travel in
+/// cleartext. Debug builds relax the non-local restriction (with a one-time
+/// warning) because they target the dev backend; see [`build_transport_policy`].
 ///
 /// `what` names the subject ("platform API", "OIDC issuer", "OIDC token
 /// endpoint") so a rejection is attributable to the URL the caller was about to
 /// use. Returning the parsed [`Url`] lets a caller compare schemes and origins
 /// without parsing a security-sensitive value a second, weaker way.
 pub fn validate_https_or_local(raw: &str, what: &str) -> Result<Url> {
+    validate_https_or_local_with(raw, what, build_transport_policy())
+}
+
+/// Pure core of [`validate_https_or_local`] with the transport policy made
+/// explicit. The policy only widens the plain-http arm for non-local hosts;
+/// every other check stays strict regardless of policy.
+pub fn validate_https_or_local_with(raw: &str, what: &str, policy: TransportPolicy) -> Result<Url> {
     if raw.is_empty() || raw.trim() != raw {
         return Err(Error::Auth(format!(
             "invalid {what}: it must be non-empty and carry no surrounding whitespace"
@@ -83,13 +124,31 @@ pub fn validate_https_or_local(raw: &str, what: &str) -> Result<Url> {
     match parsed.scheme() {
         "https" => Ok(parsed),
         "http" if is_local(&parsed) => Ok(parsed),
+        "http" if policy == TransportPolicy::AllowInsecureHttp => {
+            warn_insecure_transport_once(what, &parsed);
+            Ok(parsed)
+        }
         "http" => Err(Error::Auth(format!(
-            "refusing plain http for non-local {what} `{raw}` (use https)"
+            "refusing plain http for non-local {what} `{raw}` (use https; plain http to a \
+             non-local host is allowed only in debug builds)"
         ))),
         other => Err(Error::Auth(format!(
             "unsupported URL scheme `{other}` in `{raw}`"
         ))),
     }
+}
+
+/// One warning per process, at the moment an insecure URL is actually
+/// admitted. The URL is safe to print: credential-bearing URLs were already
+/// rejected before the scheme match.
+fn warn_insecure_transport_once(what: &str, url: &Url) {
+    static WARNED: Once = Once::new();
+    WARNED.call_once(|| {
+        println!(
+            "Warning: allowing plain http for {what} {url} (debug build; a release build \
+             requires https)"
+        );
+    });
 }
 
 /// The canonical scheme, host, and port binding of the platform API. A path,
@@ -136,18 +195,25 @@ mod tests {
         let url = resolve_api_url_from(
             Some("http://localhost:9999"),
             Some("http://127.0.0.1:1".into()),
+            TransportPolicy::Strict,
             &servers,
         )
         .expect("resolve");
         assert_eq!(url, "http://localhost:9999");
 
         // PEPPY_API_URL beats the block default.
-        let url = resolve_api_url_from(None, Some("http://127.0.0.1:1".into()), &servers)
-            .expect("resolve");
+        let url = resolve_api_url_from(
+            None,
+            Some("http://127.0.0.1:1".into()),
+            TransportPolicy::Strict,
+            &servers,
+        )
+        .expect("resolve");
         assert_eq!(url, "http://127.0.0.1:1");
 
         // The block's api is the fallback.
-        let url = resolve_api_url_from(None, None, &servers).expect("resolve");
+        let url =
+            resolve_api_url_from(None, None, TransportPolicy::Strict, &servers).expect("resolve");
         assert_eq!(url, DEFAULT_API_URL);
     }
 
@@ -167,36 +233,86 @@ mod tests {
         let servers = ResourceServers {
             api: "http://localhost:9000".into(),
         };
-        let url = resolve_api_url_from(None, None, &servers).expect("resolve");
+        let url =
+            resolve_api_url_from(None, None, TransportPolicy::Strict, &servers).expect("resolve");
         assert_eq!(url, "http://localhost:9000");
     }
 
     #[test]
     fn trailing_slash_trimmed() {
-        let url = resolve_api_url_from(Some("http://localhost:3000/"), None, &servers())
-            .expect("resolve");
+        let url = resolve_api_url_from(
+            Some("http://localhost:3000/"),
+            None,
+            TransportPolicy::Strict,
+            &servers(),
+        )
+        .expect("resolve");
         assert_eq!(url, "http://localhost:3000");
     }
 
     #[test]
     fn rejects_plain_http_for_remote_host() {
-        let err = resolve_api_url_from(Some("http://api.peppy.bot"), None, &servers()).unwrap_err();
+        let err = resolve_api_url_from(
+            Some("http://api.peppy.bot"),
+            None,
+            TransportPolicy::Strict,
+            &servers(),
+        )
+        .unwrap_err();
         assert!(err.to_string().contains("plain http"));
     }
 
     #[test]
     fn allows_https_and_local_http() {
         let servers = servers();
-        assert!(resolve_api_url_from(Some("https://api.peppy.bot"), None, &servers).is_ok());
         assert!(
-            resolve_api_url_from(Some("http://auth.peppy.localhost:8080"), None, &servers).is_ok()
+            resolve_api_url_from(
+                Some("https://api.peppy.bot"),
+                None,
+                TransportPolicy::Strict,
+                &servers
+            )
+            .is_ok()
         );
-        assert!(resolve_api_url_from(Some("http://127.0.0.1:3000"), None, &servers).is_ok());
+        assert!(
+            resolve_api_url_from(
+                Some("http://auth.peppy.localhost:8080"),
+                None,
+                TransportPolicy::Strict,
+                &servers
+            )
+            .is_ok()
+        );
+        assert!(
+            resolve_api_url_from(
+                Some("http://127.0.0.1:3000"),
+                None,
+                TransportPolicy::Strict,
+                &servers
+            )
+            .is_ok()
+        );
         // The old prefix test accepted these two for the wrong reason: it
         // matched the literal `127.` and the literal `::1` rather than asking
         // whether the parsed address is a loopback address.
-        assert!(resolve_api_url_from(Some("http://127.42.7.9:3000"), None, &servers).is_ok());
-        assert!(resolve_api_url_from(Some("http://[::1]:3000"), None, &servers).is_ok());
+        assert!(
+            resolve_api_url_from(
+                Some("http://127.42.7.9:3000"),
+                None,
+                TransportPolicy::Strict,
+                &servers
+            )
+            .is_ok()
+        );
+        assert!(
+            resolve_api_url_from(
+                Some("http://[::1]:3000"),
+                None,
+                TransportPolicy::Strict,
+                &servers
+            )
+            .is_ok()
+        );
     }
 
     /// The whole point of matching on [`Host`]: `127.example` is a domain name
@@ -207,7 +323,8 @@ mod tests {
     fn domain_names_that_merely_start_like_loopback_are_not_local() {
         let servers = servers();
         for host in ["http://127.example", "http://127.evil.test"] {
-            let err = resolve_api_url_from(Some(host), None, &servers).unwrap_err();
+            let err = resolve_api_url_from(Some(host), None, TransportPolicy::Strict, &servers)
+                .unwrap_err();
             assert!(
                 err.to_string().contains("plain http"),
                 "expected {host} to be refused as non-local, got: {err}"
@@ -218,22 +335,37 @@ mod tests {
     #[test]
     fn rejects_embedded_credentials_queries_and_fragments_for_the_api_base() {
         let servers = servers();
-        let err = resolve_api_url_from(Some("https://alice:hunter2@api.peppy.bot"), None, &servers)
-            .unwrap_err();
+        let err = resolve_api_url_from(
+            Some("https://alice:hunter2@api.peppy.bot"),
+            None,
+            TransportPolicy::Strict,
+            &servers,
+        )
+        .unwrap_err();
         assert!(
             err.to_string().contains("embedded credentials"),
             "got: {err}"
         );
 
-        let err = resolve_api_url_from(Some("https://api.peppy.bot?tenant=x"), None, &servers)
-            .unwrap_err();
+        let err = resolve_api_url_from(
+            Some("https://api.peppy.bot?tenant=x"),
+            None,
+            TransportPolicy::Strict,
+            &servers,
+        )
+        .unwrap_err();
         assert!(
             err.to_string().contains("query string or fragment"),
             "got: {err}"
         );
 
-        let err =
-            resolve_api_url_from(Some("https://api.peppy.bot#frag"), None, &servers).unwrap_err();
+        let err = resolve_api_url_from(
+            Some("https://api.peppy.bot#frag"),
+            None,
+            TransportPolicy::Strict,
+            &servers,
+        )
+        .unwrap_err();
         assert!(
             err.to_string().contains("query string or fragment"),
             "got: {err}"
@@ -250,5 +382,84 @@ mod tests {
             normalize_api_origin("http://LOCALHOST:3000/api").expect("normalize"),
             "http://localhost:3000"
         );
+    }
+
+    #[test]
+    fn transport_policy_follows_the_build_profile() {
+        let expected = if cfg!(debug_assertions) {
+            TransportPolicy::AllowInsecureHttp
+        } else {
+            TransportPolicy::Strict
+        };
+        assert_eq!(build_transport_policy(), expected);
+    }
+
+    /// An address from `100.64.0.0/10`, the shared address space Tailscale
+    /// allocates from. It stands in for the issuer a TS-mode dev stack
+    /// advertises, and it must be an IP literal rather than a name so this
+    /// exercises the `Host::Ipv4` non-loopback branch of [`is_local`].
+    const TAILSCALE_STYLE_ISSUER: &str = "http://100.64.0.7:8080";
+
+    #[test]
+    fn remote_plain_http_is_policy_gated() {
+        let err = validate_https_or_local_with(
+            TAILSCALE_STYLE_ISSUER,
+            "OIDC issuer",
+            TransportPolicy::Strict,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("plain http"), "got: {err}");
+
+        let url = validate_https_or_local_with(
+            TAILSCALE_STYLE_ISSUER,
+            "OIDC issuer",
+            TransportPolicy::AllowInsecureHttp,
+        )
+        .expect("admitted under the permissive policy");
+        assert_eq!(url.as_str(), "http://100.64.0.7:8080/");
+    }
+
+    /// The permissive policy only widens the plain-http arm for non-local
+    /// hosts; every other rejection stays in force.
+    #[test]
+    fn permissive_policy_does_not_relax_other_url_checks() {
+        let policy = TransportPolicy::AllowInsecureHttp;
+
+        let err =
+            validate_https_or_local_with("http://alice:hunter2@host.test", "OIDC issuer", policy)
+                .unwrap_err();
+        assert!(
+            err.to_string().contains("embedded credentials"),
+            "got: {err}"
+        );
+
+        let err =
+            validate_https_or_local_with("ftp://host.test", "OIDC issuer", policy).unwrap_err();
+        assert!(
+            err.to_string().contains("unsupported URL scheme"),
+            "got: {err}"
+        );
+
+        let err =
+            validate_https_or_local_with(" http://host.test", "OIDC issuer", policy).unwrap_err();
+        assert!(
+            err.to_string().contains("surrounding whitespace"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_api_url_admits_remote_http_only_under_the_permissive_policy() {
+        let servers = servers();
+        // Same shared-address-space rationale as TAILSCALE_STYLE_ISSUER, on
+        // the port the dev backend binds.
+        let flag = Some("http://100.64.0.7:3000");
+
+        let err = resolve_api_url_from(flag, None, TransportPolicy::Strict, &servers).unwrap_err();
+        assert!(err.to_string().contains("plain http"), "got: {err}");
+
+        let url = resolve_api_url_from(flag, None, TransportPolicy::AllowInsecureHttp, &servers)
+            .expect("admitted under the permissive policy");
+        assert_eq!(url, "http://100.64.0.7:3000");
     }
 }

--- a/crates/auth-internal/src/resolver.rs
+++ b/crates/auth-internal/src/resolver.rs
@@ -15,7 +15,7 @@ use secrecy::{ExposeSecret, SecretString};
 
 use super::http::HttpClient;
 use super::storage::{self, ProfileCreds};
-use super::{discovery, refresh};
+use super::{discovery, profile, refresh};
 use crate::error::{Error, Result};
 
 /// Refresh slightly before the real expiry to avoid racing a just-expired token.
@@ -114,7 +114,7 @@ pub(crate) fn refresh_and_persist(
     creds_path: &Path,
     pc: &ProfileCreds,
 ) -> Result<ProfileCreds> {
-    let endpoints = discovery::discover(http, &pc.issuer)?;
+    let endpoints = discovery::discover(http, &pc.issuer, profile::build_transport_policy())?;
     let tokens = refresh::refresh(
         http,
         &endpoints.token_endpoint,

--- a/crates/peppy/src/commands/platform/login.rs
+++ b/crates/peppy/src/commands/platform/login.rs
@@ -58,8 +58,9 @@ impl Command for LoginCommand {
             return Ok(());
         }
 
-        let cfg = cli_config::fetch(&http, &api_url)?;
-        let endpoints = discovery::discover(&http, &cfg.issuer)?;
+        let policy = profile::build_transport_policy();
+        let cfg = cli_config::fetch(&http, &api_url, policy)?;
+        let endpoints = discovery::discover(&http, &cfg.issuer, policy)?;
         let tokens = run_device_flow(
             &http,
             &endpoints,
@@ -147,7 +148,13 @@ fn run_device_flow(
 ) -> Result<TokenSet> {
     use std::io::IsTerminal;
 
-    let da = device::start(http, endpoints, client_id, scopes)?;
+    let da = device::start(
+        http,
+        endpoints,
+        client_id,
+        scopes,
+        profile::build_transport_policy(),
+    )?;
 
     let complete = da
         .verification_uri_complete


### PR DESCRIPTION
…lowing plain http to non-local hosts in debug builds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Enforced transport policies across authentication, endpoint discovery, device login, and token refresh flows.
  * Secure configurations now reject remote plain-HTTP URLs.
  * Permissive configurations may allow remote HTTP with a warning, while continuing to enforce other URL safety checks.
* **Reliability**
  * Improved endpoint discovery fallback behavior when required authorization or token endpoints are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->