### PR TITLE
Drive pairing codegen from the manifest's declared topics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,7 +573,7 @@ dependencies = [
 [[package]]
 name = "build-helpers"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#cb6424ed12bfb93cbdcfe3417259d777110a0921"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#51c33b3aa6c69e1279eade7c8222a2d36e8ee4cc"
 dependencies = [
  "sha2",
 ]
@@ -774,7 +774,7 @@ dependencies = [
 [[package]]
 name = "config-test-support"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#cb6424ed12bfb93cbdcfe3417259d777110a0921"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#51c33b3aa6c69e1279eade7c8222a2d36e8ee4cc"
 dependencies = [
  "askama",
  "git2",
@@ -918,7 +918,7 @@ dependencies = [
 [[package]]
 name = "core-node-api"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#cb6424ed12bfb93cbdcfe3417259d777110a0921"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#51c33b3aa6c69e1279eade7c8222a2d36e8ee4cc"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -1845,9 +1845,9 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "globset"
@@ -2577,7 +2577,7 @@ dependencies = [
 [[package]]
 name = "json5-pretty"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#cb6424ed12bfb93cbdcfe3417259d777110a0921"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#51c33b3aa6c69e1279eade7c8222a2d36e8ee4cc"
 dependencies = [
  "serde",
  "serde_json",
@@ -2670,9 +2670,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.187"
+version = "0.2.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7743783ea728ef5c31194c6590797eed286449b4a4e87d626d8a51f0a94e732"
+checksum = "22053b6a34f84abc97f9129e61334f40174659a1b9bd18c970b83db6a9a6348b"
 
 [[package]]
 name = "libgit2-sys"
@@ -3351,7 +3351,7 @@ dependencies = [
 [[package]]
 name = "peppy-config-model"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#cb6424ed12bfb93cbdcfe3417259d777110a0921"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#51c33b3aa6c69e1279eade7c8222a2d36e8ee4cc"
 dependencies = [
  "capnp",
  "clap",
@@ -3374,7 +3374,7 @@ version = "0.0.1"
 [[package]]
 name = "peppylib-rs"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#cb6424ed12bfb93cbdcfe3417259d777110a0921"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#51c33b3aa6c69e1279eade7c8222a2d36e8ee4cc"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -3569,7 +3569,7 @@ dependencies = [
 [[package]]
 name = "pmi"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#cb6424ed12bfb93cbdcfe3417259d777110a0921"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#51c33b3aa6c69e1279eade7c8222a2d36e8ee4cc"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -5248,14 +5248,15 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
  "futures-util",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]

--- a/crates/core-node-internal/src/services/node/sync/interfaces.rs
+++ b/crates/core-node-internal/src/services/node/sync/interfaces.rs
@@ -67,6 +67,22 @@ fn pairing_slot_link_ids(manifest: &config::node::Manifest) -> HashSet<&str> {
         .collect()
 }
 
+/// The dependency tables every consumed-interface lookup resolves against,
+/// built once per `collect_consumed_interfaces` call.
+struct ResolvedDependencies {
+    lookup: HashMap<String, DependencyLookupEntry>,
+    /// Native emits/exposes per node dependency, keyed by `(name, tag)`.
+    /// Contract-backed entries are deliberately absent: node dependencies
+    /// expose native interfaces only, and contract-backed interfaces are
+    /// consumed through `depends_on.contracts`.
+    node_offerings: HashMap<(String, String), DependencyOfferings>,
+    /// Memoized parsed contracts for `depends_on.contracts` entries, keyed by
+    /// `link_id` so two entries with the same `(name, tag)` but different
+    /// sha256 pins are cached and resolved separately. `resolve_contract_doc`
+    /// handles SHA-pin matching and on-disk drift detection per load.
+    contract_docs: HashMap<String, daemon_config::contract::PeppyContract>,
+}
+
 pub fn collect_consumed_interfaces(
     manifest: &config::node::Manifest,
     interfaces_cfg: &config::node::Interfaces,
@@ -75,35 +91,29 @@ pub fn collect_consumed_interfaces(
     on_feedback: &dyn Fn(&str),
 ) -> std::result::Result<Vec<DeploymentInterface>, String> {
     let mut interfaces = Vec::new();
-    let dep_lookup = build_dependency_lookup(manifest);
+    let mut deps = ResolvedDependencies {
+        lookup: build_dependency_lookup(manifest),
+        node_offerings: HashMap::new(),
+        contract_docs: HashMap::new(),
+    };
 
-    // Pre-resolve each unique node dependency into a per-dep offerings table
-    // of its NATIVE emits/exposes. Contract-backed entries are deliberately
-    // absent: node dependencies expose native interfaces only, and
-    // contract-backed interfaces are consumed through `depends_on.contracts`.
-    let mut node_dep_offerings: HashMap<(String, String), DependencyOfferings> = HashMap::new();
-    // Memoized parsed contracts for `depends_on.contracts`
-    // entries, keyed by `link_id` so two entries with the same
-    // `(name, tag)` but different sha256 pins are cached and resolved
-    // separately. `resolve_contract_doc` handles SHA-pin matching and
-    // on-disk drift detection per load.
-    let mut contract_dep_docs: HashMap<String, daemon_config::contract::PeppyContract> =
-        HashMap::new();
-
-    for (link_id, entry) in dep_lookup.iter() {
+    // Pre-resolve each unique dependency into its offerings table / contract
+    // document, so the per-entry lookups below are pure map reads.
+    for (link_id, entry) in deps.lookup.iter() {
         match entry.kind {
             DependencyKind::Node => {
                 let node_key = (entry.name.clone(), entry.tag.clone());
-                if node_dep_offerings.contains_key(&node_key) {
+                if deps.node_offerings.contains_key(&node_key) {
                     continue;
                 }
                 let Some(dep_config) = resolve(&entry.name, &entry.tag) else {
                     continue;
                 };
-                node_dep_offerings.insert(node_key, build_dependency_offerings(&dep_config));
+                deps.node_offerings
+                    .insert(node_key, build_dependency_offerings(&dep_config));
             }
             DependencyKind::Contract => {
-                if contract_dep_docs.contains_key(link_id) {
+                if deps.contract_docs.contains_key(link_id) {
                     continue;
                 }
                 let parsed = resolve_contract_doc(
@@ -113,7 +123,7 @@ pub fn collect_consumed_interfaces(
                     entry.sha256.as_deref(),
                     on_feedback,
                 )?;
-                contract_dep_docs.insert(link_id.clone(), parsed);
+                deps.contract_docs.insert(link_id.clone(), parsed);
             }
         }
     }
@@ -129,10 +139,7 @@ pub fn collect_consumed_interfaces(
             if pairing_slots.contains(consumed_topic.link_id.as_str()) {
                 continue;
             }
-            let Some((message_format, dependency)) = resolve_consumed_offering(
-                &dep_lookup,
-                &node_dep_offerings,
-                &contract_dep_docs,
+            let Some((message_format, dependency)) = deps.resolve_consumed_offering(
                 config::node::InterfaceKind::Topic.consumed_section(),
                 &consumed_topic.link_id,
                 consumed_topic.name.trim(),
@@ -165,26 +172,25 @@ pub fn collect_consumed_interfaces(
         && let Some(consumed_services) = &service_interfaces.consumes
     {
         for consumed_service in consumed_services {
-            let Some(((request_format, response_format), dependency)) = resolve_consumed_offering(
-                &dep_lookup,
-                &node_dep_offerings,
-                &contract_dep_docs,
-                config::node::InterfaceKind::Service.consumed_section(),
-                &consumed_service.link_id,
-                consumed_service.name.trim(),
-                |offerings, name| offerings.services.get(name).cloned(),
-                |parsed, name| {
-                    let exposed = parsed
-                        .interfaces
-                        .services
-                        .iter()
-                        .find(|s| s.name.trim() == name)?;
-                    let request_format = exposed.request_message_format.clone().unwrap_or_default();
-                    let response_format =
-                        exposed.response_message_format.clone().unwrap_or_default();
-                    Some((request_format, response_format))
-                },
-            )?
+            let Some(((request_format, response_format), dependency)) = deps
+                .resolve_consumed_offering(
+                    config::node::InterfaceKind::Service.consumed_section(),
+                    &consumed_service.link_id,
+                    consumed_service.name.trim(),
+                    |offerings, name| offerings.services.get(name).cloned(),
+                    |parsed, name| {
+                        let exposed = parsed
+                            .interfaces
+                            .services
+                            .iter()
+                            .find(|s| s.name.trim() == name)?;
+                        let request_format =
+                            exposed.request_message_format.clone().unwrap_or_default();
+                        let response_format =
+                            exposed.response_message_format.clone().unwrap_or_default();
+                        Some((request_format, response_format))
+                    },
+                )?
             else {
                 continue;
             };
@@ -201,10 +207,7 @@ pub fn collect_consumed_interfaces(
         && let Some(consumed_actions) = &action_interfaces.consumes
     {
         for consumed_action in consumed_actions {
-            let Some((action_message, dependency)) = resolve_consumed_offering(
-                &dep_lookup,
-                &node_dep_offerings,
-                &contract_dep_docs,
+            let Some((action_message, dependency)) = deps.resolve_consumed_offering(
                 config::node::InterfaceKind::Action.consumed_section(),
                 &consumed_action.link_id,
                 consumed_action.name.trim(),
@@ -232,78 +235,80 @@ pub fn collect_consumed_interfaces(
     Ok(interfaces)
 }
 
-/// Resolves a single consumed interface to its message-format payload plus the
-/// `DependencyContext` the generator needs to address it. Node dependencies
-/// resolve against the producer's native offerings only (node-addressed);
-/// contract dependencies resolve against the contract document
-/// (contract-addressed).
-///
-/// `Ok(None)` means the entry is not this collector's to report: an
-/// undeclared link_id, an unresolved node dependency, and a name the producer
-/// does not natively offer are all reported by `validate_dependency_specs`
-/// upstream, which sees node dependencies and would otherwise report each
-/// twice.
-///
-/// A name absent from a *contract* document has no upstream reporter at all:
-/// `validate_dependency_specs` stops at the declaration check for
-/// `depends_on.contracts` link_ids, and no layer below this one can open a
-/// contract document. So it errors here, or nowhere.
-fn resolve_consumed_offering<T>(
-    dep_lookup: &HashMap<String, DependencyLookupEntry>,
-    node_dep_offerings: &HashMap<(String, String), DependencyOfferings>,
-    contract_dep_docs: &HashMap<String, daemon_config::contract::PeppyContract>,
-    section: &str,
-    link_id: &str,
-    lookup_name: &str,
-    extract_from_node: impl FnOnce(&DependencyOfferings, &str) -> Option<T>,
-    extract_from_contract: impl FnOnce(&daemon_config::contract::PeppyContract, &str) -> Option<T>,
-) -> std::result::Result<Option<(T, generator::DependencyContext)>, String> {
-    let Some(entry) = dep_lookup.get(link_id) else {
-        return Ok(None);
-    };
-    match entry.kind {
-        DependencyKind::Node => {
-            let Some(offerings) = node_dep_offerings.get(&(entry.name.clone(), entry.tag.clone()))
-            else {
-                return Ok(None);
-            };
-            let Some(extracted) = extract_from_node(offerings, lookup_name) else {
-                return Ok(None);
-            };
-            Ok(Some((
-                extracted,
-                generator::DependencyContext::native(
-                    &entry.name,
-                    &entry.tag,
-                    link_id,
-                    entry.cardinality,
-                ),
-            )))
-        }
-        DependencyKind::Contract => {
-            let parsed = contract_dep_docs.get(link_id).ok_or_else(|| {
-                format!(
-                    "`{section}` entry `{lookup_name}` references link_id `{link_id}`, \
-                     whose contract `{}:{}` failed to resolve",
-                    entry.name, entry.tag
-                )
-            })?;
-            let extracted = extract_from_contract(parsed, lookup_name).ok_or_else(|| {
-                format!(
-                    "`{section}` entry `{lookup_name}` (link_id `{link_id}`) names no member \
-                     of contract `{}:{}`",
-                    entry.name, entry.tag
-                )
-            })?;
-            Ok(Some((
-                extracted,
-                generator::DependencyContext::contract(
-                    &entry.name,
-                    &entry.tag,
-                    link_id,
-                    entry.cardinality,
-                ),
-            )))
+impl ResolvedDependencies {
+    /// Resolves a single consumed interface to its message-format payload plus
+    /// the `DependencyContext` the generator needs to address it. Node
+    /// dependencies resolve against the producer's native offerings only
+    /// (node-addressed); contract dependencies resolve against the contract
+    /// document (contract-addressed).
+    ///
+    /// `Ok(None)` means the entry is not this collector's to report: an
+    /// undeclared link_id, an unresolved node dependency, and a name the
+    /// producer does not natively offer are all reported by
+    /// `validate_dependency_specs` upstream, which sees node dependencies and
+    /// would otherwise report each twice.
+    ///
+    /// A name absent from a *contract* document has no upstream reporter at
+    /// all: `validate_dependency_specs` stops at the declaration check for
+    /// `depends_on.contracts` link_ids, and no layer below this one can open a
+    /// contract document. So it errors here, or nowhere.
+    fn resolve_consumed_offering<T>(
+        &self,
+        section: &str,
+        link_id: &str,
+        lookup_name: &str,
+        extract_from_node: impl FnOnce(&DependencyOfferings, &str) -> Option<T>,
+        extract_from_contract: impl FnOnce(&daemon_config::contract::PeppyContract, &str) -> Option<T>,
+    ) -> std::result::Result<Option<(T, generator::DependencyContext)>, String> {
+        let Some(entry) = self.lookup.get(link_id) else {
+            return Ok(None);
+        };
+        match entry.kind {
+            DependencyKind::Node => {
+                let Some(offerings) = self
+                    .node_offerings
+                    .get(&(entry.name.clone(), entry.tag.clone()))
+                else {
+                    return Ok(None);
+                };
+                let Some(extracted) = extract_from_node(offerings, lookup_name) else {
+                    return Ok(None);
+                };
+                Ok(Some((
+                    extracted,
+                    generator::DependencyContext::native(
+                        &entry.name,
+                        &entry.tag,
+                        link_id,
+                        entry.cardinality,
+                    ),
+                )))
+            }
+            DependencyKind::Contract => {
+                let parsed = self.contract_docs.get(link_id).ok_or_else(|| {
+                    format!(
+                        "`{section}` entry `{lookup_name}` references link_id `{link_id}`, \
+                         whose contract `{}:{}` failed to resolve",
+                        entry.name, entry.tag
+                    )
+                })?;
+                let extracted = extract_from_contract(parsed, lookup_name).ok_or_else(|| {
+                    format!(
+                        "`{section}` entry `{lookup_name}` (link_id `{link_id}`) names no member \
+                         of contract `{}:{}`",
+                        entry.name, entry.tag
+                    )
+                })?;
+                Ok(Some((
+                    extracted,
+                    generator::DependencyContext::contract(
+                        &entry.name,
+                        &entry.tag,
+                        link_id,
+                        entry.cardinality,
+                    ),
+                )))
+            }
         }
     }
 }

--- a/crates/core-node-internal/src/services/node/sync/interfaces.rs
+++ b/crates/core-node-internal/src/services/node/sync/interfaces.rs
@@ -8,7 +8,7 @@ use config::node::InterfaceKind;
 use daemon_config::consts::PeppyDirs;
 use generator::{ConsumedActionMessage, ContractOrigin, DeploymentInterface};
 use node_stack::NodeStack;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 /// Collects consumed interfaces from a node config and resolves their message
 /// formats by looking up the exposed interfaces from dependency nodes via the
@@ -42,10 +42,29 @@ pub fn collect_all_deployment_interfaces(
             .map_err(|reason| format!("failed to resolve `manifest.implements`: {reason}"))?,
     );
     interfaces.extend(
-        super::pairings::collect_pairing_interfaces(manifest, peppy_dirs, on_feedback)
-            .map_err(|reason| format!("failed to resolve `depends_on.pairings`: {reason}"))?,
+        super::pairings::collect_pairing_interfaces(
+            manifest,
+            interfaces_cfg,
+            peppy_dirs,
+            on_feedback,
+        )
+        .map_err(|reason| format!("failed to resolve `depends_on.pairings`: {reason}"))?,
     );
     Ok(interfaces)
+}
+
+/// The `depends_on.pairings` slot link_ids of a manifest. Entries naming one
+/// are resolved by `collect_pairing_interfaces` against the pairing document
+/// and generated under `pairings/<link_id>/<topic>`, so both the consumed
+/// collector and the implements resolver must step over them: neither knows
+/// the pairing kind, and collecting an entry twice would either drop it
+/// silently or land it in the wrong module category.
+fn pairing_slot_link_ids(manifest: &config::node::Manifest) -> HashSet<&str> {
+    manifest
+        .depends_on
+        .iter()
+        .flat_map(|d| d.pairings.iter().map(|p| p.link_id.as_str()))
+        .collect()
 }
 
 pub fn collect_consumed_interfaces(
@@ -99,26 +118,39 @@ pub fn collect_consumed_interfaces(
         }
     }
 
+    let pairing_slots = pairing_slot_link_ids(manifest);
+
     if let Some(topic_interfaces) = &interfaces_cfg.topics
         && let Some(consumed_topics) = &topic_interfaces.consumes
     {
         for consumed_topic in consumed_topics {
+            // Topics are the one consumed section a pairing slot may appear
+            // in; services and actions are rejected at parse time.
+            if pairing_slots.contains(consumed_topic.link_id.as_str()) {
+                continue;
+            }
             let Some((message_format, dependency)) = resolve_consumed_offering(
                 &dep_lookup,
                 &node_dep_offerings,
                 &contract_dep_docs,
+                config::node::InterfaceKind::Topic.consumed_section(),
                 &consumed_topic.link_id,
                 consumed_topic.name.trim(),
                 |offerings, name| offerings.topics.get(name).cloned(),
+                // A contract topic declared without a `message_format`
+                // defaults like a contract service does, so a `None` here
+                // means the name is absent from the document and nothing
+                // else.
                 |parsed, name| {
                     parsed
                         .interfaces
                         .topics
                         .iter()
                         .find(|t| t.name.trim() == name)
-                        .and_then(|emitted| emitted.message_format.clone())
+                        .map(|emitted| emitted.message_format.clone().unwrap_or_default())
                 },
-            ) else {
+            )?
+            else {
                 continue;
             };
             interfaces.push(DeploymentInterface::consumed_topic(
@@ -137,6 +169,7 @@ pub fn collect_consumed_interfaces(
                 &dep_lookup,
                 &node_dep_offerings,
                 &contract_dep_docs,
+                config::node::InterfaceKind::Service.consumed_section(),
                 &consumed_service.link_id,
                 consumed_service.name.trim(),
                 |offerings, name| offerings.services.get(name).cloned(),
@@ -151,7 +184,8 @@ pub fn collect_consumed_interfaces(
                         exposed.response_message_format.clone().unwrap_or_default();
                     Some((request_format, response_format))
                 },
-            ) else {
+            )?
+            else {
                 continue;
             };
             interfaces.push(DeploymentInterface::consumed_service(
@@ -171,6 +205,7 @@ pub fn collect_consumed_interfaces(
                 &dep_lookup,
                 &node_dep_offerings,
                 &contract_dep_docs,
+                config::node::InterfaceKind::Action.consumed_section(),
                 &consumed_action.link_id,
                 consumed_action.name.trim(),
                 |offerings, name| offerings.actions.get(name).cloned(),
@@ -182,7 +217,8 @@ pub fn collect_consumed_interfaces(
                         .find(|a| a.name.trim() == name)
                         .map(action_message_from_exposed)
                 },
-            ) else {
+            )?
+            else {
                 continue;
             };
             interfaces.push(DeploymentInterface::consumed_action(
@@ -201,21 +237,40 @@ pub fn collect_consumed_interfaces(
 /// resolve against the producer's native offerings only (node-addressed);
 /// contract dependencies resolve against the contract document
 /// (contract-addressed).
+///
+/// `Ok(None)` means the entry is not this collector's to report: an
+/// undeclared link_id, an unresolved node dependency, and a name the producer
+/// does not natively offer are all reported by `validate_dependency_specs`
+/// upstream, which sees node dependencies and would otherwise report each
+/// twice.
+///
+/// A name absent from a *contract* document has no upstream reporter at all:
+/// `validate_dependency_specs` stops at the declaration check for
+/// `depends_on.contracts` link_ids, and no layer below this one can open a
+/// contract document. So it errors here, or nowhere.
 fn resolve_consumed_offering<T>(
     dep_lookup: &HashMap<String, DependencyLookupEntry>,
     node_dep_offerings: &HashMap<(String, String), DependencyOfferings>,
     contract_dep_docs: &HashMap<String, daemon_config::contract::PeppyContract>,
+    section: &str,
     link_id: &str,
     lookup_name: &str,
     extract_from_node: impl FnOnce(&DependencyOfferings, &str) -> Option<T>,
     extract_from_contract: impl FnOnce(&daemon_config::contract::PeppyContract, &str) -> Option<T>,
-) -> Option<(T, generator::DependencyContext)> {
-    let entry = dep_lookup.get(link_id)?;
+) -> std::result::Result<Option<(T, generator::DependencyContext)>, String> {
+    let Some(entry) = dep_lookup.get(link_id) else {
+        return Ok(None);
+    };
     match entry.kind {
         DependencyKind::Node => {
-            let offerings = node_dep_offerings.get(&(entry.name.clone(), entry.tag.clone()))?;
-            let extracted = extract_from_node(offerings, lookup_name)?;
-            Some((
+            let Some(offerings) = node_dep_offerings.get(&(entry.name.clone(), entry.tag.clone()))
+            else {
+                return Ok(None);
+            };
+            let Some(extracted) = extract_from_node(offerings, lookup_name) else {
+                return Ok(None);
+            };
+            Ok(Some((
                 extracted,
                 generator::DependencyContext::native(
                     &entry.name,
@@ -223,12 +278,24 @@ fn resolve_consumed_offering<T>(
                     link_id,
                     entry.cardinality,
                 ),
-            ))
+            )))
         }
         DependencyKind::Contract => {
-            let parsed = contract_dep_docs.get(link_id)?;
-            let extracted = extract_from_contract(parsed, lookup_name)?;
-            Some((
+            let parsed = contract_dep_docs.get(link_id).ok_or_else(|| {
+                format!(
+                    "`{section}` entry `{lookup_name}` references link_id `{link_id}`, \
+                     whose contract `{}:{}` failed to resolve",
+                    entry.name, entry.tag
+                )
+            })?;
+            let extracted = extract_from_contract(parsed, lookup_name).ok_or_else(|| {
+                format!(
+                    "`{section}` entry `{lookup_name}` (link_id `{link_id}`) names no member \
+                     of contract `{}:{}`",
+                    entry.name, entry.tag
+                )
+            })?;
+            Ok(Some((
                 extracted,
                 generator::DependencyContext::contract(
                     &entry.name,
@@ -236,7 +303,7 @@ fn resolve_consumed_offering<T>(
                     link_id,
                     entry.cardinality,
                 ),
-            ))
+            )))
         }
     }
 }
@@ -392,8 +459,15 @@ pub fn resolve_implements(
 
     let mut out: Vec<DeploymentInterface> = Vec::new();
     let mut coverage: HashMap<&str, SlotCoverage> = HashMap::new();
+    let pairing_slots = pairing_slot_link_ids(manifest);
 
-    for (kind, entry) in interfaces_cfg.contract_backed_entries() {
+    for (kind, entry) in interfaces_cfg.linked_entries() {
+        // A pairing-backed emit is resolved against the pairing document by
+        // `collect_pairing_interfaces`. It must not count toward any
+        // implements slot's coverage, nor trip the unknown-link_id arm below.
+        if pairing_slots.contains(entry.link_id.as_str()) {
+            continue;
+        }
         let name = entry.name.as_str();
         let Some((slot, doc)) = docs.get(entry.link_id.as_str()) else {
             // Parse-time validation guarantees every produced entry's
@@ -1115,6 +1189,207 @@ mod implements_tests {
             }
             other => panic!("expected ConsumedService variant, got {other:?}"),
         }
+    }
+
+    /// The category partition, end to end: a node holding a pairing slot AND
+    /// a contract dependency must route each entry to exactly one collector.
+    ///
+    /// This is the regression this whole design is most exposed to. Admitting
+    /// pairing link_ids into the consumed collector would either drop them
+    /// (the consumed dependency lookup knows only node and contract kinds) or
+    /// land them in the flat `consumed_topics` namespace, splitting a slot's
+    /// two directions across unrelated module trees.
+    #[test]
+    fn pairing_and_contract_entries_route_to_separate_collectors() {
+        const ARM_LINK_BODY: &str = r#"{
+            peppy_schema: "pairing/v1",
+            manifest: { name: "arm_link", tag: "v1" },
+            roles: ["controller", "arm"],
+            topics: [
+                { emitted_by: "controller", name: "joint_commands" },
+                { emitted_by: "arm", name: "joint_states" }
+            ]
+        }"#;
+
+        // One PeppyDirs holding both caches, so `collect_all_deployment_interfaces`
+        // can resolve the contract and the pairing document in one pass.
+        let tmp = TempDir::new().unwrap();
+        let contract = seed_contract(tmp.path(), "depth_camera", "v1", DEPTH_V1_BODY);
+        let (_tmp_dirs, dirs) = make_peppy_dirs_with_cache(&[contract]);
+        let pairing_path = tmp.path().join("arm_link_v1.json5");
+        fs::write(&pairing_path, ARM_LINK_BODY).expect("write pairing doc");
+        let pairing_entry = repo_cache::PairingCacheEntry {
+            pairing_name: "arm_link".to_string(),
+            tag: "v1".to_string(),
+            sha256: config::fingerprint::fingerprint_for_bytes(ARM_LINK_BODY.as_bytes()),
+            source_type: RepoSourceKind::Fs,
+            source_uri: None,
+            resolved_ref: None,
+            path: pairing_path.to_string_lossy().to_string(),
+            repo_id: 0,
+        };
+        fs::write(
+            repo_cache::pairings_repo_cache_path(&dirs),
+            serde_json5::to_string(&vec![pairing_entry]).expect("serialize pairing cache"),
+        )
+        .expect("write pairing cache");
+
+        // The relay shape plus a pairing: one implements slot, one contract
+        // dependency on the same contract, and one pairing slot. All three
+        // collectors run, and each must claim exactly its own entries.
+        let manifest: Manifest = serde_json5::from_str(
+            r#"{
+                name: "robot_arm", tag: "v1",
+                implements: [{ name: "depth_camera", tag: "v1", link_id: "cam_out" }],
+                depends_on: {
+                    contracts: [{ name: "depth_camera", tag: "v1", link_id: "cam_in" }],
+                    pairings: [{ name: "arm_link", tag: "v1", role: "arm", link_id: "controller" }]
+                }
+            }"#,
+        )
+        .expect("manifest parses");
+        let cfg = interfaces_from(
+            r#"{ topics: {
+                emits: [
+                    { link_id: "cam_out", name: "video_stream" },
+                    { link_id: "controller", name: "joint_states" },
+                ],
+                consumes: [
+                    { link_id: "controller", name: "joint_commands" },
+                    { link_id: "cam_in", name: "video_stream" },
+                ],
+            } }"#,
+        );
+
+        let out = collect_all_deployment_interfaces(&manifest, &cfg, |_, _| None, &dirs, &|_| {})
+            .expect("all three kinds resolve together");
+
+        let mut emitted_topics = Vec::new();
+        let mut peer_emitted = Vec::new();
+        let mut peer_consumed = Vec::new();
+        let mut consumed_topics = Vec::new();
+        for interface in &out {
+            match interface.interface() {
+                InterfaceVariant::EmittedTopic { topic, .. } => {
+                    emitted_topics.push(topic.name.as_str())
+                }
+                InterfaceVariant::PeerEmittedTopic { topic, .. } => {
+                    peer_emitted.push(topic.name.as_str())
+                }
+                InterfaceVariant::PeerConsumedTopic { topic, .. } => {
+                    peer_consumed.push(topic.name.as_str())
+                }
+                InterfaceVariant::ConsumedTopic { topic, .. } => {
+                    consumed_topics.push(topic.name.as_str())
+                }
+                other => panic!("unexpected variant {other:?}"),
+            }
+        }
+        assert_eq!(peer_emitted, vec!["joint_states"]);
+        assert_eq!(peer_consumed, vec!["joint_commands"]);
+        assert_eq!(
+            emitted_topics,
+            vec!["video_stream"],
+            "the pairing emit must not be counted against the implements slot"
+        );
+        assert_eq!(
+            consumed_topics,
+            vec!["video_stream"],
+            "the contract topic is the ONLY entry that may reach the consumed collector"
+        );
+        assert_eq!(out.len(), 4, "no entry may be collected twice: {out:?}");
+    }
+
+    /// A consumed entry naming no member of its contract used to resolve to
+    /// `None` and get dropped, so a typo produced a missing module and a
+    /// successful sync. Nothing upstream sees contract link_ids, so this is
+    /// the only place it can be reported.
+    #[test]
+    fn consumed_entry_absent_from_contract_is_rejected() {
+        let tmp = TempDir::new().unwrap();
+        let entry = seed_contract(tmp.path(), "depth_camera", "v1", DEPTH_V1_BODY);
+        let (_tmp_dirs, dirs) = make_peppy_dirs_with_cache(&[entry]);
+
+        let manifest: Manifest = serde_json5::from_str(
+            r#"{
+                name: "camera_consumer", tag: "v1",
+                depends_on: {
+                    contracts: [{ name: "depth_camera", tag: "v1", link_id: "cam" }]
+                }
+            }"#,
+        )
+        .expect("manifest parses");
+        let cfg = interfaces_from(
+            r#"{ topics: { consumes: [{ link_id: "cam", name: "video_strem" }] } }"#,
+        );
+
+        let err = collect_consumed_interfaces(&manifest, &cfg, |_, _| None, &dirs, &|_| {})
+            .expect_err("a name absent from the contract must not be dropped silently");
+        for needle in [
+            "video_strem",
+            "cam",
+            "depth_camera",
+            "v1",
+            "topics.consumes",
+        ] {
+            assert!(
+                err.contains(needle),
+                "error must name the entry, the slot and the document, missing {needle}: {err}"
+            );
+        }
+    }
+
+    /// The same typo against a NODE dependency is reported once, by
+    /// `validate_dependency_specs` upstream. This collector stays silent so
+    /// the user does not see it twice.
+    #[test]
+    fn unknown_node_dep_name_is_left_to_the_upstream_reporter() {
+        let (_tmp_dirs, dirs) = make_peppy_dirs_with_cache(&[]);
+
+        let producer: config::node::NodeConfig = config::node::NodeConfigParser::from_content(
+            r#"{
+                peppy_schema: "node/v1",
+                manifest: { name: "producer_node", tag: "v1" },
+                interfaces: {
+                    topics: { emits: [{ name: "debug_stream", message_format: { x: "f64" } }] },
+                },
+                execution: { language: "rust", run_cmd: ["./bin"] },
+            }"#,
+        )
+        .expect("producer parses");
+        let manifest: Manifest = serde_json5::from_str(
+            r#"{
+                name: "consumer", tag: "v1",
+                depends_on: { nodes: [{ name: "producer_node", tag: "v1", link_id: "producer" }] }
+            }"#,
+        )
+        .expect("manifest parses");
+        let cfg = interfaces_from(
+            r#"{ topics: { consumes: [{ link_id: "producer", name: "debug_strem" }] } }"#,
+        );
+
+        let out = collect_consumed_interfaces(
+            &manifest,
+            &cfg,
+            |name, _| (name == "producer_node").then(|| producer.clone()),
+            &dirs,
+            &|_| {},
+        )
+        .expect("collection itself must not fail for a node dep");
+        assert!(out.is_empty(), "nothing resolves, and nothing is reported");
+
+        let upstream = config::node::validate_dependency_specs(
+            &manifest,
+            &cfg,
+            "consumer",
+            "v1",
+            |name, _| (name == "producer_node").then(|| producer.clone()),
+        );
+        assert_eq!(
+            upstream.len(),
+            1,
+            "exactly one reporter owns this error: {upstream:?}"
+        );
     }
 
     /// Node-dependency consumption resolves the producer's NATIVE entries

--- a/crates/core-node-internal/src/services/node/sync/pairings.rs
+++ b/crates/core-node-internal/src/services/node/sync/pairings.rs
@@ -3,6 +3,7 @@
 //! validating each manifest entry's role against the doc's two roles.
 
 use crate::services::repo::cache as repo_cache;
+use config::PairingCoverageMismatch;
 use daemon_config::consts::PeppyDirs;
 use daemon_config::pairing::PeppyPairing;
 use std::collections::HashMap;
@@ -117,17 +118,73 @@ pub(crate) fn validate_pairing_specs(
     Ok(out)
 }
 
-/// Resolves every `depends_on.pairings` slot into the generator inputs for
-/// the `pairings/<link_id>/<topic>` modules: per slot, topics with
-/// `emitted_by == entry.role` become peer-emitted and all others
-/// peer-consumed. Runs [`validate_pairing_specs`] first, so role errors and
-/// cache misses surface before any codegen.
+/// A failure resolving `depends_on.pairings` against the declared interface
+/// entries. Mirrors `ImplementsError`: coverage problems are aggregated per
+/// slot so a node with several wrong entries produces one readable report.
+#[derive(Debug)]
+pub enum PairingError {
+    /// One aggregated set-diff per broken slot.
+    Coverage(Vec<PairingCoverageMismatch>),
+    Other(String),
+}
+
+impl std::fmt::Display for PairingError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Coverage(mismatches) => {
+                for (idx, mismatch) in mismatches.iter().enumerate() {
+                    if idx > 0 {
+                        write!(f, "; ")?;
+                    }
+                    write!(f, "{mismatch}")?;
+                }
+                Ok(())
+            }
+            Self::Other(reason) => write!(f, "{reason}"),
+        }
+    }
+}
+
+impl From<String> for PairingError {
+    fn from(reason: String) -> Self {
+        Self::Other(reason)
+    }
+}
+
+/// Per-slot bookkeeping while walking the node's pairing-backed entries.
+#[derive(Default)]
+struct SlotCoverage {
+    /// How many `topics.emits` entries resolved to each of the role's topics.
+    visited_emits: HashMap<String, u32>,
+    /// How many `topics.consumes` entries resolved to each counterpart topic.
+    visited_consumes: HashMap<String, u32>,
+    unknown_emits: Vec<String>,
+    wrong_role_emits: Vec<String>,
+    unknown_consumes: Vec<String>,
+    wrong_role_consumes: Vec<String>,
+}
+
+/// Resolves every `depends_on.pairings` slot into the generator inputs for the
+/// `pairings/<link_id>/<topic>` modules, driven by what the node declares:
+/// each pairing-backed `topics.emits` entry becomes peer-emitted and each
+/// pairing-backed `topics.consumes` entry becomes peer-consumed, with shape
+/// and QoS read from the pairing document.
+///
+/// Coverage mirrors contracts. The emit side must be exact: the entries for a
+/// slot are precisely the document's topics whose `emitted_by` is the slot's
+/// role, because a role that silently stops emitting one of its topics breaks
+/// its peer. The consume side may be partial: omitting a topic means no module
+/// is generated and no subscription can be created for it, which is a local
+/// decision with no effect on the peer.
+///
+/// Runs [`validate_pairing_specs`] first, so role errors and cache misses
+/// surface before any of this.
 pub fn collect_pairing_interfaces(
     manifest: &config::node::Manifest,
+    interfaces_cfg: &config::node::Interfaces,
     peppy_dirs: &PeppyDirs,
     on_feedback: &dyn Fn(&str),
-) -> std::result::Result<Vec<generator::DeploymentInterface>, String> {
-    let docs = validate_pairing_specs(manifest, peppy_dirs, on_feedback)?;
+) -> std::result::Result<Vec<generator::DeploymentInterface>, PairingError> {
     let Some(pairing_deps) = manifest
         .depends_on
         .as_ref()
@@ -136,8 +193,10 @@ pub fn collect_pairing_interfaces(
     else {
         return Ok(Vec::new());
     };
+    let docs = validate_pairing_specs(manifest, peppy_dirs, on_feedback)?;
 
     let mut out = Vec::new();
+    let mut broken = Vec::new();
     for dep in pairing_deps {
         let doc = docs
             .get(&dep.link_id)
@@ -147,26 +206,151 @@ pub fn collect_pairing_interfaces(
             pairing_name: dep.name.as_str().to_string(),
             pairing_tag: dep.tag.clone(),
         };
-        for topic in &doc.topics {
-            let emitted = config::node::NativeEmittedTopic {
-                name: topic.name.clone(),
-                qos_profile: topic.qos_profile.clone(),
-                message_format: topic.message_format.clone(),
+        let mut coverage = SlotCoverage::default();
+
+        for name in declared_topic_names(interfaces_cfg, &dep.link_id, Direction::Emits) {
+            let Some(topic) = doc.topics.iter().find(|t| t.name == name) else {
+                coverage.unknown_emits.push(name.to_string());
+                continue;
+            };
+            if topic.emitted_by != dep.role {
+                coverage
+                    .wrong_role_emits
+                    .push(format!("{name} (emitted by {})", topic.emitted_by));
+                continue;
+            }
+            *coverage.visited_emits.entry(name.to_string()).or_insert(0) += 1;
+            out.push(generator::DeploymentInterface::peer_emitted_topic(
+                native_topic(topic),
+                peer.clone(),
+            ));
+        }
+
+        for name in declared_topic_names(interfaces_cfg, &dep.link_id, Direction::Consumes) {
+            let Some(topic) = doc.topics.iter().find(|t| t.name == name) else {
+                coverage.unknown_consumes.push(name.to_string());
+                continue;
             };
             if topic.emitted_by == dep.role {
-                out.push(generator::DeploymentInterface::peer_emitted_topic(
-                    emitted,
-                    peer.clone(),
-                ));
-            } else {
-                out.push(generator::DeploymentInterface::peer_consumed_topic(
-                    emitted,
-                    peer.clone(),
-                ));
+                coverage
+                    .wrong_role_consumes
+                    .push(format!("{name} (emitted by this node's role {})", dep.role));
+                continue;
             }
+            *coverage
+                .visited_consumes
+                .entry(name.to_string())
+                .or_insert(0) += 1;
+            out.push(generator::DeploymentInterface::peer_consumed_topic(
+                native_topic(topic),
+                peer.clone(),
+            ));
+        }
+
+        let mismatch = build_mismatch(dep, doc, coverage);
+        if !mismatch.is_empty() {
+            broken.push(mismatch);
         }
     }
+
+    if !broken.is_empty() {
+        return Err(PairingError::Coverage(broken));
+    }
     Ok(out)
+}
+
+/// Which direction of `interfaces.topics` an entry walk is reading.
+#[derive(Clone, Copy)]
+enum Direction {
+    Emits,
+    Consumes,
+}
+
+/// The names declared for one pairing slot in one direction, in manifest
+/// order. Entries naming other slots (contract-backed emits, node-backed
+/// consumes) belong to the implements and consumed collectors and are skipped
+/// here, which is what keeps pairing topics out of `emitted_topics` and
+/// `consumed_topics`.
+fn declared_topic_names<'a>(
+    interfaces_cfg: &'a config::node::Interfaces,
+    link_id: &'a str,
+    direction: Direction,
+) -> Vec<&'a str> {
+    let Some(topics) = interfaces_cfg.topics.as_ref() else {
+        return Vec::new();
+    };
+    match direction {
+        Direction::Emits => topics
+            .emits
+            .iter()
+            .flatten()
+            .filter(|e| e.link_id() == Some(link_id))
+            .map(|e| e.name())
+            .collect(),
+        Direction::Consumes => topics
+            .consumes
+            .iter()
+            .flatten()
+            .filter(|c| c.link_id == link_id)
+            .map(|c| c.name.as_str())
+            .collect(),
+    }
+}
+
+/// The generator carries a pairing topic's shape in a `NativeEmittedTopic` in
+/// both directions; the document is the sole source of that shape.
+fn native_topic(topic: &daemon_config::pairing::PairingTopic) -> config::node::NativeEmittedTopic {
+    config::node::NativeEmittedTopic {
+        name: topic.name.clone(),
+        qos_profile: topic.qos_profile.clone(),
+        message_format: topic.message_format.clone(),
+    }
+}
+
+/// Turns one slot's bookkeeping into its aggregated diff. Only the emit side
+/// contributes `missing`/`duplicated` against the document: consume coverage
+/// is free, so an unlisted counterpart topic is not a defect, but naming one
+/// twice still is.
+fn build_mismatch(
+    dep: &config::node::PairingDependency,
+    doc: &PeppyPairing,
+    coverage: SlotCoverage,
+) -> PairingCoverageMismatch {
+    let mut missing_emits = Vec::new();
+    let mut duplicated_emits = Vec::new();
+    for topic in doc.topics.iter().filter(|t| t.emitted_by == dep.role) {
+        match coverage
+            .visited_emits
+            .get(&topic.name)
+            .copied()
+            .unwrap_or(0)
+        {
+            0 => missing_emits.push(topic.name.clone()),
+            1 => {}
+            _ => duplicated_emits.push(topic.name.clone()),
+        }
+    }
+    let mut duplicated_consumes: Vec<String> = coverage
+        .visited_consumes
+        .iter()
+        .filter(|(_, visits)| **visits > 1)
+        .map(|(name, _)| name.clone())
+        .collect();
+    duplicated_consumes.sort();
+
+    PairingCoverageMismatch {
+        pairing_name: dep.name.as_str().to_string(),
+        pairing_tag: dep.tag.clone(),
+        link_id: dep.link_id.clone(),
+        role: dep.role.clone(),
+        missing_emits,
+        unknown_emits: coverage.unknown_emits,
+        duplicated_emits,
+        wrong_role_emits: coverage.wrong_role_emits,
+        unknown_consumes: coverage.unknown_consumes,
+        duplicated_consumes,
+        wrong_role_consumes: coverage.wrong_role_consumes,
+    }
 }
 
 #[cfg(test)]
@@ -222,6 +406,363 @@ mod tests {
 
     fn manifest(json5: &str) -> config::node::Manifest {
         serde_json5::from_str(json5).expect("manifest parses")
+    }
+
+    fn interfaces(json5: &str) -> config::node::Interfaces {
+        serde_json5::from_str(json5).expect("interfaces parse")
+    }
+
+    /// A node playing the `arm` role of `arm_link/v1` on slot `controller`,
+    /// so it emits `joint_states` and may consume `joint_commands`.
+    fn arm_manifest() -> config::node::Manifest {
+        manifest(
+            r#"{
+                name: "robot_arm", tag: "v1",
+                depends_on: {
+                    pairings: [{ name: "arm_link", tag: "v1", role: "arm", link_id: "controller" }]
+                }
+            }"#,
+        )
+    }
+
+    fn seeded_dirs() -> (TempDir, TempDir, PeppyDirs) {
+        let tmp = TempDir::new().expect("temp dir");
+        let entry = seed_pairing(tmp.path(), "arm_link", "v1", ARM_LINK_BODY);
+        let (cache_tmp, dirs) = make_peppy_dirs_with_cache(&[entry]);
+        (tmp, cache_tmp, dirs)
+    }
+
+    fn collect(
+        manifest: &config::node::Manifest,
+        interfaces_cfg: &config::node::Interfaces,
+        dirs: &PeppyDirs,
+    ) -> std::result::Result<Vec<generator::DeploymentInterface>, PairingError> {
+        collect_pairing_interfaces(manifest, interfaces_cfg, dirs, &|_| {})
+    }
+
+    /// The `(module_path, is_emitted)` of each produced interface, so tests
+    /// assert both the direction and the `pairings/<link_id>/<topic>` path.
+    fn peer_modules(out: &[generator::DeploymentInterface]) -> Vec<(Vec<String>, bool)> {
+        out.iter()
+            .map(|i| match i.interface() {
+                generator::InterfaceVariant::PeerEmittedTopic { topic, peer } => {
+                    (peer.module_path_for(&topic.name), true)
+                }
+                generator::InterfaceVariant::PeerConsumedTopic { topic, peer } => {
+                    (peer.module_path_for(&topic.name), false)
+                }
+                other => panic!("expected a peer topic variant, got {other:?}"),
+            })
+            .collect()
+    }
+
+    fn coverage(err: PairingError) -> Vec<PairingCoverageMismatch> {
+        match err {
+            PairingError::Coverage(mismatches) => mismatches,
+            PairingError::Other(reason) => panic!("expected a coverage diff, got: {reason}"),
+        }
+    }
+
+    #[test]
+    fn exact_emit_coverage_with_full_consume_resolves_both_directions() {
+        let (_t, _c, dirs) = seeded_dirs();
+        let cfg = interfaces(
+            r#"{ topics: {
+                emits: [{ link_id: "controller", name: "joint_states" }],
+                consumes: [{ link_id: "controller", name: "joint_commands" }],
+            } }"#,
+        );
+        let out = collect(&arm_manifest(), &cfg, &dirs).expect("exact coverage resolves");
+        assert_eq!(
+            peer_modules(&out),
+            vec![
+                (
+                    vec!["controller".to_string(), "joint_states".to_string()],
+                    true
+                ),
+                (
+                    vec!["controller".to_string(), "joint_commands".to_string()],
+                    false
+                ),
+            ]
+        );
+    }
+
+    /// The shape and QoS of a pairing topic come from the document, never
+    /// from the manifest, which carries only `{link_id, name}`.
+    #[test]
+    fn resolved_topics_carry_the_documents_shape_and_qos() {
+        let (_t, _c, dirs) = seeded_dirs();
+        let cfg = interfaces(
+            r#"{ topics: { emits: [{ link_id: "controller", name: "joint_states" }] } }"#,
+        );
+        let out = collect(&arm_manifest(), &cfg, &dirs).expect("resolves");
+        let generator::InterfaceVariant::PeerEmittedTopic { topic, peer } = out[0].interface()
+        else {
+            panic!("expected a peer-emitted topic");
+        };
+        assert_eq!(topic.name, "joint_states");
+        assert_eq!(peer.pairing_name, "arm_link");
+        assert_eq!(peer.pairing_tag, "v1");
+        assert_eq!(peer.link_id, "controller");
+    }
+
+    #[test]
+    fn missing_emit_entry_is_rejected_naming_the_topic() {
+        let (_t, _c, dirs) = seeded_dirs();
+        let err = collect(&arm_manifest(), &config::node::Interfaces::default(), &dirs)
+            .expect_err("an unlisted emitted topic is a coverage failure");
+        let mismatches = coverage(err);
+        assert_eq!(mismatches.len(), 1);
+        assert_eq!(mismatches[0].missing_emits, vec!["joint_states"]);
+        assert_eq!(mismatches[0].link_id, "controller");
+        assert!(
+            mismatches[0].to_string().contains("joint_states"),
+            "rendered error must name the missing topic: {}",
+            mismatches[0]
+        );
+    }
+
+    /// Consume coverage is free: a slot may declare no consumes at all, and
+    /// only the emit side is checked against the document.
+    #[test]
+    fn zero_consume_entries_is_legal() {
+        let (_t, _c, dirs) = seeded_dirs();
+        let cfg = interfaces(
+            r#"{ topics: { emits: [{ link_id: "controller", name: "joint_states" }] } }"#,
+        );
+        let out = collect(&arm_manifest(), &cfg, &dirs).expect("partial consume coverage is legal");
+        assert_eq!(
+            peer_modules(&out),
+            vec![(
+                vec!["controller".to_string(), "joint_states".to_string()],
+                true
+            )],
+            "omitting a consume entry generates no module for that topic"
+        );
+    }
+
+    #[test]
+    fn unknown_emit_name_is_rejected() {
+        let (_t, _c, dirs) = seeded_dirs();
+        let cfg = interfaces(
+            r#"{ topics: { emits: [
+                { link_id: "controller", name: "joint_states" },
+                { link_id: "controller", name: "not_in_doc" },
+            ] } }"#,
+        );
+        let mismatches = coverage(collect(&arm_manifest(), &cfg, &dirs).expect_err("rejected"));
+        assert_eq!(mismatches[0].unknown_emits, vec!["not_in_doc"]);
+    }
+
+    #[test]
+    fn duplicate_emit_entry_is_rejected() {
+        let (_t, _c, dirs) = seeded_dirs();
+        // Parse-time dedup keys on (link_id, name), so a duplicate only
+        // reaches here when assembled programmatically; the coverage check is
+        // the backstop either way.
+        let cfg = interfaces(
+            r#"{ topics: { emits: [
+                { link_id: "controller", name: "joint_states" },
+                { link_id: "controller", name: "joint_states" },
+            ] } }"#,
+        );
+        let mismatches = coverage(collect(&arm_manifest(), &cfg, &dirs).expect_err("rejected"));
+        assert_eq!(mismatches[0].duplicated_emits, vec!["joint_states"]);
+    }
+
+    /// Listing a counterpart-role topic under `emits` claims to produce
+    /// something the peer produces, so the error names the real emitter.
+    #[test]
+    fn emit_entry_naming_a_counterpart_role_topic_is_rejected() {
+        let (_t, _c, dirs) = seeded_dirs();
+        let cfg = interfaces(
+            r#"{ topics: { emits: [
+                { link_id: "controller", name: "joint_states" },
+                { link_id: "controller", name: "joint_commands" },
+            ] } }"#,
+        );
+        let mismatches = coverage(collect(&arm_manifest(), &cfg, &dirs).expect_err("rejected"));
+        assert_eq!(
+            mismatches[0].wrong_role_emits,
+            vec!["joint_commands (emitted by controller)"],
+            "the error must state which role emits it"
+        );
+    }
+
+    #[test]
+    fn consume_entry_naming_an_own_role_topic_is_rejected() {
+        let (_t, _c, dirs) = seeded_dirs();
+        let cfg = interfaces(
+            r#"{ topics: {
+                emits: [{ link_id: "controller", name: "joint_states" }],
+                consumes: [{ link_id: "controller", name: "joint_states" }],
+            } }"#,
+        );
+        let mismatches = coverage(collect(&arm_manifest(), &cfg, &dirs).expect_err("rejected"));
+        assert_eq!(
+            mismatches[0].wrong_role_consumes,
+            vec!["joint_states (emitted by this node's role arm)"]
+        );
+    }
+
+    #[test]
+    fn consume_entry_absent_from_the_document_is_rejected() {
+        let (_t, _c, dirs) = seeded_dirs();
+        let cfg = interfaces(
+            r#"{ topics: {
+                emits: [{ link_id: "controller", name: "joint_states" }],
+                consumes: [{ link_id: "controller", name: "typo" }],
+            } }"#,
+        );
+        let mismatches = coverage(collect(&arm_manifest(), &cfg, &dirs).expect_err("rejected"));
+        assert_eq!(mismatches[0].unknown_consumes, vec!["typo"]);
+        let rendered = mismatches[0].to_string();
+        for needle in ["typo", "controller", "arm_link", "v1"] {
+            assert!(
+                rendered.contains(needle),
+                "error must name the entry, the slot and the document, missing {needle}: {rendered}"
+            );
+        }
+    }
+
+    /// Several wrong entries on one slot produce one aggregated diff rather
+    /// than a cascade of one error per entry.
+    #[test]
+    fn several_wrong_emit_entries_produce_one_aggregated_diff() {
+        let (_t, _c, dirs) = seeded_dirs();
+        let cfg = interfaces(
+            r#"{ topics: { emits: [
+                { link_id: "controller", name: "joint_commands" },
+                { link_id: "controller", name: "nope" },
+                { link_id: "controller", name: "also_nope" },
+            ] } }"#,
+        );
+        let mismatches = coverage(collect(&arm_manifest(), &cfg, &dirs).expect_err("rejected"));
+        assert_eq!(mismatches.len(), 1, "one diff per slot: {mismatches:?}");
+        assert_eq!(mismatches[0].missing_emits, vec!["joint_states"]);
+        assert_eq!(mismatches[0].unknown_emits, vec!["nope", "also_nope"]);
+        assert_eq!(
+            mismatches[0].wrong_role_emits,
+            vec!["joint_commands (emitted by controller)"]
+        );
+    }
+
+    #[test]
+    fn two_slots_with_one_broken_names_only_the_broken_slot() {
+        let tmp = TempDir::new().unwrap();
+        let entry = seed_pairing(tmp.path(), "arm_link", "v1", ARM_LINK_BODY);
+        let (_c, dirs) = make_peppy_dirs_with_cache(&[entry]);
+        let m = manifest(
+            r#"{
+                name: "commander", tag: "v1",
+                depends_on: { pairings: [
+                    { name: "arm_link", tag: "v1", role: "controller", link_id: "left" },
+                    { name: "arm_link", tag: "v1", role: "controller", link_id: "right" },
+                ] }
+            }"#,
+        );
+        let cfg =
+            interfaces(r#"{ topics: { emits: [{ link_id: "left", name: "joint_commands" }] } }"#);
+        let mismatches = coverage(collect(&m, &cfg, &dirs).expect_err("right slot is uncovered"));
+        assert_eq!(mismatches.len(), 1);
+        assert_eq!(mismatches[0].link_id, "right");
+        assert_eq!(mismatches[0].missing_emits, vec!["joint_commands"]);
+    }
+
+    /// Two slots of the same document each need their own full coverage, and
+    /// each generates its own nested module directory.
+    #[test]
+    fn two_slots_of_one_document_resolve_independently() {
+        let tmp = TempDir::new().unwrap();
+        let entry = seed_pairing(tmp.path(), "arm_link", "v1", ARM_LINK_BODY);
+        let (_c, dirs) = make_peppy_dirs_with_cache(&[entry]);
+        let m = manifest(
+            r#"{
+                name: "commander", tag: "v1",
+                depends_on: { pairings: [
+                    { name: "arm_link", tag: "v1", role: "controller", link_id: "left" },
+                    { name: "arm_link", tag: "v1", role: "controller", link_id: "right" },
+                ] }
+            }"#,
+        );
+        let cfg = interfaces(
+            r#"{ topics: {
+                emits: [
+                    { link_id: "left", name: "joint_commands" },
+                    { link_id: "right", name: "joint_commands" },
+                ],
+                consumes: [{ link_id: "left", name: "joint_states" }],
+            } }"#,
+        );
+        let out = collect(&m, &cfg, &dirs).expect("both slots covered");
+        assert_eq!(
+            peer_modules(&out),
+            vec![
+                (vec!["left".to_string(), "joint_commands".to_string()], true),
+                (vec!["left".to_string(), "joint_states".to_string()], false),
+                (
+                    vec!["right".to_string(), "joint_commands".to_string()],
+                    true
+                ),
+            ],
+            "each slot nests under its own link_id, both directions together; \
+             `right` legitimately has no consume module"
+        );
+    }
+
+    /// `optional` governs whether the slot must be paired at launch, not what
+    /// the node declares about it.
+    #[test]
+    fn optional_slot_is_coverage_checked_identically() {
+        let tmp = TempDir::new().unwrap();
+        let entry = seed_pairing(tmp.path(), "arm_link", "v1", ARM_LINK_BODY);
+        let (_c, dirs) = make_peppy_dirs_with_cache(&[entry]);
+        let m = manifest(
+            r#"{
+                name: "robot_arm", tag: "v1",
+                depends_on: { pairings: [
+                    { name: "arm_link", tag: "v1", role: "arm", link_id: "controller", optional: true },
+                ] }
+            }"#,
+        );
+        let mismatches = coverage(
+            collect(&m, &config::node::Interfaces::default(), &dirs)
+                .expect_err("an optional slot still needs exact emit coverage"),
+        );
+        assert_eq!(mismatches[0].missing_emits, vec!["joint_states"]);
+    }
+
+    /// Entries naming other slot kinds belong to the implements and consumed
+    /// collectors; the pairing collector must step over them.
+    #[test]
+    fn entries_for_other_slots_are_ignored() {
+        let (_t, _c, dirs) = seeded_dirs();
+        let cfg = interfaces(
+            r#"{ topics: {
+                emits: [
+                    { link_id: "controller", name: "joint_states" },
+                    { name: "native_telemetry" },
+                ],
+                consumes: [{ link_id: "some_node_dep", name: "unrelated" }],
+            } }"#,
+        );
+        let out = collect(&arm_manifest(), &cfg, &dirs).expect("unrelated entries are not ours");
+        assert_eq!(
+            peer_modules(&out),
+            vec![(
+                vec!["controller".to_string(), "joint_states".to_string()],
+                true
+            )]
+        );
+    }
+
+    #[test]
+    fn no_pairing_slots_yields_no_interfaces() {
+        let (_t, _c, dirs) = seeded_dirs();
+        let m = manifest(r#"{ name: "plain", tag: "v1" }"#);
+        let out = collect(&m, &config::node::Interfaces::default(), &dirs).expect("ok");
+        assert!(out.is_empty());
     }
 
     #[test]

--- a/crates/generator-internal/src/generator/rust/tests/pairings.rs
+++ b/crates/generator-internal/src/generator/rust/tests/pairings.rs
@@ -110,9 +110,13 @@ fn peer_consumed_topic_wraps_subscribe_peer_without_binding_slots() {
         ],
     );
     // No binding-slot machinery: pairing subscriptions are pinned by the
-    // live peer_update channel, never by the consumer-filter path.
+    // live peer_update channel, never by the consumer-filter path. The
+    // cardinality-typed `bound_producer` accessors belong to consumed topics
+    // and have no meaning for a slot that holds exactly one peer.
     assert!(
-        !rendered.contains("ConsumerFilter") && !rendered.contains("TopicMessenger::subscribe("),
+        !rendered.contains("ConsumerFilter")
+            && !rendered.contains("TopicMessenger::subscribe(")
+            && !rendered.contains("bound_producer"),
         "peer subscriptions must ride subscribe_peer, not the binding-slot path:\n{rendered}"
     );
 }

--- a/crates/generator-internal/tests/python/pairing_lib.rs
+++ b/crates/generator-internal/tests/python/pairing_lib.rs
@@ -71,13 +71,36 @@ fn generated_peer_modules_import_from_venv() {
         Path::new(PEPPYGEN_OUTPUT_PATH),
     );
 
-    let pairings_dir = user_node
-        .join(PEPPYGEN_OUTPUT_PATH)
-        .join("peppygen/pairings");
+    let peppygen_dir = user_node.join(PEPPYGEN_OUTPUT_PATH).join("peppygen");
+    let pairings_dir = peppygen_dir.join("pairings");
     for module in ["controller/joint_states.py", "controller/joint_commands.py"] {
         assert!(
             pairings_dir.join(module).exists(),
             "expected generated module pairings/{module}"
+        );
+    }
+    // Neither direction may leak into the flat consumed/emitted namespaces.
+    // Asserted on directory contents so a misplaced-but-working module fails
+    // loudly instead of passing by importing.
+    for category in ["consumed_topics", "emitted_topics"] {
+        let dir = peppygen_dir.join(category);
+        // The scaffold creates every category dir, so a missing one means the
+        // layout changed and this check would otherwise pass vacuously.
+        assert!(
+            dir.is_dir(),
+            "expected category dir {}; if the scaffold stopped creating empty \
+             categories, rewrite this assertion rather than deleting it",
+            dir.display()
+        );
+        let entries: Vec<String> = fs::read_dir(&dir)
+            .expect("category dir reads")
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|name| name != "__init__.py")
+            .collect();
+        assert!(
+            entries.is_empty(),
+            "pairing topics must not generate modules under {category}, found: {entries:?}"
         );
     }
 

--- a/crates/generator-internal/tests/rust/pairing_lib.rs
+++ b/crates/generator-internal/tests/rust/pairing_lib.rs
@@ -74,11 +74,36 @@ fn generated_peer_modules_compile_against_peppylib() {
     );
 
     // Both directions of the slot nest flat under pairings/<link_id>/<topic>.
-    let pairings_dir = user_node.join(PEPPYGEN_OUTPUT_PATH).join("src/pairings");
+    let src_dir = user_node.join(PEPPYGEN_OUTPUT_PATH).join("src");
+    let pairings_dir = src_dir.join("pairings");
     for module in ["arm/joint_commands.rs", "arm/joint_states.rs"] {
         assert!(
             pairings_dir.join(module).exists(),
             "expected generated module pairings/{module}"
+        );
+    }
+    // Neither direction may leak into the flat consumed/emitted namespaces.
+    // Asserted on directory contents so a misplaced-but-working module fails
+    // loudly instead of passing by compiling.
+    for category in ["consumed_topics", "emitted_topics"] {
+        let dir = src_dir.join(category);
+        // The scaffold creates every category dir, so a missing one means the
+        // layout changed and this check would otherwise pass vacuously.
+        assert!(
+            dir.is_dir(),
+            "expected category dir {}; if the scaffold stopped creating empty \
+             categories, rewrite this assertion rather than deleting it",
+            dir.display()
+        );
+        let entries: Vec<String> = fs::read_dir(&dir)
+            .expect("category dir reads")
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|name| name != "mod.rs")
+            .collect();
+        assert!(
+            entries.is_empty(),
+            "pairing topics must not generate modules under {category}, found: {entries:?}"
         );
     }
 

--- a/crates/peppy/tests/node_pair.rs
+++ b/crates/peppy/tests/node_pair.rs
@@ -26,10 +26,13 @@ use tokio::sync::watch;
 
 use super::common::{seed_pairing_repo, test_node_target};
 
-/// A node declaring one pairing slot. `run_cmd` is a plain `sleep` so the
-/// daemon has a real process to own; the node's services are emulated
-/// in-process by the test.
+/// A node declaring one pairing slot, with the `interfaces.topics` entries
+/// the role owes: `emits` must cover the role's topics exactly, `consumes`
+/// names the counterpart's. `run_cmd` is a plain `sleep` so the daemon has a
+/// real process to own; the node's services are emulated in-process by the
+/// test.
 fn node_config(name: &str, role: &str, link_id: &str) -> String {
+    let (emits, consumes) = arm_link_topics(role);
     format!(
         r#"{{
             peppy_schema: "node/v1",
@@ -42,9 +45,25 @@ fn node_config(name: &str, role: &str, link_id: &str) -> String {
                     ]
                 }}
             }},
