### PR TITLE
Uniform peppygen namespace: nest every slot-backed module at <category>/<link_id>/<member>

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,7 +573,7 @@ dependencies = [
 [[package]]
 name = "build-helpers"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#51c33b3aa6c69e1279eade7c8222a2d36e8ee4cc"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#fef31db216a9f62c6c004202fa2932b0e8c84ec9"
 dependencies = [
  "sha2",
 ]
@@ -690,9 +690,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fb99565819980999fb7b4a1796046a5c949e6d4ff132cf5fadf5a641e20d776"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -712,14 +712,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f2392eae7f16557a3d727ef3a12e57b2b2ca6f98566a5f4fb41ffe305df077"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -774,7 +774,7 @@ dependencies = [
 [[package]]
 name = "config-test-support"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#51c33b3aa6c69e1279eade7c8222a2d36e8ee4cc"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#fef31db216a9f62c6c004202fa2932b0e8c84ec9"
 dependencies = [
  "askama",
  "git2",
@@ -918,7 +918,7 @@ dependencies = [
 [[package]]
 name = "core-node-api"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#51c33b3aa6c69e1279eade7c8222a2d36e8ee4cc"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#fef31db216a9f62c6c004202fa2932b0e8c84ec9"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -2577,7 +2577,7 @@ dependencies = [
 [[package]]
 name = "json5-pretty"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#51c33b3aa6c69e1279eade7c8222a2d36e8ee4cc"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#fef31db216a9f62c6c004202fa2932b0e8c84ec9"
 dependencies = [
  "serde",
  "serde_json",
@@ -2670,9 +2670,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.188"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22053b6a34f84abc97f9129e61334f40174659a1b9bd18c970b83db6a9a6348b"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libgit2-sys"
@@ -3351,7 +3351,7 @@ dependencies = [
 [[package]]
 name = "peppy-config-model"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#51c33b3aa6c69e1279eade7c8222a2d36e8ee4cc"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#fef31db216a9f62c6c004202fa2932b0e8c84ec9"
 dependencies = [
  "capnp",
  "clap",
@@ -3374,7 +3374,7 @@ version = "0.0.1"
 [[package]]
 name = "peppylib-rs"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#51c33b3aa6c69e1279eade7c8222a2d36e8ee4cc"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#fef31db216a9f62c6c004202fa2932b0e8c84ec9"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -3569,7 +3569,7 @@ dependencies = [
 [[package]]
 name = "pmi"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#51c33b3aa6c69e1279eade7c8222a2d36e8ee4cc"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#fef31db216a9f62c6c004202fa2932b0e8c84ec9"
 dependencies = [
  "build-helpers",
  "bytes",

--- a/crates/core-node-internal/src/services/node/sync/interfaces.rs
+++ b/crates/core-node-internal/src/services/node/sync/interfaces.rs
@@ -55,7 +55,7 @@ pub fn collect_all_deployment_interfaces(
 
 /// The `depends_on.pairings` slot link_ids of a manifest. Entries naming one
 /// are resolved by `collect_pairing_interfaces` against the pairing document
-/// and generated under `pairings/<link_id>/<topic>`, so both the consumed
+/// and generated under `paired_topics/<link_id>/<topic>`, so both the consumed
 /// collector and the implements resolver must step over them: neither knows
 /// the pairing kind, and collecting an entry twice would either drop it
 /// silently or land it in the wrong module category.
@@ -419,8 +419,8 @@ struct SlotCoverage {
 ///
 /// entry -> implements slot -> contract document -> member (by name and
 /// kind) -> shape/qos, stamped with a [`ContractOrigin`] so the generator
-/// nests the artifact under `{contract_name}/{contract_tag}/{leaf}` and
-/// embeds the matching wire segments.
+/// nests the artifact under `{link_id}/{leaf}` and embeds the matching wire
+/// segments.
 ///
 /// After resolution, the Tier B coverage check runs per (slot x kind): the
 /// contract-backed entries referencing a slot must cover every member of
@@ -485,6 +485,7 @@ pub fn resolve_implements(
             )));
         };
         let origin = ContractOrigin {
+            link_id: slot.link_id.as_str().to_string(),
             contract_name: slot.name.as_str().to_string(),
             contract_tag: slot.tag.clone(),
         };

--- a/crates/core-node-internal/src/services/node/sync/pairings.rs
+++ b/crates/core-node-internal/src/services/node/sync/pairings.rs
@@ -165,7 +165,7 @@ struct SlotCoverage {
 }
 
 /// Resolves every `depends_on.pairings` slot into the generator inputs for the
-/// `pairings/<link_id>/<topic>` modules, driven by what the node declares:
+/// `paired_topics/<link_id>/<topic>` modules, driven by what the node declares:
 /// each pairing-backed `topics.emits` entry becomes peer-emitted and each
 /// pairing-backed `topics.consumes` entry becomes peer-consumed, with shape
 /// and QoS read from the pairing document.
@@ -441,7 +441,7 @@ mod tests {
     }
 
     /// The `(module_path, is_emitted)` of each produced interface, so tests
-    /// assert both the direction and the `pairings/<link_id>/<topic>` path.
+    /// assert both the direction and the `paired_topics/<link_id>/<topic>` path.
     fn peer_modules(out: &[generator::DeploymentInterface]) -> Vec<(Vec<String>, bool)> {
         out.iter()
             .map(|i| match i.interface() {

--- a/crates/core-node-internal/tests/listen_for_node_add/implements.rs
+++ b/crates/core-node-internal/tests/listen_for_node_add/implements.rs
@@ -7,7 +7,7 @@
 //! generator never saw the contract-backed's topics/services. The
 //! resulting peppygen had a flat layout (`emitted_topics.rs` was empty)
 //! and any node code importing nested paths like
-//! `peppygen::emitted_topics::<contract>::<tag>::<topic>` failed to compile
+//! `peppygen::emitted_topics::<link_id>::<topic>` failed to compile
 //! inside the container. `sync` did this correctly, which is why a sync
 //! followed by build was enough to mask the bug on a developer's
 //! workstation but the daemon-driven path produced broken artifacts.
@@ -55,7 +55,7 @@ const NODE_BODY: &str = r#"{
 
 /// `node_add` must resolve the contract-backed entries and pass the
 /// resolved topics/services to the generator so the staged peppygen nests
-/// artifacts under `{category}/{contract_name}/{contract_tag}/`. Before the
+/// artifacts under `{category}/{link_id}/`. Before the
 /// fix, the working dir's `emitted_topics.rs` and
 /// `exposed_services.rs` were empty for a node whose only contributions
 /// came through an implemented contract.
@@ -115,15 +115,14 @@ async fn node_add_generates_contract_backed_modules_in_working_dir() {
     let emitted_topics = std::fs::read_to_string(peppygen_src.join("emitted_topics.rs"))
         .expect("emitted_topics.rs should exist in staged peppygen");
     assert!(
-        emitted_topics.contains("pub mod uvc_camera;"),
-        "emitted_topics.rs should declare the implemented contract module \
-         `uvc_camera`; got:\n{emitted_topics}"
+        emitted_topics.contains("pub mod cam;"),
+        "emitted_topics.rs should declare the slot module `cam`; got:\n{emitted_topics}"
     );
     assert!(
         peppygen_src
-            .join("emitted_topics/uvc_camera/v1/video_stream.rs")
+            .join("emitted_topics/cam/video_stream.rs")
             .is_file(),
-        "expected nested `emitted_topics/uvc_camera/v1/video_stream.rs` \
+        "expected nested `emitted_topics/cam/video_stream.rs` \
          in staged peppygen at {}",
         peppygen_src.display(),
     );
@@ -131,15 +130,14 @@ async fn node_add_generates_contract_backed_modules_in_working_dir() {
     let exposed_services = std::fs::read_to_string(peppygen_src.join("exposed_services.rs"))
         .expect("exposed_services.rs should exist in staged peppygen");
     assert!(
-        exposed_services.contains("pub mod uvc_camera;"),
-        "exposed_services.rs should declare the implemented contract module \
-         `uvc_camera`; got:\n{exposed_services}"
+        exposed_services.contains("pub mod cam;"),
+        "exposed_services.rs should declare the slot module `cam`; got:\n{exposed_services}"
     );
     assert!(
         peppygen_src
-            .join("exposed_services/uvc_camera/v1/video_stream_info.rs")
+            .join("exposed_services/cam/video_stream_info.rs")
             .is_file(),
-        "expected nested `exposed_services/uvc_camera/v1/video_stream_info.rs` \
+        "expected nested `exposed_services/cam/video_stream_info.rs` \
          in staged peppygen at {}",
         peppygen_src.display(),
     );

--- a/crates/core-node-internal/tests/listen_for_node_sync.rs
+++ b/crates/core-node-internal/tests/listen_for_node_sync.rs
@@ -642,10 +642,11 @@ async fn listen_for_node_sync_generates_rust_interfaces() {
     let consumed_topic_path = brain_peppygen_dir
         .join("src")
         .join("consumed_topics")
-        .join("uvc_camera_video_stream.rs");
+        .join("uvc_camera")
+        .join("video_stream.rs");
     assert!(
         consumed_topic_path.exists(),
-        "peppygen uvc_camera_video_stream.rs should exist at {}",
+        "peppygen uvc_camera/video_stream.rs should exist at {}",
         consumed_topic_path.display()
     );
 }
@@ -800,10 +801,11 @@ async fn listen_for_node_sync_generates_rust_consumed_service_interfaces() {
     let consumed_service_path = brain_peppygen_dir
         .join("src")
         .join("consumed_services")
-        .join("uvc_camera_enable_camera.rs");
+        .join("uvc_camera")
+        .join("enable_camera.rs");
     assert!(
         consumed_service_path.exists(),
-        "peppygen uvc_camera_enable_camera.rs should exist at {}",
+        "peppygen uvc_camera/enable_camera.rs should exist at {}",
         consumed_service_path.display()
     );
 }
@@ -960,10 +962,11 @@ async fn listen_for_node_sync_generates_rust_consumed_topic_interfaces() {
     let consumed_topic_path = brain_peppygen_dir
         .join("src")
         .join("consumed_topics")
-        .join("uvc_camera_video_stream.rs");
+        .join("uvc_camera")
+        .join("video_stream.rs");
     assert!(
         consumed_topic_path.exists(),
-        "peppygen uvc_camera_video_stream.rs should exist at {}",
+        "peppygen uvc_camera/video_stream.rs should exist at {}",
         consumed_topic_path.display()
     );
 }
@@ -1126,10 +1129,11 @@ async fn listen_for_node_sync_generates_rust_consumed_action_interfaces() {
     let consumed_action_path = controller_peppygen_dir
         .join("src")
         .join("consumed_actions")
-        .join("brain_move_arm.rs");
+        .join("brain")
+        .join("move_arm.rs");
     assert!(
         consumed_action_path.exists(),
-        "peppygen brain_move_arm.rs should exist at {}",
+        "peppygen brain/move_arm.rs should exist at {}",
         consumed_action_path.display()
     );
 }
@@ -1581,7 +1585,8 @@ async fn include_repositories_true_resolves_fs_dep_from_repository() {
         .join(PEPPYGEN_OUTPUT_PATH)
         .join("src")
         .join("consumed_topics")
-        .join("uvc_camera_video_stream.rs");
+        .join("uvc_camera")
+        .join("video_stream.rs");
     assert!(
         consumed_topic_path.exists(),
         "expected peppygen file at {}",

--- a/crates/generator-internal/src/error.rs
+++ b/crates/generator-internal/src/error.rs
@@ -90,4 +90,18 @@ needs a decodable payload"
 (pairing topic names must be unique across the whole document)"
     )]
     PeerTopicNameCollision { link_id: String, topic: String },
+    /// Two sibling module segments at the same tree level sanitize to the same
+    /// on-disk name. Nesting is meant to make a name collision unrepresentable,
+    /// so this is a hard error naming both raw segments rather than a silent
+    /// numeric-suffix rename.
+    #[error(
+        "module name collision in `{category}`: `{first}` and `{second}` both \
+sanitize to the module name `{sanitized}`"
+    )]
+    ModuleNameCollision {
+        category: String,
+        first: String,
+        second: String,
+        sanitized: String,
+    },
 }

--- a/crates/generator-internal/src/generator/naming.rs
+++ b/crates/generator-internal/src/generator/naming.rs
@@ -108,38 +108,6 @@ pub(crate) fn normalize_snake_case(input: &str) -> String {
     result
 }
 
-/// Builds a sanitized module name from node and name components.
-///
-/// Returns a combined `node_name` string, or the non-empty component if the other is empty.
-pub(crate) fn module_name_from_components(node: &str, name: &str) -> String {
-    let node_component = sanitize_component(node);
-    let name_component = sanitize_component(name);
-
-    match (node_component.is_empty(), name_component.is_empty()) {
-        (false, false) => format!("{node_component}_{name_component}"),
-        (false, true) => node_component,
-        (true, false) => name_component,
-        (true, true) => String::new(),
-    }
-}
-
-/// Builds a raw (unsanitized) label from node and name components.
-///
-/// Unlike [`module_name_from_components`], this preserves the original characters
-/// so that names which differ only in separator style (e.g. `foo-bar` vs `foo_bar`)
-/// remain distinct.  Used as the grouping key for artifacts before sanitization.
-pub(crate) fn raw_module_label(node: &str, name: &str) -> String {
-    let node = node.trim();
-    let name = name.trim();
-
-    match (node.is_empty(), name.is_empty()) {
-        (false, false) => format!("{node}::{name}"),
-        (false, true) => node.to_string(),
-        (true, false) => name.to_string(),
-        (true, true) => String::new(),
-    }
-}
-
 /// Sanitizes a display name for use in generated comments and doc attributes.
 ///
 /// Trims whitespace, replaces control characters with spaces, and collapses
@@ -366,30 +334,10 @@ pub(crate) fn consumed_action_schema_keys(
     }
 }
 
-/// Generates a unique module name by appending a numeric suffix on collision.
-///
-/// `sanitize_fn` converts the raw name into a valid module name for the target language.
-/// On the first occurrence the name is used as-is; subsequent duplicates get `_1`, `_2`, etc.
-pub(crate) fn unique_module_name(
-    original: &str,
-    counts: &mut std::collections::HashMap<String, usize>,
-    sanitize_fn: fn(&str) -> String,
-) -> String {
-    let base = sanitize_fn(original);
-    let counter = counts.entry(base.clone()).or_insert(0);
-    let name = if *counter == 0 {
-        base
-    } else {
-        format!("{base}_{counter}")
-    };
-    *counter += 1;
-    name
-}
-
 /// Schema key for a pairing topic: `peer_<link_id>_<topic>`. Per-slot capnp
 /// duplication is accepted (same policy as consumed topics): two slots of the
-/// same pairing each get their own schema entry so the flattened
-/// `pairings.<link_id>.<topic>` namespace stays unambiguous.
+/// same pairing each get their own schema entry so the nested
+/// `paired_topics.<link_id>.<topic>` namespace stays unambiguous.
 pub fn peer_schema_key(link_id: &str, topic_name: &str) -> String {
     format!("peer_{link_id}_{topic_name}")
 }
@@ -451,17 +399,6 @@ mod tests {
     }
 
     #[test]
-    fn unique_module_name_deduplicates() {
-        fn identity(s: &str) -> String {
-            s.to_string()
-        }
-        let mut counts = std::collections::HashMap::new();
-        assert_eq!(unique_module_name("foo", &mut counts, identity), "foo");
-        assert_eq!(unique_module_name("foo", &mut counts, identity), "foo_1");
-        assert_eq!(unique_module_name("foo", &mut counts, identity), "foo_2");
-    }
-
-    #[test]
     fn resolve_schema_file_stem_appends_message_suffix() {
         let resolved = resolve_schema_file_stem("my_topic");
         assert_eq!(resolved.base_name, "my_topic");
@@ -509,24 +446,13 @@ mod tests {
     }
 
     #[test]
-    fn raw_module_label_uses_unambiguous_separator() {
-        assert_eq!(raw_module_label("sensor", "temp"), "sensor::temp");
-        assert_ne!(
-            raw_module_label("foo_bar", "baz"),
-            raw_module_label("foo", "bar_baz"),
-            "different (node, name) pairs must produce different labels"
+    fn peer_schema_key_is_stable_and_link_id_keyed() {
+        // Pairing capnp schema keys are keyed on link_id + topic and computed
+        // independently of the module path, so relocating the category
+        // (pairings -> paired_topics) must not change them.
+        assert_eq!(
+            peer_schema_key("arm", "joint_states"),
+            "peer_arm_joint_states"
         );
-    }
-
-    #[test]
-    fn raw_module_label_handles_empty_components() {
-        assert_eq!(raw_module_label("", "name"), "name");
-        assert_eq!(raw_module_label("node", ""), "node");
-        assert_eq!(raw_module_label("", ""), "");
-    }
-
-    #[test]
-    fn raw_module_label_trims_whitespace() {
-        assert_eq!(raw_module_label("  node  ", "  name  "), "node::name");
     }
 }

--- a/crates/generator-internal/src/generator/python.rs
+++ b/crates/generator-internal/src/generator/python.rs
@@ -13,7 +13,7 @@ mod services;
 mod topics;
 mod type_mapping;
 
-use super::naming::{module_name_from_components, resolve_schema_file_stem, to_camel_case};
+use super::naming::{resolve_schema_file_stem, to_camel_case};
 use super::types::{
     CapnpSchema, ConsumedActionMessage, ContractOrigin, DependencyContext, InterfaceArtifact,
     InterfaceKind, LanguageGenerator, goal_action_response_format, non_empty_message_format,
@@ -247,13 +247,11 @@ impl LanguageGenerator for PythonGenerator {
         );
         let schema_info = self.register_schema(&schema_key, &arguments)?;
         let code = topics::build_consumed_topic(topic, &arguments, &schema_info, dependency)?;
-        let module_label = module_name_from_components(&topic.link_id, &topic.name);
-        self.push_section(self.make_artifact(
-            &module_label,
-            None,
-            InterfaceKind::ConsumedTopic,
-            code,
-        ));
+        self.push_section(InterfaceArtifact {
+            module_path: vec![topic.link_id.clone(), topic.name.clone()],
+            kind: InterfaceKind::ConsumedTopic,
+            code_output: code,
+        });
         Ok(())
     }
 
@@ -288,13 +286,11 @@ impl LanguageGenerator for PythonGenerator {
             response_schema_info.as_ref(),
             dependency,
         )?;
-        let module_label = module_name_from_components(&service.link_id, &service.name);
-        self.push_section(self.make_artifact(
-            &module_label,
-            None,
-            InterfaceKind::ConsumedService,
-            code,
-        ));
+        self.push_section(InterfaceArtifact {
+            module_path: vec![service.link_id.clone(), service.name.clone()],
+            kind: InterfaceKind::ConsumedService,
+            code_output: code,
+        });
         Ok(())
     }
 
@@ -399,13 +395,11 @@ impl LanguageGenerator for PythonGenerator {
             },
             dependency,
         )?;
-        let module_label = module_name_from_components(&action.link_id, &action.name);
-        self.push_section(self.make_artifact(
-            &module_label,
-            None,
-            InterfaceKind::ConsumedAction,
-            code,
-        ));
+        self.push_section(InterfaceArtifact {
+            module_path: vec![action.link_id.clone(), action.name.clone()],
+            kind: InterfaceKind::ConsumedAction,
+            code_output: code,
+        });
         Ok(())
     }
 

--- a/crates/generator-internal/src/generator/python/scaffold.rs
+++ b/crates/generator-internal/src/generator/python/scaffold.rs
@@ -213,7 +213,7 @@ pub fn add_artifacts_to_lib(to_path: &Path, artifacts: Vec<InterfaceArtifact>) -
         let artifacts = grouped.remove(&category).unwrap_or_default();
         let tree = build_module_tree(artifacts);
         let mut writer = PythonTreeWriter;
-        write_module_tree(&category_dir, &tree, &mut writer)?;
+        write_module_tree(&category_dir, &tree, category, &mut writer)?;
     }
 
     Ok(())
@@ -221,7 +221,7 @@ pub fn add_artifacts_to_lib(to_path: &Path, artifacts: Vec<InterfaceArtifact>) -
 
 /// [`TreeWriter`] mirroring the Rust scaffold layout: one `.py` file per leaf
 /// and an `__init__.py` per directory that imports every sub-module so
-/// `from peppygen.emitted_topics.depth_camera.v1 import video_stream` resolves.
+/// `from peppygen.emitted_topics.depth_cam import video_stream` resolves.
 /// Traversal and sibling de-duplication live in the shared [`write_module_tree`]
 /// walker.
 struct PythonTreeWriter;
@@ -297,8 +297,13 @@ mod tests {
         );
 
         let tree = build_module_tree(vec![artifact]);
-        write_module_tree(temp_dir.path(), &tree, &mut PythonTreeWriter)
-            .expect("tree should be written");
+        write_module_tree(
+            temp_dir.path(),
+            &tree,
+            ModuleCategory::EmittedTopics,
+            &mut PythonTreeWriter,
+        )
+        .expect("tree should be written");
 
         let module_file = temp_dir.path().join("class_.py");
         assert!(module_file.exists(), "expected escaped module filename");
@@ -317,9 +322,10 @@ mod tests {
             InterfaceKind::EmittedTopic,
             String::from("NATIVE = True\n"),
         );
-        // A contract origin nests the leaf under `{contract_name}/{contract_tag}/`,
-        // i.e. module_path == ["depth_camera", "v1", "video_stream"].
+        // A contract origin nests the leaf under `{link_id}/`, i.e.
+        // module_path == ["depth_cam", "video_stream"].
         let contract_origin = ContractOrigin {
+            link_id: "depth_cam".to_string(),
             contract_name: "depth_camera".to_string(),
             contract_tag: "v1".to_string(),
         };
@@ -331,26 +337,25 @@ mod tests {
         );
 
         let tree = build_module_tree(vec![native, contract_backed]);
-        write_module_tree(temp_dir.path(), &tree, &mut PythonTreeWriter)
-            .expect("tree should be written");
+        write_module_tree(
+            temp_dir.path(),
+            &tree,
+            ModuleCategory::EmittedTopics,
+            &mut PythonTreeWriter,
+        )
+        .expect("tree should be written");
 
         assert!(temp_dir.path().join("video_stream.py").exists());
-        assert!(
-            temp_dir
-                .path()
-                .join("depth_camera/v1/video_stream.py")
-                .exists()
-        );
-        let contract_code =
-            fs::read_to_string(temp_dir.path().join("depth_camera/v1/video_stream.py"))
-                .expect("contract-backed file should be readable");
+        assert!(temp_dir.path().join("depth_cam/video_stream.py").exists());
+        let contract_code = fs::read_to_string(temp_dir.path().join("depth_cam/video_stream.py"))
+            .expect("contract-backed file should be readable");
         assert!(contract_code.contains("CONFORMED"));
         let root_init = fs::read_to_string(temp_dir.path().join("__init__.py")).unwrap();
         assert!(root_init.contains("from . import video_stream"));
-        assert!(root_init.contains("from . import depth_camera"));
-        let depth_init = fs::read_to_string(temp_dir.path().join("depth_camera/__init__.py"))
-            .expect("depth_camera __init__.py should exist");
-        assert_eq!(depth_init, "from . import v1\n");
+        assert!(root_init.contains("from . import depth_cam"));
+        let depth_init = fs::read_to_string(temp_dir.path().join("depth_cam/__init__.py"))
+            .expect("depth_cam __init__.py should exist");
+        assert_eq!(depth_init, "from . import video_stream\n");
     }
 
     /// The generated `.so` table is what the scaffolder deploys, so it must hold

--- a/crates/generator-internal/src/generator/rust.rs
+++ b/crates/generator-internal/src/generator/rust.rs
@@ -21,8 +21,8 @@ use super::types::{
 };
 use crate::error::{Error, Result};
 use crate::generator::naming::{
-    module_name_from_components, non_empty_str, raw_module_label, resolve_schema_file_stem,
-    sanitize_component, sanitize_node_display_name, to_camel_case,
+    non_empty_str, resolve_schema_file_stem, sanitize_component, sanitize_node_display_name,
+    to_camel_case,
 };
 use config::node::{
     ConsumedAction, ConsumedService, ConsumedTopic, MessageFormat, NativeEmittedTopic,
@@ -1081,11 +1081,6 @@ impl LanguageGenerator for RustGenerator {
             struct_prefix = String::from("Topic");
         }
 
-        let mut module_label = format!("{}_{}", node_name, topic.name.as_str());
-        if module_label.trim().is_empty() {
-            module_label = String::from("topic");
-        }
-
         let schema_key =
             crate::generator::naming::consumed_topic_schema_key(node_name, topic.name.as_str());
 
@@ -1138,12 +1133,11 @@ impl LanguageGenerator for RustGenerator {
         };
         let rendered = render_tokens(tokens);
 
-        self.push_section(self.make_artifact(
-            &sanitize_node_display_name(&module_label),
-            None,
-            InterfaceKind::ConsumedTopic,
-            rendered,
-        ));
+        self.push_section(InterfaceArtifact {
+            module_path: vec![topic.link_id.clone(), topic.name.clone()],
+            kind: InterfaceKind::ConsumedTopic,
+            code_output: rendered,
+        });
 
         Ok(())
     }
@@ -1402,26 +1396,16 @@ impl LanguageGenerator for RustGenerator {
             all_tokens.push(deserialize_fn);
         }
 
-        let mut module_label = raw_module_label(&service.link_id, &service.name);
-        if module_name_from_components(&service.link_id, &service.name).is_empty() {
-            module_label = method_label
-                .strip_prefix("poll_")
-                .map(|label| label.to_string())
-                .filter(|label| !label.is_empty())
-                .unwrap_or_else(|| method_label.clone());
-        }
-
         let tokens: TokenStream = quote! {
             #( #all_tokens )*
         };
         let rendered = render_tokens(tokens);
 
-        self.push_section(self.make_artifact(
-            &sanitize_node_display_name(&module_label),
-            None,
-            InterfaceKind::ConsumedService,
-            rendered,
-        ));
+        self.push_section(InterfaceArtifact {
+            module_path: vec![service.link_id.clone(), service.name.clone()],
+            kind: InterfaceKind::ConsumedService,
+            code_output: rendered,
+        });
         Ok(())
     }
 
@@ -1678,13 +1662,11 @@ impl LanguageGenerator for RustGenerator {
             #( #items )*
         };
         let rendered = render_tokens(tokens);
-        let module_label = raw_module_label(&action.link_id, &action.name);
-        self.push_section(self.make_artifact(
-            &sanitize_node_display_name(&module_label),
-            None,
-            InterfaceKind::ConsumedAction,
-            rendered,
-        ));
+        self.push_section(InterfaceArtifact {
+            module_path: vec![action.link_id.clone(), action.name.clone()],
+            kind: InterfaceKind::ConsumedAction,
+            code_output: rendered,
+        });
         Ok(())
     }
 

--- a/crates/generator-internal/src/generator/rust/scaffold.rs
+++ b/crates/generator-internal/src/generator/rust/scaffold.rs
@@ -70,7 +70,7 @@ pub fn add_artifacts_to_lib(
             category,
             category_file: &category_file,
         };
-        write_module_tree(&category_dir, &tree, &mut writer)?;
+        write_module_tree(&category_dir, &tree, category, &mut writer)?;
     }
 
     Ok(())
@@ -444,7 +444,7 @@ impl ModuleCategory {
             Self::ConsumedServices => "ConsumedServices",
             Self::ExposedActions => "ExposedActions",
             Self::ConsumedActions => "ConsumedActions",
-            Self::Pairings => "Pairings",
+            Self::PairedTopics => "PairedTopics",
         }
     }
 
@@ -456,7 +456,7 @@ impl ModuleCategory {
             Self::ConsumedServices => "consumed services",
             Self::ExposedActions => "exposed actions",
             Self::ConsumedActions => "consumed actions",
-            Self::Pairings => "pairings",
+            Self::PairedTopics => "paired topics",
         }
     }
 }

