### PR TITLE
fix(generator): honor action goal response schemas

### DIFF
--- a/crates/core-node-internal/src/services/node/sync/interfaces.rs
+++ b/crates/core-node-internal/src/services/node/sync/interfaces.rs
@@ -321,6 +321,10 @@ pub(super) fn action_message_from_exposed(
             .goal_service
             .as_ref()
             .and_then(|s| s.request_message_format.clone()),
+        goal_response: exposed_action
+            .goal_service
+            .as_ref()
+            .and_then(|s| s.response_message_format.clone()),
         feedback: exposed_action
             .feedback_topic
             .as_ref()
@@ -329,6 +333,44 @@ pub(super) fn action_message_from_exposed(
             .result_service
             .as_ref()
             .and_then(|s| s.response_message_format.clone()),
+    }
+}
+
+#[cfg(test)]
+mod action_message_tests {
+    use super::*;
+
+    #[test]
+    fn preserves_the_declared_goal_response_format_exactly() {
+        let exposed_action: config::node::NativeExposedAction = serde_json5::from_str(
+            r#"{
+                name: "move_arm",
+                goal_service: {
+                    response_message_format: {
+                        accepted: "bool"
+                    }
+                }
+            }"#,
+        )
+        .expect("action should parse");
+        let declared = exposed_action
+            .goal_service
+            .as_ref()
+            .and_then(|service| service.response_message_format.clone());
+
+        let messages = action_message_from_exposed(&exposed_action);
+
+        assert_eq!(messages.goal_response, declared);
+        assert_eq!(
+            messages
+                .goal_response
+                .as_ref()
+                .expect("declared response should be preserved")
+                .0
+                .len(),
+            1,
+            "the consumed response should contain exactly the declared field"
+        );
     }
 }
 

--- a/crates/generator-internal/src/generator/python.rs
+++ b/crates/generator-internal/src/generator/python.rs
@@ -16,8 +16,8 @@ mod type_mapping;
 use super::naming::{resolve_schema_file_stem, to_camel_case};
 use super::types::{
     CapnpSchema, ConsumedActionMessage, ContractOrigin, DependencyContext, InterfaceArtifact,
-    InterfaceKind, LanguageGenerator, goal_action_response_format, non_empty_message_format,
-    scoped_schema_key, validate_fixed_length_array_items, validate_generated_type_name_collisions,
+    InterfaceKind, LanguageGenerator, non_empty_message_format, scoped_schema_key,
+    validate_fixed_length_array_items, validate_generated_type_name_collisions,
     validate_message_format_field_names,
 };
 use crate::error::Result;
@@ -242,11 +242,12 @@ impl LanguageGenerator for PythonGenerator {
                 .as_ref()
                 .and_then(|goal_service| goal_service.request_message_format.as_ref()),
         )?;
-        // The goal acknowledgement is framework-owned ({accepted}).
-        let goal_response_fmt = goal_action_response_format();
         let goal_response_schema_info = self.register_optional_schema(
             scoped_schema_key(origin, &format!("{}_goal_response", action.name)),
-            Some(&goal_response_fmt),
+            action
+                .goal_service
+                .as_ref()
+                .and_then(|goal_service| goal_service.response_message_format.as_ref()),
         )?;
 
         // The cancel-ack reply is encoded by the peppylib engine (a fixed
@@ -402,11 +403,9 @@ impl LanguageGenerator for PythonGenerator {
             &action_schema_keys.goal_request,
             messages.goal_request.as_ref(),
         )?;
-        // The goal acknowledgement is framework-owned ({accepted}).
-        let goal_response_fmt = goal_action_response_format();
         let goal_response_schema_info = self.register_optional_schema(
             &action_schema_keys.goal_response,
-            Some(&goal_response_fmt),
+            messages.goal_response.as_ref(),
         )?;
 
         // The cancel reply is the framework-owned cancel-ack, decoded Rust-side

--- a/crates/generator-internal/src/generator/python.rs
+++ b/crates/generator-internal/src/generator/python.rs
@@ -242,7 +242,7 @@ impl LanguageGenerator for PythonGenerator {
                 .as_ref()
                 .and_then(|goal_service| goal_service.request_message_format.as_ref()),
         )?;