+            interfaces: {{
+                topics: {{
+                    emits: [{{ link_id: "{link_id}", name: "{emits}" }}],
+                    consumes: [{{ link_id: "{link_id}", name: "{consumes}" }}]
+                }}
+            }},
             execution: {{ language: "rust", run_cmd: ["sleep", "30"] }}
         }}"#
     )
+}
+
+/// The `(emitted, consumed)` topic names of `common::ARM_LINK_PAIRING` for a
+/// role, so a manifest's entries stay in step with the document.
+fn arm_link_topics(role: &str) -> (&'static str, &'static str) {
+    match role {
+        "controller" => ("joint_commands", "joint_states"),
+        "arm" => ("joint_states", "joint_commands"),
+        other => panic!("arm_link declares no role `{other}`"),
+    }
 }
 
 /// Writes a node dir with the given config and `node add --build`s it (no

--- a/crates/peppy/tests/node_sync.rs
+++ b/crates/peppy/tests/node_sync.rs
@@ -524,6 +524,12 @@ async fn node_sync_generates_peer_modules_for_pairing_slots() {
                     ]
                 }
             },
+            interfaces: {
+                topics: {
+                    emits: [{ link_id: "controller", name: "joint_states" }],
+                    consumes: [{ link_id: "controller", name: "joint_commands" }]
+                }
+            },
             execution: { language: "rust", run_cmd: ["sleep", "1"] }
         }"#,
     )
