### PR TITLE
fix(actions): adopt split goal/result endpoint types; framework-owned result request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,7 +573,7 @@ dependencies = [
 [[package]]
 name = "build-helpers"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#73a62863efcd57410ead31879018c9ab34b4c0a6"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#6ea71ec0b758232c79658237a40e5b2437e60332"
 dependencies = [
  "sha2",
 ]
@@ -774,7 +774,7 @@ dependencies = [
 [[package]]
 name = "config-test-support"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#73a62863efcd57410ead31879018c9ab34b4c0a6"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#6ea71ec0b758232c79658237a40e5b2437e60332"
 dependencies = [
  "askama",
  "git2",
@@ -918,7 +918,7 @@ dependencies = [
 [[package]]
 name = "core-node-api"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#73a62863efcd57410ead31879018c9ab34b4c0a6"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#6ea71ec0b758232c79658237a40e5b2437e60332"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -2577,7 +2577,7 @@ dependencies = [
 [[package]]
 name = "json5-pretty"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#73a62863efcd57410ead31879018c9ab34b4c0a6"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#6ea71ec0b758232c79658237a40e5b2437e60332"
 dependencies = [
  "serde",
  "serde_json",
@@ -3366,7 +3366,7 @@ dependencies = [
 [[package]]
 name = "peppy-config-model"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#73a62863efcd57410ead31879018c9ab34b4c0a6"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#6ea71ec0b758232c79658237a40e5b2437e60332"
 dependencies = [
  "capnp",
  "clap",
@@ -3389,7 +3389,7 @@ version = "0.0.1"
 [[package]]
 name = "peppylib-rs"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#73a62863efcd57410ead31879018c9ab34b4c0a6"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#6ea71ec0b758232c79658237a40e5b2437e60332"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -3584,7 +3584,7 @@ dependencies = [
 [[package]]
 name = "pmi"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#73a62863efcd57410ead31879018c9ab34b4c0a6"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#6ea71ec0b758232c79658237a40e5b2437e60332"
 dependencies = [
  "build-helpers",
  "bytes",

--- a/crates/daemon-config-internal/src/contract/types.rs
+++ b/crates/daemon-config-internal/src/contract/types.rs
@@ -279,6 +279,37 @@ mod tests {
         assert!(action.feedback_topic.is_none());
     }
 
+    /// A contract must not advertise a user-defined result request: the action
+    /// protocol has none, so `deny_unknown_fields` rejects it at parse time
+    /// rather than letting a contract require an API no implementation or
+    /// consumer can honor.
+    #[test]
+    fn action_rejects_result_service_request_message_format() {
+        let json5 = r#"{
+            peppy_schema: "contract/v1",
+            manifest: { name: "arm", tag: "v1" },
+            interfaces: {
+                actions: [
+                    {
+                        name: "move_arm",
+                        result_service: {
+                            request_message_format: { include_diagnostics: "bool" },
+                            response_message_format: { success: "bool" },
+                        }
+                    }
+                ]
+            }
+        }"#;
+
+        let err = serde_json5::from_str::<PeppyContract>(json5)
+            .expect_err("result_service.request_message_format must be rejected");
+        let message = err.to_string();
+        assert!(
+            message.contains("request_message_format"),
+            "error should name the rejected field, got: {message}"
+        );
+    }
+
     /// The schema field is the source of truth: a node-shaped document
     /// must not be accepted by the contract parser, even if no
     /// contract-specific field is present.

--- a/crates/generator-internal/tests/python/actions_implements.rs
+++ b/crates/generator-internal/tests/python/actions_implements.rs
@@ -2,8 +2,8 @@
 
 use crate::helpers::{prepare_directories, test_peppy_dirs};
 use config::node::{
-    ActionServiceEndpoint, MessageFormat, NativeExposedAction, PeppygenLanguage, QoSProfile,
-    SchemaType, TypeToken,
+    GoalServiceEndpoint, MessageFormat, NativeExposedAction, PeppygenLanguage, SchemaType,
+    TypeToken,
 };
 use generator::{
     ContractOrigin, CrateDeployMode, DeploymentInterface, InterfaceVariant, generate_peppygen_lib,
@@ -19,10 +19,9 @@ fn make_action(marker: &str) -> NativeExposedAction {
     resp.insert(format!("{marker}_ack"), SchemaType::Type(TypeToken::Bool));
     NativeExposedAction {
         name: "move_arm".to_string(),
-        goal_service: Some(ActionServiceEndpoint {
+        goal_service: Some(GoalServiceEndpoint {
             request_message_format: Some(MessageFormat(req)),
             response_message_format: Some(MessageFormat(resp)),
-            qos_profile: QoSProfile::Reliable,
         }),
         feedback_topic: None,
         result_service: None,

--- a/crates/generator-internal/tests/rust/actions_implements.rs
+++ b/crates/generator-internal/tests/rust/actions_implements.rs
@@ -6,8 +6,8 @@
 
 use crate::helpers::{prepare_directories, test_peppy_dirs};
 use config::node::{
-    ActionServiceEndpoint, MessageFormat, NativeExposedAction, PeppygenLanguage, QoSProfile,
-    SchemaType, TypeToken,
+    GoalServiceEndpoint, MessageFormat, NativeExposedAction, PeppygenLanguage, SchemaType,
+    TypeToken,
 };
 use generator::{
     ContractOrigin, CrateDeployMode, DeploymentInterface, InterfaceVariant, generate_peppygen_lib,
@@ -23,10 +23,9 @@ fn make_action(marker: &str) -> NativeExposedAction {
     resp.insert(format!("{marker}_ack"), SchemaType::Type(TypeToken::Bool));
     NativeExposedAction {
         name: "move_arm".to_string(),
-        goal_service: Some(ActionServiceEndpoint {
+        goal_service: Some(GoalServiceEndpoint {
             request_message_format: Some(MessageFormat(req)),
             response_message_format: Some(MessageFormat(resp)),
-            qos_profile: QoSProfile::Reliable,
         }),
         feedback_topic: None,
         result_service: None,

--- a/docs/src/content/docs/advanced_guides/actions.mdx
+++ b/docs/src/content/docs/advanced_guides/actions.mdx
@@ -169,7 +169,9 @@ Each action defines a `goal_service`, a `feedback_topic`, and a `result_service`
   </TabItem>
 </Tabs>
 
-Every payload on `goal_service` and `result_service` is optional: any of `goal_service.request_message_format`, `goal_service.response_message_format`, `result_service.request_message_format`, and `result_service.response_message_format` can be omitted (or set to `{}`) when the corresponding payload is empty. For example, a `calibrate` action can omit `goal_service.request_message_format` because it has no goal parameters, and a `result_service` that only needs to signal completion can omit `request_message_format`.
+The `goal_service` payloads and the `result_service` response are all optional: any of `goal_service.request_message_format`, `goal_service.response_message_format`, and `result_service.response_message_format` can be omitted (or set to `{}`) when the corresponding payload is empty. For example, a `calibrate` action can omit `goal_service.request_message_format` because it has no goal parameters, and a `result_service` that only signals completion can omit its `response_message_format` too.
+
+The `result_service` never carries a user-defined request. A `get_result` call is correlated to its goal by the `goal_id` the framework assigns at `fire_goal`, so the only payload you declare on the result side is `response_message_format`, which the producer supplies through `complete` or `complete_cancelled`. Declaring a `result_service.request_message_format` is rejected when the config is parsed, since no generated API, wire message, or producer handler could ever read it.
 
 The `feedback_topic` block is optional: actions that don't stream progress can omit it entirely. When you do declare `feedback_topic`, however, its `message_format` is required and cannot be empty: every feedback message must carry a non-empty payload, since empty payloads are reserved as the framework's per-goal end-of-stream signal (see [Receiving feedback](#receiving-feedback)). Code generation will fail if `feedback_topic` is declared without a `message_format`.
 


### PR DESCRIPTION
Consumer side of the action result-request fix. Pairs with **Peppy-bot/public-peppy-libs#62** (merged to `main`).

## Change

- Adopt the `GoalServiceEndpoint` / `ResultServiceEndpoint` split from libs#62. Generators (Rust + Python), dependency sync, and benchmark sizing read only surviving fields (`goal.request/response`, `result.response`) and compile unchanged; the two direct construction sites in the generator tests move to `GoalServiceEndpoint` and drop the removed `qos_profile`.
- Add a **contract-side** test that `result_service.request_message_format` is rejected, mirroring the native path (contracts reuse `NativeExposedAction`, so the type split covers them automatically).
- **Docs** (`advanced_guides/actions.mdx`): remove the false claim that `result_service.request_message_format` is an optional user payload. Document the result request as framework-owned: `get_result` is correlated by `goal_id`; users declare only `result_service.response_message_format`, supplied through `complete` / `complete_cancelled`.
- `Cargo.lock`: bump the `public-peppy-libs` git deps to the #62 merge commit on `main` (source-rev only, no transitive churn).

## Tests (local, against libs `main`)

- `daemon-config` contract tests: **23 pass** (incl. the new rejection test).
- `generator` full compile + **54 Rust/Python action tests** pass (`actions_implements`, `actions_communication` — generated `get_result` APIs still compile and retrieve declared result responses).
- `core-node` compile + `action_message` test pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified which action service message formats are optional.
  - Documented that result services do not accept user-defined request message formats.
  - Explained that results are correlated to goals through the goal ID.

- **Bug Fixes**
  - Added validation coverage to reject invalid result service request format configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->