--- a/crates/generator-internal/src/generator/rust/tests/actions.rs
+++ b/crates/generator-internal/src/generator/rust/tests/actions.rs
@@ -721,19 +721,19 @@ fn consumed_two_actions_same_node() {
         .map(|artifact| (artifact.leaf_name().to_string(), artifact.code_output))
         .collect();
 
-    let move_arm_module =
-        sanitize_node_display_name(&raw_module_label("brain", &move_arm_action.name));
-    let rotate_module = sanitize_node_display_name(&raw_module_label("brain", &rotate_action.name));
-
+    // Consumed artifacts nest as `[link_id, action_name]`, so the leaf segment
+    // is the raw action name.
     let move_arm = artifact_map
-        .get(&move_arm_module)
-        .unwrap_or_else(|| panic!("move_arm artifact `{}` is present", move_arm_module));
-    let rotate_servo = artifact_map.get(&rotate_module).unwrap_or_else(|| {
-        panic!(
-            "rotate_servo_clockwise artifact `{}` is present",
-            rotate_module
-        )
-    });
+        .get(move_arm_action.name.as_str())
+        .unwrap_or_else(|| panic!("move_arm artifact `{}` is present", move_arm_action.name));
+    let rotate_servo = artifact_map
+        .get(rotate_action.name.as_str())
+        .unwrap_or_else(|| {
+            panic!(
+                "rotate_servo_clockwise artifact `{}` is present",
+                rotate_action.name
+            )
+        });
 
     // move_arm - constants and struct hierarchy
     assert_contains_all(
@@ -1036,8 +1036,8 @@ fn clippy_single_exposed_action_empty_goal_request() {
     assert_contains_all(
         &consumed_actions_contents,
         &[
-            "pub mod brain_move_arm;",
-            "pub mod controller_rotate_servo_clockwise;",
+            "pub mod brain;",
+            "pub mod controller;",
         ],
     );
 }
@@ -1138,8 +1138,8 @@ fn compile_lib_with_exposed_and_consumed_actions() {
     assert_contains_all(
         &consumed_actions_contents,
         &[
-            "pub mod brain_move_arm;",
-            "pub mod controller_rotate_servo_clockwise;",
+            "pub mod brain;",
+            "pub mod controller;",
         ],
     );
 
@@ -1155,17 +1155,17 @@ fn compile_lib_with_exposed_and_consumed_actions() {
         "Expected generated rotate_servo_clockwise action module at {:?}",
         expose_rotate_path
     );
-    let subscribed_brain_path = output_dir.join("src/consumed_actions/brain_move_arm.rs");
+    let subscribed_brain_path = output_dir.join("src/consumed_actions/brain/move_arm.rs");
     assert!(
         subscribed_brain_path.exists(),
-        "Expected brain_move_arm consumed action module at {:?}",
+        "Expected brain/move_arm consumed action module at {:?}",
         subscribed_brain_path
     );
     let subscribed_controller_path =
-        output_dir.join("src/consumed_actions/controller_rotate_servo_clockwise.rs");
+        output_dir.join("src/consumed_actions/controller/rotate_servo_clockwise.rs");
     assert!(
         subscribed_controller_path.exists(),
-        "Expected controller_rotate_servo_clockwise consumed action module at {:?}",
+        "Expected controller/rotate_servo_clockwise consumed action module at {:?}",
         subscribed_controller_path
     );
 }

--- a/crates/generator-internal/src/generator/rust/tests/pairings.rs
+++ b/crates/generator-internal/src/generator/rust/tests/pairings.rs
@@ -43,7 +43,7 @@ fn peer_emitted_topic_publishes_slot_scoped_under_pairing_target() {
     assert_eq!(
         artifact.module_path,
         vec!["arm".to_string(), "joint_commands".to_string()],
-        "peer artifacts nest flat under pairings/<link_id>/<topic>"
+        "peer artifacts nest under paired_topics/<link_id>/<topic>"
     );
 
     let rendered = &artifact.code_output;

--- a/crates/generator-internal/src/generator/rust/tests/services.rs
+++ b/crates/generator-internal/src/generator/rust/tests/services.rs
@@ -556,8 +556,8 @@ fn clippy_single_exposed_service_without_request_body() {
     assert_contains_all(
         &consumed_actions_contents,
         &[
-            "pub mod brain_move_arm;",
-            "pub mod controller_rotate_servo_clockwise;",
+            "pub mod brain;",
+            "pub mod controller;",
         ],
     );
 }
@@ -655,15 +655,15 @@ fn compile_lib_with_exposed_and_consumed_services() {
     );
     assert!(
         output_dir
-            .join("src/consumed_services/uvc_camera_enable_camera.rs")
+            .join("src/consumed_services/uvc_camera/enable_camera.rs")
             .exists(),
-        "Expected uvc_camera_enable_camera subscriber module"
+        "Expected uvc_camera/enable_camera subscriber module"
     );
     assert!(
         output_dir
-            .join("src/consumed_services/uvc_camera_get_camera_info.rs")
+            .join("src/consumed_services/uvc_camera/get_camera_info.rs")
             .exists(),
-        "Expected uvc_camera_get_camera_info subscriber module"
+        "Expected uvc_camera/get_camera_info subscriber module"
     );
 }
 

--- a/crates/generator-internal/src/generator/rust/tests/topics.rs
+++ b/crates/generator-internal/src/generator/rust/tests/topics.rs
@@ -182,6 +182,7 @@ fn emit_topic() {
 fn emitted_topic_via_contract_origin_targets_contract() {
     let topic = parse_emitted_topic(EMITTED_TOPIC_EXAMPLE);
     let origin = crate::ContractOrigin {
+        link_id: "depth_cam".to_string(),
         contract_name: "depth_camera".to_string(),
         contract_tag: "v1".to_string(),
     };
@@ -791,8 +792,8 @@ fn clippy_single_emitted_topic_empty_format() {
     assert_contains_all(
         &consumed_actions_contents,
         &[
-            "pub mod brain_move_arm;",
-            "pub mod controller_rotate_servo_clockwise;",
+            "pub mod brain;",
+            "pub mod controller;",
         ],
     );
 }
@@ -870,15 +871,15 @@ fn compile_lib_with_emitted_and_consumed_topics() {
     );
     assert!(
         output_dir
-            .join("src/consumed_topics/uvc_camera_video_stream.rs")
+            .join("src/consumed_topics/uvc_camera/video_stream.rs")
             .exists(),
-        "Expected uvc_camera_video_stream subscriber module"
+        "Expected uvc_camera/video_stream subscriber module"
     );
     assert!(
         output_dir
-            .join("src/consumed_topics/uvc_camera_sound.rs")
+            .join("src/consumed_topics/uvc_camera/sound.rs")
             .exists(),
-        "Expected uvc_camera_sound subscriber module"
+        "Expected uvc_camera/sound subscriber module"
     );
 }
 

--- a/crates/generator-internal/src/generator/rust/topics.rs
+++ b/crates/generator-internal/src/generator/rust/topics.rs
@@ -219,8 +219,9 @@ fn build_topic_build_message(
 }
 
 /// Module-level constants + `paired()`/`wait_paired()` helpers shared by both
-/// directions of a peer topic module. Every `pairings/<link_id>/<topic>` module
-/// carries its slot identity as consts and exposes the slot's live pin state.
+/// directions of a peer topic module. Every `paired_topics/<link_id>/<topic>`
+/// module carries its slot identity as consts and exposes the slot's live pin
+/// state.
 pub fn build_peer_module_header(
     topic_name: &str,
     peer: &crate::generator::types::PeerContext,

--- a/crates/generator-internal/src/generator/scaffold_tree.rs
+++ b/crates/generator-internal/src/generator/scaffold_tree.rs
@@ -5,9 +5,8 @@
 //! shape: directories keyed by raw segment, leaves keyed by their final
 //! segment. Only the per-file/per-`__init__` rendering differs.
 
-use super::naming::unique_module_name;
 use super::types::{InterfaceArtifact, ModuleCategory};
-use crate::error::Result;
+use crate::error::{Error, Result};
 use std::collections::{BTreeMap, HashMap};
 use std::path::Path;
 
@@ -98,31 +97,38 @@ pub(crate) trait TreeWriter {
 }
 
 /// Walks `tree`, writing one leaf file per leaf and one index file per
-/// directory via `writer`. Sibling module names are de-duplicated independently
-/// at each level (via [`unique_module_name`]) so a leaf `foo` can coexist with a
-/// child directory of the same name.
+/// directory via `writer`. Sibling module names must be unique after
+/// per-language sanitization at each level: two raw segments that sanitize to
+/// the same name are a hard [`Error::ModuleNameCollision`] naming both, not a
+/// silent rename, so a module can never become reachable under a name the
+/// author did not write.
 pub(crate) fn write_module_tree<W: TreeWriter>(
     dir: &Path,
     tree: &ModuleTree,
+    category: ModuleCategory,
     writer: &mut W,
 ) -> Result<()> {
-    write_tree_level(dir, tree, writer, true)
+    write_tree_level(dir, tree, category, writer, true)
 }
 
 fn write_tree_level<W: TreeWriter>(
     dir: &Path,
     tree: &ModuleTree,
+    category: ModuleCategory,
     writer: &mut W,
     is_root: bool,
 ) -> Result<()> {
     std::fs::create_dir_all(dir)?;
-    let mut counts: HashMap<String, usize> = HashMap::new();
+    // Sanitized module name -> the raw segment that first claimed it, shared
+    // across leaves and sub-directories at this level so a leaf and a sibling
+    // directory that sanitize alike also collide.
+    let mut seen: HashMap<String, String> = HashMap::new();
     let mut entries: Vec<ModuleEntry> = Vec::new();
 
     // Leaves first, then sub-directories. `BTreeMap` already gives deterministic
     // alphabetical ordering inside each bucket.
     for (raw_leaf, artifacts) in &tree.leaves {
-        let module_name = unique_module_name(raw_leaf, &mut counts, W::sanitize_module_name);
+        let module_name = claim_module_name(raw_leaf, category, &mut seen, W::sanitize_module_name)?;
         writer.write_leaf(dir, &module_name, raw_leaf, artifacts)?;
         entries.push(ModuleEntry {
             module_name,
@@ -132,9 +138,10 @@ fn write_tree_level<W: TreeWriter>(
     }
 
     for (raw_segment, child) in &tree.children {
-        let module_name = unique_module_name(raw_segment, &mut counts, W::sanitize_module_name);
+        let module_name =
+            claim_module_name(raw_segment, category, &mut seen, W::sanitize_module_name)?;
         let child_dir = dir.join(&module_name);
-        write_tree_level(&child_dir, child, writer, false)?;
+        write_tree_level(&child_dir, child, category, writer, false)?;
         entries.push(ModuleEntry {
             module_name,
             raw_name: raw_segment.clone(),
@@ -143,4 +150,125 @@ fn write_tree_level<W: TreeWriter>(
     }
 
     writer.write_index(dir, &entries, is_root)
+}
+
+/// Sanitizes `raw` for the target language and records the result in `seen`.
+/// Returns a hard [`Error::ModuleNameCollision`] if a different raw segment at
+/// this level already claimed the same sanitized name.
+fn claim_module_name(
+    raw: &str,
+    category: ModuleCategory,
+    seen: &mut HashMap<String, String>,
+    sanitize_fn: fn(&str) -> String,
+) -> Result<String> {
+    let sanitized = sanitize_fn(raw);
+    if let Some(first) = seen.get(&sanitized) {
+        return Err(Error::ModuleNameCollision {
+            category: category.dir_name().to_string(),
+            first: first.clone(),
+            second: raw.to_string(),
+            sanitized,
+        });
+    }
+    seen.insert(sanitized.clone(), raw.to_string());
+    Ok(sanitized)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::generator::naming::sanitize_component;
+    use crate::generator::types::InterfaceKind;
+    use tempfile::TempDir;
+
+    /// Minimal writer: sanitizes like the real backends and writes nothing, so
+    /// the collision check in `claim_module_name` is exercised in isolation.
+    struct NoopWriter;
+    impl TreeWriter for NoopWriter {
+        fn sanitize_module_name(raw: &str) -> String {
+            sanitize_component(raw)
+        }
+        fn write_leaf(
+            &mut self,
+            _dir: &Path,
+            _module_name: &str,
+            _raw_name: &str,
+            _artifacts: &[InterfaceArtifact],
+        ) -> Result<()> {
+            Ok(())
+        }
+        fn write_index(
+            &mut self,
+            _dir: &Path,
+            _entries: &[ModuleEntry],
+            _is_root: bool,
+        ) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    fn leaf(path: &[&str]) -> InterfaceArtifact {
+        InterfaceArtifact {
+            module_path: path.iter().map(|s| s.to_string()).collect(),
+            kind: InterfaceKind::ConsumedTopic,
+            code_output: "x\n".to_string(),
+        }
+    }
+
+    #[test]
+    fn colliding_slot_directories_are_a_hard_error() {
+        // Two slots whose link_ids differ only by separator (`arm-1` vs `arm_1`)
+        // sanitize to the same directory name; nesting makes that
+        // unrepresentable, so it must be a hard error, not a silent rename.
+        let tree = build_module_tree(vec![leaf(&["arm-1", "states"]), leaf(&["arm_1", "states"])]);
+        let temp = TempDir::new().unwrap();
+        let err = write_module_tree(
+            temp.path(),
+            &tree,
+            ModuleCategory::ConsumedTopics,
+            &mut NoopWriter,
+        )
+        .expect_err("colliding link_ids must be rejected");
+        assert!(
+            matches!(err, Error::ModuleNameCollision { .. }),
+            "expected ModuleNameCollision, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn native_leaf_colliding_with_slot_directory_is_a_hard_error() {
+        // A native produced topic named `arm` collides with a slot directory
+        // `arm`; the leaf and the sibling directory share one namespace.
+        let tree = build_module_tree(vec![leaf(&["arm"]), leaf(&["arm", "states"])]);
+        let temp = TempDir::new().unwrap();
+        let err = write_module_tree(
+            temp.path(),
+            &tree,
+            ModuleCategory::EmittedTopics,
+            &mut NoopWriter,
+        )
+        .expect_err("a native leaf colliding with a slot directory must be rejected");
+        assert!(
+            matches!(err, Error::ModuleNameCollision { .. }),
+            "expected ModuleNameCollision, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn distinct_slots_and_leaves_write_cleanly() {
+        // The happy path: distinct link_ids and a distinct native leaf coexist.
+        let tree = build_module_tree(vec![
+            leaf(&["video_stream"]),
+            leaf(&["front_cam", "frames"]),
+            leaf(&["rear_cam", "frames"]),
+        ]);
+        let temp = TempDir::new().unwrap();
+        write_module_tree(
+            temp.path(),
+            &tree,
+            ModuleCategory::EmittedTopics,
+            &mut NoopWriter,
+        )
+        .expect("distinct names must write without collision");
+    }
 }

--- a/crates/generator-internal/src/generator/types.rs
+++ b/crates/generator-internal/src/generator/types.rs
@@ -37,25 +37,22 @@ pub struct ConsumedActionMessage {
 ///
 /// `None` on a producer variant means the artifact is the node's own (native)
 /// declaration; `Some` means it is a contract-backed entry resolved through a
-/// `manifest.implements` slot. The pair `(contract_name, contract_tag)` drives
-/// both the generated module nesting
-/// (`emitted_topics::{contract_name}::{contract_tag}::{topic}`) and the two
-/// extra Zenoh segments on the wire path.
+/// `manifest.implements` slot. `link_id` is that slot's identifier and drives
+/// the generated module nesting (`emitted_topics::{link_id}::{topic}`).
+/// `(contract_name, contract_tag)` drive the two extra Zenoh segments on the
+/// wire path and the scoped schema key, both of which stay keyed on contract
+/// identity.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ContractOrigin {
+    pub link_id: String,
     pub contract_name: String,
     pub contract_tag: String,
 }
 
 impl ContractOrigin {
-    /// Module path for an artifact contributed by this origin:
-    /// `[contract_name, sanitized_tag, leaf_name]`.
+    /// Module path for an artifact contributed by this origin: `[link_id, leaf_name]`.
     pub fn module_path_for(&self, leaf_name: &str) -> Vec<String> {
-        vec![
-            self.contract_name.clone(),
-            crate::generator::naming::sanitize_contract_tag(&self.contract_tag),
-            leaf_name.to_string(),
-        ]
+        vec![self.link_id.clone(), leaf_name.to_string()]
     }
 
     /// Namespaces `local` with `contract_name` + sanitized tag so a leaf name
@@ -81,10 +78,8 @@ pub fn scoped_schema_key(origin: Option<&ContractOrigin>, local: &str) -> String
 
 /// Identifies the pairing slot a peer topic belongs to. "Pairing" names the
 /// mechanism/contract/slot; "peer" names the other end. Both directions of a
-/// pairing live under the slot's module (`pairings/<link_id>/<topic>`), so the
-/// module path is flat `[link_id, topic]`, deliberately NOT reusing
-/// [`ContractOrigin`], whose `[name, tag, leaf]` nesting reflects contract
-/// identity rather than slot identity.
+/// pairing live under the slot's module (`paired_topics/<link_id>/<topic>`),
+/// keyed by `link_id` like every other slot-backed category.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PeerContext {
     /// The node's own pairing-slot link_id (`depends_on.pairings[].link_id`).
@@ -101,7 +96,7 @@ impl PeerContext {
 }
 
 /// Backstop for the pairing document's flat topic-name uniqueness rule:
-/// two peer artifacts must never land on the same `pairings/<link_id>/<topic>`
+/// two peer artifacts must never land on the same `paired_topics/<link_id>/<topic>`
 /// module path. Shared by the Rust and Python generators so the invariant
 /// cannot drift between them.
 pub fn ensure_no_peer_collision(
@@ -190,14 +185,16 @@ impl DependencyContext {
     ) -> Self {
         let contract_name = contract_name.into();
         let contract_tag = contract_tag.into();
+        let link_id = link_id.into();
         Self {
             producer_name: contract_name.clone(),
             producer_tag: contract_tag.clone(),
             origin: Some(ContractOrigin {
+                link_id: link_id.clone(),
                 contract_name,
                 contract_tag,
             }),
-            link_id: link_id.into(),
+            link_id,
             cardinality,
         }
     }
@@ -401,20 +398,18 @@ impl DeploymentInterface {
 #[derive(Clone)]
 pub struct InterfaceArtifact {
     /// Module path under the category dir, leaf-last. Native artifacts have a
-    /// single segment (the topic/service/action name); contract-backed
-    /// artifacts have three segments
-    /// (`[contract_name, contract_tag, leaf_name]`) so they nest as
-    /// `emitted_topics/{contract_name}/{contract_tag}/{leaf_name}.rs`.
+    /// single segment (the topic/service/action name); slot-backed artifacts
+    /// have two segments (`[link_id, leaf_name]`) so they nest as
+    /// `emitted_topics/{link_id}/{leaf_name}.rs`.
     pub module_path: Vec<String>,
     pub kind: InterfaceKind,
     pub code_output: String,
 }
 
 impl InterfaceArtifact {
-    /// Builds an artifact for `leaf_name`, nesting under
-    /// `{contract_name}/{contract_tag}/{leaf_name}` when contract-backed,
-    /// or a single-segment `[leaf_name]` for the node's own (native)
-    /// declarations.
+    /// Builds an artifact for `leaf_name`, nesting under `{link_id}/{leaf_name}`
+    /// when contract-backed, or a single-segment `[leaf_name]` for the node's
+    /// own (native) declarations.
     pub fn for_leaf(
         origin: Option<&ContractOrigin>,
         leaf_name: &str,
@@ -457,8 +452,8 @@ impl InterfaceArtifact {
 /// directly.
 pub trait LanguageGenerator {
     /// `origin` is `Some` when the topic is contract-backed (nests the
-    /// artifact under `{contract_name}/{contract_tag}/{leaf}`) and `None`
-    /// for the node's own native declarations.
+    /// artifact under `{link_id}/{leaf}`) and `None` for the node's own
+    /// native declarations.
     fn add_emitted_topic(
         &mut self,
         topic: &NativeEmittedTopic,
@@ -807,11 +802,33 @@ mod tests {
         assert_eq!(
             contract.origin,
             Some(ContractOrigin {
+                link_id: "cam_left".to_string(),
                 contract_name: "camera_contract".to_string(),
                 contract_tag: "v2".to_string(),
             })
         );
         assert_eq!(contract.link_id, "cam_left");
+    }
+
+    #[test]
+    fn module_path_uses_link_id_but_schema_key_stays_contract_scoped() {
+        let origin = ContractOrigin {
+            link_id: "cam_left".to_string(),
+            contract_name: "depth_camera".to_string(),
+            contract_tag: "v1".to_string(),
+        };
+        // The generated module path is keyed on the slot's link_id.
+        assert_eq!(
+            origin.module_path_for("video_stream"),
+            vec!["cam_left".to_string(), "video_stream".to_string()]
+        );
+        // The capnp schema key stays keyed on contract identity, independent of
+        // the module path: relocating a module must never move its schema entry.
+        assert_eq!(
+            origin.scoped_schema_key("video_stream"),
+            "depth_camera_v1_video_stream"
+        );
+        assert!(!origin.scoped_schema_key("video_stream").contains("cam_left"));
     }
 
     #[test]
@@ -1072,8 +1089,8 @@ pub(crate) enum ModuleCategory {
     ConsumedServices,
     ExposedActions,
     ConsumedActions,
-    /// Both directions of every pairing slot: `pairings/<link_id>/<topic>`.
-    Pairings,
+    /// Both directions of every pairing slot: `paired_topics/<link_id>/<topic>`.
+    PairedTopics,
 }
 
 impl ModuleCategory {
@@ -1084,7 +1101,7 @@ impl ModuleCategory {
         Self::ConsumedServices,
         Self::ExposedActions,
         Self::ConsumedActions,
-        Self::Pairings,
+        Self::PairedTopics,
     ];
 
     pub fn from_kind(kind: InterfaceKind) -> Self {
@@ -1095,7 +1112,7 @@ impl ModuleCategory {
             InterfaceKind::ConsumedService => Self::ConsumedServices,
             InterfaceKind::ExposedAction => Self::ExposedActions,
             InterfaceKind::ConsumedAction => Self::ConsumedActions,
-            InterfaceKind::PeerEmittedTopic | InterfaceKind::PeerConsumedTopic => Self::Pairings,
+            InterfaceKind::PeerEmittedTopic | InterfaceKind::PeerConsumedTopic => Self::PairedTopics,
         }
     }
 
@@ -1107,7 +1124,7 @@ impl ModuleCategory {
             Self::ConsumedServices => "consumed_services",
             Self::ExposedActions => "exposed_actions",
             Self::ConsumedActions => "consumed_actions",
-            Self::Pairings => "pairings",
+            Self::PairedTopics => "paired_topics",
         }
     }
 }

--- a/crates/generator-internal/templates/peppygen/python/peppygen/__init__.py
+++ b/crates/generator-internal/templates/peppygen/python/peppygen/__init__.py
@@ -6,6 +6,6 @@ from . import exposed_services
 from . import consumed_services
 from . import exposed_actions
 from . import consumed_actions
-from . import pairings
+from . import paired_topics
 
 from peppylib import QoSProfile, NodeBuilder, NodeRunner, StandaloneConfig

--- a/crates/generator-internal/templates/peppygen/rust/src/lib.rs
+++ b/crates/generator-internal/templates/peppygen/rust/src/lib.rs
@@ -8,7 +8,7 @@ pub mod exposed_actions;
 pub mod exposed_services;
 pub mod consumed_actions;
 pub mod consumed_services;
-pub mod pairings;
+pub mod paired_topics;
 
 pub use parameters::Parameters;
 pub use peppylib::config::QoSProfile;

--- a/crates/generator-internal/tests/python/actions_communication.rs
+++ b/crates/generator-internal/tests/python/actions_communication.rs
@@ -150,7 +150,7 @@ async fn actions_communication(#[case] topology: crate::helpers::LocalNodesTopol
 import asyncio
 from peppygen import NodeBuilder, QoSProfile
 from peppygen.exposed_services import move_arm_flow_done
-from peppygen.consumed_actions import brain_move_arm
+from peppygen.consumed_actions.brain import move_arm as brain_move_arm
 
 async def run_consumer(node_runner):
     request = brain_move_arm.GoalRequest(arm_id=7, desired_position=[10, 20, 30])
@@ -493,7 +493,7 @@ async fn actions_communication_cancel_goal(#[case] topology: crate::helpers::Loc
 import asyncio
 from peppygen import NodeBuilder, QoSProfile
 from peppygen.exposed_services import move_arm_cancel_flow_done
-from peppygen.consumed_actions import brain_move_arm
+from peppygen.consumed_actions.brain import move_arm as brain_move_arm
 
 async def run_consumer(node_runner):
     request = brain_move_arm.GoalRequest(arm_id=7, desired_position=[10, 20, 30])
@@ -820,7 +820,7 @@ async fn actions_communication_async_goal_decider(
 import asyncio
 from peppygen import NodeBuilder, QoSProfile
 from peppygen.exposed_services import move_arm_in_handler_flow_done
-from peppygen.consumed_actions import brain_move_arm
+from peppygen.consumed_actions.brain import move_arm as brain_move_arm
 
 async def run_consumer(node_runner):
     request = brain_move_arm.GoalRequest(arm_id=7, desired_position=[10, 20, 30])
@@ -1174,7 +1174,7 @@ async fn actions_communication_cancel_accept_closes_feedback_stream(
 import asyncio
 from peppygen import NodeBuilder, QoSProfile
 from peppygen.exposed_services import move_arm_cancel_accept_flow_done
-from peppygen.consumed_actions import brain_move_arm
+from peppygen.consumed_actions.brain import move_arm as brain_move_arm
 
 async def run_consumer(node_runner):
     request = brain_move_arm.GoalRequest(arm_id=7, desired_position=[10, 20, 30])
@@ -1539,7 +1539,7 @@ async fn actions_communication_cancel_reject_keeps_feedback_open(
 import asyncio
 from peppygen import NodeBuilder, QoSProfile
 from peppygen.exposed_services import move_arm_cancel_reject_flow_done
-from peppygen.consumed_actions import brain_move_arm
+from peppygen.consumed_actions.brain import move_arm as brain_move_arm
 
 async def run_consumer(node_runner):
     request = brain_move_arm.GoalRequest(arm_id=7, desired_position=[10, 20, 30])
@@ -1926,7 +1926,7 @@ async fn actions_communication_drain_loop_until_end_signal(
 import asyncio
 from peppygen import NodeBuilder, QoSProfile
 from peppygen.exposed_services import move_arm_drain_loop_flow_done
-from peppygen.consumed_actions import brain_move_arm
+from peppygen.consumed_actions.brain import move_arm as brain_move_arm
 
 async def run_consumer(node_runner):
     request = brain_move_arm.GoalRequest(arm_id=7, desired_position=[10, 20, 30])
@@ -2280,7 +2280,7 @@ async fn actions_communication_producer_killed_yields_connection_error_and_aband
 import asyncio
 import time
 from peppygen import NodeBuilder, QoSProfile
-from peppygen.consumed_actions import brain_move_arm
+from peppygen.consumed_actions.brain import move_arm as brain_move_arm
 
 async def run_consumer(node_runner):
     request = brain_move_arm.GoalRequest(arm_id=7, desired_position=[10, 20, 30])

--- a/crates/generator-internal/tests/python/actions_implements.rs
+++ b/crates/generator-internal/tests/python/actions_implements.rs
@@ -29,10 +29,16 @@ fn make_action(marker: &str) -> NativeExposedAction {
     }
 }
 
-fn contract_backed(name: &str, tag: &str, action: NativeExposedAction) -> DeploymentInterface {
+fn contract_backed(
+    link_id: &str,
+    name: &str,
+    tag: &str,
+    action: NativeExposedAction,
+) -> DeploymentInterface {
     DeploymentInterface::new(InterfaceVariant::ExposedAction {
         action,
         origin: Some(ContractOrigin {
+            link_id: link_id.to_string(),
             contract_name: name.to_string(),
             contract_tag: tag.to_string(),
         }),
@@ -66,14 +72,14 @@ const NODE_CONFIG: &str = r#"{
 "#;
 
 #[test]
-fn nests_contract_backed_actions_under_contract_name_and_tag() {
+fn nests_contract_backed_actions_under_link_id() {
     let temp_dir = TempDir::new_in(crate::helpers::test_tmp_root()).expect("temp dir");
     let (_output_dir, user_node, peppy_node_config) = prepare_directories(&temp_dir);
     fs::write(&peppy_node_config, NODE_CONFIG).expect("write node config");
 
     let extras = vec![
-        contract_backed("arm", "v1", make_action("arm_v1_marker")),
-        contract_backed("arm", "v2", make_action("arm_v2_marker")),
+        contract_backed("arm_v1", "arm", "v1", make_action("arm_v1_marker")),
+        contract_backed("arm_v2", "arm", "v2", make_action("arm_v2_marker")),
     ];
 
     let peppy_dirs = test_peppy_dirs();
@@ -94,8 +100,8 @@ fn nests_contract_backed_actions_under_contract_name_and_tag() {
     let act_dir = pkg.join("exposed_actions");
 
     let native_path = act_dir.join("move_arm.py");
-    let arm_v1 = act_dir.join("arm/v1/move_arm.py");
-    let arm_v2 = act_dir.join("arm/v2/move_arm.py");
+    let arm_v1 = act_dir.join("arm_v1/move_arm.py");
+    let arm_v2 = act_dir.join("arm_v2/move_arm.py");
 
     for path in [&native_path, &arm_v1, &arm_v2] {
         assert!(path.exists(), "expected action file at {path:?}");

--- a/crates/generator-internal/tests/python/consumed_services_dedup.rs
+++ b/crates/generator-internal/tests/python/consumed_services_dedup.rs
@@ -75,13 +75,13 @@ def capnp_loaders(mod):
         if name.endswith("_capnp") and name.startswith("_") and callable(getattr(mod, name))
     ]
 
-front = importlib.import_module("peppygen.consumed_services.front_cam_enable")
-rear = importlib.import_module("peppygen.consumed_services.rear_cam_enable")
+front = importlib.import_module("peppygen.consumed_services.front_cam.enable")
+rear = importlib.import_module("peppygen.consumed_services.rear_cam.enable")
 
 front_loaders = capnp_loaders(front)
 rear_loaders = capnp_loaders(rear)
-assert front_loaders, "no capnp loaders found in front_cam_enable"
-assert rear_loaders, "no capnp loaders found in rear_cam_enable"
+assert front_loaders, "no capnp loaders found in front_cam/enable"
+assert rear_loaders, "no capnp loaders found in rear_cam/enable"
 
 # Per-producer scoping check: the loader functions in the two modules must
 # resolve to DIFFERENT pycapnp modules. If they returned the same object,
@@ -156,8 +156,8 @@ fn python_cross_producer_same_service_name_keeps_schemas_separate() {
     .expect("failed to generate peppygen lib");
 
     let peppygen_dir = user_node_dir.join(PEPPYGEN_OUTPUT_PATH);
-    let front_module = peppygen_dir.join("peppygen/consumed_services/front_cam_enable.py");
-    let rear_module = peppygen_dir.join("peppygen/consumed_services/rear_cam_enable.py");
+    let front_module = peppygen_dir.join("peppygen/consumed_services/front_cam/enable.py");
+    let rear_module = peppygen_dir.join("peppygen/consumed_services/rear_cam/enable.py");
     assert!(
         front_module.exists(),
         "front consumer module missing at {}",

--- a/crates/generator-internal/tests/python/consumed_topics_dedup.rs
+++ b/crates/generator-internal/tests/python/consumed_topics_dedup.rs
@@ -74,8 +74,8 @@ def capnp_loader(mod):
             return getattr(mod, name)
     sys.exit(f"no capnp loader found in {mod.__name__}")
 
-left = importlib.import_module("peppygen.consumed_topics.left_arm_joint_states")
-right = importlib.import_module("peppygen.consumed_topics.right_arm_joint_states")
+left = importlib.import_module("peppygen.consumed_topics.left_arm.joint_states")
+right = importlib.import_module("peppygen.consumed_topics.right_arm.joint_states")
 
 left_schema = capnp_loader(left)()
 right_schema = capnp_loader(right)()
@@ -134,8 +134,8 @@ fn python_handles_two_consumed_topics_sharing_topic_name() {
     .expect("failed to generate peppygen lib");
 
     let peppygen_dir = user_node_dir.join(PEPPYGEN_OUTPUT_PATH);
-    let left_module = peppygen_dir.join("peppygen/consumed_topics/left_arm_joint_states.py");
-    let right_module = peppygen_dir.join("peppygen/consumed_topics/right_arm_joint_states.py");
+    let left_module = peppygen_dir.join("peppygen/consumed_topics/left_arm/joint_states.py");
+    let right_module = peppygen_dir.join("peppygen/consumed_topics/right_arm/joint_states.py");
     assert!(
         left_module.exists(),
         "left consumer module missing at {}",

--- a/crates/generator-internal/tests/python/generate_lib.rs
+++ b/crates/generator-internal/tests/python/generate_lib.rs
@@ -440,7 +440,7 @@ fn generate_peppygen_python_lib_emitted_and_consumed_topics() {
     let consumer_peppygen_dir = consumer_node_dir.join(PEPPYGEN_OUTPUT_PATH);
     assert!(
         consumer_peppygen_dir
-            .join("peppygen/consumed_topics/topic_exposer_test_topic.py")
+            .join("peppygen/consumed_topics/topic_exposer/test_topic.py")
             .exists(),
         "consumed topic module should exist in peppygen package at {}",
         consumer_peppygen_dir.display()
@@ -565,7 +565,7 @@ fn generate_peppygen_python_lib_exposed_and_consumed_services() {
 
     let consumer_peppygen_dir = consumer_node_dir.join(PEPPYGEN_OUTPUT_PATH);
     let consumed_service_module_path =
-        consumer_peppygen_dir.join("peppygen/consumed_services/service_exposer_test_service.py");
+        consumer_peppygen_dir.join("peppygen/consumed_services/service_exposer/test_service.py");
     assert!(
         consumed_service_module_path.exists(),
         "consumed service module should exist in peppygen package at {}",
@@ -715,7 +715,7 @@ fn generate_peppygen_python_lib_exposed_and_consumed_actions() {
     let consumer_peppygen_dir = consumer_node_dir.join(PEPPYGEN_OUTPUT_PATH);
     assert!(
         consumer_peppygen_dir
-            .join("peppygen/consumed_actions/action_exposer_test_action.py")
+            .join("peppygen/consumed_actions/action_exposer/test_action.py")
             .exists(),
         "consumed action module should exist in peppygen package at {}",
         consumer_peppygen_dir.display()

--- a/crates/generator-internal/tests/python/pairing_lib.rs
+++ b/crates/generator-internal/tests/python/pairing_lib.rs
@@ -1,6 +1,6 @@
 //! Generate-and-import fixture for pairing peer modules (Python) — twin of
 //! the Rust `pairing_lib` test: a synthetic two-role pairing (`arm_link/v1`,
-//! seen from the arm side) generates `pairings/<link_id>/<topic>` modules, and
+//! seen from the arm side) generates `paired_topics/<link_id>/<topic>` modules, and
 //! importing them from the project venv proves the generated code parses and
 //! its whole surface (slot consts, `paired()`/`wait_paired()`, publisher,
 //! subscription) resolves against the installed peppylib.
@@ -72,11 +72,11 @@ fn generated_peer_modules_import_from_venv() {
     );
 
     let peppygen_dir = user_node.join(PEPPYGEN_OUTPUT_PATH).join("peppygen");
-    let pairings_dir = peppygen_dir.join("pairings");
+    let paired_topics_dir = peppygen_dir.join("paired_topics");
     for module in ["controller/joint_states.py", "controller/joint_commands.py"] {
         assert!(
-            pairings_dir.join(module).exists(),
-            "expected generated module pairings/{module}"
+            paired_topics_dir.join(module).exists(),
+            "expected generated module paired_topics/{module}"
         );
     }
     // Neither direction may leak into the flat consumed/emitted namespaces.
@@ -109,7 +109,7 @@ fn generated_peer_modules_import_from_venv() {
 
     let check = r#"
 import inspect
-from peppygen.pairings.controller import joint_states, joint_commands
+from peppygen.paired_topics.controller import joint_states, joint_commands
 
 # Slot consts shared by both directions of the slot.
 assert joint_states.LINK_ID == "controller"

--- a/crates/generator-internal/tests/python/services_communication.rs
+++ b/crates/generator-internal/tests/python/services_communication.rs
@@ -121,7 +121,7 @@ async fn services_communication_no_target_instance_id(
     let consumer_main = r#"
 import asyncio
 from peppygen import NodeBuilder
-from peppygen.consumed_services import uvc_camera_enable_camera
+from peppygen.consumed_services.uvc_camera import enable_camera as uvc_camera_enable_camera
 
 async def poll_service(node_runner):
     request = uvc_camera_enable_camera.Request(enable=True)
@@ -453,7 +453,7 @@ async fn services_communication_exposed_service_without_request_body(
     let consumer_main = r#"
 import asyncio
 from peppygen import NodeBuilder
-from peppygen.consumed_services import uvc_camera_get_system_status
+from peppygen.consumed_services.uvc_camera import get_system_status as uvc_camera_get_system_status
 
 async def poll_service(node_runner):
     camera = uvc_camera_get_system_status.bound_producer(node_runner)
@@ -768,7 +768,7 @@ async fn services_communication_multiple_exposed_instances_bound_slot_routes_to_
     let consumer_main = r#"
 import asyncio
 from peppygen import NodeBuilder
-from peppygen.consumed_services import uvc_camera_enable_camera
+from peppygen.consumed_services.uvc_camera import enable_camera as uvc_camera_enable_camera
 
 async def poll_service(node_runner):
     request = uvc_camera_enable_camera.Request(enable=True)

--- a/crates/generator-internal/tests/python/services_implements.rs
+++ b/crates/generator-internal/tests/python/services_implements.rs
@@ -1,6 +1,6 @@
 //! Python mirror of `tests/rust/services_implements.rs`: verifies the
 //! Python generator nests contract-backed services under
-//! `peppygen/exposed_services/{iface_name}/{iface_tag}/<service>.py` and
+//! `peppygen/exposed_services/{link_id}/<service>.py` and
 //! splices the matching `peppylib.SenderTarget.contract(...)` expression
 //! into each `ServiceMessenger.listen` call (or
 //! `peppylib.SenderTarget.node(...)` for the native leaf).
@@ -26,10 +26,16 @@ fn make_service(marker: &str) -> NativeExposedService {
     }
 }
 
-fn contract_backed(name: &str, tag: &str, service: NativeExposedService) -> DeploymentInterface {
+fn contract_backed(
+    link_id: &str,
+    name: &str,
+    tag: &str,
+    service: NativeExposedService,
+) -> DeploymentInterface {
     DeploymentInterface::new(InterfaceVariant::ExposedService {
         service,
         origin: Some(ContractOrigin {
+            link_id: link_id.to_string(),
             contract_name: name.to_string(),
             contract_tag: tag.to_string(),
         }),
@@ -61,14 +67,14 @@ const NODE_CONFIG: &str = r#"{
 "#;
 
 #[test]
-fn nests_contract_backed_services_under_contract_name_and_tag() {
+fn nests_contract_backed_services_under_link_id() {
     let temp_dir = TempDir::new_in(crate::helpers::test_tmp_root()).expect("temp dir");
     let (_output_dir, user_node, peppy_node_config) = prepare_directories(&temp_dir);
     fs::write(&peppy_node_config, NODE_CONFIG).expect("write node config");
 
     let extras = vec![
-        contract_backed("camera", "v1", make_service("camera_v1_marker")),
-        contract_backed("arm", "v2", make_service("arm_v2_marker")),
+        contract_backed("cam", "camera", "v1", make_service("camera_v1_marker")),
+        contract_backed("arm", "arm", "v2", make_service("arm_v2_marker")),
     ];
 
     let peppy_dirs = test_peppy_dirs();
@@ -89,8 +95,8 @@ fn nests_contract_backed_services_under_contract_name_and_tag() {
     let svc_dir = pkg.join("exposed_services");
 
     let native_path = svc_dir.join("control.py");
-    let camera_v1 = svc_dir.join("camera/v1/control.py");
-    let arm_v2 = svc_dir.join("arm/v2/control.py");
+    let camera_v1 = svc_dir.join("cam/control.py");
+    let arm_v2 = svc_dir.join("arm/control.py");
 
     for path in [&native_path, &camera_v1, &arm_v2] {
         assert!(path.exists(), "expected service file at {path:?}");

--- a/crates/generator-internal/tests/python/topics_communication.rs
+++ b/crates/generator-internal/tests/python/topics_communication.rs
@@ -111,7 +111,7 @@ import os
 import sys
 from peppygen import NodeBuilder
 from peppygen.exposed_services import frame_received_ack
-from peppygen.consumed_topics import uvc_camera_video_stream
+from peppygen.consumed_topics.uvc_camera import video_stream as uvc_camera_video_stream
 
 async def receive_frames(node_runner, frame_received):
     # `next()` returns None once the subscription has closed; unpacking that

--- a/crates/generator-internal/tests/python/topics_implements.rs
+++ b/crates/generator-internal/tests/python/topics_implements.rs
@@ -1,6 +1,6 @@
 //! Python mirror of `tests/rust/topics_implements.rs`: same realsense_d435
 //! scenario, but verifying the Python generator emits the corresponding
-//! `peppygen/emitted_topics/{contract_name}/{contract_tag}/{topic}.py` files
+//! `peppygen/emitted_topics/{link_id}/{topic}.py` files
 //! with the right `__init__.py` chains and the matching `contract_name` /
 //! `contract_tag` strings inside each declare_publisher call.
 
@@ -28,10 +28,16 @@ fn make_topic(distinguishing_field: &str) -> NativeEmittedTopic {
     }
 }
 
-fn contract_backed(name: &str, tag: &str, topic: NativeEmittedTopic) -> DeploymentInterface {
+fn contract_backed(
+    link_id: &str,
+    name: &str,
+    tag: &str,
+    topic: NativeEmittedTopic,
+) -> DeploymentInterface {
     DeploymentInterface::new(InterfaceVariant::EmittedTopic {
         topic,
         origin: Some(ContractOrigin {
+            link_id: link_id.to_string(),
             contract_name: name.to_string(),
             contract_tag: tag.to_string(),
         }),
@@ -67,7 +73,7 @@ const NODE_CONFIG: &str = r#"{
 /// (`depth_camera:v1`, `depth_camera:v2`, `uvc_camera:v1`) each shaped as
 /// `video_stream` with a distinguishing marker field. Verifies that:
 ///   1. Contract-backed artifacts nest under
-///      `emitted_topics/{contract_name}/{contract_tag}/{topic}.py` while the
+///      `emitted_topics/{link_id}/{topic}.py` while the
 ///      native artifact stays flat at `emitted_topics/{topic}.py`.
 ///   2. The `__init__.py` chain at each level imports its direct children.
 ///   3. Each leaf's declare_publisher body passes the matching sender target to
@@ -76,15 +82,15 @@ const NODE_CONFIG: &str = r#"{
 ///   4. The per-interface marker fields land in their own files, proof the
 ///      four artifacts weren't cross-wired during generation.
 #[test]
-fn nests_contract_backed_topics_under_contract_name_and_tag() {
+fn nests_contract_backed_topics_under_link_id() {
     let temp_dir = TempDir::new_in(crate::helpers::test_tmp_root()).expect("temp dir");
     let (_output_dir, user_node, peppy_node_config) = prepare_directories(&temp_dir);
     fs::write(&peppy_node_config, NODE_CONFIG).expect("write node config");
 
     let extras = vec![
-        contract_backed("depth_camera", "v1", make_topic("depth_v1_marker")),
-        contract_backed("depth_camera", "v2", make_topic("depth_v2_marker")),
-        contract_backed("uvc_camera", "v1", make_topic("uvc_v1_marker")),
+        contract_backed("depth_v1", "depth_camera", "v1", make_topic("depth_v1_marker")),
+        contract_backed("depth_v2", "depth_camera", "v2", make_topic("depth_v2_marker")),
+        contract_backed("uvc_v1", "uvc_camera", "v1", make_topic("uvc_v1_marker")),
     ];
 
     let peppy_dirs = test_peppy_dirs();
@@ -111,11 +117,10 @@ fn nests_contract_backed_topics_under_contract_name_and_tag() {
         "native video_stream.py should exist at {native_path:?}",
     );
 
-    // Contract-backed artifacts nest one level deeper than the rust scaffold:
-    // category dir, then contract_name, then contract_tag.
-    let depth_v1 = emit_dir.join("depth_camera/v1/video_stream.py");
-    let depth_v2 = emit_dir.join("depth_camera/v2/video_stream.py");
-    let uvc_v1 = emit_dir.join("uvc_camera/v1/video_stream.py");
+    // Contract-backed artifacts nest under `<link_id>/`.
+    let depth_v1 = emit_dir.join("depth_v1/video_stream.py");
+    let depth_v2 = emit_dir.join("depth_v2/video_stream.py");
+    let uvc_v1 = emit_dir.join("uvc_v1/video_stream.py");
     for path in [&depth_v1, &depth_v2, &uvc_v1] {
         assert!(path.exists(), "expected contract-backed topic at {path:?}");
     }
@@ -124,8 +129,9 @@ fn nests_contract_backed_topics_under_contract_name_and_tag() {
     let root_init = fs::read_to_string(emit_dir.join("__init__.py")).expect("root __init__.py");
     for expected in [
         "from . import video_stream",
-        "from . import depth_camera",
-        "from . import uvc_camera",
+        "from . import depth_v1",
+        "from . import depth_v2",
+        "from . import uvc_v1",
     ] {
         assert!(
             root_init.contains(expected),
@@ -133,11 +139,17 @@ fn nests_contract_backed_topics_under_contract_name_and_tag() {
         );
     }
 
-    let depth_init = fs::read_to_string(emit_dir.join("depth_camera/__init__.py"))
-        .expect("depth_camera/__init__.py");
+    let depth_v1_init = fs::read_to_string(emit_dir.join("depth_v1/__init__.py"))
+        .expect("depth_v1/__init__.py");
     assert!(
-        depth_init.contains("from . import v1") && depth_init.contains("from . import v2"),
-        "depth_camera/__init__.py should import v1 and v2:\n{depth_init}",
+        depth_v1_init.contains("from . import video_stream"),
+        "depth_v1/__init__.py should import video_stream:\n{depth_v1_init}",
+    );
+    let depth_v2_init = fs::read_to_string(emit_dir.join("depth_v2/__init__.py"))
+        .expect("depth_v2/__init__.py");
+    assert!(
+        depth_v2_init.contains("from . import video_stream"),
+        "depth_v2/__init__.py should import video_stream:\n{depth_v2_init}",
     );
 
     // Each leaf's declare_publisher body passes a matching `peppylib.SenderTarget`
@@ -177,8 +189,8 @@ fn nests_contract_backed_topics_under_contract_name_and_tag() {
     // Capnp schemas are resolved via `importlib.resources.files("peppygen")`,
     // which is independent of the calling file's depth. This regressed once
     // when the loader used `_PKG_DIR = Path(__file__).parent.parent` (fine
-    // for the flat native path but two levels short for nested contract-backed
-    // artifacts at `peppygen/<category>/<contract>/<tag>/<leaf>.py`), which made
+    // for the flat native path but one level short for nested contract-backed
+    // artifacts at `peppygen/<category>/<link_id>/<leaf>.py`), which made
     // `capnp.load()` raise silently inside the asyncio loop and hung the
     // consumer. All four files (native + three contract-backed) should now produce
     // the same loader form.
@@ -201,18 +213,19 @@ fn nests_contract_backed_topics_under_contract_name_and_tag() {
     }
 }
 
-/// Exercises hyphen-to-underscore normalization in the `contract_tag` for the
-/// Python generator: a tag `v1-beta` becomes the directory `v1_beta` (Python
-/// identifiers can't carry hyphens) while the literal `"v1-beta"` is still
-/// embedded in the declare_publisher body; the messaging layer normalizes hyphens
+/// Exercises hyphen-to-underscore normalization of the slot `link_id` for the
+/// Python generator: a link_id `depth-beta` becomes the directory `depth_beta`
+/// (Python identifiers can't carry hyphens) while the literal `"v1-beta"` tag is
+/// still embedded in the declare_publisher body; the messaging layer normalizes hyphens
 /// at the wire boundary, so the generator keeps the raw value.
 #[test]
-fn hyphenated_tag_lands_in_underscore_directory() {
+fn hyphenated_link_id_lands_in_underscore_directory() {
     let temp_dir = TempDir::new_in(crate::helpers::test_tmp_root()).expect("temp dir");
     let (_output_dir, user_node, peppy_node_config) = prepare_directories(&temp_dir);
     fs::write(&peppy_node_config, NODE_CONFIG).expect("write node config");
 
     let extras = vec![contract_backed(
+        "depth-beta",
         "depth_camera",
         "v1-beta",
         make_topic("hyphen_marker"),
@@ -234,10 +247,10 @@ fn hyphenated_tag_lands_in_underscore_directory() {
         .join(config::consts::PEPPYGEN_OUTPUT_PATH)
         .join("peppygen")
         .join("emitted_topics");
-    let leaf = emit_dir.join("depth_camera/v1_beta/video_stream.py");
+    let leaf = emit_dir.join("depth_beta/video_stream.py");
     assert!(
         leaf.exists(),
-        "hyphenated tag should land under underscored dir at {leaf:?}",
+        "hyphenated link_id should land in an underscored dir at {leaf:?}",
     );
     let src = fs::read_to_string(&leaf).expect("read leaf");
     assert!(

--- a/crates/generator-internal/tests/python/wire_compat.rs
+++ b/crates/generator-internal/tests/python/wire_compat.rs
@@ -324,7 +324,7 @@ if __name__ == "__main__":
 import asyncio
 from peppygen import NodeBuilder, QoSProfile
 from peppygen.exposed_services import result_received
-from peppygen.consumed_actions import producer_perform_scan
+from peppygen.consumed_actions.producer import perform_scan as producer_perform_scan
 
 async def consume_action(node_runner, done):
     request = producer_perform_scan.GoalRequest(scan_id=7)
@@ -691,7 +691,7 @@ if __name__ == "__main__":
 import asyncio
 from peppygen import NodeBuilder
 from peppygen.exposed_services import response_received
-from peppygen.consumed_services import producer_report_status
+from peppygen.consumed_services.producer import report_status as producer_report_status
 
 async def poll_service(node_runner, done):
     request = producer_report_status.Request(detail=True)
@@ -1043,7 +1043,7 @@ import os
 import sys
 from peppygen import NodeBuilder
 from peppygen.exposed_services import received_ack
-from peppygen.consumed_topics import producer_telemetry_feed
+from peppygen.consumed_topics.producer import telemetry_feed as producer_telemetry_feed
 
 async def receive_one(node_runner, msg_received):
     try:

--- a/crates/generator-internal/tests/rust/actions_communication.rs
+++ b/crates/generator-internal/tests/rust/actions_communication.rs
@@ -139,7 +139,7 @@ async fn actions_pinned_binding_routes_to_bound_instance_of_two() {
 
     init_cargo_user_node(&user_node_consumer);
     let consumer_main = r#"
-use peppygen::consumed_actions::brain_move_arm;
+use peppygen::consumed_actions::brain::move_arm as brain_move_arm;
 use peppygen::NodeBuilder;
 use peppygen::Result;
 use std::time::Duration;
@@ -490,7 +490,7 @@ async fn actions_communication(#[case] topology: crate::helpers::LocalNodesTopol
 
     init_cargo_user_node(&user_node_consumer);
     let consumer_main = r#"
-use peppygen::consumed_actions::brain_move_arm;
+use peppygen::consumed_actions::brain::move_arm as brain_move_arm;
 use peppygen::NodeBuilder;
 use peppygen::Result;
 use std::time::Duration;
@@ -830,7 +830,7 @@ async fn actions_communication_cancel_goal(#[case] topology: crate::helpers::Loc
 
     init_cargo_user_node(&user_node_consumer);
     let consumer_main = r#"
-use peppygen::consumed_actions::brain_move_arm;
+use peppygen::consumed_actions::brain::move_arm as brain_move_arm;
 use peppygen::NodeBuilder;
 use peppygen::Result;
 use std::time::Duration;
@@ -1179,7 +1179,7 @@ async fn actions_communication_drain_loop_until_end_signal(
 
     init_cargo_user_node(&user_node_consumer);
     let consumer_main = r#"
-use peppygen::consumed_actions::brain_move_arm;
+use peppygen::consumed_actions::brain::move_arm as brain_move_arm;
 use peppygen::NodeBuilder;
 use peppygen::Result;
 use std::time::Duration;
@@ -1572,7 +1572,7 @@ async fn actions_communication_cancel_accept_closes_feedback_stream(
 
     init_cargo_user_node(&user_node_consumer);
     let consumer_main = r#"
-use peppygen::consumed_actions::brain_move_arm;
+use peppygen::consumed_actions::brain::move_arm as brain_move_arm;
 use peppygen::NodeBuilder;
 use peppygen::Result;
 use std::time::Duration;
@@ -1949,7 +1949,7 @@ async fn actions_communication_cancel_reject_keeps_feedback_open(
 
     init_cargo_user_node(&user_node_consumer);
     let consumer_main = r#"
-use peppygen::consumed_actions::brain_move_arm;
+use peppygen::consumed_actions::brain::move_arm as brain_move_arm;
 use peppygen::NodeBuilder;
 use peppygen::Result;
 use std::time::Duration;
@@ -2344,7 +2344,7 @@ async fn actions_communication_producer_sigkill_unblocks_drain_and_abandons(
 
     init_cargo_user_node(&user_node_consumer);
     let consumer_main = r#"
-use peppygen::consumed_actions::brain_move_arm;
+use peppygen::consumed_actions::brain::move_arm as brain_move_arm;
 use peppygen::NodeBuilder;
 use peppygen::Result;
 use std::time::Duration;

--- a/crates/generator-internal/tests/rust/actions_implements.rs
+++ b/crates/generator-internal/tests/rust/actions_implements.rs
@@ -33,10 +33,16 @@ fn make_action(marker: &str) -> NativeExposedAction {
     }
 }
 
-fn contract_backed(name: &str, tag: &str, action: NativeExposedAction) -> DeploymentInterface {
+fn contract_backed(
+    link_id: &str,
+    name: &str,
+    tag: &str,
+    action: NativeExposedAction,
+) -> DeploymentInterface {
     DeploymentInterface::new(InterfaceVariant::ExposedAction {
         action,
         origin: Some(ContractOrigin {
+            link_id: link_id.to_string(),
             contract_name: name.to_string(),
             contract_tag: tag.to_string(),
         }),
@@ -81,14 +87,14 @@ const NODE_CONFIG: &str = r#"{
 ///      leaves and `SenderTarget::node("name", "tag")?` for the native leaf.
 ///   4. Per-interface marker fields land in the right file.
 #[test]
-fn nests_contract_backed_actions_under_contract_name_and_tag() {
+fn nests_contract_backed_actions_under_link_id() {
     let temp_dir = TempDir::new_in(crate::helpers::test_tmp_root()).expect("temp dir");
     let (_output_dir, user_node, peppy_node_config) = prepare_directories(&temp_dir);
     fs::write(&peppy_node_config, NODE_CONFIG).expect("write node config");
 
     let extras = vec![
-        contract_backed("arm", "v1", make_action("arm_v1_marker")),
-        contract_backed("arm", "v2", make_action("arm_v2_marker")),
+        contract_backed("arm_v1", "arm", "v1", make_action("arm_v1_marker")),
+        contract_backed("arm_v2", "arm", "v2", make_action("arm_v2_marker")),
     ];
 
     let peppy_dirs = test_peppy_dirs();
@@ -109,8 +115,8 @@ fn nests_contract_backed_actions_under_contract_name_and_tag() {
     let act_dir = src.join("exposed_actions");
 
     let native_path = act_dir.join("move_arm.rs");
-    let arm_v1 = act_dir.join("arm/v1/move_arm.rs");
-    let arm_v2 = act_dir.join("arm/v2/move_arm.rs");
+    let arm_v1 = act_dir.join("arm_v1/move_arm.rs");
+    let arm_v2 = act_dir.join("arm_v2/move_arm.rs");
 
     for path in [&native_path, &arm_v1, &arm_v2] {
         assert!(path.exists(), "expected action file at {path:?}");
@@ -118,17 +124,24 @@ fn nests_contract_backed_actions_under_contract_name_and_tag() {
 
     let category_mod = fs::read_to_string(src.join("exposed_actions.rs"))
         .expect("exposed_actions.rs should exist");
-    for expected in ["pub mod move_arm;", "pub mod arm;"] {
+    for expected in ["pub mod move_arm;", "pub mod arm_v1;", "pub mod arm_v2;"] {
         assert!(
             category_mod.contains(expected),
             "exposed_actions.rs missing `{expected}`:\n{category_mod}",
         );
     }
 
-    let arm_mod = fs::read_to_string(act_dir.join("arm/mod.rs")).expect("arm/mod.rs should exist");
+    let arm_v1_mod =
+        fs::read_to_string(act_dir.join("arm_v1/mod.rs")).expect("arm_v1/mod.rs should exist");
     assert!(
-        arm_mod.contains("pub mod v1;") && arm_mod.contains("pub mod v2;"),
-        "arm/mod.rs should declare v1 and v2:\n{arm_mod}",
+        arm_v1_mod.contains("pub mod move_arm;"),
+        "arm_v1/mod.rs should declare move_arm:\n{arm_v1_mod}",
+    );
+    let arm_v2_mod =
+        fs::read_to_string(act_dir.join("arm_v2/mod.rs")).expect("arm_v2/mod.rs should exist");
+    assert!(
+        arm_v2_mod.contains("pub mod move_arm;"),
+        "arm_v2/mod.rs should declare move_arm:\n{arm_v2_mod}",
     );
 
     let native_src = fs::read_to_string(&native_path).expect("read native");

--- a/crates/generator-internal/tests/rust/consumed_services_dedup.rs
+++ b/crates/generator-internal/tests/rust/consumed_services_dedup.rs
@@ -62,7 +62,8 @@ const REAR_REQUEST_FORMAT: &str = r#"{ enabled: "bool", intensity: "u32" }"#;
 const REAR_RESPONSE_FORMAT: &str = r#"{ status_code: "i32" }"#;
 
 const USER_MAIN: &str = r#"
-use peppygen::consumed_services::{front_cam_enable, rear_cam_enable};
+use peppygen::consumed_services::front_cam::enable as front_cam_enable;
+use peppygen::consumed_services::rear_cam::enable as rear_cam_enable;
 
 #[allow(dead_code)]
 fn _references_both_link_keyed_modules() {
@@ -118,8 +119,8 @@ fn rust_cross_producer_same_service_name_keeps_schemas_separate() {
     .expect("failed to generate peppygen lib");
 
     let peppygen_dir = user_node_dir.join(PEPPYGEN_OUTPUT_PATH);
-    let front_module = peppygen_dir.join("src/consumed_services/front_cam_enable.rs");
-    let rear_module = peppygen_dir.join("src/consumed_services/rear_cam_enable.rs");
+    let front_module = peppygen_dir.join("src/consumed_services/front_cam/enable.rs");
+    let rear_module = peppygen_dir.join("src/consumed_services/rear_cam/enable.rs");
     assert!(
         front_module.exists(),
         "front consumer module missing at {}",

--- a/crates/generator-internal/tests/rust/consumed_topics_dedup.rs
+++ b/crates/generator-internal/tests/rust/consumed_topics_dedup.rs
@@ -50,7 +50,8 @@ const RIGHT_CONSUMER: &str = r#"{ link_id: "right_arm", name: "joint_states" }"#
 /// the test is exercising and mirror the explicit-probe style of the Python
 /// counterpart.
 const USER_MAIN: &str = r#"
-use peppygen::consumed_topics::{left_arm_joint_states, right_arm_joint_states};
+use peppygen::consumed_topics::left_arm::joint_states as left_arm_joint_states;
+use peppygen::consumed_topics::right_arm::joint_states as right_arm_joint_states;
 
 #[allow(dead_code)]
 fn _references_both_link_keyed_modules() {
@@ -103,8 +104,8 @@ fn rust_handles_two_consumed_topics_sharing_topic_name() {
     .expect("failed to generate peppygen lib");
 
     let peppygen_dir = user_node_dir.join(PEPPYGEN_OUTPUT_PATH);
-    let left_module = peppygen_dir.join("src/consumed_topics/left_arm_joint_states.rs");
-    let right_module = peppygen_dir.join("src/consumed_topics/right_arm_joint_states.rs");
+    let left_module = peppygen_dir.join("src/consumed_topics/left_arm/joint_states.rs");
+    let right_module = peppygen_dir.join("src/consumed_topics/right_arm/joint_states.rs");
     assert!(
         left_module.exists(),
         "left consumer module missing at {}",

--- a/crates/generator-internal/tests/rust/generate_lib.rs
+++ b/crates/generator-internal/tests/rust/generate_lib.rs
@@ -430,7 +430,7 @@ fn generate_peppygen_rust_lib_emitted_and_consumed_topics() {
     let consumer_peppygen_dir = consumer_node_dir.join(PEPPYGEN_OUTPUT_PATH);
     assert!(
         consumer_peppygen_dir
-            .join("src/consumed_topics/topic_exposer_test_topic.rs")
+            .join("src/consumed_topics/topic_exposer/test_topic.rs")
             .exists(),
         "consumed topic module should exist in peppygen crate at {}",
         consumer_peppygen_dir.display()
@@ -553,7 +553,7 @@ fn generate_peppygen_rust_lib_exposed_and_consumed_services() {
 
     let consumer_peppygen_dir = consumer_node_dir.join(PEPPYGEN_OUTPUT_PATH);
     let consumed_service_module_path =
-        consumer_peppygen_dir.join("src/consumed_services/service_exposer_test_service.rs");
+        consumer_peppygen_dir.join("src/consumed_services/service_exposer/test_service.rs");
     assert!(
         consumed_service_module_path.exists(),
         "consumed service module should exist in peppygen crate at {}",
@@ -701,7 +701,7 @@ fn generate_peppygen_rust_lib_exposed_and_consumed_actions() {
     let consumer_peppygen_dir = consumer_node_dir.join(PEPPYGEN_OUTPUT_PATH);
     assert!(
         consumer_peppygen_dir
-            .join("src/consumed_actions/action_exposer_test_action.rs")
+            .join("src/consumed_actions/action_exposer/test_action.rs")
             .exists(),
         "consumed action module should exist in peppygen crate at {}",
         consumer_peppygen_dir.display()

--- a/crates/generator-internal/tests/rust/multi_binding_communication.rs
+++ b/crates/generator-internal/tests/rust/multi_binding_communication.rs
@@ -141,8 +141,8 @@ async fn one_or_more_slot_fans_in_topics_and_directs_services(
 
     init_cargo_user_node(&user_node_consumer);
     let consumer_main = r#"
-use peppygen::consumed_services::cameras_enable_camera;
-use peppygen::consumed_topics::cameras_video_stream;
+use peppygen::consumed_services::cameras::enable_camera as cameras_enable_camera;
+use peppygen::consumed_topics::cameras::video_stream as cameras_video_stream;
 use peppygen::{NodeBuilder, ProducerRef, Result};
 use std::collections::HashSet;
 use std::time::Duration;

--- a/crates/generator-internal/tests/rust/pairing_lib.rs
+++ b/crates/generator-internal/tests/rust/pairing_lib.rs
@@ -1,6 +1,6 @@
 //! Generate-and-compile fixture for pairing peer modules (Rust): a synthetic
 //! two-role pairing (`arm_link/v1`, roles controller/arm) generates
-//! `pairings/<link_id>/<topic>` modules for both directions, and a user node
+//! `paired_topics/<link_id>/<topic>` modules for both directions, and a user node
 //! exercising the full generated surface — slot consts, `paired()` /
 //! `wait_paired()`, the slot-scoped publisher, and the pin-following
 //! subscription — must compile against the real peppylib. This is the
@@ -73,13 +73,13 @@ fn generated_peer_modules_compile_against_peppylib() {
         Path::new(PEPPYGEN_OUTPUT_PATH),
     );
 
-    // Both directions of the slot nest flat under pairings/<link_id>/<topic>.
+    // Both directions of the slot nest under paired_topics/<link_id>/<topic>.
     let src_dir = user_node.join(PEPPYGEN_OUTPUT_PATH).join("src");
-    let pairings_dir = src_dir.join("pairings");
+    let paired_topics_dir = src_dir.join("paired_topics");
     for module in ["arm/joint_commands.rs", "arm/joint_states.rs"] {
         assert!(
-            pairings_dir.join(module).exists(),
-            "expected generated module pairings/{module}"
+            paired_topics_dir.join(module).exists(),
+            "expected generated module paired_topics/{module}"
         );
     }
     // Neither direction may leak into the flat consumed/emitted namespaces.
@@ -113,7 +113,7 @@ fn generated_peer_modules_compile_against_peppylib() {
     let user_main = r#"
 use peppygen::NodeBuilder;
 use peppygen::Result;
-use peppygen::pairings::arm::{joint_commands, joint_states};
+use peppygen::paired_topics::arm::{joint_commands, joint_states};
 
 fn main() -> Result<()> {
     NodeBuilder::new().run(|_parameters: peppygen::Parameters, node_runner| async move {

--- a/crates/generator-internal/tests/rust/services_communication.rs
+++ b/crates/generator-internal/tests/rust/services_communication.rs
@@ -119,7 +119,7 @@ async fn services_communication_no_target_instance_id(
 
     init_cargo_user_node(&user_node_consumer);
     let consumer_main = r#"
-use peppygen::consumed_services::uvc_camera_enable_camera;
+use peppygen::consumed_services::uvc_camera::enable_camera as uvc_camera_enable_camera;
 use peppygen::NodeBuilder;
 use peppygen::Result;
 use std::time::Duration;
@@ -432,7 +432,7 @@ async fn services_communication_exposed_service_without_request_body(
 
     init_cargo_user_node(&user_node_consumer);
     let consumer_main = r#"
-use peppygen::consumed_services::uvc_camera_get_system_status;
+use peppygen::consumed_services::uvc_camera::get_system_status as uvc_camera_get_system_status;
 use peppygen::NodeBuilder;
 use peppygen::Result;
 use std::time::Duration;
@@ -735,7 +735,7 @@ async fn services_communication_multiple_exposed_instances_bound_slot_routes_to_
 
     init_cargo_user_node(&user_node_consumer);
     let consumer_main = r#"
-use peppygen::consumed_services::uvc_camera_enable_camera;
+use peppygen::consumed_services::uvc_camera::enable_camera as uvc_camera_enable_camera;
 use peppygen::NodeBuilder;
 use peppygen::Result;
 use std::time::Duration;

--- a/crates/generator-internal/tests/rust/services_implements.rs
+++ b/crates/generator-internal/tests/rust/services_implements.rs
@@ -25,10 +25,16 @@ fn make_service(marker: &str) -> NativeExposedService {
     }
 }
 
-fn contract_backed(name: &str, tag: &str, service: NativeExposedService) -> DeploymentInterface {
+fn contract_backed(
+    link_id: &str,
+    name: &str,
+    tag: &str,
+    service: NativeExposedService,
+) -> DeploymentInterface {
     DeploymentInterface::new(InterfaceVariant::ExposedService {
         service,
         origin: Some(ContractOrigin {
+            link_id: link_id.to_string(),
             contract_name: name.to_string(),
             contract_tag: tag.to_string(),
         }),
@@ -71,14 +77,14 @@ const NODE_CONFIG: &str = r#"{
 ///      and `SenderTarget::node(...)` for the native leaf.
 ///   4. Per-interface marker fields land in the right file (no cross-wiring).
 #[test]
-fn nests_contract_backed_services_under_contract_name_and_tag() {
+fn nests_contract_backed_services_under_link_id() {
     let temp_dir = TempDir::new_in(crate::helpers::test_tmp_root()).expect("temp dir");
     let (_output_dir, user_node, peppy_node_config) = prepare_directories(&temp_dir);
     fs::write(&peppy_node_config, NODE_CONFIG).expect("write node config");
 
     let extras = vec![
-        contract_backed("camera", "v1", make_service("camera_v1_marker")),
-        contract_backed("arm", "v2", make_service("arm_v2_marker")),
+        contract_backed("cam", "camera", "v1", make_service("camera_v1_marker")),
+        contract_backed("arm", "arm", "v2", make_service("arm_v2_marker")),
     ];
 
     let peppy_dirs = test_peppy_dirs();
@@ -99,8 +105,8 @@ fn nests_contract_backed_services_under_contract_name_and_tag() {
     let svc_dir = src.join("exposed_services");
 
     let native_path = svc_dir.join("control.rs");
-    let camera_v1 = svc_dir.join("camera/v1/control.rs");
-    let arm_v2 = svc_dir.join("arm/v2/control.rs");
+    let camera_v1 = svc_dir.join("cam/control.rs");
+    let arm_v2 = svc_dir.join("arm/control.rs");
 
     for path in [&native_path, &camera_v1, &arm_v2] {
         assert!(path.exists(), "expected service file at {path:?}");
@@ -108,7 +114,7 @@ fn nests_contract_backed_services_under_contract_name_and_tag() {
 
     let category_mod = fs::read_to_string(src.join("exposed_services.rs"))
         .expect("exposed_services.rs should exist");
-    for expected in ["pub mod control;", "pub mod camera;", "pub mod arm;"] {
+    for expected in ["pub mod control;", "pub mod cam;", "pub mod arm;"] {
         assert!(
             category_mod.contains(expected),
             "exposed_services.rs missing `{expected}`:\n{category_mod}",

--- a/crates/generator-internal/tests/rust/topics_communication.rs
+++ b/crates/generator-internal/tests/rust/topics_communication.rs
@@ -98,7 +98,7 @@ async fn topics_communication(#[case] topology: crate::helpers::LocalNodesTopolo
     // TODO: An exit signal should be sent to the receiver to terminate the process
     let receiver_main = r#"
 use peppygen::NodeBuilder;
-use peppygen::consumed_topics::uvc_camera_video_stream::subscribe;
+use peppygen::consumed_topics::uvc_camera::video_stream::subscribe;
 use peppygen::Result;
 
 fn main() -> Result<()> {

--- a/crates/generator-internal/tests/rust/topics_implements.rs
+++ b/crates/generator-internal/tests/rust/topics_implements.rs
@@ -41,10 +41,16 @@ fn make_topic(distinguishing_field: &str) -> NativeEmittedTopic {
     }
 }
 
-fn contract_backed(name: &str, tag: &str, topic: NativeEmittedTopic) -> DeploymentInterface {
+fn contract_backed(
+    link_id: &str,
+    name: &str,
+    tag: &str,
+    topic: NativeEmittedTopic,
+) -> DeploymentInterface {
     DeploymentInterface::new(InterfaceVariant::EmittedTopic {
         topic,
         origin: Some(ContractOrigin {
+            link_id: link_id.to_string(),
             contract_name: name.to_string(),
             contract_tag: tag.to_string(),
         }),
@@ -91,15 +97,15 @@ const NODE_CONFIG: &str = r#"{
 ///   4. The per-interface marker fields land in their own files, proof the
 ///      four artifacts weren't cross-wired during generation.
 #[test]
-fn nests_contract_backed_topics_under_contract_name_and_tag() {
+fn nests_contract_backed_topics_under_link_id() {
     let temp_dir = TempDir::new_in(crate::helpers::test_tmp_root()).expect("temp dir");
     let (_output_dir, user_node, peppy_node_config) = prepare_directories(&temp_dir);
     fs::write(&peppy_node_config, NODE_CONFIG).expect("write node config");
 
     let extras = vec![
-        contract_backed("depth_camera", "v1", make_topic("depth_v1_marker")),
-        contract_backed("depth_camera", "v2", make_topic("depth_v2_marker")),
-        contract_backed("uvc_camera", "v1", make_topic("uvc_v1_marker")),
+        contract_backed("depth_v1", "depth_camera", "v1", make_topic("depth_v1_marker")),
+        contract_backed("depth_v2", "depth_camera", "v2", make_topic("depth_v2_marker")),
+        contract_backed("uvc_v1", "uvc_camera", "v1", make_topic("uvc_v1_marker")),
     ];
 
     let peppy_dirs = test_peppy_dirs();
@@ -126,34 +132,37 @@ fn nests_contract_backed_topics_under_contract_name_and_tag() {
         "native video_stream.rs should exist at {native_path:?}",
     );
 
-    // Conformed artifacts nest under `<iface_name>/<iface_tag>/`.
-    let depth_v1 = emit_dir.join("depth_camera/v1/video_stream.rs");
-    let depth_v2 = emit_dir.join("depth_camera/v2/video_stream.rs");
-    let uvc_v1 = emit_dir.join("uvc_camera/v1/video_stream.rs");
+    // Conformed artifacts nest under `<link_id>/`.
+    let depth_v1 = emit_dir.join("depth_v1/video_stream.rs");
+    let depth_v2 = emit_dir.join("depth_v2/video_stream.rs");
+    let uvc_v1 = emit_dir.join("uvc_v1/video_stream.rs");
     for path in [&depth_v1, &depth_v2, &uvc_v1] {
         assert!(path.exists(), "expected contract-backed topic at {path:?}");
     }
 
-    // The container mod.rs files declare every direct child module.
-    let depth_mod = fs::read_to_string(emit_dir.join("depth_camera/mod.rs"))
-        .expect("depth_camera/mod.rs should exist");
+    // Each slot's `mod.rs` declares its leaf module.
+    let depth_v1_mod = fs::read_to_string(emit_dir.join("depth_v1/mod.rs"))
+        .expect("depth_v1/mod.rs should exist");
     assert!(
-        depth_mod.contains("pub mod v1;"),
-        "depth_camera/mod.rs missing v1: {depth_mod}",
+        depth_v1_mod.contains("pub mod video_stream;"),
+        "depth_v1/mod.rs missing video_stream: {depth_v1_mod}",
     );
+    let depth_v2_mod = fs::read_to_string(emit_dir.join("depth_v2/mod.rs"))
+        .expect("depth_v2/mod.rs should exist");
     assert!(
-        depth_mod.contains("pub mod v2;"),
-        "depth_camera/mod.rs missing v2: {depth_mod}",
+        depth_v2_mod.contains("pub mod video_stream;"),
+        "depth_v2/mod.rs missing video_stream: {depth_v2_mod}",
     );
 
     // The category file at `src/emitted_topics.rs` lists the four entries:
-    // the native leaf and the three interface directories.
+    // the native leaf and the three slot directories.
     let category_mod =
         fs::read_to_string(src.join("emitted_topics.rs")).expect("emitted_topics.rs should exist");
     for expected in [
         "pub mod video_stream;",
-        "pub mod depth_camera;",
-        "pub mod uvc_camera;",
+        "pub mod depth_v1;",
+        "pub mod depth_v2;",
+        "pub mod uvc_v1;",
     ] {
         assert!(
             category_mod.contains(expected),
@@ -230,18 +239,19 @@ fn nests_contract_backed_topics_under_contract_name_and_tag() {
     );
 }
 
-/// Exercises hyphen-to-underscore normalization in the `iface_tag` for the
-/// Rust generator: a tag `v1-beta` becomes the directory `v1_beta` (Rust
-/// module names can't carry hyphens) while the literal `"v1-beta"` is still
-/// embedded in the declare_publisher body; messaging.rs normalizes hyphens at the wire
-/// boundary, so the generator keeps the raw value.
+/// Exercises hyphen-to-underscore normalization of the slot `link_id` for the
+/// Rust generator: a link_id `depth-beta` becomes the directory `depth_beta`
+/// (Rust module names can't carry hyphens) while the literal `"v1-beta"` tag is
+/// still embedded in the declare_publisher body; messaging.rs normalizes hyphens
+/// at the wire boundary, so the generator keeps the raw value.
 #[test]
-fn hyphenated_tag_lands_in_underscore_directory() {
+fn hyphenated_link_id_lands_in_underscore_directory() {
     let temp_dir = TempDir::new_in(crate::helpers::test_tmp_root()).expect("temp dir");
     let (_output_dir, user_node, peppy_node_config) = prepare_directories(&temp_dir);
     fs::write(&peppy_node_config, NODE_CONFIG).expect("write node config");
 
     let extras = vec![contract_backed(
+        "depth-beta",
         "depth_camera",
         "v1-beta",
         make_topic("hyphen_marker"),
@@ -263,10 +273,10 @@ fn hyphenated_tag_lands_in_underscore_directory() {
         .join(config::consts::PEPPYGEN_OUTPUT_PATH)
         .join("src")
         .join("emitted_topics");
-    let leaf = emit_dir.join("depth_camera/v1_beta/video_stream.rs");
+    let leaf = emit_dir.join("depth_beta/video_stream.rs");
     assert!(
         leaf.exists(),
-        "hyphenated tag should land in underscored dir at {leaf:?}",
+        "hyphenated link_id should land in an underscored dir at {leaf:?}",
     );
     let src = fs::read_to_string(&leaf).expect("read leaf");
     assert!(

--- a/crates/peppy/tests/node_sync.rs
+++ b/crates/peppy/tests/node_sync.rs
@@ -549,16 +549,16 @@ async fn node_sync_generates_peer_modules_for_pairing_slots() {
     .expect("node sync with a cached pairing doc should succeed");
 
     // Both directions of the slot: the arm emits joint_states and consumes
-    // joint_commands, all under pairings/<link_id>/.
-    let pairings_dir = node_dir
+    // joint_commands, all under paired_topics/<link_id>/.
+    let paired_topics_dir = node_dir
         .path()
         .join(config::consts::PEPPYGEN_OUTPUT_PATH)
-        .join("src/pairings/controller");
+        .join("src/paired_topics/controller");
     for module in ["joint_states.rs", "joint_commands.rs"] {
         assert!(
-            pairings_dir.join(module).exists(),
+            paired_topics_dir.join(module).exists(),
             "expected generated module at {}",
-            pairings_dir.join(module).display()
+            paired_topics_dir.join(module).display()
         );
     }
 }

--- a/crates/peppy/tests/node_sync.rs
+++ b/crates/peppy/tests/node_sync.rs
@@ -492,7 +492,7 @@ async fn node_sync_with_include_repositories_prints_provenance() {
     );
 }
 
-/// A node declaring `depends_on.pairings` syncs into `pairings/<link_id>/<topic>`
+/// A node declaring `depends_on.pairings` syncs into `paired_topics/<link_id>/<topic>`
 /// modules once the pairing doc is in the daemon's pairing cache.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn node_sync_generates_peer_modules_for_pairing_slots() {

--- a/docs/src/content/docs/advanced_guides/actions.mdx
+++ b/docs/src/content/docs/advanced_guides/actions.mdx
@@ -496,19 +496,19 @@ Use `fire_goal` to send a goal, then listen for feedback and request the result:
 <Tabs>
   <TabItem label="Rust">
 ```rust
-use peppygen::consumed_actions::brain_move_arm;
+use peppygen::consumed_actions::brain::move_arm;
 use peppygen::{NodeBuilder, Parameters, QoSProfile, Result};
 use std::time::Duration;
 
 fn main() -> Result<()> {
     NodeBuilder::new().run(|_args: Parameters, node_runner| async move {
         // `one`: the accessor returns the slot's sole producer directly.
-        let arm = brain_move_arm::bound_producer(&node_runner);
-        let request = brain_move_arm::GoalRequest {
+        let arm = move_arm::bound_producer(&node_runner);
+        let request = move_arm::GoalRequest {
             arm_id: 7,
             desired_position: [10, 20, 30],
         };
-        let action_handle = brain_move_arm::ActionHandle::fire_goal(
+        let action_handle = move_arm::ActionHandle::fire_goal(
             &node_runner,
             arm,                    // which bound instance executes the goal
             Duration::from_secs(5), // timeout
@@ -529,14 +529,14 @@ fn main() -> Result<()> {
 import asyncio
 
 from peppygen import NodeBuilder, QoSProfile
-from peppygen.consumed_actions import brain_move_arm
+from peppygen.consumed_actions.brain import move_arm
 
 
 async def run(node_runner):
     # `one`: the accessor returns the slot's sole producer directly.
-    arm = brain_move_arm.bound_producer(node_runner)
-    request = brain_move_arm.GoalRequest(arm_id=7, desired_position=[10, 20, 30])
-    action_handle = await brain_move_arm.ActionHandle.fire_goal(
+    arm = move_arm.bound_producer(node_runner)
+    request = move_arm.GoalRequest(arm_id=7, desired_position=[10, 20, 30])
+    action_handle = await move_arm.ActionHandle.fire_goal(
         node_runner,
         arm,                    # which bound instance executes the goal
         request,
@@ -619,19 +619,19 @@ Use `get_result` on the handle to request the final result. The call is routed t
 let result = action_handle.get_result(Duration::from_secs(5)).await?;
 
 match result.outcome {
-    brain_move_arm::ResultOutcome::Completed(data) => println!(
+    move_arm::ResultOutcome::Completed(data) => println!(
         "completed: success={} error={:?} final_position={:?}",
         data.success,
         data.error_msg.as_deref(),
         data.final_position,
     ),
-    brain_move_arm::ResultOutcome::Cancelled(data) => {
+    move_arm::ResultOutcome::Cancelled(data) => {
         println!("cancelled at {:?}", data.final_position)
     }
-    brain_move_arm::ResultOutcome::Abandoned => {
+    move_arm::ResultOutcome::Abandoned => {
         println!("the worker abandoned the goal without producing a result")
     }
-    brain_move_arm::ResultOutcome::Expired => {
+    move_arm::ResultOutcome::Expired => {
         println!("the result expired before it was fetched")
     }
 }
@@ -641,17 +641,17 @@ match result.outcome {
 ```python
 result = await action_handle.get_result(5.0)
 
-if result.status == brain_move_arm.ResultStatus.COMPLETED:
+if result.status == move_arm.ResultStatus.COMPLETED:
     print(
         f"completed: success={result.data.success} error={result.data.error_msg} "
         f"final_position={result.data.final_position}",
         flush=True,
     )
-elif result.status == brain_move_arm.ResultStatus.CANCELLED:
+elif result.status == move_arm.ResultStatus.CANCELLED:
     print(f"cancelled at {result.data.final_position}", flush=True)
-elif result.status == brain_move_arm.ResultStatus.ABANDONED:
+elif result.status == move_arm.ResultStatus.ABANDONED:
     print("the worker abandoned the goal without producing a result", flush=True)
-elif result.status == brain_move_arm.ResultStatus.EXPIRED:
+elif result.status == move_arm.ResultStatus.EXPIRED:
     print("the result expired before it was fetched", flush=True)
 ```
   </TabItem>
@@ -675,9 +675,9 @@ Use `cancel_goal` on the handle to request cancellation of that specific goal. I
 let cancel_response = action_handle.cancel_goal(Duration::from_secs(5)).await?;
 
 match cancel_response.state {
-    brain_move_arm::CancelState::Signalled => println!("cancel delivered to a live goal"),
-    brain_move_arm::CancelState::AlreadyTerminal => println!("goal had already finished"),
-    brain_move_arm::CancelState::Unknown => println!("no goal with that id is known"),
+    move_arm::CancelState::Signalled => println!("cancel delivered to a live goal"),
+    move_arm::CancelState::AlreadyTerminal => println!("goal had already finished"),
+    move_arm::CancelState::Unknown => println!("no goal with that id is known"),
 }
 ```
   </TabItem>
@@ -685,11 +685,11 @@ match cancel_response.state {
 ```python
 cancel_response = await action_handle.cancel_goal(5.0)
 
-if cancel_response.state == brain_move_arm.CancelState.SIGNALLED:
+if cancel_response.state == move_arm.CancelState.SIGNALLED:
     print("cancel delivered to a live goal", flush=True)
-elif cancel_response.state == brain_move_arm.CancelState.ALREADY_TERMINAL:
+elif cancel_response.state == move_arm.CancelState.ALREADY_TERMINAL:
     print("goal had already finished", flush=True)
-elif cancel_response.state == brain_move_arm.CancelState.UNKNOWN:
+elif cancel_response.state == move_arm.CancelState.UNKNOWN:
     print("no goal with that id is known", flush=True)
 ```
   </TabItem>
@@ -768,8 +768,8 @@ A client that wires two depth cameras to two dedicated slots:
 
 Three contract statements follow from this manifest:
 
-1. `fire_goal` on the `wrist_left_camera_<action>` module reaches `left_cam`.
-2. `fire_goal` on the `wrist_right_camera_<action>` module reaches `right_cam`.
+1. `fire_goal` on the nested `wrist_left_camera.<action>` (Python) / `wrist_left_camera::<action>` (Rust) module reaches `left_cam`.
+2. `fire_goal` on the nested `wrist_right_camera.<action>` (Python) / `wrist_right_camera::<action>` (Rust) module reaches `right_cam`.
 3. If the `wrist_right_camera` binding line were removed, validation would reject the launch (every declared slot must have a binding): a goal cycle has no wildcard fallback.
 
 ### Why an explicit single target?

--- a/docs/src/content/docs/advanced_guides/contract_implementation.mdx
+++ b/docs/src/content/docs/advanced_guides/contract_implementation.mdx
@@ -129,7 +129,7 @@ A producer node claims a contract in `manifest.implements`. Each entry names a c
 
 A contract-backed entry is exactly `{link_id, name}`. The shape and QoS come from the contract document, never from the manifest: an inline `message_format`, `qos_profile`, or service/action payload field on a contract-backed entry is rejected at parse time. The `name` is a strict selector, byte-equal to a member the contract declares.
 
-The producer node is named `realsense_d405`, not `depth_camera`. The two names are unrelated. The only thing that makes `realsense_d405` a valid `depth_camera` is the explicit `implements` claim. After `peppy node sync`, code generation emits the same `video_stream` and `video_stream_info` modules that a node declaring the shapes natively would get, nested under the contract's identity (`emitted_topics/depth_camera/v1/video_stream`).
+The producer node is named `realsense_d405`, not `depth_camera`. The two names are unrelated. The only thing that makes `realsense_d405` a valid `depth_camera` is the explicit `implements` claim. After `peppy node sync`, code generation emits the same `video_stream` and `video_stream_info` modules that a node declaring the shapes natively would get, nested under the implements slot's `link_id` (`emitted_topics/cam/video_stream`), not the contract's name or tag.
 
 #### Full coverage is mandatory
 
@@ -395,7 +395,7 @@ Then the launcher binds each slot to its producer instance:
 }
 ```
 
-The three bindings feed the three slots, and the consumer receives the streams through the generated `front_video_stream`, `back_left_video_stream`, and `back_right_video_stream` modules. A fourth camera launched without a slot of its own would reach no consumer at all: only bound producers feed a slot.
+The three bindings feed the three slots, and the consumer receives the streams through the generated `video_stream` modules under the `front`, `back_left`, and `back_right` slots. A fourth camera launched without a slot of its own would reach no consumer at all: only bound producers feed a slot.
 
 Inside the consumer, every consumed-topic API returns the **producer's full `(core_node, instance_id)` identity** alongside the message payload. The consumer never hard-codes the launcher's instance ids; it just uses the returned identity as a runtime key to keep per-producer state (latest frame, frame count, last-seen timestamp, etc.) when merging its slots into one aggregate, so the launcher can re-point a slot at a different implementing instance with no consumer code change.
 
@@ -405,11 +405,9 @@ Inside the consumer, every consumed-topic API returns the **producer's full `(co
     import asyncio
 
     from peppylib import ProducerRef
-    from peppygen.consumed_topics import (
-        back_left_video_stream,
-        back_right_video_stream,
-        front_video_stream,
-    )
+    from peppygen.consumed_topics.front import video_stream as front_video_stream
+    from peppygen.consumed_topics.back_left import video_stream as back_left_video_stream
+    from peppygen.consumed_topics.back_right import video_stream as back_right_video_stream
 
     frames_by_producer: dict[ProducerRef, Frame] = {}
 
@@ -430,7 +428,9 @@ Inside the consumer, every consumed-topic API returns the **producer's full `(co
   <TabItem label="Rust">
     ```rust
     use peppygen::consumed_topics::{
-        back_left_video_stream, back_right_video_stream, front_video_stream,
+        front::video_stream as front_video_stream,
+        back_left::video_stream as back_left_video_stream,
+        back_right::video_stream as back_right_video_stream,
     };
     use peppylib::messaging::ProducerRef;
     use std::collections::HashMap;

--- a/docs/src/content/docs/advanced_guides/pairing.mdx
+++ b/docs/src/content/docs/advanced_guides/pairing.mdx
@@ -166,7 +166,7 @@ arm_controller:v1   ctrl_1     arm ⇌ arm_1:controller@cn-adoring-wiles (arm_li
 
 ## Using the generated API
 
-`peppy node sync` generates a module per declared slot topic under `peppygen.pairings.<link_id>.<topic>` (Python) / `peppygen::pairings::<link_id>::<topic>` (Rust); both directions of a slot live under the same `link_id`. The modules follow the manifest's entries, not the document's full topic list, so a counterpart topic you left out of `consumes` simply has no module. Pairing topics never appear under `consumed_topics` or `emitted_topics`, whichever direction they travel. Emitting and consuming look exactly like ordinary topics, plus two pin-state helpers on every module: `paired()` returns the current peer's identity (or `None`/`None` while unpaired), and `wait_paired()` awaits one.
+`peppy node sync` generates a module per declared slot topic under `peppygen.paired_topics.<link_id>.<topic>` (Python) / `peppygen::paired_topics::<link_id>::<topic>` (Rust); both directions of a slot live under the same `link_id`. The modules follow the manifest's entries, not the document's full topic list, so a counterpart topic you left out of `consumes` simply has no module. Pairing topics never appear under `consumed_topics` or `emitted_topics`, whichever direction they travel. Emitting and consuming look exactly like ordinary topics, plus two pin-state helpers on every module: `paired()` returns the current peer's identity (or `None`/`None` while unpaired), and `wait_paired()` awaits one.
 
 <Tabs>
   <TabItem label="Python">
@@ -251,7 +251,7 @@ peppy node run --instance-id cmd_1 two_arm_commander:v1 \
   --pair left_arm@arm_l --pair right_arm@arm_r
 ```
 
-The generated code addresses each arm through its slot module (`pairings.left_arm.joint_commands` vs `pairings.right_arm.joint_commands` in Python, `pairings::left_arm::joint_commands` vs `pairings::right_arm::joint_commands` in Rust), and each subscription receives only its own arm's states. When a peer instance declares several complementary slots (pairing two commanders' arms to each other, say), disambiguate the target with `--pair left_arm@cmd_2/right_arm`.
+The generated code addresses each arm through its slot module (`paired_topics.left_arm.joint_commands` vs `paired_topics.right_arm.joint_commands` in Python, `paired_topics::left_arm::joint_commands` vs `paired_topics::right_arm::joint_commands` in Rust), and each subscription receives only its own arm's states. When a peer instance declares several complementary slots (pairing two commanders' arms to each other, say), disambiguate the target with `--pair left_arm@cmd_2/right_arm`.
 
 ## Why topics only?
 

--- a/docs/src/content/docs/advanced_guides/services.mdx
+++ b/docs/src/content/docs/advanced_guides/services.mdx
@@ -355,7 +355,7 @@ import asyncio
 
 from peppygen import NodeBuilder, NodeRunner
 from peppygen.parameters import Parameters
-from peppygen.consumed_services import uvc_camera_enable_camera
+from peppygen.consumed_services.uvc_camera import enable_camera
 
 
 async def call_service(node_runner: NodeRunner):
@@ -363,9 +363,9 @@ async def call_service(node_runner: NodeRunner):
     # accessor is singular and infallible; no emptiness handling exists.
     # The target is still passed explicitly, same discipline as the
     # multi cardinalities.
-    camera = uvc_camera_enable_camera.bound_producer(node_runner)
-    request = uvc_camera_enable_camera.Request(enable=True)
-    response = await uvc_camera_enable_camera.poll(
+    camera = enable_camera.bound_producer(node_runner)
+    request = enable_camera.Request(enable=True)
+    response = await enable_camera.poll(
         node_runner,
         camera,  # the slot's sole producer
         request,
@@ -393,7 +393,7 @@ if __name__ == "__main__":
   </TabItem>
   <TabItem label="Rust">
 ```rust
-use peppygen::consumed_services::uvc_camera_enable_camera;
+use peppygen::consumed_services::uvc_camera::enable_camera;
 use peppygen::{NodeBuilder, Parameters, Result};
 use std::time::Duration;
 
@@ -403,9 +403,9 @@ fn main() -> Result<()> {
         // accessor is singular and infallible; no emptiness handling exists.
         // The target is still passed explicitly, same discipline as the
         // multi cardinalities.
-        let camera = uvc_camera_enable_camera::bound_producer(&node_runner);
-        let request = uvc_camera_enable_camera::Request::new(true);
-        let response = uvc_camera_enable_camera::poll(
+        let camera = enable_camera::bound_producer(&node_runner);
+        let request = enable_camera::Request::new(true);
+        let response = enable_camera::poll(
             &node_runner,
             camera,                 // the slot's sole producer
             Duration::from_secs(5), // timeout
@@ -438,20 +438,20 @@ For a service without a request body, `poll` simply takes no request:
 <Tabs>
   <TabItem label="Python">
 ```python
-from peppygen.consumed_services import uvc_camera_get_camera_info
+from peppygen.consumed_services.uvc_camera import get_camera_info
 
-camera = uvc_camera_get_camera_info.bound_producer(node_runner)
-response = await uvc_camera_get_camera_info.poll(node_runner, camera, 5.0)
+camera = get_camera_info.bound_producer(node_runner)
+response = await get_camera_info.poll(node_runner, camera, 5.0)
 
 print(f"Camera: {response.data.card_type} {response.data.size}")
 ```
   </TabItem>
   <TabItem label="Rust">
 ```rust
-use peppygen::consumed_services::uvc_camera_get_camera_info;
+use peppygen::consumed_services::uvc_camera::get_camera_info;
 
-let camera = uvc_camera_get_camera_info::bound_producer(&node_runner);
-let response = uvc_camera_get_camera_info::poll(
+let camera = get_camera_info::bound_producer(&node_runner);
+let response = get_camera_info::poll(
     &node_runner,
     camera,
     Duration::from_secs(5),
@@ -472,9 +472,9 @@ Codegen provides only single-target operations; calling every member of a multi-
 # Runs once per bound producer, in binding declaration order.
 # `one_or_more`: the list is never empty, so the body runs at least once.
 # `zero_or_more`: an empty list makes the loop a no-op; no request is sent.
-for camera in camera_enable_camera.bound_producers(node_runner):
-    request = camera_enable_camera.Request(enable=True)
-    response = await camera_enable_camera.poll(node_runner, camera, request, 5.0)
+for camera in enable_camera.bound_producers(node_runner):
+    request = enable_camera.Request(enable=True)
+    response = await enable_camera.poll(node_runner, camera, request, 5.0)
     print(f"{response.instance_id}@{response.core_node}: enabled={response.data.enabled}")
 ```
   </TabItem>
@@ -483,10 +483,10 @@ for camera in camera_enable_camera.bound_producers(node_runner):
 // Runs once per bound producer, in binding declaration order.
 // `one_or_more`: the set is never empty, so the body runs at least once.
 // `zero_or_more`: an empty slice makes the loop a no-op; no request is sent.
-let cameras = camera_enable_camera::bound_producers(&node_runner);
+let cameras = enable_camera::bound_producers(&node_runner);
 for camera in cameras {
-    let request = camera_enable_camera::Request::new(true);
-    let response = camera_enable_camera::poll(
+    let request = enable_camera::Request::new(true);
+    let response = enable_camera::poll(
         &node_runner,
         camera,
         Duration::from_secs(5),
@@ -505,7 +505,7 @@ for camera in cameras {
 To address one member of a multi slot instead of all of them, pick it from the same set; on a `one_or_more` slot the set is never empty, so selecting the first member needs no unwrap:
 
 ```rust
-let camera = camera_enable_camera::bound_producers(&node_runner).first();
+let camera = enable_camera::bound_producers(&node_runner).first();
 ```
 
 ## Bindings and routing
@@ -573,8 +573,8 @@ A consumer that wires two depth cameras to two dedicated slots:
 
 Three contract statements follow from this manifest:
 
-1. `poll` on the `wrist_left_camera_<service>` module reaches `left_cam`.
-2. `poll` on the `wrist_right_camera_<service>` module reaches `right_cam`.
+1. `poll` on the nested `wrist_left_camera.<service>` (Python) / `wrist_left_camera::<service>` (Rust) module reaches `left_cam`.
+2. `poll` on the nested `wrist_right_camera.<service>` (Python) / `wrist_right_camera::<service>` (Rust) module reaches `right_cam`.
 3. If the `wrist_right_camera` binding line were removed, validation would reject the launch (every declared `one` / `one_or_more` slot must be bound): a service call has no wildcard fallback.
 
 ### Why an explicit single target?

--- a/docs/src/content/docs/advanced_guides/topics.mdx
+++ b/docs/src/content/docs/advanced_guides/topics.mdx
@@ -323,7 +323,8 @@ To depend on a contract instead of a specific producer node, so any implementing
 ### Receiving messages
 
 The code generator creates a module for each consumed topic under `peppygen.consumed_topics` (Python) / `peppygen::consumed_topics` (Rust).
-The module name is `<link_id>_<topic_name>` based on the `link_id` field; in this case `uvc_camera_video_stream`.
+Every slot-backed module lives at `<category>/<link_id>/<member>`, keyed on the author's `link_id`.
+The consumed module is therefore `consumed_topics/<link_id>/<topic_name>`, imported as `from peppygen.consumed_topics.uvc_camera import video_stream` (Python) / `peppygen::consumed_topics::uvc_camera::video_stream` (Rust); here the `link_id` is `uvc_camera` and the topic is `video_stream`.
 Call `subscribe` once to obtain a held `Subscription`, then await `next` for each message:
 
 <Tabs>
@@ -333,14 +334,14 @@ import asyncio
 
 from peppygen import NodeBuilder, NodeRunner
 from peppygen.parameters import Parameters
-from peppygen.consumed_topics import uvc_camera_video_stream
+from peppygen.consumed_topics.uvc_camera import video_stream
 
 
 async def receive_frames(node_runner: NodeRunner):
     # Same subscribe() as every cardinality: it covers the slot's complete
     # bound set, which for `one` is exactly one producer. The yielded
     # ProducerRef is constant here, so the loop ignores it.
-    subscription = await uvc_camera_video_stream.subscribe(node_runner)
+    subscription = await video_stream.subscribe(node_runner)
 
     async for _producer, frame in subscription:
         print(f"frame: {frame.width}x{frame.height}")
@@ -360,7 +361,7 @@ if __name__ == "__main__":
   </TabItem>
   <TabItem label="Rust">
 ```rust
-use peppygen::consumed_topics::uvc_camera_video_stream;
+use peppygen::consumed_topics::uvc_camera::video_stream;
 use peppygen::{NodeBuilder, Parameters, Result};
 
 fn main() -> Result<()> {
@@ -368,7 +369,7 @@ fn main() -> Result<()> {
         // Same subscribe() as every cardinality: it covers the slot's complete
         // bound set, which for `one` is exactly one producer. The yielded
         // ProducerRef is constant here, so the loop ignores it.
-        let mut subscription = uvc_camera_video_stream::subscribe(&node_runner).await?;
+        let mut subscription = video_stream::subscribe(&node_runner).await?;
 
         while let Some((_, frame)) = subscription.next().await? {
             println!("frame: {}x{}", frame.width, frame.height);
@@ -429,7 +430,7 @@ import sys
 
 from peppygen import NodeBuilder, NodeRunner
 from peppygen.parameters import Parameters
-from peppygen.consumed_topics import uvc_camera_video_stream
+from peppygen.consumed_topics.uvc_camera import video_stream
 
 
 async def process_frame(producer, frame):
@@ -441,7 +442,7 @@ async def process_frame(producer, frame):
 
 async def receive_frames(node_runner: NodeRunner):
     try:
-        subscription = await uvc_camera_video_stream.subscribe(node_runner)
+        subscription = await video_stream.subscribe(node_runner)
     except Exception as e:
         print(f"Failed to subscribe: {e}", file=sys.stderr)
         return
@@ -471,7 +472,7 @@ if __name__ == "__main__":
   <TabItem label="Rust">
 ```rust
 use std::sync::Arc;
-use peppygen::consumed_topics::uvc_camera_video_stream;
+use peppygen::consumed_topics::uvc_camera::video_stream;
 use peppygen::{NodeBuilder, NodeRunner, Parameters, Result};
 
 fn main() -> Result<()> {
@@ -482,7 +483,7 @@ fn main() -> Result<()> {
 }
 
 async fn receive_frames(node_runner: Arc<NodeRunner>) {
-    let mut subscription = match uvc_camera_video_stream::subscribe(&node_runner).await {
+    let mut subscription = match video_stream::subscribe(&node_runner).await {
         Ok(subscription) => subscription,
         Err(e) => {
             eprintln!("Failed to subscribe: {e}");
@@ -521,7 +522,7 @@ Nothing changes at the call site when the slot's [cardinality](#dependency-cardi
 <Tabs>
   <TabItem label="Rust">
 ```rust
-use peppygen::consumed_topics::camera_video_stream;
+use peppygen::consumed_topics::camera::video_stream;
 use peppygen::{NodeBuilder, Parameters, ProducerRef, Result};
 use std::collections::HashMap;
 
@@ -534,7 +535,7 @@ fn main() -> Result<()> {
         // `one_or_more`: the merged subscription covers at least one producer.
         // `zero_or_more`: the slot may be empty; the subscription then
         // yields nothing until the node stops.
-        let mut subscription = camera_video_stream::subscribe(&node_runner).await?;
+        let mut subscription = video_stream::subscribe(&node_runner).await?;
 
         let mut frames_per_camera: HashMap<ProducerRef, u64> = HashMap::new();
         while let Some((producer, frame)) = subscription.next().await? {
@@ -555,13 +556,13 @@ fn main() -> Result<()> {
   </TabItem>
   <TabItem label="Python">
 ```python
-from peppygen.consumed_topics import camera_video_stream
+from peppygen.consumed_topics.camera import video_stream
 
 
 async def count_frames(node_runner):
     # One subscription covering every producer bound to the `camera`
     # slot; the yielded producer tells per-camera streams apart.
-    subscription = await camera_video_stream.subscribe(node_runner)
+    subscription = await video_stream.subscribe(node_runner)
 
     frames_per_camera: dict = {}
     async for producer, frame in subscription:
@@ -684,8 +685,8 @@ And the launcher that binds it:
 
 Three contract statements follow from this manifest:
 
-1. A frame from `left_cam` arrives only on the `wrist_left_camera_video_stream` slot.
-2. A frame from `right_cam` arrives only on the `wrist_right_camera_video_stream` slot.
+1. A frame from `left_cam` arrives only on the `wrist_left_camera` slot.
+2. A frame from `right_cam` arrives only on the `wrist_right_camera` slot.
 3. If the `wrist_right_camera` binding line were removed, the launch would be rejected: every declared slot except `zero_or_more` must be bound. A producer named by no binding is simply ignored, but a declared `one` or `one_or_more` slot with no binding is an error, not a silent gap.
 
 Dedicated slots (one `link_id` per camera, as here) and one multi-cardinality slot (`cameras: ["left_cam", "right_cam"]`) are both valid designs. Dedicated slots give each producer a distinct role in code; a multi slot treats the producers as an N-of-a-kind set behind one API.

--- a/docs/src/content/docs/guides/snippets/python/arm_controller/src/arm_controller/__main__.py
+++ b/docs/src/content/docs/guides/snippets/python/arm_controller/src/arm_controller/__main__.py
@@ -3,10 +3,10 @@ import sys
 
 from peppygen import NodeBuilder, NodeRunner
 from peppygen.parameters import Parameters
-from peppygen.pairings.arm import joint_commands, joint_states
+from peppygen.paired_topics.arm import joint_commands, joint_states
 
 # `arm_controller` plays the `controller` role of the `arm_link` pairing.
-# Both directions of its `arm` slot live under `peppygen.pairings.arm`: it
+# Both directions of its `arm` slot live under `peppygen.paired_topics.arm`: it
 # emits `joint_commands` to and consumes `joint_states` from the single
 # arm instance currently paired on the slot. If that arm dies, the slot
 # unpairs and the loop simply stops receiving until a new arm is paired.

--- a/docs/src/content/docs/guides/snippets/python/hello_receiver/src/hello_receiver/__main__.py
+++ b/docs/src/content/docs/guides/snippets/python/hello_receiver/src/hello_receiver/__main__.py
@@ -2,7 +2,7 @@ import asyncio
 
 from peppygen import NodeBuilder, NodeRunner
 from peppygen.parameters import Parameters
-from peppygen.consumed_topics import hello_world_param_message_stream
+from peppygen.consumed_topics.hello_world_param import message_stream
 
 
 async def setup(_params: Parameters, node_runner: NodeRunner) -> list[asyncio.Task]:
@@ -12,7 +12,7 @@ async def setup(_params: Parameters, node_runner: NodeRunner) -> list[asyncio.Ta
 async def receive_messages(node_runner: NodeRunner):
     # Subscribe once; the held subscription buffers every message in order, so
     # iterating never drops a message published between iterations.
-    subscription = await hello_world_param_message_stream.subscribe(node_runner)
+    subscription = await message_stream.subscribe(node_runner)
     async for producer, message in subscription:
         print(f"Received from {producer.instance_id}: {message.message}")
 

--- a/docs/src/content/docs/guides/snippets/python/robot_arm/src/robot_arm/__main__.py
+++ b/docs/src/content/docs/guides/snippets/python/robot_arm/src/robot_arm/__main__.py
@@ -4,11 +4,11 @@ import time
 
 from peppygen import NodeBuilder, NodeRunner
 from peppygen.parameters import Parameters
-from peppygen.pairings.controller import joint_commands, joint_states
+from peppygen.paired_topics.controller import joint_commands, joint_states
 
 # `robot_arm` plays the `arm` role of the `arm_link` pairing. Both
 # directions of its `controller` slot live under
-# `peppygen.pairings.controller`: it consumes `joint_commands` from and emits
+# `peppygen.paired_topics.controller`: it consumes `joint_commands` from and emits
 # `joint_states` to whichever single controller instance is currently
 # paired on the slot. Unpaired, the subscription stays silent and
 # publishes go nowhere; the code does not change either way.

--- a/docs/src/content/docs/guides/snippets/rust/arm_controller/src/main.rs
+++ b/docs/src/content/docs/guides/snippets/rust/arm_controller/src/main.rs
@@ -1,8 +1,8 @@
-use peppygen::pairings::arm::{joint_commands, joint_states};
+use peppygen::paired_topics::arm::{joint_commands, joint_states};
 use peppygen::{NodeBuilder, Parameters, Result};
 
 // `arm_controller` plays the `controller` role of the `arm_link` pairing.
-// Both directions of its `arm` slot live under `peppygen::pairings::arm`: it
+// Both directions of its `arm` slot live under `peppygen::paired_topics::arm`: it
 // emits `joint_commands` to and consumes `joint_states` from the single
 // arm instance currently paired on the slot. If that arm dies, the slot
 // unpairs and the loop simply stops receiving until a new arm is paired.

--- a/docs/src/content/docs/guides/snippets/rust/hello_receiver/src/main.rs
+++ b/docs/src/content/docs/guides/snippets/rust/hello_receiver/src/main.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use peppygen::consumed_topics::hello_world_param_message_stream;
+use peppygen::consumed_topics::hello_world_param::message_stream;
 use peppygen::{NodeBuilder, NodeRunner, Parameters, Result};
 
 fn main() -> Result<()> {
@@ -13,7 +13,7 @@ fn main() -> Result<()> {
 async fn receive_messages(node_runner: Arc<NodeRunner>) {
     // Subscribe once; the held subscription buffers every message in order, so
     // looping on `next` never drops a message published between iterations.
-    let mut subscription = match hello_world_param_message_stream::subscribe(&node_runner).await {
+    let mut subscription = match message_stream::subscribe(&node_runner).await {
         Ok(subscription) => subscription,
         Err(e) => {
             eprintln!("Failed to subscribe: {e}");

--- a/docs/src/content/docs/guides/snippets/rust/robot_arm/src/main.rs
+++ b/docs/src/content/docs/guides/snippets/rust/robot_arm/src/main.rs
@@ -1,9 +1,9 @@
-use peppygen::pairings::controller::{joint_commands, joint_states};
+use peppygen::paired_topics::controller::{joint_commands, joint_states};
 use peppygen::{NodeBuilder, Parameters, Result};
 
 // `robot_arm` plays the `arm` role of the `arm_link` pairing. Both
 // directions of its `controller` slot live under
-// `peppygen::pairings::controller`: it consumes `joint_commands` from and
+// `peppygen::paired_topics::controller`: it consumes `joint_commands` from and
 // emits `joint_states` to whichever single controller instance is
 // currently paired on the slot. Unpaired, the subscription stays silent
 // and publishes go nowhere; the code does not change either way.


### PR DESCRIPTION
## What

Unify the seven generated `peppygen` categories on one rule: every slot-backed module nests as `<category>/<link_id>/<member>`, and the `pairings` category is renamed `paired_topics`.

- **Contract-backed produced** modules key on the implements slot's `link_id` instead of `<contract_name>/<contract_tag>`. `ContractOrigin` gains a `link_id`; `module_path_for` returns `[link_id, leaf]`. The capnp schema key stays keyed on contract identity, so schema entries do not move (pinned by a test).
- **Consumed** modules nest `<link_id>/<name>` instead of the flat, non-injective `<link_id>_<name>` join (which could silently collide: slot `arm` + topic `link_states` vs slot `arm_link` + topic `states`).
- **Pairing** modules already nested by `link_id`; only the category directory renames to `paired_topics`.

The silent `unique_module_name` numeric-suffix dedup is replaced by a hard `Error::ModuleNameCollision` naming both colliding raw segments, so a module can never be reachable under a name the author did not write.

No manifest schema, wire format, validation rule, or runtime behavior changes: a pure relocation of generated modules plus one category rename. Docs, snippets, and every generator test are updated here.

## Tests

- `cargo test -p generator --lib` — 158 passed
- `cargo test -p generator --test rust` — 38 passed
- `cargo test -p generator --test python` — 42 passed
- `cargo test --workspace --no-run` — clean

New tests cover both collision surfaces (two link_ids that sanitize alike; a native leaf colliding with a slot directory) and pin schema-key independence from the module path.

## Sequencing

Breaking change, no compatibility path. Must merge **before** the node-repo PRs (nodes-hub, openarm-nodes #77), which import paths that only exist once this generator emits them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Generated Rust and Python interfaces now use nested, slot-based module paths for consumed and exposed topics, services, and actions.
  * Pairing-generated topics are available under the `paired_topics` namespace.
  * Module-name collisions during generation now produce a clear error instead of being silently renamed.

* **Documentation**
  * Updated guides and examples with the new import paths, module organization, and pairing terminology.

* **Bug Fixes**
  * Improved handling of contract-backed interfaces by associating generated artifacts with their link identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->