@@ -578,6 +584,12 @@ async fn node_sync_pairing_cache_miss_suggests_repo_refresh() {
                     pairings: [
                         { name: "arm_link", tag: "v1", role: "arm", link_id: "controller" }
                     ]
+                }
+            },
+            interfaces: {
+                topics: {
+                    emits: [{ link_id: "controller", name: "joint_states" }],
+                    consumes: [{ link_id: "controller", name: "joint_commands" }]
                 }
             },
             execution: { language: "rust", run_cmd: ["sleep", "1"] }

--- a/crates/peppy/tests/stack_launch.rs
+++ b/crates/peppy/tests/stack_launch.rs
@@ -2376,7 +2376,12 @@ async fn stack_launch_establishes_launcher_pairings() {
             r#"{ pairings: [{ name: "arm_link", tag: "v1", role: "arm", link_id: "controller" }] }"#,
         ),
         None,
-        None,
+        Some(
+            r#"{ topics: {
+                emits: [{ link_id: "controller", name: "joint_states" }],
+                consumes: [{ link_id: "controller", name: "joint_commands" }]
+            } }"#,
+        ),
     );
     let ctrl_path = write_node_config_for_helper(
         nodes_dir.path(),
@@ -2388,7 +2393,12 @@ async fn stack_launch_establishes_launcher_pairings() {
             r#"{ pairings: [{ name: "arm_link", tag: "v1", role: "controller", link_id: "arm" }] }"#,
         ),
         None,
-        None,
+        Some(
+            r#"{ topics: {
+                emits: [{ link_id: "arm", name: "joint_commands" }],
+                consumes: [{ link_id: "arm", name: "joint_states" }]
+            } }"#,
+        ),
     );
 
     // In-process node services for both instances, including the
