### PR TITLE
Runtime improvements for embedded binaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,7 +297,7 @@ checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -573,7 +573,7 @@ dependencies = [
 [[package]]
 name = "build-helpers"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#97d398b1e55f7a2086c97f366d8b9cbed4791922"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#172beab37973ec5694ed3425f9b0538a639eb404"
 dependencies = [
  "sha2",
 ]
@@ -719,7 +719,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -774,7 +774,7 @@ dependencies = [
 [[package]]
 name = "config-test-support"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#97d398b1e55f7a2086c97f366d8b9cbed4791922"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#172beab37973ec5694ed3425f9b0538a639eb404"
 dependencies = [
  "askama",
  "git2",
@@ -918,7 +918,7 @@ dependencies = [
 [[package]]
 name = "core-node-api"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#97d398b1e55f7a2086c97f366d8b9cbed4791922"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#172beab37973ec5694ed3425f9b0538a639eb404"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -2577,7 +2577,7 @@ dependencies = [
 [[package]]
 name = "json5-pretty"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#97d398b1e55f7a2086c97f366d8b9cbed4791922"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#172beab37973ec5694ed3425f9b0538a639eb404"
 dependencies = [
  "serde",
  "serde_json",
@@ -2585,9 +2585,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.48.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39d785c0683d1027839f1ac6a43b6d07c63d58ecd363d8146dda4531d53465a1"
+checksum = "f05a6cff806294a7699d48761d4ae2bdebab7fa2eef05e4a0b83320f0ff46901"
 dependencies = [
  "ahash",
  "bytecount",
@@ -2599,6 +2599,7 @@ dependencies = [
  "idna",
  "itoa",
  "jsonschema-regex",
+ "jsonschema-value",
  "num-cmp",
  "num-traits",
  "percent-encoding",
@@ -2615,11 +2616,25 @@ dependencies = [
 
 [[package]]
 name = "jsonschema-regex"
-version = "0.48.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "917b3be16b2662538aafb55201790561e1f1ad1a0454baf42f33bd9de343778b"
+checksum = "84708dd3f6c5327478a96f37378adb27deed6a626cf84d19de780d9e8ae84b17"
 dependencies = [
  "regex-syntax",
+]
+
+[[package]]
+name = "jsonschema-value"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd8c04ab4ce60e42c4e302d3bd9d184652bb56f212495d2eea23573bcbf72556"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "fraction",
+ "num-cmp",
+ "num-traits",
+ "serde_json",
 ]
 
 [[package]]
@@ -3351,7 +3366,7 @@ dependencies = [
 [[package]]
 name = "peppy-config-model"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#97d398b1e55f7a2086c97f366d8b9cbed4791922"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#172beab37973ec5694ed3425f9b0538a639eb404"
 dependencies = [
  "capnp",
  "clap",
@@ -3374,7 +3389,7 @@ version = "0.0.1"
 [[package]]
 name = "peppylib-rs"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#97d398b1e55f7a2086c97f366d8b9cbed4791922"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#172beab37973ec5694ed3425f9b0538a639eb404"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -3405,9 +3420,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.7"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47627dd7305c6a2d6c8c6bcd24c5a4c17dbbf425f4f9c5313e724b38fc9782e9"
+checksum = "7df728be843c7070fab6ab7c328c4e9e9d78e23bf749c0669c86ee7ebfa050a2"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -3415,9 +3430,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.7"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b4254325ecad416ab689e27ba51da03ba01a9632bc6e108f5fe7c3c4ad29d58"
+checksum = "9e2dd6fc3b26b3462ee188aac870f5a41d398f1cd5e2408d16531bd71c9591fd"
 dependencies = [
  "pest",
  "pest_generator",
@@ -3425,9 +3440,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.7"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c4c0e91ead7a8f7acecbca6f003fc2e8282b1dbe2dd9c9d2f16aba42995e0a7"
+checksum = "6a7a9205cfb6f596a9e8b689c0a15f9ceb7a1aafae7aaf788150ac65b29975b6"
 dependencies = [
  "pest",
  "pest_meta",
@@ -3438,9 +3453,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.8.7"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9744bc48116fee06334924bb5f2bad41eed5e89bd26e29b0b799f9a3f82c210"
+checksum = "85abd351c0de1e8384fc791a0737111a350394937e92b956b743dac12429f57c"
 dependencies = [
  "pest",
 ]
@@ -3569,7 +3584,7 @@ dependencies = [
 [[package]]
 name = "pmi"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#97d398b1e55f7a2086c97f366d8b9cbed4791922"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#172beab37973ec5694ed3425f9b0538a639eb404"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -3957,14 +3972,14 @@ checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "referencing"
-version = "0.48.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2b21a85c07fcf1cb95ff7ab8a687fcd37fa70db59975b5a032abdaadfdf42e"
+checksum = "980e77f5cfffc592c0e7dfb6d20770a0b96a6ab94d403de7454ed9799505e4ba"
 dependencies = [
  "ahash",
  "fluent-uri",
@@ -4481,7 +4496,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4549,7 +4564,7 @@ checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4949,9 +4964,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5094,7 +5109,7 @@ checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -5225,9 +5240,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
 dependencies = [
  "futures-core",
  "pin-project-lite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,7 +573,7 @@ dependencies = [
 [[package]]
 name = "build-helpers"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#51c33b3aa6c69e1279eade7c8222a2d36e8ee4cc"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#97d398b1e55f7a2086c97f366d8b9cbed4791922"
 dependencies = [
  "sha2",
 ]
@@ -774,7 +774,7 @@ dependencies = [
 [[package]]
 name = "config-test-support"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#51c33b3aa6c69e1279eade7c8222a2d36e8ee4cc"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#97d398b1e55f7a2086c97f366d8b9cbed4791922"
 dependencies = [
  "askama",
  "git2",
@@ -918,7 +918,7 @@ dependencies = [
 [[package]]
 name = "core-node-api"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#51c33b3aa6c69e1279eade7c8222a2d36e8ee4cc"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#97d398b1e55f7a2086c97f366d8b9cbed4791922"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -2577,7 +2577,7 @@ dependencies = [
 [[package]]
 name = "json5-pretty"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#51c33b3aa6c69e1279eade7c8222a2d36e8ee4cc"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#97d398b1e55f7a2086c97f366d8b9cbed4791922"
 dependencies = [
  "serde",
  "serde_json",
@@ -3351,7 +3351,7 @@ dependencies = [
 [[package]]
 name = "peppy-config-model"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#51c33b3aa6c69e1279eade7c8222a2d36e8ee4cc"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#97d398b1e55f7a2086c97f366d8b9cbed4791922"
 dependencies = [
  "capnp",
  "clap",
@@ -3374,7 +3374,7 @@ version = "0.0.1"
 [[package]]
 name = "peppylib-rs"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#51c33b3aa6c69e1279eade7c8222a2d36e8ee4cc"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#97d398b1e55f7a2086c97f366d8b9cbed4791922"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -3569,7 +3569,7 @@ dependencies = [
 [[package]]
 name = "pmi"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#51c33b3aa6c69e1279eade7c8222a2d36e8ee4cc"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#97d398b1e55f7a2086c97f366d8b9cbed4791922"
 dependencies = [
  "build-helpers",
  "bytes",

--- a/crates/daemon-config-internal/src/atomic_write.rs
+++ b/crates/daemon-config-internal/src/atomic_write.rs
@@ -32,9 +32,14 @@ where
     // on drop, so a panic or early return between stage and rename
     // doesn't leave a stray.
     let tmp = tempfile::NamedTempFile::new_in(parent)?;
-    let tmp_path = tmp.path().to_path_buf();
-    write(&tmp_path)?;
-    tmp.persist(final_path).map_err(|e| e.error)?;
+    // Callers populate the temporary file through its path, so close the
+    // descriptor opened by NamedTempFile before handing that path to them.
+    // In particular, this ensures an executable is never published while the
+    // staging descriptor is still open for writing, which Linux rejects with
+    // ETXTBSY when the executable is launched immediately after publication.
+    let tmp_path = tmp.into_temp_path();
+    write(tmp_path.as_ref())?;
+    tmp_path.persist(final_path).map_err(|e| e.error)?;
     Ok(final_path.to_path_buf())
 }
 
@@ -64,6 +69,25 @@ mod tests {
         publish_atomic(&target, |tmp| std::fs::write(tmp, b"x")).expect("publish");
 
         assert!(target.exists(), "expected {} to exist", target.display());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn closes_the_staging_descriptor_before_the_write_callback() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        let target = dir.path().join("executable");
+
+        publish_atomic(&target, |tmp| {
+            std::fs::write(tmp, b"#!/bin/sh\nexit 0\n")?;
+            std::fs::set_permissions(tmp, std::fs::Permissions::from_mode(0o755))?;
+
+            let status = std::process::Command::new(tmp).status()?;
+            assert!(status.success(), "staged executable should run");
+            Ok(())
+        })
+        .expect("publish executable");
     }
 
     #[test]

--- a/crates/daemon-config-internal/src/consts.rs
+++ b/crates/daemon-config-internal/src/consts.rs
@@ -126,13 +126,14 @@ impl PeppyDirs {
         self.root.join("tmp")
     }
 
-    /// Directory holding the peppy-provided binaries (`peppy`, `zenohd`,
-    /// `apptainer`, and the extracted `capnp`).
+    /// Directory holding peppy-managed runtime binaries.
     ///
-    /// This is the same `~/.peppy/bin` the installer populates as
-    /// `PEPPY_BIN_DIR` (see `scripts/install.sh`); exposing it here gives the
-    /// runtime code one source of truth for that location instead of the path
-    /// being known only to the shell installer.
+    /// This resolves to `$PEPPY_HOME/bin`, defaulting to `~/.peppy/bin` in a
+    /// production build. The installer places `peppy`, `zenohd`, and the
+    /// container tools there by default, and peppy extracts its bundled Cap'n
+    /// Proto compiler there on first use. A custom installer `PEPPY_BIN_DIR`
+    /// relocates the installer-managed tools only; it does not change this
+    /// runtime directory.
     pub fn bin_dir(&self) -> PathBuf {
         self.root.join("bin")
     }

--- a/crates/daemon-config-internal/src/consts.rs
+++ b/crates/daemon-config-internal/src/consts.rs
@@ -126,6 +126,17 @@ impl PeppyDirs {
         self.root.join("tmp")
     }
 
+    /// Directory holding the peppy-provided binaries (`peppy`, `zenohd`,
+    /// `apptainer`, and the extracted `capnp`).
+    ///
+    /// This is the same `~/.peppy/bin` the installer populates as
+    /// `PEPPY_BIN_DIR` (see `scripts/install.sh`); exposing it here gives the
+    /// runtime code one source of truth for that location instead of the path
+    /// being known only to the shell installer.
+    pub fn bin_dir(&self) -> PathBuf {
+        self.root.join("bin")
+    }
+
     /// Path to the stack operations log file.
     ///
     /// Records daemon-initiated lifecycle events (e.g. automatic instance

--- a/crates/encoding-internal/build.rs
+++ b/crates/encoding-internal/build.rs
@@ -4,20 +4,20 @@ mod capnp_build {
     use std::io::Write;
     use std::path::PathBuf;
 
-    /// Embed the bundled capnp binary for the host platform.
+    /// Embed the bundled capnp binary for the target platform.
     ///
     /// The binary is the single source of truth shipped with `build-helpers`
     /// in public-peppy-libs (`peppy-shared/peppy-config-model/tools`). peppy
     /// pulls build-helpers as a cargo git dependency, so the tools dir is always
     /// present in the checkout: no superproject sibling and no cmake required.
     pub fn run() {
-        let binary_path = build_helpers::bundled_capnp_path().unwrap_or_else(|| {
+        let target = build_helpers::build_target_triple();
+        let platform = build_helpers::CapnpPlatform::try_from(target.as_str())
+            .unwrap_or_else(|error| panic!("{error}"));
+        let binary_path = build_helpers::bundled_capnp_path(platform).unwrap_or_else(|| {
             panic!(
-                "No bundled capnp binary for this host platform ({}/{}). Supported: \
-                 linux x86_64/aarch64, macos aarch64. Add a binary to public-peppy-libs \
+                "No bundled capnp binary for target {target}. Add a binary to public-peppy-libs \
                  peppy-shared/peppy-config-model/tools/.",
-                env::consts::OS,
-                env::consts::ARCH,
             )
         });
         println!("cargo:rerun-if-changed={}", binary_path.display());

--- a/crates/encoding-internal/src/facade.rs
+++ b/crates/encoding-internal/src/facade.rs
@@ -2,6 +2,7 @@ use crate::{Error, Result};
 use capnpc::CompilerCommand;
 use std::env;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 #[cfg(unix)]
 use std::fs;
@@ -90,26 +91,51 @@ impl CapnpFacade {
     }
 
     fn resolve_capnp_binary() -> Result<PathBuf> {
-        // 1. Runtime env var override takes precedence (hard error if explicitly
-        //    set but missing).
-        if let Some(path) = env::var_os("CAPNP_BINARY_PATH") {
-            return Self::validate_path(PathBuf::from(path));
+        // An explicit override wins and must fail loudly: it is an opt-in escape
+        // hatch for development and testing, not a silent fallback to whatever
+        // capnp happens to be installed on the system.
+        if let Some(raw) = env::var_os("CAPNP_BINARY_PATH") {
+            let path = PathBuf::from(raw);
+            if !path.exists() {
+                return Err(Error::Encoding(format!(
+                    "CAPNP_BINARY_PATH is set to {}, which does not exist",
+                    path.display()
+                )));
+            }
+            Self::ensure_executable(&path)?;
+            Self::verify_runs(&path)?;
+            return Ok(path);
         }
 
-        // 2. Embedded/bundled binary (the production path for distributed builds).
-        Self::validate_path(Self::bundled_capnp_binary()?)
+        // Otherwise use the capnp binary peppy ships and extracts itself. peppy
+        // never consults a system capnp on PATH.
+        Self::bundled_capnp_binary()
     }
 
-    fn validate_path(path: PathBuf) -> Result<PathBuf> {
-        if path.exists() {
-            Self::ensure_executable(&path)?;
-            Ok(path)
-        } else {
-            Err(Error::Encoding(format!(
-                "capnp binary not found at {}",
-                path.display()
-            )))
+    /// Runs `<path> --version` to prove the binary is actually executable on
+    /// this host before it is handed to the capnp compiler. A wrong-architecture
+    /// binary is rejected by the kernel with `ENOEXEC` here, which lets us report
+    /// the real path and errno instead of the capnp compiler's later, generic
+    /// "install capnp" message.
+    fn verify_runs(path: &Path) -> Result<()> {
+        let output = Command::new(path).arg("--version").output().map_err(|err| {
+            Error::Encoding(format!(
+                "capnp binary at {} failed to execute on {}/{}: {err}",
+                path.display(),
+                env::consts::OS,
+                env::consts::ARCH
+            ))
+        })?;
+
+        if !output.status.success() {
+            return Err(Error::Encoding(format!(
+                "capnp binary at {} exited with {} when run with `--version`",
+                path.display(),
+                output.status
+            )));
         }
+
+        Ok(())
     }
 
     fn ensure_executable(path: &Path) -> Result<()> {
@@ -146,13 +172,13 @@ impl CapnpFacade {
     fn bundled_capnp_binary() -> Result<PathBuf> {
         use std::sync::OnceLock;
 
-        // Ensure the embedded binary is extracted to disk exactly once per process.
-        // Multiple test threads share the same PID, so without this guard they race
-        // on the same temp file and hit ENOENT / ETXTBSY.
-        static EXTRACTED: OnceLock<std::result::Result<PathBuf, String>> = OnceLock::new();
+        // Extract-and-verify runs exactly once per process. Multiple test
+        // threads share the same PID, so without this guard they race on the
+        // same file and hit ENOENT / ETXTBSY.
+        static RESOLVED: OnceLock<std::result::Result<PathBuf, String>> = OnceLock::new();
 
         let result =
-            EXTRACTED.get_or_init(|| Self::extract_bundled_binary().map_err(|e| e.to_string()));
+            RESOLVED.get_or_init(|| Self::ensure_bundled_binary().map_err(|e| e.to_string()));
 
         match result {
             Ok(path) => Ok(path.clone()),
@@ -160,7 +186,7 @@ impl CapnpFacade {
         }
     }
 
-    fn extract_bundled_binary() -> Result<PathBuf> {
+    fn ensure_bundled_binary() -> Result<PathBuf> {
         mod embedded {
             include!(concat!(env!("OUT_DIR"), "/embedded_capnp.rs"));
         }
@@ -173,28 +199,55 @@ impl CapnpFacade {
             ))
         })?;
 
-        let temp_dir = std::env::temp_dir();
-        let binary_path = temp_dir.join("peppy_capnp_binary");
+        let bin_dir = daemon_config::consts::PeppyDirs::default().bin_dir();
+        let binary_path = bin_dir.join("peppy_capnp_binary");
 
-        if !binary_path.exists() {
-            let result = daemon_config::atomic_write::publish_atomic(&binary_path, |tmp_path| {
-                std::fs::write(tmp_path, binary_bytes)?;
-                #[cfg(unix)]
-                {
-                    fs::set_permissions(tmp_path, fs::Permissions::from_mode(0o755))?;
-                }
-                Ok(())
-            });
-            // Tolerate a lost rename race against another process; if the
-            // file is now in place, that's the outcome we wanted.
-            if let Err(err) = result
-                && !binary_path.exists()
-            {
-                return Err(Error::Encoding(format!(
-                    "failed to install bundled capnp binary: {err}"
-                )));
-            }
+        // Reuse an already-extracted binary only if it still runs. A stale file
+        // left by an earlier (broken or different-arch) install is re-extracted
+        // rather than trusted, which replaces the old "never overwrite" guard.
+        if binary_path.exists() && Self::verify_runs(&binary_path).is_ok() {
+            return Ok(binary_path);
         }
+
+        std::fs::create_dir_all(&bin_dir).map_err(|err| {
+            Error::Encoding(format!(
+                "failed to create peppy bin directory {}: {err}",
+                bin_dir.display()
+            ))
+        })?;
+
+        let result = daemon_config::atomic_write::publish_atomic(&binary_path, |tmp_path| {
+            std::fs::write(tmp_path, binary_bytes)?;
+            #[cfg(unix)]
+            {
+                fs::set_permissions(tmp_path, fs::Permissions::from_mode(0o755))?;
+            }
+            Ok(())
+        });
+        // Tolerate a lost rename race against another process; if the file is
+        // now in place, that is the outcome we wanted and the verification
+        // below still gates it.
+        if let Err(err) = result
+            && !binary_path.exists()
+        {
+            return Err(Error::Encoding(format!(
+                "failed to install bundled capnp binary at {}: {err}",
+                binary_path.display()
+            )));
+        }
+
+        // Prove the freshly written binary runs on this host. This is where a
+        // wrong-arch embedded binary is caught, with guidance pointed at the
+        // real fix rather than at installing a system capnp peppy will not use.
+        Self::verify_runs(&binary_path).map_err(|err| {
+            Error::Encoding(format!(
+                "{err}. This capnp is bundled with peppy (peppy does not use a \
+                 system capnp); the installed peppy build looks corrupt or was \
+                 built for a different architecture. Reinstall peppy with \
+                 `curl -fsSL https://peppy.bot/install.sh | bash` or report the \
+                 broken release at https://github.com/Peppy-bot/peppy/issues"
+            ))
+        })?;
 
         Ok(binary_path)
     }
@@ -211,6 +264,56 @@ mod tests {
             path.exists(),
             "expected bundled capnp binary at {}",
             path.display()
+        );
+    }
+
+    #[cfg(unix)]
+    fn write_executable(dir: &Path, name: &str, contents: &[u8]) -> PathBuf {
+        let path = dir.join(name);
+        std::fs::write(&path, contents).expect("write stub");
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).expect("chmod stub");
+        path
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn verify_runs_reports_the_path_for_a_non_runnable_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        // Bytes that are neither a valid binary for this host nor a script, so
+        // running them fails just like a wrong-arch capnp does. Depending on the
+        // platform this surfaces as an exec error (ENOEXEC) or, via the libc
+        // execvp `/bin/sh` fallback, a non-zero exit. Both must be rejected and
+        // must name the path, which is what we assert.
+        let path = write_executable(&dir.path(), "not_a_binary", b"\x00\x01\x02 definitely not exec");
+
+        let err = CapnpFacade::verify_runs(&path).expect_err("non-runnable file should fail");
+        let message = err.to_string();
+
+        assert!(
+            message.contains(&path.display().to_string()),
+            "error should name the path it tried, got: {message}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn verify_runs_accepts_a_binary_that_runs_successfully() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = write_executable(&dir.path(), "ok", b"#!/bin/sh\nexit 0\n");
+
+        CapnpFacade::verify_runs(&path).expect("a script that exits 0 should verify");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn verify_runs_rejects_a_binary_that_exits_nonzero() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = write_executable(&dir.path(), "boom", b"#!/bin/sh\nexit 3\n");
+
+        let err = CapnpFacade::verify_runs(&path).expect_err("a failing exit should not verify");
+        assert!(
+            err.to_string().contains("exited with"),
+            "error should report the unsuccessful exit, got: {err}"
         );
     }
 }

--- a/crates/encoding-internal/src/facade.rs
+++ b/crates/encoding-internal/src/facade.rs
@@ -186,6 +186,19 @@ impl CapnpFacade {
         }
     }
 
+    /// Returns whether the file at `path` is byte-for-byte the `expected`
+    /// embedded binary. A cheap size check runs first so a mismatched file
+    /// (typically a different capnp version from an earlier install) is rejected
+    /// without reading its contents; only a same-size file is fully compared.
+    fn matches_embedded(path: &Path, expected: &[u8]) -> bool {
+        match std::fs::metadata(path) {
+            Ok(metadata) if metadata.len() == expected.len() as u64 => std::fs::read(path)
+                .map(|actual| actual.as_slice() == expected)
+                .unwrap_or(false),
+            _ => false,
+        }
+    }
+
     fn ensure_bundled_binary() -> Result<PathBuf> {
         mod embedded {
             include!(concat!(env!("OUT_DIR"), "/embedded_capnp.rs"));
@@ -202,10 +215,14 @@ impl CapnpFacade {
         let bin_dir = daemon_config::consts::PeppyDirs::default().bin_dir();
         let binary_path = bin_dir.join("peppy_capnp_binary");
 
-        // Reuse an already-extracted binary only if it still runs. A stale file
-        // left by an earlier (broken or different-arch) install is re-extracted
-        // rather than trusted, which replaces the old "never overwrite" guard.
-        if binary_path.exists() && Self::verify_runs(&binary_path).is_ok() {
+        // Reuse an already-extracted binary only if it matches the bytes this
+        // build embeds and still runs. A stale file left by an earlier install
+        // (different capnp version, or a broken/wrong-arch binary) fails the
+        // content comparison or the run probe and is re-extracted rather than
+        // trusted, which replaces the old "never overwrite" guard.
+        if Self::matches_embedded(&binary_path, binary_bytes)
+            && Self::verify_runs(&binary_path).is_ok()
+        {
             return Ok(binary_path);
         }
 
@@ -264,6 +281,40 @@ mod tests {
             path.exists(),
             "expected bundled capnp binary at {}",
             path.display()
+        );
+    }
+
+    #[test]
+    fn matches_embedded_requires_identical_contents() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let embedded = b"capnp v1 bytes";
+
+        let missing = dir.path().join("absent");
+        assert!(
+            !CapnpFacade::matches_embedded(&missing, embedded),
+            "a missing file cannot match"
+        );
+
+        let wrong_size = dir.path().join("wrong_size");
+        std::fs::write(&wrong_size, b"capnp v2 longer bytes").expect("write");
+        assert!(
+            !CapnpFacade::matches_embedded(&wrong_size, embedded),
+            "a different-length file (e.g. a new capnp version) must be rejected"
+        );
+
+        let same_size_diff = dir.path().join("same_size_diff");
+        std::fs::write(&same_size_diff, b"capnp X bytes!").expect("write");
+        assert_eq!(same_size_diff.metadata().unwrap().len(), embedded.len() as u64);
+        assert!(
+            !CapnpFacade::matches_embedded(&same_size_diff, embedded),
+            "a same-length but differing file must be rejected"
+        );
+
+        let identical = dir.path().join("identical");
+        std::fs::write(&identical, embedded).expect("write");
+        assert!(
+            CapnpFacade::matches_embedded(&identical, embedded),
+            "a byte-for-byte identical file must match"
         );
     }
 

--- a/crates/encoding-internal/src/facade.rs
+++ b/crates/encoding-internal/src/facade.rs
@@ -118,14 +118,17 @@ impl CapnpFacade {
     /// the real path and errno instead of the capnp compiler's later, generic
     /// "install capnp" message.
     fn verify_runs(path: &Path) -> Result<()> {
-        let output = Command::new(path).arg("--version").output().map_err(|err| {
-            Error::Encoding(format!(
-                "capnp binary at {} failed to execute on {}/{}: {err}",
-                path.display(),
-                env::consts::OS,
-                env::consts::ARCH
-            ))
-        })?;
+        let output = Command::new(path)
+            .arg("--version")
+            .output()
+            .map_err(|err| {
+                Error::Encoding(format!(
+                    "capnp binary at {} failed to execute on {}/{}: {err}",
+                    path.display(),
+                    env::consts::OS,
+                    env::consts::ARCH
+                ))
+            })?;
 
         if !output.status.success() {
             return Err(Error::Encoding(format!(
@@ -199,6 +202,73 @@ impl CapnpFacade {
         }
     }
 
+    fn accept_publication_result(
+        binary_path: &Path,
+        binary_bytes: &[u8],
+        result: std::io::Result<PathBuf>,
+    ) -> Result<()> {
+        if let Err(err) = result
+            && !Self::matches_embedded(binary_path, binary_bytes)
+        {
+            return Err(Error::Encoding(format!(
+                "failed to install bundled capnp binary at {}: {err}",
+                binary_path.display()
+            )));
+        }
+        Ok(())
+    }
+
+    fn install_bundled_binary(binary_path: &Path, binary_bytes: &[u8]) -> Result<PathBuf> {
+        // Reuse an already-extracted binary only if it matches the bytes this
+        // build embeds and still runs. A stale file left by an earlier install
+        // (different capnp version, or a broken/wrong-arch binary) fails the
+        // content comparison or the run probe and is re-extracted rather than
+        // trusted, which replaces the old "never overwrite" guard.
+        if Self::matches_embedded(binary_path, binary_bytes)
+            && Self::verify_runs(binary_path).is_ok()
+        {
+            return Ok(binary_path.to_path_buf());
+        }
+
+        let result = daemon_config::atomic_write::publish_atomic(binary_path, |tmp_path| {
+            std::fs::write(tmp_path, binary_bytes)?;
+            #[cfg(unix)]
+            {
+                fs::set_permissions(tmp_path, fs::Permissions::from_mode(0o755))?;
+            }
+            Ok(())
+        });
+        // A concurrent process may have published the same embedded bytes
+        // while this process was staging its file. Accept that one race only;
+        // every other publication failure must remain visible.
+        Self::accept_publication_result(binary_path, binary_bytes, result)?;
+
+        // Re-check after publication so a competing stale writer cannot make
+        // this process return a path whose contents differ from its embedded
+        // artifact.
+        if !Self::matches_embedded(binary_path, binary_bytes) {
+            return Err(Error::Encoding(format!(
+                "installed capnp binary at {} does not match the binary embedded in peppy",
+                binary_path.display()
+            )));
+        }
+
+        // Prove the freshly written binary runs on this host. This is where a
+        // wrong-arch embedded binary is caught, with guidance pointed at the
+        // real fix rather than at installing a system capnp peppy will not use.
+        Self::verify_runs(binary_path).map_err(|err| {
+            Error::Encoding(format!(
+                "{err}. This capnp is bundled with peppy (peppy does not use a \
+                 system capnp); the installed peppy build looks corrupt or was \
+                 built for a different architecture. Reinstall peppy with \
+                 `curl -fsSL https://peppy.bot/install.sh | bash` or report the \
+                 broken release at https://github.com/Peppy-bot/peppy/issues"
+            ))
+        })?;
+
+        Ok(binary_path.to_path_buf())
+    }
+
     fn ensure_bundled_binary() -> Result<PathBuf> {
         mod embedded {
             include!(concat!(env!("OUT_DIR"), "/embedded_capnp.rs"));
@@ -212,61 +282,10 @@ impl CapnpFacade {
             ))
         })?;
 
-        let bin_dir = daemon_config::consts::PeppyDirs::default().bin_dir();
-        let binary_path = bin_dir.join("peppy_capnp_binary");
-
-        // Reuse an already-extracted binary only if it matches the bytes this
-        // build embeds and still runs. A stale file left by an earlier install
-        // (different capnp version, or a broken/wrong-arch binary) fails the
-        // content comparison or the run probe and is re-extracted rather than
-        // trusted, which replaces the old "never overwrite" guard.
-        if Self::matches_embedded(&binary_path, binary_bytes)
-            && Self::verify_runs(&binary_path).is_ok()
-        {
-            return Ok(binary_path);
-        }
-
-        std::fs::create_dir_all(&bin_dir).map_err(|err| {
-            Error::Encoding(format!(
-                "failed to create peppy bin directory {}: {err}",
-                bin_dir.display()
-            ))
-        })?;
-
-        let result = daemon_config::atomic_write::publish_atomic(&binary_path, |tmp_path| {
-            std::fs::write(tmp_path, binary_bytes)?;
-            #[cfg(unix)]
-            {
-                fs::set_permissions(tmp_path, fs::Permissions::from_mode(0o755))?;
-            }
-            Ok(())
-        });
-        // Tolerate a lost rename race against another process; if the file is
-        // now in place, that is the outcome we wanted and the verification
-        // below still gates it.
-        if let Err(err) = result
-            && !binary_path.exists()
-        {
-            return Err(Error::Encoding(format!(
-                "failed to install bundled capnp binary at {}: {err}",
-                binary_path.display()
-            )));
-        }
-
-        // Prove the freshly written binary runs on this host. This is where a
-        // wrong-arch embedded binary is caught, with guidance pointed at the
-        // real fix rather than at installing a system capnp peppy will not use.
-        Self::verify_runs(&binary_path).map_err(|err| {
-            Error::Encoding(format!(
-                "{err}. This capnp is bundled with peppy (peppy does not use a \
-                 system capnp); the installed peppy build looks corrupt or was \
-                 built for a different architecture. Reinstall peppy with \
-                 `curl -fsSL https://peppy.bot/install.sh | bash` or report the \
-                 broken release at https://github.com/Peppy-bot/peppy/issues"
-            ))
-        })?;
-
-        Ok(binary_path)
+        let binary_path = daemon_config::consts::PeppyDirs::default()
+            .bin_dir()
+            .join("peppy_capnp_binary");
+        Self::install_bundled_binary(&binary_path, binary_bytes)
     }
 }
 
@@ -277,11 +296,16 @@ mod tests {
     #[test]
     fn bundled_capnp_exists() {
         let path = CapnpFacade::bundled_capnp_binary().expect("bundled capnp binary should exist");
+        let expected = daemon_config::consts::PeppyDirs::default()
+            .bin_dir()
+            .join("peppy_capnp_binary");
+        assert_eq!(path, expected);
         assert!(
             path.exists(),
             "expected bundled capnp binary at {}",
             path.display()
         );
+        CapnpFacade::verify_runs(&path).expect("installed bundled capnp binary should run");
     }
 
     #[test]
@@ -304,7 +328,10 @@ mod tests {
 
         let same_size_diff = dir.path().join("same_size_diff");
         std::fs::write(&same_size_diff, b"capnp X bytes!").expect("write");
-        assert_eq!(same_size_diff.metadata().unwrap().len(), embedded.len() as u64);
+        assert_eq!(
+            same_size_diff.metadata().unwrap().len(),
+            embedded.len() as u64
+        );
         assert!(
             !CapnpFacade::matches_embedded(&same_size_diff, embedded),
             "a same-length but differing file must be rejected"
@@ -335,7 +362,11 @@ mod tests {
         // platform this surfaces as an exec error (ENOEXEC) or, via the libc
         // execvp `/bin/sh` fallback, a non-zero exit. Both must be rejected and
         // must name the path, which is what we assert.
-        let path = write_executable(&dir.path(), "not_a_binary", b"\x00\x01\x02 definitely not exec");
+        let path = write_executable(
+            dir.path(),
+            "not_a_binary",
+            b"\x00\x01\x02 definitely not exec",
+        );
 
         let err = CapnpFacade::verify_runs(&path).expect_err("non-runnable file should fail");
         let message = err.to_string();
@@ -350,7 +381,7 @@ mod tests {
     #[test]
     fn verify_runs_accepts_a_binary_that_runs_successfully() {
         let dir = tempfile::tempdir().expect("tempdir");
-        let path = write_executable(&dir.path(), "ok", b"#!/bin/sh\nexit 0\n");
+        let path = write_executable(dir.path(), "ok", b"#!/bin/sh\nexit 0\n");
 
         CapnpFacade::verify_runs(&path).expect("a script that exits 0 should verify");
     }
@@ -359,12 +390,128 @@ mod tests {
     #[test]
     fn verify_runs_rejects_a_binary_that_exits_nonzero() {
         let dir = tempfile::tempdir().expect("tempdir");
-        let path = write_executable(&dir.path(), "boom", b"#!/bin/sh\nexit 3\n");
+        let path = write_executable(dir.path(), "boom", b"#!/bin/sh\nexit 3\n");
 
         let err = CapnpFacade::verify_runs(&path).expect_err("a failing exit should not verify");
         assert!(
             err.to_string().contains("exited with"),
             "error should report the unsuccessful exit, got: {err}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn install_bundled_binary_creates_the_managed_executable() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("nested").join("capnp");
+        let expected = b"#!/bin/sh\nexit 0\n# bundled\n";
+
+        let installed =
+            CapnpFacade::install_bundled_binary(&path, expected).expect("install bundled binary");
+
+        assert_eq!(installed, path);
+        assert_eq!(
+            std::fs::read(&path).expect("read installed binary"),
+            expected
+        );
+        assert_ne!(
+            std::fs::metadata(&path)
+                .expect("metadata")
+                .permissions()
+                .mode()
+                & 0o111,
+            0,
+            "installed binary must be executable"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn install_bundled_binary_replaces_runnable_stale_bytes() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = write_executable(
+            dir.path(),
+            "capnp",
+            b"#!/bin/sh\nexit 0\n# stale but runnable\n",
+        );
+        let expected = b"#!/bin/sh\nexit 0\n# current bundled binary\n";
+
+        CapnpFacade::install_bundled_binary(&path, expected)
+            .expect("replace stale runnable binary");
+
+        assert_eq!(std::fs::read(path).expect("read replacement"), expected);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn install_bundled_binary_repairs_non_executable_matching_bytes() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("capnp");
+        let expected = b"#!/bin/sh\nexit 0\n";
+        std::fs::write(&path, expected).expect("write non-executable binary");
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).expect("chmod fixture");
+
+        CapnpFacade::install_bundled_binary(&path, expected)
+            .expect("repair executable permissions");
+
+        assert_ne!(
+            std::fs::metadata(path)
+                .expect("metadata")
+                .permissions()
+                .mode()
+                & 0o111,
+            0,
+            "matching bytes with broken permissions must be republished"
+        );
+    }
+
+    #[test]
+    fn install_bundled_binary_reports_an_unusable_destination() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("capnp");
+        std::fs::create_dir(&path).expect("create conflicting destination directory");
+
+        let error = CapnpFacade::install_bundled_binary(&path, b"not published")
+            .expect_err("a destination directory cannot become the binary");
+
+        assert!(
+            error
+                .to_string()
+                .contains("failed to install bundled capnp binary"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn publication_error_is_accepted_only_when_a_concurrent_writer_installed_exact_bytes() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("capnp");
+        let expected = b"expected bytes";
+        std::fs::write(&path, expected).expect("write concurrent result");
+
+        CapnpFacade::accept_publication_result(
+            &path,
+            expected,
+            Err(std::io::Error::new(
+                std::io::ErrorKind::AlreadyExists,
+                "simulated publication race",
+            )),
+        )
+        .expect("matching concurrent publication should be accepted");
+
+        std::fs::write(&path, b"different bytes").expect("write mismatched result");
+        let error = CapnpFacade::accept_publication_result(
+            &path,
+            expected,
+            Err(std::io::Error::new(
+                std::io::ErrorKind::AlreadyExists,
+                "simulated publication race",
+            )),
+        )
+        .expect_err("mismatched concurrent publication must be rejected");
+        assert!(
+            error.to_string().contains("simulated publication race"),
+            "original publication error should be preserved: {error}"
         );
     }
 }

--- a/crates/encoding-internal/src/facade.rs
+++ b/crates/encoding-internal/src/facade.rs
@@ -3,6 +3,7 @@ use capnpc::CompilerCommand;
 use std::env;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::time::Duration;
 
 #[cfg(unix)]
 use std::fs;
@@ -113,22 +114,36 @@ impl CapnpFacade {
     }
 
     /// Runs `<path> --version` to prove the binary is actually executable on
-    /// this host before it is handed to the capnp compiler. A wrong-architecture
+    /// this host before it is handed to the capnp compiler. Transient `ETXTBSY`
+    /// errors are retried because another thread can fork while the freshly
+    /// extracted executable is briefly open for writing. A wrong-architecture
     /// binary is rejected by the kernel with `ENOEXEC` here, which lets us report
     /// the real path and errno instead of the capnp compiler's later, generic
     /// "install capnp" message.
     fn verify_runs(path: &Path) -> Result<()> {
-        let output = Command::new(path)
-            .arg("--version")
-            .output()
-            .map_err(|err| {
-                Error::Encoding(format!(
-                    "capnp binary at {} failed to execute on {}/{}: {err}",
-                    path.display(),
-                    env::consts::OS,
-                    env::consts::ARCH
-                ))
-            })?;
+        const MAX_TRANSIENT_RETRIES: u32 = 50;
+
+        let mut attempt = 0;
+        let output = loop {
+            match Command::new(path).arg("--version").output() {
+                Ok(output) => break output,
+                Err(err)
+                    if Self::is_transient_exec_error(&err) && attempt < MAX_TRANSIENT_RETRIES =>
+                {
+                    attempt += 1;
+                    let backoff = Duration::from_millis((10 * attempt as u64).min(100));
+                    std::thread::sleep(backoff);
+                }
+                Err(err) => {
+                    return Err(Error::Encoding(format!(
+                        "capnp binary at {} failed to execute on {}/{}: {err}",
+                        path.display(),
+                        env::consts::OS,
+                        env::consts::ARCH
+                    )));
+                }
+            }
+        };
 
         if !output.status.success() {
             return Err(Error::Encoding(format!(
@@ -139,6 +154,12 @@ impl CapnpFacade {
         }
 
         Ok(())
+    }
+
+    /// `ETXTBSY` has no stable [`std::io::ErrorKind`] variant. Its errno is 26
+    /// on the Unix targets peppy supports.
+    fn is_transient_exec_error(error: &std::io::Error) -> bool {
+        cfg!(unix) && error.raw_os_error() == Some(26)
     }
 
     fn ensure_executable(path: &Path) -> Result<()> {
@@ -397,6 +418,27 @@ mod tests {
             err.to_string().contains("exited with"),
             "error should report the unsuccessful exit, got: {err}"
         );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn verify_runs_retries_a_temporarily_busy_executable() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = write_executable(dir.path(), "busy", b"#!/bin/sh\nexit 0\n");
+        let writable = std::fs::OpenOptions::new()
+            .write(true)
+            .open(&path)
+            .expect("hold executable open for writing");
+        let verify_path = path.clone();
+
+        let verifier = std::thread::spawn(move || CapnpFacade::verify_runs(&verify_path));
+        std::thread::sleep(Duration::from_millis(100));
+        drop(writable);
+
+        verifier
+            .join()
+            .expect("verification thread should not panic")
+            .expect("verification should retry after ETXTBSY");
     }
 
     #[cfg(unix)]

--- a/crates/encoding-internal/src/lib.rs
+++ b/crates/encoding-internal/src/lib.rs
@@ -62,9 +62,13 @@ impl MessageFormatMapper {
     /// Despite the `map_` name this is **not** a pure transform: resolving the
     /// Rust type mapping shells out to the Cap'n Proto compiler. The call
     /// creates a temporary directory, writes the generated schema into it,
-    /// invokes the bundled `capnp` binary (locating/extracting it on first
-    /// use), and reads back the code-generator request. Expect filesystem I/O
-    /// and a subprocess, not just in-memory work.
+    /// invokes the `capnp` binary, and reads back the code-generator request.
+    /// Expect filesystem I/O and a subprocess, not just in-memory work.
+    ///
+    /// The binary is resolved as `CAPNP_BINARY_PATH` (an explicit override for
+    /// development and testing) if set, otherwise the capnp that peppy ships and
+    /// extracts to `~/.peppy/bin` on first use. peppy never falls back to a
+    /// system capnp on `PATH`.
     pub fn map_message_format_to_capnpn(&self) -> Result<CapnpSchemaArtifacts> {
         let mut generator = CapnpSchemaGenerator::default();
         let mut schema = String::new();

--- a/crates/encoding-internal/src/lib.rs
+++ b/crates/encoding-internal/src/lib.rs
@@ -67,8 +67,10 @@ impl MessageFormatMapper {
     ///
     /// The binary is resolved as `CAPNP_BINARY_PATH` (an explicit override for
     /// development and testing) if set, otherwise the capnp that peppy ships and
-    /// extracts to `~/.peppy/bin` on first use. peppy never falls back to a
-    /// system capnp on `PATH`.
+    /// extracts to `$PEPPY_HOME/bin` on first use. This defaults to
+    /// `~/.peppy/bin` in production and is not affected by the installer's
+    /// optional `PEPPY_BIN_DIR`. peppy never falls back to a system capnp on
+    /// `PATH`.
     pub fn map_message_format_to_capnpn(&self) -> Result<CapnpSchemaArtifacts> {
         let mut generator = CapnpSchemaGenerator::default();
         let mut schema = String::new();

--- a/crates/generator-internal/src/generator/rust/tests/actions.rs
+++ b/crates/generator-internal/src/generator/rust/tests/actions.rs
@@ -1035,10 +1035,7 @@ fn clippy_single_exposed_action_empty_goal_request() {
         fs::read_to_string(&consumed_actions_mod).expect("failed to read consumed_actions module");
     assert_contains_all(
         &consumed_actions_contents,
-        &[
-            "pub mod brain;",
-            "pub mod controller;",
-        ],
+        &["pub mod brain;", "pub mod controller;"],
     );
 }
 
@@ -1137,10 +1134,7 @@ fn compile_lib_with_exposed_and_consumed_actions() {
         fs::read_to_string(&consumed_actions_mod).expect("failed to read consumed_actions module");
     assert_contains_all(
         &consumed_actions_contents,
-        &[
-            "pub mod brain;",
-            "pub mod controller;",
-        ],
+        &["pub mod brain;", "pub mod controller;"],
     );
 
     let expose_move_arm_path = output_dir.join("src/exposed_actions/move_arm.rs");

--- a/crates/generator-internal/src/generator/rust/tests/services.rs
+++ b/crates/generator-internal/src/generator/rust/tests/services.rs
@@ -555,10 +555,7 @@ fn clippy_single_exposed_service_without_request_body() {
             .expect("failed to read consumed_actions module");
     assert_contains_all(
         &consumed_actions_contents,
-        &[
-            "pub mod brain;",
-            "pub mod controller;",
-        ],
+        &["pub mod brain;", "pub mod controller;"],
     );
 }
 

--- a/crates/generator-internal/src/generator/rust/tests/topics.rs
+++ b/crates/generator-internal/src/generator/rust/tests/topics.rs
@@ -791,10 +791,7 @@ fn clippy_single_emitted_topic_empty_format() {
             .expect("failed to read consumed_actions module");
     assert_contains_all(
         &consumed_actions_contents,
-        &[
-            "pub mod brain;",
-            "pub mod controller;",
-        ],
+        &["pub mod brain;", "pub mod controller;"],
     );
 }
 

--- a/crates/generator-internal/src/generator/scaffold_tree.rs
+++ b/crates/generator-internal/src/generator/scaffold_tree.rs
@@ -128,7 +128,8 @@ fn write_tree_level<W: TreeWriter>(
     // Leaves first, then sub-directories. `BTreeMap` already gives deterministic
     // alphabetical ordering inside each bucket.
     for (raw_leaf, artifacts) in &tree.leaves {
-        let module_name = claim_module_name(raw_leaf, category, &mut seen, W::sanitize_module_name)?;
+        let module_name =
+            claim_module_name(raw_leaf, category, &mut seen, W::sanitize_module_name)?;
         writer.write_leaf(dir, &module_name, raw_leaf, artifacts)?;
         entries.push(ModuleEntry {
             module_name,

--- a/crates/generator-internal/src/generator/types.rs
+++ b/crates/generator-internal/src/generator/types.rs
@@ -828,7 +828,11 @@ mod tests {
             origin.scoped_schema_key("video_stream"),
             "depth_camera_v1_video_stream"
         );
-        assert!(!origin.scoped_schema_key("video_stream").contains("cam_left"));
+        assert!(
+            !origin
+                .scoped_schema_key("video_stream")
+                .contains("cam_left")
+        );
     }
 
     #[test]
@@ -1112,7 +1116,9 @@ impl ModuleCategory {
             InterfaceKind::ConsumedService => Self::ConsumedServices,
             InterfaceKind::ExposedAction => Self::ExposedActions,
             InterfaceKind::ConsumedAction => Self::ConsumedActions,
-            InterfaceKind::PeerEmittedTopic | InterfaceKind::PeerConsumedTopic => Self::PairedTopics,
+            InterfaceKind::PeerEmittedTopic | InterfaceKind::PeerConsumedTopic => {
+                Self::PairedTopics
+            }
         }
     }
 

--- a/crates/generator-internal/tests/python/topics_implements.rs
+++ b/crates/generator-internal/tests/python/topics_implements.rs
@@ -88,8 +88,18 @@ fn nests_contract_backed_topics_under_link_id() {
     fs::write(&peppy_node_config, NODE_CONFIG).expect("write node config");
 
     let extras = vec![
-        contract_backed("depth_v1", "depth_camera", "v1", make_topic("depth_v1_marker")),
-        contract_backed("depth_v2", "depth_camera", "v2", make_topic("depth_v2_marker")),
+        contract_backed(
+            "depth_v1",
+            "depth_camera",
+            "v1",
+            make_topic("depth_v1_marker"),
+        ),
+        contract_backed(
+            "depth_v2",
+            "depth_camera",
+            "v2",
+            make_topic("depth_v2_marker"),
+        ),
         contract_backed("uvc_v1", "uvc_camera", "v1", make_topic("uvc_v1_marker")),
     ];
 
@@ -139,14 +149,14 @@ fn nests_contract_backed_topics_under_link_id() {
         );
     }
 
-    let depth_v1_init = fs::read_to_string(emit_dir.join("depth_v1/__init__.py"))
-        .expect("depth_v1/__init__.py");
+    let depth_v1_init =
+        fs::read_to_string(emit_dir.join("depth_v1/__init__.py")).expect("depth_v1/__init__.py");
     assert!(
         depth_v1_init.contains("from . import video_stream"),
         "depth_v1/__init__.py should import video_stream:\n{depth_v1_init}",
     );
-    let depth_v2_init = fs::read_to_string(emit_dir.join("depth_v2/__init__.py"))
-        .expect("depth_v2/__init__.py");
+    let depth_v2_init =
+        fs::read_to_string(emit_dir.join("depth_v2/__init__.py")).expect("depth_v2/__init__.py");
     assert!(
         depth_v2_init.contains("from . import video_stream"),
         "depth_v2/__init__.py should import video_stream:\n{depth_v2_init}",

--- a/crates/generator-internal/tests/rust/topics_implements.rs
+++ b/crates/generator-internal/tests/rust/topics_implements.rs
@@ -103,8 +103,18 @@ fn nests_contract_backed_topics_under_link_id() {
     fs::write(&peppy_node_config, NODE_CONFIG).expect("write node config");
 
     let extras = vec![
-        contract_backed("depth_v1", "depth_camera", "v1", make_topic("depth_v1_marker")),
-        contract_backed("depth_v2", "depth_camera", "v2", make_topic("depth_v2_marker")),
+        contract_backed(
+            "depth_v1",
+            "depth_camera",
+            "v1",
+            make_topic("depth_v1_marker"),
+        ),
+        contract_backed(
+            "depth_v2",
+            "depth_camera",
+            "v2",
+            make_topic("depth_v2_marker"),
+        ),
         contract_backed("uvc_v1", "uvc_camera", "v1", make_topic("uvc_v1_marker")),
     ];
 
@@ -141,14 +151,14 @@ fn nests_contract_backed_topics_under_link_id() {
     }
 
     // Each slot's `mod.rs` declares its leaf module.
-    let depth_v1_mod = fs::read_to_string(emit_dir.join("depth_v1/mod.rs"))
-        .expect("depth_v1/mod.rs should exist");
+    let depth_v1_mod =
+        fs::read_to_string(emit_dir.join("depth_v1/mod.rs")).expect("depth_v1/mod.rs should exist");
     assert!(
         depth_v1_mod.contains("pub mod video_stream;"),
         "depth_v1/mod.rs missing video_stream: {depth_v1_mod}",
     );
-    let depth_v2_mod = fs::read_to_string(emit_dir.join("depth_v2/mod.rs"))
-        .expect("depth_v2/mod.rs should exist");
+    let depth_v2_mod =
+        fs::read_to_string(emit_dir.join("depth_v2/mod.rs")).expect("depth_v2/mod.rs should exist");
     assert!(
         depth_v2_mod.contains("pub mod video_stream;"),
         "depth_v2/mod.rs missing video_stream: {depth_v2_mod}",

--- a/scripts/tests/lima_helpers.py
+++ b/scripts/tests/lima_helpers.py
@@ -118,10 +118,15 @@ def lima_env() -> dict[str, str]:
     """Environment with LIMA_HOME pointing to a test-specific directory.
 
     When running under pytest-xdist, each worker gets its own LIMA_HOME
-    to avoid conflicts between parallel VM operations.
+    to avoid conflicts between parallel VM operations. The optional
+    PEPPY_TEST_LIMA_HOME sets a shorter base directory for environments whose
+    home path would make Lima's Unix socket path exceed UNIX_PATH_MAX.
     """
     worker = os.environ.get("PYTEST_XDIST_WORKER", "gw0")
-    lima_home = Path.home() / ".peppy" / f"lti-{worker}"
+    base_dir = Path(
+        os.environ.get("PEPPY_TEST_LIMA_HOME", Path.home() / ".peppy")
+    )
+    lima_home = base_dir / f"lti-{worker}"
     lima_home.mkdir(parents=True, exist_ok=True)
     return {**os.environ, "LIMA_HOME": str(lima_home)}
 

--- a/scripts/tests/test_install.py
+++ b/scripts/tests/test_install.py
@@ -489,6 +489,11 @@ peppy node init test-node
 
 # Give the node a real message format so code generation exercises the bundled
 # capnp binary instead of only deploying the prebuilt peppylib extension.
+CONFIG_FILE=/var/tmp/test-node/peppy.json5
+if ! grep -Fqx '  interfaces: {{}},' "$CONFIG_FILE"; then
+    echo "ERROR: Expected empty interfaces entry not found in $CONFIG_FILE"
+    exit 1
+fi
 sed -i '/  interfaces: {{}},/c\
   interfaces: {{\
     topics: {{\
@@ -498,24 +503,43 @@ sed -i '/  interfaces: {{}},/c\
         message_format: {{ value: "u32" }}\
       }}]\
     }}\
-  }},' test-node/peppy.json5
+  }},' "$CONFIG_FILE" || {{
+    echo "ERROR: Failed to update interfaces in $CONFIG_FILE"
+    exit 1
+}}
+if ! grep -Fq 'name: "architecture_probe"' "$CONFIG_FILE"; then
+    echo "ERROR: Interface update was not applied to $CONFIG_FILE"
+    exit 1
+fi
 
 # Sync and add the node to the daemon, regenerating after the config edit and
 # triggering peppylib .so and capnp extraction.
 # This may fail if uv is not installed. Both architecture artifacts are
 # extracted before build_cmd, which is all this test needs.
-peppy node add --sync /var/tmp/test-node || true
+NODE_ADD_STATUS=0
+NODE_ADD_OUTPUT=$(peppy node add --sync /var/tmp/test-node 2>&1) || NODE_ADD_STATUS=$?
+printf '%s\n' "$NODE_ADD_OUTPUT"
+if [ "$NODE_ADD_STATUS" -ne 0 ]; then
+    case "$NODE_ADD_OUTPUT" in
+        *'failed to execute build_cmd `uv sync --no-editable`: No such file or directory (os error 2)'*)
+            echo "WARNING: node add reached the expected missing-uv build failure"
+            ;;
+        *)
+            echo "ERROR: peppy node add --sync failed with status $NODE_ADD_STATUS"
+            exit "$NODE_ADD_STATUS"
+            ;;
+    esac
+fi
 
-# Find .abi3.so — it may be in the node working dir, the daemon's data
-# directory (~/.peppy), or the custom PEPPY_HOME.
-SO_FILE=$(find /var/tmp/test-node {home} $HOME/.peppy -name '*.abi3*.so' -type f 2>/dev/null | head -1)
+# Find .abi3.so only in this run's node working dir or custom PEPPY_HOME.
+SO_FILE=$(find /var/tmp/test-node "{home}" -name '*.abi3*.so' -type f 2>/dev/null | head -1)
 CAPNP_FILE={home}/bin/peppy_capnp_binary
 
 # Kill daemon before checking results to avoid SIGTERM exit codes
 kill $DAEMON_PID 2>/dev/null; wait $DAEMON_PID 2>/dev/null || true
 
 if [ -z "$SO_FILE" ]; then
-    echo "ERROR: No .abi3.so found in /var/tmp/test-node, {home}, or ~/.peppy"
+    echo "ERROR: No .abi3.so found in /var/tmp/test-node or {home}"
     exit 1
 fi
 echo "FOUND_SO=$SO_FILE"

--- a/scripts/tests/test_install.py
+++ b/scripts/tests/test_install.py
@@ -487,10 +487,24 @@ cd /var/tmp
 rm -rf test-node
 peppy node init test-node
 
-# Add the node to the daemon (triggers peppylib .so and capnp extraction).
-# This may fail if uv is not installed — that's OK, we only need the
-# .so extraction which happens before build_cmd.
-peppy node add /var/tmp/test-node || true
+# Give the node a real message format so code generation exercises the bundled
+# capnp binary instead of only deploying the prebuilt peppylib extension.
+sed -i '/  interfaces: {{}},/c\
+  interfaces: {{\
+    topics: {{\
+      emits: [{{\
+        name: "architecture_probe",\
+        qos_profile: "sensor_data",\
+        message_format: {{ value: "u32" }}\
+      }}]\
+    }}\
+  }},' test-node/peppy.json5
+
+# Sync and add the node to the daemon, regenerating after the config edit and
+# triggering peppylib .so and capnp extraction.
+# This may fail if uv is not installed. Both architecture artifacts are
+# extracted before build_cmd, which is all this test needs.
+peppy node add --sync /var/tmp/test-node || true
 
 # Find .abi3.so — it may be in the node working dir, the daemon's data
 # directory (~/.peppy), or the custom PEPPY_HOME.

--- a/scripts/tests/test_install.py
+++ b/scripts/tests/test_install.py
@@ -388,8 +388,8 @@ def test_reinstall_over_existing(lima_vm: VMConfig) -> None:
 def test_binary_architecture(lima_vm: VMConfig) -> None:
     """Verify installed binaries match the guest architecture.
 
-    Checks both the peppy binary and the apptainer binary via the ``file``
-    command to ensure ELF architecture matches what the guest expects.
+    Checks peppy, zenohd, and apptainer via the ``file`` command to ensure
+    their ELF architecture matches what the guest expects.
     This catches cross-architecture bundling bugs like the v0.5.6 issue
     where an aarch64 Apptainer binary was shipped in the x86_64 release.
     """
@@ -412,6 +412,13 @@ def test_binary_architecture(lima_vm: VMConfig) -> None:
     check = lima_shell(f"file {home}/bin/peppy", instance=config.instance_name)
     assert expected_arch in check.stdout, (
         f"peppy binary arch mismatch on {config.pytest_id()}: "
+        f"expected '{expected_arch}'{diagnostic(check)}"
+    )
+
+    # Check zenohd binary
+    check = lima_shell(f"file {home}/bin/zenohd", instance=config.instance_name)
+    assert expected_arch in check.stdout, (
+        f"zenohd binary arch mismatch on {config.pytest_id()}: "
         f"expected '{expected_arch}'{diagnostic(check)}"
     )
 
@@ -480,7 +487,7 @@ cd /var/tmp
 rm -rf test-node
 peppy node init test-node
 
-# Add the node to the daemon (triggers peppylib .so extraction).
+# Add the node to the daemon (triggers peppylib .so and capnp extraction).
 # This may fail if uv is not installed — that's OK, we only need the
 # .so extraction which happens before build_cmd.
 peppy node add /var/tmp/test-node || true
@@ -488,6 +495,7 @@ peppy node add /var/tmp/test-node || true
 # Find .abi3.so — it may be in the node working dir, the daemon's data
 # directory (~/.peppy), or the custom PEPPY_HOME.
 SO_FILE=$(find /var/tmp/test-node {home} $HOME/.peppy -name '*.abi3*.so' -type f 2>/dev/null | head -1)
+CAPNP_FILE={home}/bin/peppy_capnp_binary
 
 # Kill daemon before checking results to avoid SIGTERM exit codes
 kill $DAEMON_PID 2>/dev/null; wait $DAEMON_PID 2>/dev/null || true
@@ -497,7 +505,15 @@ if [ -z "$SO_FILE" ]; then
     exit 1
 fi
 echo "FOUND_SO=$SO_FILE"
-file "$SO_FILE"
+echo "SO_FILE_INFO=$(file -b "$SO_FILE")"
+
+if [ ! -x "$CAPNP_FILE" ]; then
+    echo "ERROR: No executable bundled capnp found at $CAPNP_FILE"
+    exit 1
+fi
+"$CAPNP_FILE" --version
+echo "FOUND_CAPNP=$CAPNP_FILE"
+echo "CAPNP_FILE_INFO=$(file -b "$CAPNP_FILE")"
 """
     result = lima_shell(script, instance=config.instance_name, timeout=timeout)
 
@@ -505,7 +521,23 @@ file "$SO_FILE"
     assert result.returncode == 0, (
         f"peppylib .so test failed on {config.pytest_id()}{diagnostic(result)}"
     )
-    assert expected_arch in result.stdout, (
+    so_info = next(
+        (line for line in result.stdout.splitlines() if line.startswith("SO_FILE_INFO=")),
+        "",
+    )
+    assert expected_arch in so_info, (
         f".abi3.so arch mismatch on {config.pytest_id()}: "
+        f"expected '{expected_arch}'{diagnostic(result)}"
+    )
+    capnp_info = next(
+        (
+            line
+            for line in result.stdout.splitlines()
+            if line.startswith("CAPNP_FILE_INFO=")
+        ),
+        "",
+    )
+    assert expected_arch in capnp_info, (
+        f"capnp binary arch mismatch on {config.pytest_id()}: "
         f"expected '{expected_arch}'{diagnostic(result)}"
     )

--- a/scripts/tests/test_lima.py
+++ b/scripts/tests/test_lima.py
@@ -36,7 +36,10 @@ def _populate_so_dir(base: Path) -> Path:
 
 
 def test_lima_env_honours_short_base_override(tmp_path: Path) -> None:
-    with patch.dict(os.environ, {"PEPPY_TEST_LIMA_HOME": str(tmp_path)}):
+    with patch.dict(
+        os.environ,
+        {"PEPPY_TEST_LIMA_HOME": str(tmp_path), "PYTEST_XDIST_WORKER": "gw0"},
+    ):
         env = lima_env()
 
     assert env["LIMA_HOME"] == str(tmp_path / "lti-gw0")

--- a/scripts/tests/test_lima.py
+++ b/scripts/tests/test_lima.py
@@ -23,6 +23,7 @@ from functions.lima import (
     require_prebuilt_peppylib_so,
     stop_lima_vm,
 )
+from .lima_helpers import lima_env
 
 
 def _populate_so_dir(base: Path) -> Path:
@@ -32,6 +33,13 @@ def _populate_so_dir(base: Path) -> Path:
     for name in (*RELEASE_PLATFORM_SO, SO_BUILD_STATE_MARKER):
         (so_dir / name).write_bytes(b"x")
     return so_dir
+
+
+def test_lima_env_honours_short_base_override(tmp_path: Path) -> None:
+    with patch.dict(os.environ, {"PEPPY_TEST_LIMA_HOME": str(tmp_path)}):
+        env = lima_env()
+
+    assert env["LIMA_HOME"] == str(tmp_path / "lti-gw0")
 
 
 def test_find_limactl_from_build_output(tmp_path: Path) -> None:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a first-class accessor for the daemon-managed `{root}/bin` directory.
  - Bundled Cap’n Proto compiler resolution now uses Peppy’s managed `bin` directory.
- **Bug Fixes**
  - Hardened `CAPNP_BINARY_PATH` handling: it must exist and be runnable via a `--version` probe.
  - Improved bundled binary install: reuse only exact matches; otherwise atomically replace and re-verify executability.
- **Documentation**
  - Expanded Cap’n Proto resolution docs to clearly describe override and fallback behavior (no system `capnp` fallback).
- **Tests**
  - Added/extended binary architecture and runtime validation tests, plus Lima home base override coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->