-        // The goal acknowledgement is framework-owned ({accepted, error_message}).
+        // The goal acknowledgement is framework-owned ({accepted}).
         let goal_response_fmt = goal_action_response_format();
         let goal_response_schema_info = self.register_optional_schema(
             scoped_schema_key(origin, &format!("{}_goal_response", action.name)),
@@ -402,7 +402,7 @@ impl LanguageGenerator for PythonGenerator {
             &action_schema_keys.goal_request,
             messages.goal_request.as_ref(),
         )?;
-        // The goal acknowledgement is framework-owned ({accepted, error_message}).
+        // The goal acknowledgement is framework-owned ({accepted}).
         let goal_response_fmt = goal_action_response_format();
         let goal_response_schema_info = self.register_optional_schema(
             &action_schema_keys.goal_response,

--- a/crates/generator-internal/src/generator/python/actions.rs
+++ b/crates/generator-internal/src/generator/python/actions.rs
@@ -61,7 +61,7 @@ pub fn build_exposed_action(
         .goal_service
         .as_ref()
         .and_then(|goal| non_empty_message_format(goal.request_message_format.as_ref()));
-    // The goal acknowledgement is framework-owned ({accepted, error_message});
+    // The goal acknowledgement is framework-owned ({accepted});
     // any goal response declared in the action schema is ignored.
     let goal_response_fmt = goal_action_response_format();
     let goal_response_format = Some(&goal_response_fmt);
@@ -97,27 +97,25 @@ pub fn build_exposed_action(
         );
     }
 
-    // GoalResponse: the framework goal acknowledgement ({accepted,
-    // error_message}). The decider returns one via GoalResponse.accept() or
-    // GoalResponse.reject(reason); the `accepted` flag is the single source of
-    // truth for the accept/reject decision and the value the client reads.
+    // GoalResponse: the framework goal acknowledgement ({accepted}). The
+    // decider returns one via GoalResponse.accept() or GoalResponse.reject();
+    // the `accepted` flag is the single source of truth for the accept/reject
+    // decision and the value the client reads.
     builder.add_import("from dataclasses import dataclass");
-    builder.add_import("from typing import Optional");
     builder.line("@dataclass");
     builder.line("class GoalResponse:");
     builder.indent();
     builder.line("accepted: bool");
-    builder.line("error_message: Optional[str]");
     builder.blank_line();
     builder.line("@staticmethod");
     builder.line("def accept():");
     builder.indent();
-    builder.line("return GoalResponse(True, None)");
+    builder.line("return GoalResponse(True)");
     builder.dedent();
     builder.line("@staticmethod");
-    builder.line("def reject(reason):");
+    builder.line("def reject():");
     builder.indent();
-    builder.line("return GoalResponse(False, reason)");
+    builder.line("return GoalResponse(False)");
     builder.dedent();
     builder.dedent();
     builder.blank_line();
@@ -368,7 +366,7 @@ pub fn build_consumed_action(
     let mut builder = PythonCodeBuilder::new();
 
     let goal_request_format = non_empty_message_format(messages.goal_request.as_ref());
-    // The goal acknowledgement is framework-owned ({accepted, error_message}).
+    // The goal acknowledgement is framework-owned ({accepted}).
     let goal_response_fmt = goal_action_response_format();
     let goal_response_format = Some(&goal_response_fmt);
     let feedback_format = non_empty_message_format(messages.feedback.as_ref());

--- a/crates/generator-internal/src/generator/python/actions.rs
+++ b/crates/generator-internal/src/generator/python/actions.rs
@@ -6,9 +6,7 @@ use super::services::sender_target_python_expr;
 use super::topics::{capnp_loader_fn_name, emit_capnp_loader_fn, emit_capnp_preamble};
 use super::type_mapping::{collect_fields_from_format, uses_optional};
 use crate::error::Result;
-use crate::generator::types::{
-    ConsumedActionMessage, ContractOrigin, goal_action_response_format, non_empty_message_format,
-};
+use crate::generator::types::{ConsumedActionMessage, ContractOrigin, non_empty_message_format};
 use config::node::{ConsumedAction, NativeExposedAction};
 
 // ---------------------------------------------------------------------------
@@ -61,10 +59,10 @@ pub fn build_exposed_action(
         .goal_service
         .as_ref()
         .and_then(|goal| non_empty_message_format(goal.request_message_format.as_ref()));
-    // The goal acknowledgement is framework-owned ({accepted});
-    // any goal response declared in the action schema is ignored.
-    let goal_response_fmt = goal_action_response_format();
-    let goal_response_format = Some(&goal_response_fmt);
+    let goal_response_format = action
+        .goal_service
+        .as_ref()
+        .and_then(|goal| non_empty_message_format(goal.response_message_format.as_ref()));
     let result_response_format = action
         .result_service
         .as_ref()
@@ -75,9 +73,10 @@ pub fn build_exposed_action(
         .and_then(|topic| non_empty_message_format(topic.message_format.as_ref()));
 
     let has_goal_request = goal_request_format.is_some();
+    let has_goal_response = goal_response_format.is_some();
 
     // ---------------------------------------------------------------
-    // Dataclasses: GoalRequest[Data], GoalResponse (framework ack)
+    // Dataclasses: GoalRequest[Data], GoalResponse, GoalDecision
     // ---------------------------------------------------------------
 
     if let Some(fmt) = goal_request_format {
@@ -97,26 +96,46 @@ pub fn build_exposed_action(
         );
     }
 
-    // GoalResponse: the framework goal acknowledgement ({accepted}). The
-    // decider returns one via GoalResponse.accept() or GoalResponse.reject();
-    // the `accepted` flag is the single source of truth for the accept/reject
-    // decision and the value the client reads.
-    builder.add_import("from dataclasses import dataclass");
-    builder.line("@dataclass");
-    builder.line("class GoalResponse:");
+    if let Some(fmt) = goal_response_format {
+        emit_format_as_dataclass(&mut builder, "GoalResponse", fmt)?;
+    }
+
+    // GoalDecision controls framework acceptance independently of the response
+    // payload. Both branches carry the declared GoalResponse when one exists.
+    builder.line("class GoalDecision:");
     builder.indent();
-    builder.line("accepted: bool");
-    builder.blank_line();
-    builder.line("@staticmethod");
-    builder.line("def accept():");
-    builder.indent();
-    builder.line("return GoalResponse(True)");
-    builder.dedent();
-    builder.line("@staticmethod");
-    builder.line("def reject():");
-    builder.indent();
-    builder.line("return GoalResponse(False)");
-    builder.dedent();
+    if has_goal_response {
+        builder.line("def __init__(self, accepted: bool, response):");
+        builder.indent();
+        builder.line("self.accepted = accepted");
+        builder.line("self.response = response");
+        builder.dedent();
+        builder.line("@staticmethod");
+        builder.line("def accept(response):");
+        builder.indent();
+        builder.line("return GoalDecision(True, response)");
+        builder.dedent();
+        builder.line("@staticmethod");
+        builder.line("def reject(response):");
+        builder.indent();
+        builder.line("return GoalDecision(False, response)");
+        builder.dedent();
+    } else {
+        builder.line("def __init__(self, accepted: bool):");
+        builder.indent();
+        builder.line("self.accepted = accepted");
+        builder.dedent();
+        builder.line("@staticmethod");
+        builder.line("def accept():");
+        builder.indent();
+        builder.line("return GoalDecision(True)");
+        builder.dedent();
+        builder.line("@staticmethod");
+        builder.line("def reject():");
+        builder.indent();
+        builder.line("return GoalDecision(False)");
+        builder.dedent();
+    }
     builder.dedent();
     builder.blank_line();
 
@@ -193,7 +212,7 @@ pub fn build_exposed_action(
 
     // handle_goal_next_request
     builder.line(
-        "async def handle_goal_next_request(self, handler: Callable[[GoalRequest], GoalResponse]) -> \"GoalContext | None\":",
+        "async def handle_goal_next_request(self, handler: Callable[[GoalRequest], GoalDecision]) -> \"GoalContext | None\":",
     );
     builder.indent();
     builder.line("while True:");
@@ -213,13 +232,14 @@ pub fn build_exposed_action(
             "request = GoalRequest(instance_id=pending.instance_id, core_node=pending.core_node)",
         );
     }
-    builder.line("response = handler(request)");
-    builder.line("if hasattr(response, \"__await__\"):");
+    builder.line("decision = handler(request)");
+    builder.line("if hasattr(decision, \"__await__\"):");
     builder.indent();
-    builder.line("response = await response");
+    builder.line("decision = await decision");
     builder.dedent();
     // Serialize the GoalResponse once; both accept and reject reply with it.
     if let Some((fmt, info)) = goal_response_format.zip(goal_response_schema_info) {
+        builder.line("response = decision.response");
         let loader_fn_name = capnp_loader_fn_name(info);
         builder.line(&format!(
             "capnp_msg = {loader_fn_name}().{}.new_message()",
@@ -237,7 +257,7 @@ pub fn build_exposed_action(
     } else {
         builder.line("response_bytes = b\"\"");
     }
-    builder.line("if response.accepted:");
+    builder.line("if decision.accepted:");
     builder.indent();
     builder.line("ctx = await pending.accept(response_bytes)");
     builder.line("return GoalContext(ctx, request)");
@@ -366,9 +386,7 @@ pub fn build_consumed_action(
     let mut builder = PythonCodeBuilder::new();
 
     let goal_request_format = non_empty_message_format(messages.goal_request.as_ref());
-    // The goal acknowledgement is framework-owned ({accepted}).
-    let goal_response_fmt = goal_action_response_format();
-    let goal_response_format = Some(&goal_response_fmt);
+    let goal_response_format = non_empty_message_format(messages.goal_response.as_ref());
     let feedback_format = non_empty_message_format(messages.feedback.as_ref());
     let result_response_format = non_empty_message_format(messages.result_response.as_ref());
 

--- a/crates/generator-internal/src/generator/python/tests/actions.rs
+++ b/crates/generator-internal/src/generator/python/tests/actions.rs
@@ -113,6 +113,12 @@ pub(super) const SUBSCRIBED_ACTION_GOAL_FORMAT1: &str = r#"
 }
 "#;
 
+const SUBSCRIBED_ACTION_GOAL_RESPONSE_FORMAT: &str = r#"
+{
+  accepted: "bool"
+}
+"#;
+
 pub(super) const SUBSCRIBED_ACTION_FEEDBACK_FORMAT1: &str = r#"
 {
   new_position: {
@@ -204,21 +210,18 @@ fn exposed_action() {
         ],
     );
 
-    // GoalResponse: framework-owned goal acknowledgement dataclass with
-    // accept()/reject() staticmethods the decider returns.
+    // GoalResponse mirrors response_message_format exactly. GoalDecision
+    // controls framework acceptance independently and carries that payload in
+    // both branches.
     assert_contains_all(
         &rendered,
         &[
             "class GoalResponse:",
             "accepted: bool",
-            "def accept():",
-            "def reject():",
+            "class GoalDecision:",
+            "def accept(response):",
+            "def reject(response):",
         ],
-    );
-    assert_rendered!(
-        !rendered.contains("error_message"),
-        rendered,
-        "goal responses must not gain an undeclared error_message field"
     );
 
     // ActionHandle class
@@ -263,9 +266,10 @@ fn exposed_action() {
     assert_contains_all(
         &rendered,
         &[
-            "async def handle_goal_next_request(self, handler: Callable[[GoalRequest], GoalResponse]) -> \"GoalContext | None\":",
+            "async def handle_goal_next_request(self, handler: Callable[[GoalRequest], GoalDecision]) -> \"GoalContext | None\":",
             "pending = await self._inner.recv_next_goal()",
             "request = GoalRequest(instance_id=pending.instance_id, core_node=pending.core_node, data=request_data)",
+            "response = decision.response",
             "ctx = await pending.accept(response_bytes)",
             "return GoalContext(ctx, request)",
             "await pending.reject(response_bytes)",
@@ -303,14 +307,15 @@ fn expose_action_without_request_body() {
         .expect("artifact is present");
 
     // GoalRequest still exists (with metadata) even without request data. The
-    // framework GoalResponse (+ accept/reject) is always present.
+    // declared GoalResponse and framework GoalDecision remain present.
     assert_contains_all(
         &rendered,
         &[
             "class GoalRequest:",
             "class GoalResponse:",
-            "def accept():",
-            "def reject():",
+            "class GoalDecision:",
+            "def accept(response):",
+            "def reject(response):",
             "async def handle_goal_next_request(",
         ],
     );
@@ -459,6 +464,7 @@ fn consumed_action_with_link_id_splices_runtime_binding_target() {
         serde_json5::from_str(SUBSCRIBED_ACTION_GOAL_FORMAT1).unwrap();
     let format = ConsumedActionMessage {
         goal_request: Some(goal_request_format),
+        goal_response: Some(serde_json5::from_str(SUBSCRIBED_ACTION_GOAL_RESPONSE_FORMAT).unwrap()),
         feedback: None,
         result_response: None,
     };
@@ -492,6 +498,7 @@ fn consumed_action() {
         serde_json5::from_str(SUBSCRIBED_ACTION_RESULT_RESPONSE_FORMAT1).unwrap();
     let format = ConsumedActionMessage {
         goal_request: Some(goal_request_format),
+        goal_response: Some(serde_json5::from_str(SUBSCRIBED_ACTION_GOAL_RESPONSE_FORMAT).unwrap()),
         feedback: Some(feedback_format),
         result_response: Some(result_response_format),
     };
@@ -715,6 +722,7 @@ fn consumed_two_actions_same_node() {
         serde_json5::from_str(SUBSCRIBED_ACTION_RESULT_RESPONSE_FORMAT1).unwrap();
     let move_arm_messages = ConsumedActionMessage {
         goal_request: Some(move_arm_goal_request),
+        goal_response: Some(serde_json5::from_str(SUBSCRIBED_ACTION_GOAL_RESPONSE_FORMAT).unwrap()),
         feedback: Some(move_arm_feedback),
         result_response: Some(move_arm_result_response),
     };
@@ -728,6 +736,7 @@ fn consumed_two_actions_same_node() {
         serde_json5::from_str(SUBSCRIBED_ACTION_RESULT_RESPONSE_FORMAT2).unwrap();
     let rotate_messages = ConsumedActionMessage {
         goal_request: None,
+        goal_response: Some(serde_json5::from_str(SUBSCRIBED_ACTION_GOAL_RESPONSE_FORMAT).unwrap()),
         feedback: Some(rotate_feedback),
         result_response: Some(rotate_result_response),
     };
@@ -857,6 +866,7 @@ fn consumed_action_without_response_payload() {
 
     let format = ConsumedActionMessage {
         goal_request: Some(goal_request_format),
+        goal_response: None,
         feedback: Some(feedback_format),
         result_response: None,
     };
@@ -885,9 +895,13 @@ fn consumed_action_without_response_payload() {
         ],
     );
 
-    // The goal acknowledgement is framework-owned, so goal_response
-    // deserialization is always present even when the action declares none.
-    assert_contains_all(&rendered, &["def _deserialize_goal_response("]);
+    assert_rendered!(
+        !rendered.contains("GoalResponseData")
+            && !rendered.contains("_deserialize_goal_response")
+            && !rendered.contains("handle.data"),
+        &rendered,
+        "no goal-response API should be generated without response_message_format"
+    );
     // result_response is NOT framework-owned, so it stays absent here.
     assert_rendered!(
         !rendered.contains("def _deserialize_result_response"),
@@ -905,9 +919,8 @@ fn consumed_action_without_response_payload() {
     // ActionHandle class
     assert_contains_all(&rendered, &["class ActionHandle:"]);
 
-    // fire_goal should have serialization (goal_request exists). The goal
-    // acknowledgement is framework-owned, so GoalResponseData and handle.data
-    // are always present even when the action declares no goal response.
+    // fire_goal still serializes the declared goal request and returns a handle
+    // without response data.
     assert_contains_all(
         &rendered,
         &[
@@ -915,10 +928,7 @@ fn consumed_action_without_response_payload() {
             "handle = cls()",
             "handle._messenger = node_runner.messenger()",
             "handle._inner = action_handle",
-            "handle.data = goal_response_data",
             "return handle",
-            "class GoalResponseData:",
-            "accepted: bool",
         ],
     );
 
@@ -940,6 +950,7 @@ fn consumed_action_without_feedback() {
 
     let format = ConsumedActionMessage {
         goal_request: Some(goal_request_format),
+        goal_response: Some(serde_json5::from_str(SUBSCRIBED_ACTION_GOAL_RESPONSE_FORMAT).unwrap()),
         feedback: None,
         result_response: None,
     };

--- a/crates/generator-internal/src/generator/python/tests/actions.rs
+++ b/crates/generator-internal/src/generator/python/tests/actions.rs
@@ -205,16 +205,20 @@ fn exposed_action() {
     );
 
     // GoalResponse: framework-owned goal acknowledgement dataclass with
-    // accept()/reject(reason) staticmethods the decider returns.
+    // accept()/reject() staticmethods the decider returns.
     assert_contains_all(
         &rendered,
         &[
             "class GoalResponse:",
             "accepted: bool",
-            "error_message: Optional[str]",
             "def accept():",
-            "def reject(reason):",
+            "def reject():",
         ],
+    );
+    assert_rendered!(
+        !rendered.contains("error_message"),
+        rendered,
+        "goal responses must not gain an undeclared error_message field"
     );
 
     // ActionHandle class
@@ -306,7 +310,7 @@ fn expose_action_without_request_body() {
             "class GoalRequest:",
             "class GoalResponse:",
             "def accept():",
-            "def reject(reason):",
+            "def reject():",
             "async def handle_goal_next_request(",
         ],
     );

--- a/crates/generator-internal/src/generator/python/tests/topics.rs
+++ b/crates/generator-internal/src/generator/python/tests/topics.rs
@@ -848,6 +848,7 @@ fn no_user_facing_producer_identity_params() {
         serde_json5::from_str(super::actions::SUBSCRIBED_ACTION_RESULT_RESPONSE_FORMAT1).unwrap();
     let action_messages = ConsumedActionMessage {
         goal_request: Some(goal_request_format),
+        goal_response: None,
         feedback: Some(feedback_format),
         result_response: Some(result_response_format),
     };

--- a/crates/generator-internal/src/generator/rust.rs
+++ b/crates/generator-internal/src/generator/rust.rs
@@ -16,8 +16,7 @@ pub use parameters::{generate_parameters_struct, validate_parameter_schema};
 
 use super::types::{
     CapnpSchema, ConsumedActionMessage, ContractOrigin, DependencyContext, InterfaceArtifact,
-    InterfaceKind, LanguageGenerator, goal_action_response_format, non_empty_message_format,
-    scoped_schema_key,
+    InterfaceKind, LanguageGenerator, non_empty_message_format, scoped_schema_key,
 };
 use crate::error::{Error, Result};
 use crate::generator::naming::{
@@ -38,8 +37,8 @@ use std::path::Path;
 use actions::{
     build_action_expose_method, build_action_handle_struct, build_action_request_deserializer,
     build_goal_context_base_methods, build_goal_context_complete,
-    build_goal_context_publish_feedback, build_goal_context_struct,
-    build_goal_response_constructors, build_handle_goal_next_request,
+    build_goal_context_publish_feedback, build_goal_context_struct, build_goal_decision_enum,
+    build_handle_goal_next_request,
 };
 use context::{GenerationContext, collect_function_params, map_message_format};
 use deserialization::{build_deserialize_fn, deserialize_format_fields};
@@ -936,7 +935,7 @@ impl LanguageGenerator for RustGenerator {
         // publish_feedback and complete/complete_cancelled when applicable).
         let mut goal_context_methods: Vec<TokenStream> = Vec::new();
         let mut helper_tokens: Vec<TokenStream> = Vec::new();
-        // Free items (the GoalResponse constructors).
+        // Free items (the GoalDecision enum).
         let mut extra_items: Vec<TokenStream> = Vec::new();
 
         let action_name_literal = Literal::string(&action.name);
@@ -956,12 +955,10 @@ impl LanguageGenerator for RustGenerator {
                 &format!("{label}_request"),
                 goal_service.and_then(|goal| goal.request_message_format.as_ref()),
             )?;
-            // The goal acknowledgement is framework-owned ({accepted}); any
-            // goal response declared in the action schema is ignored. The
-            // decider returns GoalResponse::accept() / GoalResponse::reject().
-            let goal_response_format = goal_action_response_format();
-            let response_artifacts =
-                map_message_format(&format!("{label}_response"), Some(&goal_response_format))?;
+            let response_artifacts = map_message_format(
+                &format!("{label}_response"),
+                goal_service.and_then(|goal| goal.response_message_format.as_ref()),
+            )?;
 
             // Generates `GoalResponse` (+ `new`) when there is a response, and
             // returns the request params used to build `GoalRequestData`.
@@ -1013,29 +1010,35 @@ impl LanguageGenerator for RustGenerator {
                 helper_tokens.push(deserializer_fn);
             }
 
-            // The decider returns a framework `GoalResponse`
-            // (`accept()` / `reject()`).
-            extra_items.push(build_goal_response_constructors());
+            // The user closure returns this to accept or reject the goal.
+            extra_items.push(build_goal_decision_enum(response_artifacts.is_some()));
 
-            // Serialization for the `GoalResponse` (reads a local `response`).
-            // The goal response is framework-owned, so it is always present.
-            let return_artifacts = response_artifacts
-                .as_ref()
-                .expect("framework goal response format always yields artifacts");
-            let response_schema_prefix = format!("{schema_struct_prefix}Response");
-            let schema_key = scoped_schema_key(origin, &format!("{label}_response"));
-            let schema_info =
-                self.register_schema(&schema_key, &response_schema_prefix, return_artifacts)?;
-            let spec = ServiceResponseSpec {
-                format: return_artifacts.message_format(),
-                struct_ident: Ident::new("GoalResponse", Span::call_site()),
-                builder_type: schema_info.builder_type_tokens(),
-                include_service_instance_id: false,
+            // Serialization for the accepted/rejected `GoalResponse` (reads a
+            // local `response` variable). `None` when the goal has no response.
+            let response_serialization = if let Some(return_artifacts) = response_artifacts.as_ref()
+            {
+                let response_schema_prefix = format!("{schema_struct_prefix}Response");
+                let schema_key = scoped_schema_key(origin, &format!("{label}_response"));
+                let schema_info =
+                    self.register_schema(&schema_key, &response_schema_prefix, return_artifacts)?;
+                let spec = ServiceResponseSpec {
+                    format: return_artifacts.message_format(),
+                    struct_ident: Ident::new("GoalResponse", Span::call_site()),
+                    builder_type: schema_info.builder_type_tokens(),
+                    include_service_instance_id: false,
+                };
+                let response_ident = Ident::new("response", Span::call_site());
+                let error_context =
+                    quote!(format!("{} {}", "handle_goal_next_request", ACTION_NAME));
+                Some(build_response_payload_tokens(
+                    &spec,
+                    &response_ident,
+                    &error_context,
+                    None,
+                )?)
+            } else {
+                None
             };
-            let response_ident = Ident::new("response", Span::call_site());
-            let error_context = quote!(format!("{} {}", "handle_goal_next_request", ACTION_NAME));
-            let response_serialization =
-                build_response_payload_tokens(&spec, &response_ident, &error_context, None)?;
 
             action_handle_methods.push(build_handle_goal_next_request(
                 goal_request_data_struct.is_some(),
@@ -1610,18 +1613,25 @@ impl LanguageGenerator for RustGenerator {
         let node_name_literal = Literal::string(dependency_node_name);
         let action_name_literal = Literal::string(action.name.as_str());
         let link_id_literal = Literal::string(&dependency.link_id);
+
+        let goal_request_format = non_empty_message_format(messages.goal_request.as_ref());
+        let goal_response_format = non_empty_message_format(messages.goal_response.as_ref());
+        let feedback_format = non_empty_message_format(messages.feedback.as_ref());
+        let result_response_format = non_empty_message_format(messages.result_response.as_ref());
+        let target_node_name_constant = if goal_request_format.is_some()
+            || goal_response_format.is_some()
+            || feedback_format.is_some()
+            || result_response_format.is_some()
+        {
+            quote!(const TARGET_NODE_NAME: &str = #node_name_literal;)
+        } else {
+            TokenStream::new()
+        };
         let constants_tokens = quote! {
-            const TARGET_NODE_NAME: &str = #node_name_literal;
+            #target_node_name_constant
             const TARGET_ACTION_NAME: &str = #action_name_literal;
             const LINK_ID: &str = #link_id_literal;
         };
-
-        let goal_request_format = non_empty_message_format(messages.goal_request.as_ref());
-        // The goal acknowledgement is framework-owned ({accepted}).
-        let goal_response_fmt = goal_action_response_format();
-        let goal_response_format = Some(&goal_response_fmt);
-        let feedback_format = non_empty_message_format(messages.feedback.as_ref());
-        let result_response_format = non_empty_message_format(messages.result_response.as_ref());
 
         let (goal_method, mut goal_helpers, has_goal_response_data) = self
             .build_consumed_action_fire_goal_method(

--- a/crates/generator-internal/src/generator/rust.rs
+++ b/crates/generator-internal/src/generator/rust.rs
@@ -956,10 +956,9 @@ impl LanguageGenerator for RustGenerator {
                 &format!("{label}_request"),
                 goal_service.and_then(|goal| goal.request_message_format.as_ref()),
             )?;
-            // The goal acknowledgement is framework-owned ({accepted,
-            // error_message}); any goal response declared in the action schema
-            // is ignored. The decider returns GoalResponse::accept() /
-            // GoalResponse::reject(reason).
+            // The goal acknowledgement is framework-owned ({accepted}); any
+            // goal response declared in the action schema is ignored. The
+            // decider returns GoalResponse::accept() / GoalResponse::reject().
             let goal_response_format = goal_action_response_format();
             let response_artifacts =
                 map_message_format(&format!("{label}_response"), Some(&goal_response_format))?;
@@ -1015,7 +1014,7 @@ impl LanguageGenerator for RustGenerator {
             }
 
             // The decider returns a framework `GoalResponse`
-            // (`accept()` / `reject(reason)`).
+            // (`accept()` / `reject()`).
             extra_items.push(build_goal_response_constructors());
 
             // Serialization for the `GoalResponse` (reads a local `response`).
@@ -1618,7 +1617,7 @@ impl LanguageGenerator for RustGenerator {
         };
 
         let goal_request_format = non_empty_message_format(messages.goal_request.as_ref());
-        // The goal acknowledgement is framework-owned ({accepted, error_message}).
+        // The goal acknowledgement is framework-owned ({accepted}).
         let goal_response_fmt = goal_action_response_format();
         let goal_response_format = Some(&goal_response_fmt);
         let feedback_format = non_empty_message_format(messages.feedback.as_ref());

--- a/crates/generator-internal/src/generator/rust/actions.rs
+++ b/crates/generator-internal/src/generator/rust/actions.rs
@@ -52,22 +52,21 @@ pub fn build_action_expose_method(
 
 /// Framework constructors for the goal acknowledgement the decider returns.
 /// `accept()` admits the goal (the worker gets a `GoalContext`); `reject`
-/// declines it (no context) and carries the reason back to the client. This is
-/// how the user controls concurrency, e.g. rejecting a goal for a busy resource.
-/// The `accepted` flag is the single source of truth for the accept/reject
-/// decision and the value the client reads from `fire_goal`.
+/// declines it (no context). This is how the user controls concurrency, e.g.
+/// rejecting a goal for a busy resource. The `accepted` flag is the single
+/// source of truth for the accept/reject decision and the value the client
+/// reads from `fire_goal`.
 pub fn build_goal_response_constructors() -> TokenStream {
     quote! {
         impl GoalResponse {
             /// Accept the goal. The client sees `accepted == true`.
             pub fn accept() -> Self {
-                Self::new(true, None)
+                Self::new(true)
             }
 
-            /// Reject the goal, carrying the reason to the client (which sees
-            /// `accepted == false` and `error_message == Some(reason)`).
-            pub fn reject(reason: impl Into<String>) -> Self {
-                Self::new(false, Some(reason.into()))
+            /// Reject the goal. The client sees `accepted == false`.
+            pub fn reject() -> Self {
+                Self::new(false)
             }
         }
     }
@@ -75,7 +74,7 @@ pub fn build_goal_response_constructors() -> TokenStream {
 
 /// `handle_goal_next_request`: returns the next *accepted* goal as a
 /// `GoalContext`. The user decider runs on each incoming goal and returns a
-/// `GoalResponse` (`GoalResponse::accept()` / `GoalResponse::reject(reason)`);
+/// `GoalResponse` (`GoalResponse::accept()` / `GoalResponse::reject()`);
 /// the framework `accepted` flag decides whether the goal is admitted. Rejected
 /// goals are answered and skipped transparently (the method keeps polling), so a
 /// returned `Ok(None)` means the goal stream has closed (the node is shutting

--- a/crates/generator-internal/src/generator/rust/actions.rs
+++ b/crates/generator-internal/src/generator/rust/actions.rs
@@ -50,41 +50,40 @@ pub fn build_action_expose_method(
     }
 }
 
-/// Framework constructors for the goal acknowledgement the decider returns.
-/// `accept()` admits the goal (the worker gets a `GoalContext`); `reject`
-/// declines it (no context). This is how the user controls concurrency, e.g.
-/// rejecting a goal for a busy resource. The `accepted` flag is the single
-/// source of truth for the accept/reject decision and the value the client
-/// reads from `fire_goal`.
-pub fn build_goal_response_constructors() -> TokenStream {
-    quote! {
-        impl GoalResponse {
-            /// Accept the goal. The client sees `accepted == true`.
-            pub fn accept() -> Self {
-                Self::new(true)
+/// The framework decision returned by a goal handler. Accept and reject both
+/// carry the declared `GoalResponse` when one exists, keeping control flow
+/// independent of the response payload's fields.
+pub fn build_goal_decision_enum(has_response: bool) -> TokenStream {
+    if has_response {
+        quote! {
+            #[allow(dead_code)]
+            pub enum GoalDecision {
+                Accept(GoalResponse),
+                Reject(GoalResponse),
             }
-
-            /// Reject the goal. The client sees `accepted == false`.
-            pub fn reject() -> Self {
-                Self::new(false)
+        }
+    } else {
+        quote! {
+            #[allow(dead_code)]
+            pub enum GoalDecision {
+                Accept,
+                Reject,
             }
         }
     }
 }
 
 /// `handle_goal_next_request`: returns the next *accepted* goal as a
-/// `GoalContext`. The user decider runs on each incoming goal and returns a
-/// `GoalResponse` (`GoalResponse::accept()` / `GoalResponse::reject()`);
-/// the framework `accepted` flag decides whether the goal is admitted. Rejected
-/// goals are answered and skipped transparently (the method keeps polling), so a
+/// `GoalContext`. The user decider runs on each incoming goal; rejected goals
+/// are answered and skipped transparently (the method keeps polling), so a
 /// returned `Ok(None)` means the goal stream has closed (the node is shutting
 /// down) and the caller should stop its accept loop. Errors propagate as `Err`.
 ///
-/// `response_serialization` serializes a local `response` (`GoalResponse`) into
-/// a `peppylib::Payload`.
+/// `response_serialization`, when present, serializes a local `response`
+/// (`GoalResponse`) into a `peppylib::Payload`.
 pub fn build_handle_goal_next_request(
     has_request_data: bool,
-    response_serialization: TokenStream,
+    response_serialization: Option<TokenStream>,
 ) -> TokenStream {
     let decode_and_build_request = if has_request_data {
         quote! {
@@ -104,13 +103,51 @@ pub fn build_handle_goal_next_request(
         }
     };
 
+    let (accept_arm, reject_arm) = match response_serialization {
+        Some(serialize) => {
+            let serialize_reject = serialize.clone();
+            (
+                quote! {
+                    GoalDecision::Accept(response) => {
+                        let response_payload = #serialize;
+                        let inner = pending.accept(response_payload).await?;
+                        return Ok(Some(GoalContext { inner, request }));
+                    }
+                },
+                quote! {
+                    // Rejected: answer the client and keep polling for the
+                    // next goal. A reject never ends the accept loop.
+                    GoalDecision::Reject(response) => {
+                        let response_payload = #serialize_reject;
+                        pending.reject(response_payload).await?;
+                    }
+                },
+            )
+        }
+        None => (
+            quote! {
+                GoalDecision::Accept => {
+                    let inner = pending.accept(peppylib::Payload::new()).await?;
+                    return Ok(Some(GoalContext { inner, request }));
+                }
+            },
+            quote! {
+                // Rejected: answer the client and keep polling for the next
+                // goal. A reject never ends the accept loop.
+                GoalDecision::Reject => {
+                    pending.reject(peppylib::Payload::new()).await?;
+                }
+            },
+        ),
+    };
+
     quote! {
         pub async fn handle_goal_next_request<F>(
             &mut self,
             decider: F,
         ) -> crate::Result<Option<GoalContext>>
         where
-            F: Fn(&GoalRequest) -> crate::Result<GoalResponse>,
+            F: Fn(&GoalRequest) -> crate::Result<GoalDecision>,
         {
             loop {
                 let Some(pending) = self.inner.recv_next_goal().await? else {
@@ -118,16 +155,10 @@ pub fn build_handle_goal_next_request(
                     return Ok(None);
                 };
                 #decode_and_build_request
-                let response = decider(&request)?;
-                let accepted = response.accepted;
-                let response_payload = #response_serialization;
-                if accepted {
-                    let inner = pending.accept(response_payload).await?;
-                    return Ok(Some(GoalContext { inner, request }));
+                match decider(&request)? {
+                    #accept_arm
+                    #reject_arm
                 }
-                // Rejected: answer the client and keep polling for the next
-                // goal. A reject never ends the accept loop.
-                pending.reject(response_payload).await?;
             }
         }
     }

--- a/crates/generator-internal/src/generator/rust/tests/actions.rs
+++ b/crates/generator-internal/src/generator/rust/tests/actions.rs
@@ -142,6 +142,12 @@ pub(super) const SUBSCRIBED_ACTION_GOAL_FORMAT1: &str = r#"
 }
 "#;
 
+const SUBSCRIBED_ACTION_GOAL_RESPONSE_FORMAT: &str = r#"
+{
+  accepted: "bool"
+}
+"#;
+
 pub(super) const SUBSCRIBED_ACTION_FEEDBACK_FORMAT1: &str = r#"
 {
   new_position: {
@@ -227,23 +233,18 @@ fn exposed_action() {
         ],
     );
 
-    // GoalResponse struct: framework-owned goal acknowledgement ({accepted})
-    // with its `new` constructor and the accept/reject helpers the decider
-    // returns.
+    // GoalResponse mirrors the declared response_message_format exactly. The
+    // framework decision is a separate enum whose branches both carry it.
     assert_contains_all(
         &rendered,
         &[
             "pub struct GoalResponse",
             "impl GoalResponse",
             "pub fn new(accepted: bool) -> Self",
-            "pub fn accept() -> Self",
-            "pub fn reject() -> Self",
+            "pub enum GoalDecision",
+            "Accept(GoalResponse)",
+            "Reject(GoalResponse)",
         ],
-    );
-    assert_rendered!(
-        !rendered.contains("error_message"),
-        rendered,
-        "goal responses must not gain an undeclared error_message field"
     );
 
     // ActionHandle wraps the concurrent-action engine.
@@ -264,15 +265,20 @@ fn exposed_action() {
         ],
     );
 
-    // handle_goal_next_request returns a per-goal GoalContext (or None when
-    // rejected / the stream closed).
+    // handle_goal_next_request returns a per-goal GoalContext. Rejected goals
+    // send their declared response and are skipped; None means the stream
+    // closed.
     assert_contains_all(
         &rendered,
         &[
             "pub async fn handle_goal_next_request",
-            "F: Fn(&GoalRequest) -> crate::Result<GoalResponse>",
+            "F: Fn(&GoalRequest) -> crate::Result<GoalDecision>",
             "crate::Result<Option<GoalContext>>",
             "recv_next_goal",
+            "GoalDecision::Accept(response)",
+            "pending.accept(response_payload).await?",
+            "GoalDecision::Reject(response)",
+            "pending.reject(response_payload).await?",
         ],
     );
 
@@ -310,16 +316,18 @@ fn expose_action_without_request_body() {
         .expect("artifact is present");
 
     // GoalRequest still exists (with instance_id and core_node) even without
-    // data. The framework GoalResponse (+ accept/reject) is always present.
+    // data. The declared GoalResponse and framework GoalDecision remain
+    // present.
     assert_contains_all(
         &rendered,
         &[
             "pub struct GoalRequest",
             "pub struct GoalResponse",
-            "pub fn accept() -> Self",
-            "pub fn reject() -> Self",
+            "pub enum GoalDecision",
+            "Accept(GoalResponse)",
+            "Reject(GoalResponse)",
             "pub async fn handle_goal_next_request",
-            "F: Fn(&GoalRequest) -> crate::Result<GoalResponse>",
+            "F: Fn(&GoalRequest) -> crate::Result<GoalDecision>",
         ],
     );
     // No request data → GoalRequest has no `data` field and no deserializer.
@@ -408,17 +416,18 @@ fn expose_feedback_only_action() {
             "pub async fn expose(node_runner: &crate::NodeRunner) -> crate::Result<Self>",
             "peppylib::messaging::ConcurrentAction::expose",
             "pub async fn handle_goal_next_request",
-            "pub struct GoalResponse",
+            "pub enum GoalDecision",
+            "Accept",
+            "Reject",
             "pub struct GoalContext",
             "pub async fn publish_feedback",
         ],
     );
 
-    // The goal acknowledgement is framework-owned, so even a feedback-only
-    // action gets the GoalResponse accept/reject helpers.
-    assert_contains_all(
-        &rendered,
-        &["pub fn accept() -> Self", "pub fn reject() -> Self"],
+    assert_rendered!(
+        !rendered.contains("pub struct GoalResponse"),
+        rendered,
+        "an action without response_message_format has no GoalResponse payload"
     );
     // No result service → no completion methods.
     assert_rendered!(
@@ -475,7 +484,7 @@ fn expose_two_actions() {
         rotate_servo,
         &[
             "pub async fn handle_goal_next_request",
-            "F: Fn(&GoalRequest) -> crate::Result<GoalResponse>",
+            "F: Fn(&GoalRequest) -> crate::Result<GoalDecision>",
             "pub struct GoalResponse",
             "pub async fn complete",
             "pub async fn publish_feedback",
@@ -495,6 +504,7 @@ fn consumed_action() {
         serde_json5::from_str(SUBSCRIBED_ACTION_RESULT_RESPONSE_FORMAT1).unwrap();
     let format = ConsumedActionMessage {
         goal_request: Some(goal_request_format),
+        goal_response: Some(serde_json5::from_str(SUBSCRIBED_ACTION_GOAL_RESPONSE_FORMAT).unwrap()),
         feedback: Some(feedback_format),
         result_response: Some(result_response_format),
     };
@@ -677,6 +687,7 @@ fn consumed_two_actions_same_node() {
         serde_json5::from_str(SUBSCRIBED_ACTION_RESULT_RESPONSE_FORMAT1).unwrap();
     let move_arm_messages = ConsumedActionMessage {
         goal_request: Some(move_arm_goal_request),
+        goal_response: Some(serde_json5::from_str(SUBSCRIBED_ACTION_GOAL_RESPONSE_FORMAT).unwrap()),
         feedback: Some(move_arm_feedback),
         result_response: Some(move_arm_result_response),
     };
@@ -690,6 +701,7 @@ fn consumed_two_actions_same_node() {
         serde_json5::from_str(SUBSCRIBED_ACTION_RESULT_RESPONSE_FORMAT2).unwrap();
     let rotate_messages = ConsumedActionMessage {
         goal_request: None,
+        goal_response: Some(serde_json5::from_str(SUBSCRIBED_ACTION_GOAL_RESPONSE_FORMAT).unwrap()),
         feedback: Some(rotate_feedback),
         result_response: Some(rotate_result_response),
     };
@@ -832,6 +844,7 @@ fn consumed_action_with_link_id_splices_runtime_binding_target() {
         serde_json5::from_str(SUBSCRIBED_ACTION_GOAL_FORMAT1).unwrap();
     let format = ConsumedActionMessage {
         goal_request: Some(goal_request_format),
+        goal_response: Some(serde_json5::from_str(SUBSCRIBED_ACTION_GOAL_RESPONSE_FORMAT).unwrap()),
         feedback: None,
         result_response: None,
     };
@@ -869,6 +882,7 @@ fn consumed_action_without_response_payload() {
 
     let format = ConsumedActionMessage {
         goal_request: Some(goal_request_format),
+        goal_response: None,
         feedback: Some(feedback_format),
         result_response: None,
     };
@@ -886,25 +900,27 @@ fn consumed_action_without_response_payload() {
     );
     let rendered = artifacts.into_iter().next().expect("artifact is present");
 
-    // The goal acknowledgement is framework-owned, so GoalResponseData and the
-    // `pub data` field are always present even when the action declares no goal
-    // response format.
+    // No declared goal response means the client handle carries no response
+    // data and needs no goal-response deserializer.
     assert_contains_all(
         &rendered,
         &[
             "pub struct ActionHandle",
             "messenger: peppylib::MessengerHandle",
             "inner: peppylib::messaging::ActionGoalHandle",
-            "pub data: GoalResponseData",
             "impl ActionHandle",
             "pub async fn fire_goal",
             "pub async fn get_result",
             "peppylib::ActionMessenger::send_goal",
             "peppylib::ActionMessenger::request_result",
-            "pub struct GoalResponseData",
-            "pub accepted: bool",
-            "fn deserialize_goal_response",
         ],
+    );
+    assert_rendered!(
+        !rendered.contains("GoalResponseData")
+            && !rendered.contains("pub data:")
+            && !rendered.contains("deserialize_goal_response"),
+        rendered,
+        "no goal-response API should be generated without response_message_format"
     );
 }
 
@@ -916,6 +932,7 @@ fn consumed_action_without_feedback() {
 
     let format = ConsumedActionMessage {
         goal_request: Some(goal_request_format),
+        goal_response: Some(serde_json5::from_str(SUBSCRIBED_ACTION_GOAL_RESPONSE_FORMAT).unwrap()),
         feedback: None,
         result_response: None,
     };
@@ -975,6 +992,7 @@ fn clippy_single_exposed_action_empty_goal_request() {
         serde_json5::from_str(SUBSCRIBED_ACTION_RESULT_RESPONSE_FORMAT1).unwrap();
     let consumed_action1_messages = ConsumedActionMessage {
         goal_request: Some(consumed_action1_goal_request),
+        goal_response: Some(serde_json5::from_str(SUBSCRIBED_ACTION_GOAL_RESPONSE_FORMAT).unwrap()),
         feedback: Some(consumed_action1_feedback),
         result_response: Some(consumed_action1_result_response),
     };
@@ -987,6 +1005,7 @@ fn clippy_single_exposed_action_empty_goal_request() {
         serde_json5::from_str(SUBSCRIBED_ACTION_RESULT_RESPONSE_FORMAT2).unwrap();
     let consumed_action2_messages = ConsumedActionMessage {
         goal_request: None,
+        goal_response: Some(serde_json5::from_str(SUBSCRIBED_ACTION_GOAL_RESPONSE_FORMAT).unwrap()),
         feedback: Some(consumed_action2_feedback),
         result_response: Some(consumed_action2_result_response),
     };
@@ -1058,6 +1077,7 @@ fn compile_lib_with_exposed_and_consumed_actions() {
         serde_json5::from_str(SUBSCRIBED_ACTION_RESULT_RESPONSE_FORMAT1).unwrap();
     let consumed_action1_messages = ConsumedActionMessage {
         goal_request: Some(consumed_action1_goal_request),
+        goal_response: Some(serde_json5::from_str(SUBSCRIBED_ACTION_GOAL_RESPONSE_FORMAT).unwrap()),
         feedback: Some(consumed_action1_feedback),
         result_response: Some(consumed_action1_result_response),
     };
@@ -1070,6 +1090,7 @@ fn compile_lib_with_exposed_and_consumed_actions() {
         serde_json5::from_str(SUBSCRIBED_ACTION_RESULT_RESPONSE_FORMAT2).unwrap();
     let consumed_action2_messages = ConsumedActionMessage {
         goal_request: None,
+        goal_response: Some(serde_json5::from_str(SUBSCRIBED_ACTION_GOAL_RESPONSE_FORMAT).unwrap()),
         feedback: Some(consumed_action2_feedback),
         result_response: Some(consumed_action2_result_response),
     };
@@ -1182,6 +1203,7 @@ fn clippy_consumed_action_empty_goal_request() {
     .unwrap();
     let action_messages = ConsumedActionMessage {
         goal_request: None,
+        goal_response: Some(serde_json5::from_str(SUBSCRIBED_ACTION_GOAL_RESPONSE_FORMAT).unwrap()),
         feedback: None,
         result_response: None,
     };

--- a/crates/generator-internal/src/generator/rust/tests/actions.rs
+++ b/crates/generator-internal/src/generator/rust/tests/actions.rs
@@ -227,18 +227,23 @@ fn exposed_action() {
         ],
     );
 
-    // GoalResponse struct: framework-owned goal acknowledgement
-    // ({accepted, error_message}) with its `new` constructor and the
-    // accept/reject helpers the decider returns.
+    // GoalResponse struct: framework-owned goal acknowledgement ({accepted})
+    // with its `new` constructor and the accept/reject helpers the decider
+    // returns.
     assert_contains_all(
         &rendered,
         &[
             "pub struct GoalResponse",
             "impl GoalResponse",
-            "pub fn new(accepted: bool, error_message: Option<String>) -> Self",
+            "pub fn new(accepted: bool) -> Self",
             "pub fn accept() -> Self",
-            "pub fn reject(reason: impl Into<String>) -> Self",
+            "pub fn reject() -> Self",
         ],
+    );
+    assert_rendered!(
+        !rendered.contains("error_message"),
+        rendered,
+        "goal responses must not gain an undeclared error_message field"
     );
 
     // ActionHandle wraps the concurrent-action engine.
@@ -312,7 +317,7 @@ fn expose_action_without_request_body() {
             "pub struct GoalRequest",
             "pub struct GoalResponse",
             "pub fn accept() -> Self",
-            "pub fn reject(reason: impl Into<String>) -> Self",
+            "pub fn reject() -> Self",
             "pub async fn handle_goal_next_request",
             "F: Fn(&GoalRequest) -> crate::Result<GoalResponse>",
         ],
@@ -413,10 +418,7 @@ fn expose_feedback_only_action() {
     // action gets the GoalResponse accept/reject helpers.
     assert_contains_all(
         &rendered,
-        &[
-            "pub fn accept() -> Self",
-            "pub fn reject(reason: impl Into<String>) -> Self",
-        ],
+        &["pub fn accept() -> Self", "pub fn reject() -> Self"],
     );
     // No result service → no completion methods.
     assert_rendered!(

--- a/crates/generator-internal/src/generator/rust/tests/services.rs
+++ b/crates/generator-internal/src/generator/rust/tests/services.rs
@@ -511,6 +511,7 @@ fn clippy_single_exposed_service_without_request_body() {
     .unwrap();
     let action_messages = ConsumedActionMessage {
         goal_request: None,
+        goal_response: None,
         feedback: None,
         result_response: None,
     };

--- a/crates/generator-internal/src/generator/rust/tests/topics.rs
+++ b/crates/generator-internal/src/generator/rust/tests/topics.rs
@@ -750,6 +750,7 @@ fn clippy_single_emitted_topic_empty_format() {
     .unwrap();
     let action_messages = ConsumedActionMessage {
         goal_request: None,
+        goal_response: None,
         feedback: None,
         result_response: None,
     };
@@ -908,6 +909,7 @@ fn no_user_facing_producer_identity_params() {
         serde_json5::from_str(super::actions::SUBSCRIBED_ACTION_RESULT_RESPONSE_FORMAT1).unwrap();
     let action_messages = ConsumedActionMessage {
         goal_request: Some(goal_request_format),
+        goal_response: None,
         feedback: Some(feedback_format),
         result_response: Some(result_response_format),
     };

--- a/crates/generator-internal/src/generator/types.rs
+++ b/crates/generator-internal/src/generator/types.rs
@@ -23,13 +23,14 @@ pub enum InterfaceKind {
     ObservedTopic,
 }
 
-/// The message formats a consumer needs to talk to a producer's action: the goal request, the
-/// feedback topic format, and the result response. The goal acknowledgement is framework-owned
-/// (see [`goal_action_response_format`]) and there is no result-request wire message, so neither
-/// is carried here.
+/// The message formats a consumer needs to talk to a producer's action.
+///
+/// There is no result-request wire message, so only the goal request/response,
+/// feedback, and result response formats are carried here.
 #[derive(Debug, Clone)]
 pub struct ConsumedActionMessage {
     pub goal_request: Option<MessageFormat>,
+    pub goal_response: Option<MessageFormat>,
     pub feedback: Option<MessageFormat>,
     pub result_response: Option<MessageFormat>,
 }
@@ -712,17 +713,6 @@ pub fn validate_message_format_field_names(format: &MessageFormat, context: &str
         context
     };
     validate_field_map(format.0.iter(), "", normalized_context)
-}
-
-/// Returns the framework-owned goal-action response format used by both generators.
-///
-/// The goal acknowledgement is framework-owned (not declared by the action
-/// schema): every goal response contains only `accepted: bool`. Distinct from
-/// the cancel-ack format, which carries a typed `state`.
-pub fn goal_action_response_format() -> MessageFormat {
-    let mut fields = IndexMap::new();
-    fields.insert(String::from("accepted"), SchemaType::Type(TypeToken::Bool));
-    MessageFormat(fields)
 }
 
 /// Validates that generated type names for nested objects and array-of-object items

--- a/crates/generator-internal/src/generator/types.rs
+++ b/crates/generator-internal/src/generator/types.rs
@@ -3,7 +3,7 @@ use crate::generator::common::CrateDeployMode;
 use crate::generator::naming::{array_item_type_name, to_camel_case};
 use config::node::{
     Cardinality, ConsumedAction, ConsumedService, ConsumedTopic, MessageFormat, NativeEmittedTopic,
-    NativeExposedAction, NativeExposedService, PrimitiveSchema, SchemaType, TypeToken,
+    NativeExposedAction, NativeExposedService, SchemaType, TypeToken,
 };
 use daemon_config::consts::PeppyDirs;
 use indexmap::IndexMap;
@@ -714,25 +714,14 @@ pub fn validate_message_format_field_names(format: &MessageFormat, context: &str
     validate_field_map(format.0.iter(), "", normalized_context)
 }
 
-/// Returns the hardcoded goal-action response format used by both Rust and Python generators.
+/// Returns the framework-owned goal-action response format used by both generators.
 ///
 /// The goal acknowledgement is framework-owned (not declared by the action
-/// schema): every goal response is `accepted: bool` plus an optional
-/// `error_message: Optional[String]` carrying the rejection reason. The
-/// generated `GoalResponse::accept()` / `GoalResponse::reject(reason)`
-/// constructors produce it. Distinct from the cancel-ack format (which now
-/// carries a typed `state` instead), so `fire_goal`'s accept/reject wire is
-/// unchanged.
+/// schema): every goal response contains only `accepted: bool`. Distinct from
+/// the cancel-ack format, which carries a typed `state`.
 pub fn goal_action_response_format() -> MessageFormat {
     let mut fields = IndexMap::new();
     fields.insert(String::from("accepted"), SchemaType::Type(TypeToken::Bool));
-    fields.insert(
-        String::from("error_message"),
-        SchemaType::Primitive(PrimitiveSchema {
-            kind: TypeToken::String,
-            optional: true,
-        }),
-    );
     MessageFormat(fields)
 }
 

--- a/crates/generator-internal/tests/helpers.rs
+++ b/crates/generator-internal/tests/helpers.rs
@@ -1165,6 +1165,12 @@ pub const CONSUMED_ACTION_GOAL_FORMAT: &str = r#"
 }
 "#;
 
+pub const CONSUMED_ACTION_GOAL_RESPONSE_FORMAT: &str = r#"
+{
+  accepted: "bool"
+}
+"#;
+
 pub const TOPIC_DEDUP_SHARED_FORMAT: &str = r#"{
   positions: { $type: "array", $items: "f64", $length: 3 },
   velocities: { $type: "array", $items: "f64", $length: 3 },

--- a/crates/generator-internal/tests/python/actions_communication.rs
+++ b/crates/generator-internal/tests/python/actions_communication.rs
@@ -1,6 +1,7 @@
 use crate::helpers::{
-    CONSUMED_ACTION_FEEDBACK_FORMAT, CONSUMED_ACTION_GOAL_FORMAT, CONSUMED_ACTION_RESULT_FORMAT,
-    EXPOSED_ACTION_EXAMPLE, bind_slot, python_consumer_stub_node_config,
+    CONSUMED_ACTION_FEEDBACK_FORMAT, CONSUMED_ACTION_GOAL_FORMAT,
+    CONSUMED_ACTION_GOAL_RESPONSE_FORMAT, CONSUMED_ACTION_RESULT_FORMAT, EXPOSED_ACTION_EXAMPLE,
+    bind_slot, python_consumer_stub_node_config,
 };
 use crate::helpers::{
     CapturedChild, DEFAULT_WAIT_TIMEOUT, STUB_PYTHON_NODE_CONFIG, WaitContext,
@@ -94,6 +95,7 @@ async fn actions_communication(#[case] topology: crate::helpers::LocalNodesTopol
         serde_json5::from_str(CONSUMED_ACTION_RESULT_FORMAT).unwrap();
     let action_messages = ConsumedActionMessage {
         goal_request: Some(goal_request_format),
+        goal_response: Some(serde_json5::from_str(CONSUMED_ACTION_GOAL_RESPONSE_FORMAT).unwrap()),
         feedback: Some(feedback_format),
         result_response: Some(result_response_format),
     };
@@ -232,7 +234,7 @@ async def run_exposer(node_runner):
             f"server received goal arm_id={request.data.arm_id} desired={request.data.desired_position}",
             flush=True,
         )
-        return move_arm.GoalResponse.accept()
+        return move_arm.GoalDecision.accept(move_arm.GoalResponse(True))
 
     while True:
         ctx = await action.handle_goal_next_request(goal_handler)
@@ -437,6 +439,7 @@ async fn actions_communication_cancel_goal(#[case] topology: crate::helpers::Loc
         serde_json5::from_str(CONSUMED_ACTION_RESULT_FORMAT).unwrap();
     let action_messages = ConsumedActionMessage {
         goal_request: Some(goal_request_format),
+        goal_response: Some(serde_json5::from_str(CONSUMED_ACTION_GOAL_RESPONSE_FORMAT).unwrap()),
         feedback: Some(feedback_format),
         result_response: Some(result_response_format),
     };
@@ -571,7 +574,7 @@ async def run_exposer(node_runner):
             f"server received goal arm_id={request.data.arm_id} desired={request.data.desired_position}",
             flush=True,
         )
-        return move_arm.GoalResponse.accept()
+        return move_arm.GoalDecision.accept(move_arm.GoalResponse(True))
 
     while True:
         ctx = await action.handle_goal_next_request(goal_handler)
@@ -764,6 +767,7 @@ async fn actions_communication_async_goal_decider(
         serde_json5::from_str(CONSUMED_ACTION_RESULT_FORMAT).unwrap();
     let action_messages = ConsumedActionMessage {
         goal_request: Some(goal_request_format),
+        goal_response: Some(serde_json5::from_str(CONSUMED_ACTION_GOAL_RESPONSE_FORMAT).unwrap()),
         feedback: Some(feedback_format),
         result_response: Some(result_response_format),
     };
@@ -906,7 +910,7 @@ async def run_exposer(node_runner):
             f"server received goal arm_id={request.data.arm_id} desired={request.data.desired_position}",
             flush=True,
         )
-        return move_arm.GoalResponse.accept()
+        return move_arm.GoalDecision.accept(move_arm.GoalResponse(True))
 
     while True:
         ctx = await action.handle_goal_next_request(goal_handler)
@@ -1118,6 +1122,7 @@ async fn actions_communication_cancel_accept_closes_feedback_stream(
         serde_json5::from_str(CONSUMED_ACTION_RESULT_FORMAT).unwrap();
     let action_messages = ConsumedActionMessage {
         goal_request: Some(goal_request_format),
+        goal_response: Some(serde_json5::from_str(CONSUMED_ACTION_GOAL_RESPONSE_FORMAT).unwrap()),
         feedback: Some(feedback_format),
         result_response: Some(result_response_format),
     };
@@ -1256,7 +1261,7 @@ async def run_exposer(node_runner):
     action = await move_arm.ActionHandle.expose(node_runner)
 
     def goal_handler(_request):
-        return move_arm.GoalResponse.accept()
+        return move_arm.GoalDecision.accept(move_arm.GoalResponse(True))
 
     while True:
         ctx = await action.handle_goal_next_request(goal_handler)
@@ -1483,6 +1488,7 @@ async fn actions_communication_cancel_reject_keeps_feedback_open(
         serde_json5::from_str(CONSUMED_ACTION_RESULT_FORMAT).unwrap();
     let action_messages = ConsumedActionMessage {
         goal_request: Some(goal_request_format),
+        goal_response: Some(serde_json5::from_str(CONSUMED_ACTION_GOAL_RESPONSE_FORMAT).unwrap()),
         feedback: Some(feedback_format),
         result_response: Some(result_response_format),
     };
@@ -1631,7 +1637,7 @@ async def run_exposer(node_runner):
     action = await move_arm.ActionHandle.expose(node_runner)
 
     def goal_handler(_request):
-        return move_arm.GoalResponse.accept()
+        return move_arm.GoalDecision.accept(move_arm.GoalResponse(True))
 
     while True:
         ctx = await action.handle_goal_next_request(goal_handler)
@@ -1870,6 +1876,7 @@ async fn actions_communication_drain_loop_until_end_signal(
         serde_json5::from_str(CONSUMED_ACTION_RESULT_FORMAT).unwrap();
     let action_messages = ConsumedActionMessage {
         goal_request: Some(goal_request_format),
+        goal_response: Some(serde_json5::from_str(CONSUMED_ACTION_GOAL_RESPONSE_FORMAT).unwrap()),
         feedback: Some(feedback_format),
         result_response: Some(result_response_format),
     };
@@ -2014,7 +2021,7 @@ async def run_exposer(node_runner):
     action = await move_arm.ActionHandle.expose(node_runner)
 
     def goal_handler(_request):
-        return move_arm.GoalResponse.accept()
+        return move_arm.GoalDecision.accept(move_arm.GoalResponse(True))
 
     while True:
         ctx = await action.handle_goal_next_request(goal_handler)
@@ -2229,6 +2236,7 @@ async fn actions_communication_producer_killed_yields_connection_error_and_aband
         serde_json5::from_str(CONSUMED_ACTION_RESULT_FORMAT).unwrap();
     let action_messages = ConsumedActionMessage {
         goal_request: Some(goal_request_format),
+        goal_response: Some(serde_json5::from_str(CONSUMED_ACTION_GOAL_RESPONSE_FORMAT).unwrap()),
         feedback: Some(feedback_format),
         result_response: Some(result_response_format),
     };
@@ -2373,7 +2381,7 @@ async def run_exposer(node_runner):
     action = await move_arm.ActionHandle.expose(node_runner)
 
     def goal_handler(_request):
-        return move_arm.GoalResponse.accept()
+        return move_arm.GoalDecision.accept(move_arm.GoalResponse(True))
 
     while True:
         ctx = await action.handle_goal_next_request(goal_handler)

--- a/crates/generator-internal/tests/python/actions_implements.rs
+++ b/crates/generator-internal/tests/python/actions_implements.rs
@@ -116,17 +116,29 @@ fn nests_contract_backed_actions_under_link_id() {
         native_src.contains("peppylib.SenderTarget.node("),
         "native leaf should pass `peppylib.SenderTarget.node(...)`:\n{native_src}",
     );
+    assert!(
+        native_src.contains("native_marker") && native_src.contains("native_marker_ack"),
+        "native source should carry its declared request and response fields",
+    );
 
     let arm_v1_src = fs::read_to_string(&arm_v1).expect("read arm v1");
     assert!(
         arm_v1_src.contains("peppylib.SenderTarget.contract(\"arm\", \"v1\")"),
         "arm v1 leaf should pass `SenderTarget.contract(\"arm\", \"v1\")`:\n{arm_v1_src}",
     );
+    assert!(
+        arm_v1_src.contains("arm_v1_marker") && arm_v1_src.contains("arm_v1_marker_ack"),
+        "arm v1 source should carry its declared request and response fields",
+    );
 
     let arm_v2_src = fs::read_to_string(&arm_v2).expect("read arm v2");
     assert!(
         arm_v2_src.contains("peppylib.SenderTarget.contract(\"arm\", \"v2\")"),
         "arm v2 leaf should pass `SenderTarget.contract(\"arm\", \"v2\")`:\n{arm_v2_src}",
+    );
+    assert!(
+        arm_v2_src.contains("arm_v2_marker") && arm_v2_src.contains("arm_v2_marker_ack"),
+        "arm v2 source should carry its declared request and response fields",
     );
 
     // Capnp schemas are resolved via `importlib.resources.files("peppygen")`,

--- a/crates/generator-internal/tests/python/generate_lib.rs
+++ b/crates/generator-internal/tests/python/generate_lib.rs
@@ -653,6 +653,19 @@ fn generate_peppygen_python_lib_exposed_and_consumed_actions() {
         "exposed action module should exist in peppygen package at {}",
         exposed_peppygen_dir.display()
     );
+    let goal_response_schema = fs::read_to_string(
+        exposed_peppygen_dir.join("peppygen/capnp/test_action_goal_response_message.capnp"),
+    )
+    .expect("failed to read exposed action goal response schema");
+    assert!(
+        goal_response_schema.contains("accepted @0 :Bool;"),
+        "goal response schema should contain the declared accepted field:\n{goal_response_schema}"
+    );
+    assert!(
+        !goal_response_schema.contains("errorMessage"),
+        "goal response schema must not gain an undeclared errorMessage field:\n\
+         {goal_response_schema}"
+    );
 
     let consumer_dir =
         TempDir::new_in(crate::helpers::test_tmp_root()).expect("failed to create temp directory");

--- a/crates/generator-internal/tests/python/generate_lib.rs
+++ b/crates/generator-internal/tests/python/generate_lib.rs
@@ -661,10 +661,15 @@ fn generate_peppygen_python_lib_exposed_and_consumed_actions() {
         goal_response_schema.contains("accepted @0 :Bool;"),
         "goal response schema should contain the declared accepted field:\n{goal_response_schema}"
     );
-    assert!(
-        !goal_response_schema.contains("errorMessage"),
-        "goal response schema must not gain an undeclared errorMessage field:\n\
-         {goal_response_schema}"
+    let goal_response_fields: Vec<_> = goal_response_schema
+        .lines()
+        .map(str::trim)
+        .filter(|line| line.contains(" @"))
+        .collect();
+    assert_eq!(
+        goal_response_fields,
+        ["accepted @0 :Bool;"],
+        "goal response schema should exactly match response_message_format"
     );
 
     let consumer_dir =
@@ -704,6 +709,10 @@ fn generate_peppygen_python_lib_exposed_and_consumed_actions() {
 
     let action_messages = ConsumedActionMessage {
         goal_request: Some(goal_request_format),
+        goal_response: Some(
+            serde_json5::from_str(r#"{ accepted: "bool" }"#)
+                .expect("failed to parse goal response format"),
+        ),
         feedback: Some(feedback_format),
         result_response: Some(result_response_format),
     };

--- a/crates/generator-internal/tests/python/wire_compat.rs
+++ b/crates/generator-internal/tests/python/wire_compat.rs
@@ -223,7 +223,7 @@ async def run_exposer(node_runner):
 
     def goal_handler(request):
         print(f"server received scan goal scan_id={request.data.scan_id}", flush=True)
-        return perform_scan.GoalResponse.accept()
+        return perform_scan.GoalDecision.accept(perform_scan.GoalResponse(True))
 
     while True:
         ctx = await action.handle_goal_next_request(goal_handler)
@@ -275,6 +275,10 @@ if __name__ == "__main__":
             .goal_service
             .as_ref()
             .and_then(|s| s.request_message_format.clone()),
+        goal_response: exposed_action
+            .goal_service
+            .as_ref()
+            .and_then(|s| s.response_message_format.clone()),
         feedback: exposed_action
             .feedback_topic
             .as_ref()

--- a/crates/generator-internal/tests/rust/actions_communication.rs
+++ b/crates/generator-internal/tests/rust/actions_communication.rs
@@ -1,6 +1,6 @@
 use crate::helpers::{
-    CONSUMED_ACTION_FEEDBACK_FORMAT, CONSUMED_ACTION_GOAL_FORMAT, CONSUMED_ACTION_RESULT_FORMAT,
-    EXPOSED_ACTION_EXAMPLE,
+    CONSUMED_ACTION_FEEDBACK_FORMAT, CONSUMED_ACTION_GOAL_FORMAT,
+    CONSUMED_ACTION_GOAL_RESPONSE_FORMAT, CONSUMED_ACTION_RESULT_FORMAT, EXPOSED_ACTION_EXAMPLE,
 };
 use crate::helpers::{
     CapturedChild, DEFAULT_WAIT_TIMEOUT, STUB_NODE_CONFIG, WaitContext, bind_slot, compile_project,
@@ -84,6 +84,7 @@ async fn actions_pinned_binding_routes_to_bound_instance_of_two() {
     let consumed_action: ConsumedAction = serde_json5::from_str(CONSUMED_ACTION_EXAMPLE).unwrap();
     let action_messages = ConsumedActionMessage {
         goal_request: Some(serde_json5::from_str(CONSUMED_ACTION_GOAL_FORMAT).unwrap()),
+        goal_response: Some(serde_json5::from_str(CONSUMED_ACTION_GOAL_RESPONSE_FORMAT).unwrap()),
         feedback: Some(serde_json5::from_str(CONSUMED_ACTION_FEEDBACK_FORMAT).unwrap()),
         result_response: Some(serde_json5::from_str(CONSUMED_ACTION_RESULT_FORMAT).unwrap()),
     };
@@ -234,9 +235,9 @@ async fn expose_action(node_runner: &peppygen::NodeRunner) -> Result<()> {
     tokio::spawn(async move {
         loop {
             let maybe_ctx = action
-                .handle_goal_next_request(|request| -> Result<move_arm::GoalResponse> {
+                .handle_goal_next_request(|request| -> Result<move_arm::GoalDecision> {
                     println!("server received goal arm_id={}", request.data.arm_id);
-                    Ok(move_arm::GoalResponse::accept())
+                    Ok(move_arm::GoalDecision::Accept(move_arm::GoalResponse::new(true)))
                 })
                 .await;
             match maybe_ctx {
@@ -442,6 +443,7 @@ async fn actions_communication(#[case] topology: crate::helpers::LocalNodesTopol
         serde_json5::from_str(CONSUMED_ACTION_RESULT_FORMAT).unwrap();
     let action_messages = ConsumedActionMessage {
         goal_request: Some(goal_request_format),
+        goal_response: Some(serde_json5::from_str(CONSUMED_ACTION_GOAL_RESPONSE_FORMAT).unwrap()),
         feedback: Some(feedback_format),
         result_response: Some(result_response_format),
     };
@@ -585,12 +587,12 @@ async fn expose_action(node_runner: &peppygen::NodeRunner) -> Result<()> {
     tokio::spawn(async move {
         loop {
             let maybe_ctx = action
-                .handle_goal_next_request(|request| -> Result<move_arm::GoalResponse> {
+                .handle_goal_next_request(|request| -> Result<move_arm::GoalDecision> {
                     println!(
                         "server received goal arm_id={} desired={:?}",
                         request.data.arm_id, request.data.desired_position
                     );
-                    Ok(move_arm::GoalResponse::accept())
+                    Ok(move_arm::GoalDecision::Accept(move_arm::GoalResponse::new(true)))
                 })
                 .await;
 
@@ -782,6 +784,7 @@ async fn actions_communication_cancel_goal(#[case] topology: crate::helpers::Loc
         serde_json5::from_str(CONSUMED_ACTION_RESULT_FORMAT).unwrap();
     let action_messages = ConsumedActionMessage {
         goal_request: Some(goal_request_format),
+        goal_response: Some(serde_json5::from_str(CONSUMED_ACTION_GOAL_RESPONSE_FORMAT).unwrap()),
         feedback: Some(feedback_format),
         result_response: Some(result_response_format),
     };
@@ -914,12 +917,12 @@ async fn expose_action(node_runner: &peppygen::NodeRunner) -> Result<()> {
     tokio::spawn(async move {
         loop {
             let maybe_ctx = action
-                .handle_goal_next_request(|request| -> Result<move_arm::GoalResponse> {
+                .handle_goal_next_request(|request| -> Result<move_arm::GoalDecision> {
                     println!(
                         "server received goal arm_id={} desired={:?}",
                         request.data.arm_id, request.data.desired_position
                     );
-                    Ok(move_arm::GoalResponse::accept())
+                    Ok(move_arm::GoalDecision::Accept(move_arm::GoalResponse::new(true)))
                 })
                 .await;
 
@@ -1131,6 +1134,7 @@ async fn actions_communication_drain_loop_until_end_signal(
         serde_json5::from_str(CONSUMED_ACTION_RESULT_FORMAT).unwrap();
     let action_messages = ConsumedActionMessage {
         goal_request: Some(goal_request_format),
+        goal_response: Some(serde_json5::from_str(CONSUMED_ACTION_GOAL_RESPONSE_FORMAT).unwrap()),
         feedback: Some(feedback_format),
         result_response: Some(result_response_format),
     };
@@ -1284,12 +1288,12 @@ async fn expose_action(node_runner: &peppygen::NodeRunner) -> Result<()> {
     tokio::spawn(async move {
         loop {
             let maybe_ctx = action
-                .handle_goal_next_request(|request| -> Result<move_arm::GoalResponse> {
+                .handle_goal_next_request(|request| -> Result<move_arm::GoalDecision> {
                     println!(
                         "server received goal arm_id={} desired={:?}",
                         request.data.arm_id, request.data.desired_position
                     );
-                    Ok(move_arm::GoalResponse::accept())
+                    Ok(move_arm::GoalDecision::Accept(move_arm::GoalResponse::new(true)))
                 })
                 .await;
 
@@ -1524,6 +1528,7 @@ async fn actions_communication_cancel_accept_closes_feedback_stream(
         serde_json5::from_str(CONSUMED_ACTION_RESULT_FORMAT).unwrap();
     let action_messages = ConsumedActionMessage {
         goal_request: Some(goal_request_format),
+        goal_response: Some(serde_json5::from_str(CONSUMED_ACTION_GOAL_RESPONSE_FORMAT).unwrap()),
         feedback: Some(feedback_format),
         result_response: Some(result_response_format),
     };
@@ -1672,8 +1677,8 @@ async fn expose_action(node_runner: &peppygen::NodeRunner) -> Result<()> {
     tokio::spawn(async move {
         loop {
             let maybe_ctx = action
-                .handle_goal_next_request(|_request| -> Result<move_arm::GoalResponse> {
-                    Ok(move_arm::GoalResponse::accept())
+                .handle_goal_next_request(|_request| -> Result<move_arm::GoalDecision> {
+                    Ok(move_arm::GoalDecision::Accept(move_arm::GoalResponse::new(true)))
                 })
                 .await;
 
@@ -1901,6 +1906,7 @@ async fn actions_communication_cancel_reject_keeps_feedback_open(
         serde_json5::from_str(CONSUMED_ACTION_RESULT_FORMAT).unwrap();
     let action_messages = ConsumedActionMessage {
         goal_request: Some(goal_request_format),
+        goal_response: Some(serde_json5::from_str(CONSUMED_ACTION_GOAL_RESPONSE_FORMAT).unwrap()),
         feedback: Some(feedback_format),
         result_response: Some(result_response_format),
     };
@@ -2061,8 +2067,8 @@ async fn expose_action(node_runner: &peppygen::NodeRunner) -> Result<()> {
     tokio::spawn(async move {
         loop {
             let maybe_ctx = action
-                .handle_goal_next_request(|_request| -> Result<move_arm::GoalResponse> {
-                    Ok(move_arm::GoalResponse::accept())
+                .handle_goal_next_request(|_request| -> Result<move_arm::GoalDecision> {
+                    Ok(move_arm::GoalDecision::Accept(move_arm::GoalResponse::new(true)))
                 })
                 .await;
 
@@ -2296,6 +2302,7 @@ async fn actions_communication_producer_sigkill_unblocks_drain_and_abandons(
         serde_json5::from_str(CONSUMED_ACTION_RESULT_FORMAT).unwrap();
     let action_messages = ConsumedActionMessage {
         goal_request: Some(goal_request_format),
+        goal_response: Some(serde_json5::from_str(CONSUMED_ACTION_GOAL_RESPONSE_FORMAT).unwrap()),
         feedback: Some(feedback_format),
         result_response: Some(result_response_format),
     };
@@ -2456,8 +2463,8 @@ async fn expose_action(node_runner: &peppygen::NodeRunner) -> Result<()> {
     tokio::spawn(async move {
         loop {
             let maybe_ctx = action
-                .handle_goal_next_request(|_request| -> Result<move_arm::GoalResponse> {
-                    Ok(move_arm::GoalResponse::accept())
+                .handle_goal_next_request(|_request| -> Result<move_arm::GoalDecision> {
+                    Ok(move_arm::GoalDecision::Accept(move_arm::GoalResponse::new(true)))
                 })
                 .await;
 

--- a/crates/generator-internal/tests/rust/actions_implements.rs
+++ b/crates/generator-internal/tests/rust/actions_implements.rs
@@ -154,8 +154,8 @@ fn nests_contract_backed_actions_under_link_id() {
         "native leaf should pass `SenderTarget::node(...)`:\n{native_src}",
     );
     assert!(
-        native_src.contains("native_marker"),
-        "native source should carry its distinguishing field",
+        native_src.contains("native_marker") && native_src.contains("native_marker_ack"),
+        "native source should carry its declared request and response fields",
     );
 
     let arm_v1_src = fs::read_to_string(&arm_v1).expect("read arm v1");
@@ -168,8 +168,8 @@ fn nests_contract_backed_actions_under_link_id() {
         "arm v1 leaf should pass `arm`,`v1`:\n{arm_v1_src}",
     );
     assert!(
-        arm_v1_src.contains("arm_v1_marker"),
-        "arm v1 source should carry its distinguishing field",
+        arm_v1_src.contains("arm_v1_marker") && arm_v1_src.contains("arm_v1_marker_ack"),
+        "arm v1 source should carry its declared request and response fields",
     );
 
     let arm_v2_src = fs::read_to_string(&arm_v2).expect("read arm v2");
@@ -182,7 +182,7 @@ fn nests_contract_backed_actions_under_link_id() {
         "arm v2 leaf should pass `arm`,`v2`:\n{arm_v2_src}",
     );
     assert!(
-        arm_v2_src.contains("arm_v2_marker"),
-        "arm v2 source should carry its distinguishing field",
+        arm_v2_src.contains("arm_v2_marker") && arm_v2_src.contains("arm_v2_marker_ack"),
+        "arm v2 source should carry its declared request and response fields",
     );
 }

--- a/crates/generator-internal/tests/rust/generate_lib.rs
+++ b/crates/generator-internal/tests/rust/generate_lib.rs
@@ -648,10 +648,15 @@ fn generate_peppygen_rust_lib_exposed_and_consumed_actions() {
         goal_response_schema.contains("accepted @0 :Bool;"),
         "goal response schema should contain the declared accepted field:\n{goal_response_schema}"
     );
-    assert!(
-        !goal_response_schema.contains("errorMessage"),
-        "goal response schema must not gain an undeclared errorMessage field:\n\
-         {goal_response_schema}"
+    let goal_response_fields: Vec<_> = goal_response_schema
+        .lines()
+        .map(str::trim)
+        .filter(|line| line.contains(" @"))
+        .collect();
+    assert_eq!(
+        goal_response_fields,
+        ["accepted @0 :Bool;"],
+        "goal response schema should exactly match response_message_format"
     );
 
     let consumer_dir =
@@ -690,6 +695,10 @@ fn generate_peppygen_rust_lib_exposed_and_consumed_actions() {
 
     let action_messages = ConsumedActionMessage {
         goal_request: Some(goal_request_format),
+        goal_response: Some(
+            serde_json5::from_str(r#"{ accepted: "bool" }"#)
+                .expect("failed to parse goal response format"),
+        ),
         feedback: Some(feedback_format),
         result_response: Some(result_response_format),
     };

--- a/crates/generator-internal/tests/rust/generate_lib.rs
+++ b/crates/generator-internal/tests/rust/generate_lib.rs
@@ -640,6 +640,19 @@ fn generate_peppygen_rust_lib_exposed_and_consumed_actions() {
         "exposed action module should exist in peppygen crate at {}",
         exposed_peppygen_dir.display()
     );
+    let goal_response_schema = fs::read_to_string(
+        exposed_peppygen_dir.join("src/capnp/test_action_goal_response_message.capnp"),
+    )
+    .expect("failed to read exposed action goal response schema");
+    assert!(
+        goal_response_schema.contains("accepted @0 :Bool;"),
+        "goal response schema should contain the declared accepted field:\n{goal_response_schema}"
+    );
+    assert!(
+        !goal_response_schema.contains("errorMessage"),
+        "goal response schema must not gain an undeclared errorMessage field:\n\
+         {goal_response_schema}"
+    );
 
     let consumer_dir =
         TempDir::new_in(crate::helpers::test_tmp_root()).expect("failed to create temp directory");

--- a/docs/src/content/docs/advanced_guides/actions.mdx
+++ b/docs/src/content/docs/advanced_guides/actions.mdx
@@ -275,9 +275,9 @@ if __name__ == "__main__":
   </TabItem>
 </Tabs>
 
-The decider returns a `GoalResponse`, the framework acknowledgement (`accepted` plus an optional rejection reason):
+The decider returns a `GoalResponse`, the framework acknowledgement containing `accepted`:
 - `GoalResponse::accept()` (`GoalResponse.accept()` in Python) admits the goal, replies to the client, and yields a `GoalContext`.
-- `GoalResponse::reject(reason)` (`GoalResponse.reject(reason)` in Python) declines it: the client receives the response with `accepted == false` and the reason in `error_message`, no context is created, and the accept loop transparently moves on to the next goal. This is where you enforce per-resource concurrency limits.
+- `GoalResponse::reject()` (`GoalResponse.reject()` in Python) declines it: the client receives the response with `accepted == false`, no context is created, and the accept loop transparently moves on to the next goal. This is where you enforce per-resource concurrency limits.
 
 The `GoalRequest` passed to the decider contains:
 - `instance_id`: the client instance that sent the goal. The producer is binding-agnostic; it doesn't know which slot on the client this goal is heading to.
@@ -312,11 +312,7 @@ while let Ok(Some(ctx)) = action
             if busy.lock().unwrap().insert(request.data.arm_id) {
                 Ok(move_arm::GoalResponse::accept())
             } else {
-                // The reason rides back to the client in `error_message`.
-                Ok(move_arm::GoalResponse::reject(format!(
-                    "arm {} is already moving",
-                    request.data.arm_id
-                )))
+                Ok(move_arm::GoalResponse::reject())
             }
         }
     })
@@ -349,8 +345,7 @@ async def drive(ctx):
 def decide(request):
     arm_id = request.data.arm_id
     if arm_id in busy:
-        # This arm is already moving; reject with a reason the caller can read.
-        return move_arm.GoalResponse.reject(f"arm {arm_id} is already moving")
+        return move_arm.GoalResponse.reject()
     busy.add(arm_id)
     return move_arm.GoalResponse.accept()
 
@@ -798,5 +793,5 @@ This makes the "one server, many resources" pattern natural: include a
 discriminator in the goal request (e.g. `arm_id` or `device_id`) and route to a
 per-resource worker. Your goal handler is responsible for the concurrency
 policy: accept goals to run them in parallel, or reject a goal (with
-`GoalResponse::reject(reason)`) when its target resource is already busy. A goal
+`GoalResponse::reject()`) when its target resource is already busy. A goal
 that is not accepted yields no `GoalContext` and cannot be cancelled or completed.

--- a/docs/src/content/docs/advanced_guides/actions.mdx
+++ b/docs/src/content/docs/advanced_guides/actions.mdx
@@ -195,14 +195,16 @@ fn main() -> Result<()> {
             // answered and skipped, so the loop ends only when the stream
             // closes (None) or errors.
             while let Ok(Some(ctx)) = action
-                .handle_goal_next_request(|request| -> Result<move_arm::GoalResponse> {
+                .handle_goal_next_request(|request| -> Result<move_arm::GoalDecision> {
                     println!(
                         "goal from {}: arm_id={} desired={:?}",
                         request.instance_id, request.data.arm_id, request.data.desired_position
                     );
                     // The decider sets the concurrency policy: e.g. reject a
                     // goal for a busy `arm_id`.
-                    Ok(move_arm::GoalResponse::accept())
+                    Ok(move_arm::GoalDecision::Accept(
+                        move_arm::GoalResponse::new(true),
+                    ))
                 })
                 .await
             {
@@ -251,7 +253,7 @@ async def run_action(node_runner):
             f"desired={request.data.desired_position}",
             flush=True,
         )
-        return move_arm.GoalResponse.accept()
+        return move_arm.GoalDecision.accept(move_arm.GoalResponse(True))
 
     while True:
         ctx = await action.handle_goal_next_request(decide)
@@ -275,9 +277,12 @@ if __name__ == "__main__":
   </TabItem>
 </Tabs>
 
-The decider returns a `GoalResponse`, the framework acknowledgement containing `accepted`:
-- `GoalResponse::accept()` (`GoalResponse.accept()` in Python) admits the goal, replies to the client, and yields a `GoalContext`.
-- `GoalResponse::reject()` (`GoalResponse.reject()` in Python) declines it: the client receives the response with `accepted == false`, no context is created, and the accept loop transparently moves on to the next goal. This is where you enforce per-resource concurrency limits.
+`GoalResponse` contains exactly the fields declared in `goal_service.response_message_format`. The framework never adds an `accepted` or error field. `GoalDecision` controls admission independently of that payload:
+
+- `GoalDecision::Accept(response)` (`GoalDecision.accept(response)` in Python) admits the goal, sends `response` to the client, and yields a `GoalContext`.
+- `GoalDecision::Reject(response)` (`GoalDecision.reject(response)` in Python) declines it: the client receives the supplied response, no context is created, and the accept loop transparently moves on to the next goal. This is where you enforce per-resource concurrency limits.
+
+Both decisions send the response, including `Reject`. If `response_message_format` is omitted, use the corresponding decision without a response argument. The framework decision remains separate and still works with an empty response payload.
 
 The `GoalRequest` passed to the decider contains:
 - `instance_id`: the client instance that sent the goal. The producer is binding-agnostic; it doesn't know which slot on the client this goal is heading to.
@@ -307,12 +312,16 @@ let busy: Arc<Mutex<HashSet<u16>>> = Arc::new(Mutex::new(HashSet::new()));
 while let Ok(Some(ctx)) = action
     .handle_goal_next_request({
         let busy = Arc::clone(&busy);
-        move |request| -> Result<move_arm::GoalResponse> {
+        move |request| -> Result<move_arm::GoalDecision> {
             // `HashSet::insert` returns false when the arm is already busy.
             if busy.lock().unwrap().insert(request.data.arm_id) {
-                Ok(move_arm::GoalResponse::accept())
+                Ok(move_arm::GoalDecision::Accept(
+                    move_arm::GoalResponse::new(true),
+                ))
             } else {
-                Ok(move_arm::GoalResponse::reject())
+                Ok(move_arm::GoalDecision::Reject(
+                    move_arm::GoalResponse::new(false),
+                ))
             }
         }
     })
@@ -345,9 +354,9 @@ async def drive(ctx):
 def decide(request):
     arm_id = request.data.arm_id
     if arm_id in busy:
-        return move_arm.GoalResponse.reject()
+        return move_arm.GoalDecision.reject(move_arm.GoalResponse(False))
     busy.add(arm_id)
-    return move_arm.GoalResponse.accept()
+    return move_arm.GoalDecision.accept(move_arm.GoalResponse(True))
 
 
 while True:
@@ -793,5 +802,5 @@ This makes the "one server, many resources" pattern natural: include a
 discriminator in the goal request (e.g. `arm_id` or `device_id`) and route to a
 per-resource worker. Your goal handler is responsible for the concurrency
 policy: accept goals to run them in parallel, or reject a goal (with
-`GoalResponse::reject()`) when its target resource is already busy. A goal
+`GoalDecision::Reject(response)`) when its target resource is already busy. A goal
 that is not accepted yields no `GoalContext` and cannot be cancelled or completed.


### PR DESCRIPTION
## Summary

- treat `goal_service.response_message_format` as the source of truth for generated Rust, Python, and Cap'n Proto goal response types
- propagate the declared goal response schema from producers to consumers
- keep framework admission in a separate `GoalDecision`, with both accept and reject sending the declared response payload
- support actions with no goal response payload without generating a `GoalResponse`
- update action documentation and regression coverage for the breaking API

## Root cause

The generator replaced the declared goal response schema with a framework-owned schema and coupled the framework decision to an `accepted` payload field. That caused undeclared fields to appear and made user payload data control admission.

## Impact

This is an intentional breaking change with no legacy shims. Generated `GoalResponse` types contain exactly the declared fields. Goal handlers now return `GoalDecision::Accept(response)` or `GoalDecision::Reject(response)` in Rust, and `GoalDecision.accept(response)` or `GoalDecision.reject(response)` in Python. When no response format is declared, the corresponding decision carries no response argument.

Rejected goals still send a response and remain transparent to the accept loop. The decision is independent of every field in the declared payload.

## Test plan

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p generator` (160 unit/generated-code tests, 42 Python integration tests, 39 Rust integration tests)
- `cargo test -p core-node preserves_the_declared_goal_response_format_exactly --lib -- --nocapture`
- `cargo check -p core-node`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Action goal responses now follow each action’s declared response format.
  * Added explicit accept/reject decisions with optional response payloads.
  * Actions without response schemas no longer generate unnecessary response APIs.

* **Bug Fixes**
  * Preserved declared goal-response fields accurately across generated Rust and Python code.

* **Documentation**
  * Updated action-handling guidance and examples for the new decision workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->