@@ -2524,7 +2534,12 @@ async fn stack_launch_rejects_uncovered_pairing_slot() {
             r#"{ pairings: [{ name: "arm_link", tag: "v1", role: "arm", link_id: "controller" }] }"#,
         ),
         None,
-        None,
+        Some(
+            r#"{ topics: {
+                emits: [{ link_id: "controller", name: "joint_states" }],
+                consumes: [{ link_id: "controller", name: "joint_commands" }]
+            } }"#,
+        ),
     );
 
     let launcher_path = nodes_dir.path().join("peppy_launcher.json5");

--- a/docs/src/content/docs/advanced_guides/contract_implementation.mdx
+++ b/docs/src/content/docs/advanced_guides/contract_implementation.mdx
@@ -147,8 +147,10 @@ This is the point of the explicit-entry design: the node's `peppy.json5` shows w
 
 Implements link_ids share one flat namespace with `depends_on.{nodes,contracts,pairings}` link_ids; a collision is rejected at parse time. Direction matters:
 
-- A produced entry (`topics.emits`, `services.exposes`, `actions.exposes`) may only reference a `manifest.implements` slot.
-- A consumed entry (`*.consumes`) may only reference a `depends_on.{nodes,contracts}` slot.
+- `services.exposes` and `actions.exposes` may only reference a `manifest.implements` slot.
+- `topics.emits` may reference a `manifest.implements` slot or a `depends_on.pairings` slot, because a [pairing](/advanced_guides/pairing) role produces the document's topics as well as consuming them.
+- `services.consumes` and `actions.consumes` may only reference a `depends_on.{nodes,contracts}` slot; a pairing document declares topics only, so it exposes no service or action to consume.
+- `topics.consumes` may additionally reference a `depends_on.pairings` slot, naming a topic the counterpart role emits.
 
 Pick semantic short names for implements link_ids (`cam`, `collision`, `hw_ready`, `moves`), matching the consumer-side style, rather than echoing the contract name.
 

--- a/docs/src/content/docs/advanced_guides/pairing.mdx
+++ b/docs/src/content/docs/advanced_guides/pairing.mdx
@@ -66,6 +66,8 @@ After `peppy repo refresh`, the pairing is cached and addressable by `(name, tag
 
 Each node declares a **pairing slot** under `depends_on.pairings`: the contract, the role this node plays, and a `link_id` naming the slot. The `link_id` is how the node's own code and the pairing commands refer to *the other end*; while paired, exactly one peer instance sits behind it.
 
+The slot says *which* conversation the node joins. `interfaces.topics` says *what the node uses through it*, exactly like a contract implementer and a contract consumer. A pairing-backed entry is just `{ link_id, name }`: the pairing document remains the single source of shape and QoS, so an inline `message_format` or `qos_profile` on one of these entries is rejected.
+
 <Tabs>
   <TabItem label="Python">
     <Code code={robotArmPythonConfig} lang="json5" title="robot_arm/peppy.json5" />
@@ -84,12 +86,23 @@ Each node declares a **pairing slot** under `depends_on.pairings`: the contract,
   </TabItem>
 </Tabs>
 
+The two manifests are mirror images, which is what makes the conversation legible from either side alone:
+
 | Node | Role in `arm_link` | Slot (`link_id`) | Emits to the peer | Consumes from the peer |
 |---|---|---|---|---|
 | `robot_arm` | `arm` | `controller` | `joint_states` | `joint_commands` |
 | `arm_controller` | `controller` | `arm` | `joint_commands` | `joint_states` |
 
-A slot is **required** by default: starting the instance without pairing it (or explicitly deferring it) fails loudly. Mark a slot `optional: true` to let the instance boot unpaired with no ceremony.
+### Coverage: emit side complete, consume side free
+
+The two directions are checked differently, and for the same reasons contracts are:
+
+- **`emits` must be exact.** The entries for a slot are precisely the document's topics whose `emitted_by` is the slot's role: no missing entry, no unknown name, no duplicate, and never a topic the *counterpart* role emits. A role that silently stopped emitting one of its topics would break its peer, and the pairing document is the promise that it will not.
+- **`consumes` may be partial.** List any subset of the counterpart role's topics. Omitting one is a legitimate way to ignore part of a pairing: no module is generated for that topic, so no subscription can be created for it. This is a local decision with no effect on the peer. Declaring zero consumes is fine, including for a slot whose counterpart role emits nothing.
+
+Naming a topic under `consumes` that this node's own role emits is an error, as is naming a topic that is absent from the document. Both are reported as one aggregated diff per slot, so a manifest with several wrong entries produces one readable report rather than a cascade.
+
+A slot is **required** by default: starting the instance without pairing it (or explicitly deferring it) fails loudly. Mark a slot `optional: true` to let the instance boot unpaired with no ceremony. Optionality governs whether the slot must be paired at launch, not what the node declares about it: an optional slot is coverage-checked identically.
 
 ## Establishing pairs
 
@@ -153,7 +166,7 @@ arm_controller:v1   ctrl_1     arm ⇌ arm_1:controller@cn-adoring-wiles (arm_li
 
 ## Using the generated API
 
-`peppy node sync` generates a module per slot topic under `peppygen.pairings.<link_id>.<topic>` (Python) / `peppygen::pairings::<link_id>::<topic>` (Rust); both directions of a slot live under the same `link_id`. Emitting and consuming look exactly like ordinary topics, plus two pin-state helpers on every module: `paired()` returns the current peer's identity (or `None`/`None` while unpaired), and `wait_paired()` awaits one.
+`peppy node sync` generates a module per declared slot topic under `peppygen.pairings.<link_id>.<topic>` (Python) / `peppygen::pairings::<link_id>::<topic>` (Rust); both directions of a slot live under the same `link_id`. The modules follow the manifest's entries, not the document's full topic list, so a counterpart topic you left out of `consumes` simply has no module. Pairing topics never appear under `consumed_topics` or `emitted_topics`, whichever direction they travel. Emitting and consuming look exactly like ordinary topics, plus two pin-state helpers on every module: `paired()` returns the current peer's identity (or `None`/`None` while unpaired), and `wait_paired()` awaits one.
 
 <Tabs>
   <TabItem label="Python">
@@ -205,6 +218,8 @@ Pairing state lives in the daemon, alongside the node stack itself. Like the sta
 
 Because the slot, not the node, is the unit of pairing, a node can declare several slots of the *same* pairing and hold one peer per slot, each a fully isolated stream:
 
+Each slot is declared and covered on its own, so the two arms stay independent all the way down to the generated modules:
+
 ```json5
 // commander/peppy.json5 (manifest excerpt)
 depends_on: {
@@ -212,6 +227,20 @@ depends_on: {
     { name: "arm_link", tag: "v1", role: "controller", link_id: "left_arm" },
     { name: "arm_link", tag: "v1", role: "controller", link_id: "right_arm" },
   ],
+},
+interfaces: {
+  topics: {
+    // Emit coverage is per slot, so the controller role's `joint_commands`
+    // is listed once for each arm.
+    emits: [
+      { link_id: "left_arm", name: "joint_commands" },
+      { link_id: "right_arm", name: "joint_commands" },
+    ],
+    consumes: [
+      { link_id: "left_arm", name: "joint_states" },
+      { link_id: "right_arm", name: "joint_states" },
+    ],
+  },
 },
 ```
 
@@ -245,6 +274,8 @@ Pairing and [contract implementation](/advanced_guides/contract_implementation) 
 
 | | Pairing | Contract |
 |---|---|---|
+| Declaration model | The node enumerates what it uses in `interfaces.topics`; the document owns shape and QoS | The node enumerates what it uses in `interfaces`; the document owns shape and QoS |
+| Coverage | Produced side (`emits`) exact per slot, consumed side free | Produced side (`implements`) exact per slot, consumed side free |
 | Cardinality | Exactly 1:1 per slot, exclusive (no `cardinality` key) | Declared per slot: exactly one by default, an application-selected set for `one_or_more` / `zero_or_more` |
 | Directionality | Both directions in one contract (two roles) | One direction per contract |
 | Establishment | Explicit (`--pair` / `pairings:`), at instance start | Explicit (`--bind` / `bindings:`), at instance start |

--- a/docs/src/content/docs/guides/snippets/python/arm_controller/peppy.json5
+++ b/docs/src/content/docs/guides/snippets/python/arm_controller/peppy.json5
@@ -11,6 +11,18 @@
       ],
     },
   },
+  interfaces: {
+    topics: {
+      // The mirror image of the arm's block: this role emits the commands and
+      // consumes the states.
+      emits: [
+        { link_id: "arm", name: "joint_commands" },
+      ],
+      consumes: [
+        { link_id: "arm", name: "joint_states" },
+      ],
+    },
+  },
   execution: {
     language: "python",
     build_cmd: ["uv", "sync"],

--- a/docs/src/content/docs/guides/snippets/python/robot_arm/peppy.json5
+++ b/docs/src/content/docs/guides/snippets/python/robot_arm/peppy.json5
@@ -12,6 +12,20 @@
       ],
     },
   },
+  interfaces: {
+    topics: {
+      // The `arm` role's side of the conversation, declared the same way a
+      // contract implementer declares its contract members. The pairing
+      // document stays the source of shape and QoS; these entries only say
+      // which of its topics this node uses.
+      emits: [
+        { link_id: "controller", name: "joint_states" },
+      ],
+      consumes: [
+        { link_id: "controller", name: "joint_commands" },
+      ],
+    },
+  },
   execution: {
     language: "python",
     build_cmd: ["uv", "sync"],

--- a/docs/src/content/docs/guides/snippets/rust/arm_controller/peppy.json5
+++ b/docs/src/content/docs/guides/snippets/rust/arm_controller/peppy.json5
@@ -11,6 +11,18 @@
       ],
     },
   },
+  interfaces: {
+    topics: {
+      // The mirror image of the arm's block: this role emits the commands and
+      // consumes the states.
+      emits: [
+        { link_id: "arm", name: "joint_commands" },
+      ],
+      consumes: [
+        { link_id: "arm", name: "joint_states" },
+      ],
+    },
+  },
   execution: {
     language: "rust",
     build_cmd: ["cargo", "build", "--release"],

--- a/docs/src/content/docs/guides/snippets/rust/robot_arm/peppy.json5
+++ b/docs/src/content/docs/guides/snippets/rust/robot_arm/peppy.json5
@@ -12,6 +12,20 @@
       ],
     },
   },
+  interfaces: {
+    topics: {
+      // The `arm` role's side of the conversation, declared the same way a
+      // contract implementer declares its contract members. The pairing
+      // document stays the source of shape and QoS; these entries only say
+      // which of its topics this node uses.
+      emits: [
+        { link_id: "controller", name: "joint_states" },
+      ],
+      consumes: [
+        { link_id: "controller", name: "joint_commands" },
+      ],
+    },
+  },
   execution: {
     language: "rust",
     build_cmd: ["cargo", "build", "--release"],


### PR DESCRIPTION
## What

`collect_pairing_interfaces` iterated the pairing document's topic list and never read the node's `interfaces` block at all. It now resolves the entries the node declares in `interfaces.topics` against the document.

Companion to Peppy-bot/public-peppy-libs (parse-time rules and the `LinkedEntry` rename), which must merge first. **CI here will fail until it does**: `Cargo.lock` pins the published libs revision, which does not yet have `LinkedEntry`, `PairingCoverageMismatch`, or `InterfaceKind::consumed_section`. The lock needs a `cargo update -p peppy-config-model` once that PR lands.

## Coverage policy

Mirrors contracts exactly:

- **Emit side exact.** The entries for a slot are precisely the document's topics whose `emitted_by` is the slot's role. A missing entry, an unknown name, a duplicate, or a counterpart-role topic is an error. A role that silently stops emitting one of its topics breaks its peer, and the pairing document is the promise that it will not.
- **Consume side partial.** Omitting a topic means no module is generated and no subscription can be created for it. That is a local decision with no effect on the peer. Zero consume entries is legal.

Problems are reported as one aggregated `PairingCoverageMismatch` per slot, so a node with several wrong entries produces one readable report rather than a cascade. An `optional: true` slot is checked identically: optionality governs whether the slot must be paired at launch, not what the node declares about it.

## The generated namespace does not change

Pairing modules stay at `peppygen.pairings.<link_id>.<topic>` / `peppygen::pairings::<link_id>::<topic>`. No application code changes anywhere.

That is the part most exposed to regression. Naively admitting pairing link_ids into the existing collectors would put pairing topics in `peppygen.consumed_topics.<link_id>_<topic>` and `peppygen.emitted_topics.<topic>`, which would:

- split one slot's two directions across two unrelated namespaces;
- flatten the nested per-slot grouping into `<link_id>_<topic>`, where a duplicate leaf name is silently renamed with a numeric suffix decided by map iteration order;
- expose cardinality-typed `bound_producer` accessors that have no meaning for a slot holding exactly one peer.

So the entries are partitioned before any collector runs: `collect_consumed_interfaces` and `resolve_implements` step over pairing-linked entries. Without that, a pairing consume resolves to nothing and is dropped (the consumed dependency lookup knows only node and contract kinds), and a pairing emit is counted against an implements slot's coverage.

`crates/core-node-internal/src/services/node/sync/interfaces.rs::pairing_and_contract_entries_route_to_separate_collectors` pins this end to end, on a node holding an implements slot, a contract dependency and a pairing slot at once.

## Two bugs fixed along the way

**Silent drop on the contract side.** A consumed entry naming no member of its contract returned `None` and was skipped, so a typo produced a missing module and a successful `node sync`. It is now an error naming the entry, the slot and the document. `validate_dependency_specs` never reaches a `depends_on.contracts` link_id (it short-circuits at the declaration check), so this is the only place it can be reported. Node dependencies are deliberately left to that upstream reporter, so a typo there still produces exactly one error, not two.

**A contract topic with no `message_format`.** Turning the above into an error exposed an adjacent bug: such a topic also resolved to `None` and would have been misreported as naming no member of the contract. It now defaults the format the way a contract service already does, so the new error means only what it says.

## Migration in this PR

- 4 docs snippet manifests (`guides/snippets/{python,rust}/{robot_arm,arm_controller}`), exercised by `docs-integration-tests`, which adds, builds and launches them.
- Inline pairing manifests in `node_pair.rs`, `node_sync.rs`, `stack_launch.rs`.

Pairing documents, the wire format, pairing establishment, the peer update service, the launcher and the CLI are all untouched.

## Docs

The pairing guide gains the new manifest shape (both languages, via the snippet imports), the coverage policy, a note that omitting a consume entry is a legitimate way to ignore part of a pairing, and declaration-model plus coverage rows in the "Pairing vs. contracts" table.

`contract_implementation.mdx` had two statements this change falsifies, now corrected: "a produced entry may only reference a `manifest.implements` slot" and "a consumed entry may only reference a `depends_on.{nodes,contracts}` slot".

## Testing

- `cargo test`: 575 passed, 0 failed
- `cargo test -p docs-integration-tests`: 11 passed, 0 failed (none `#[ignore]`d, so the pairing snippets really were added, built and launched)
- 15 new pairing coverage tests, plus the three-collector partition test above

Codegen assertions are on directory contents, not just compilation, so a misplaced-but-working module fails loudly: both `pairing_lib` tests assert the `consumed_topics` and `emitted_topics` directories contain no pairing modules, and assert those directories exist first so the check cannot pass vacuously if the scaffold layout changes. The Rust `bound_producer` negative assertion, which the Python side already had, was added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pairing interfaces now support per-slot topic declarations and generate modules only for declared topics.
  * Pairing coverage validation reports missing, duplicate, unknown, and wrong-role entries together.
  * Contract interface validation now rejects references to nonexistent contract members.
* **Bug Fixes**
  * Prevented pairing-backed interfaces from being double-counted in contract coverage.
  * Improved handling of incomplete or invalid pairing declarations.
* **Documentation**
  * Clarified pairing coverage, link ID rules, generated APIs, and contract-versus-pairing behavior.
  * Updated example manifests with explicit topic configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->