### PR TITLE
feat(actions): adopt the framework goal-ack envelope

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,7 +573,7 @@ dependencies = [
 [[package]]
 name = "build-helpers"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#6ea71ec0b758232c79658237a40e5b2437e60332"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#b622f119896aeb1c549bfa784972abd2c0f437a5"
 dependencies = [
  "sha2",
 ]
@@ -774,7 +774,7 @@ dependencies = [
 [[package]]
 name = "config-test-support"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#6ea71ec0b758232c79658237a40e5b2437e60332"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#b622f119896aeb1c549bfa784972abd2c0f437a5"
 dependencies = [
  "askama",
  "git2",
@@ -918,7 +918,7 @@ dependencies = [
 [[package]]
 name = "core-node-api"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#6ea71ec0b758232c79658237a40e5b2437e60332"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#b622f119896aeb1c549bfa784972abd2c0f437a5"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -1256,7 +1256,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1404,7 +1404,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2577,7 +2577,7 @@ dependencies = [
 [[package]]
 name = "json5-pretty"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#6ea71ec0b758232c79658237a40e5b2437e60332"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#b622f119896aeb1c549bfa784972abd2c0f437a5"
 dependencies = [
  "serde",
  "serde_json",
@@ -2981,7 +2981,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3366,7 +3366,7 @@ dependencies = [
 [[package]]
 name = "peppy-config-model"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#6ea71ec0b758232c79658237a40e5b2437e60332"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#b622f119896aeb1c549bfa784972abd2c0f437a5"
 dependencies = [
  "capnp",
  "clap",
@@ -3389,7 +3389,7 @@ version = "0.0.1"
 [[package]]
 name = "peppylib-rs"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#6ea71ec0b758232c79658237a40e5b2437e60332"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#b622f119896aeb1c549bfa784972abd2c0f437a5"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -3584,7 +3584,7 @@ dependencies = [
 [[package]]
 name = "pmi"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#6ea71ec0b758232c79658237a40e5b2437e60332"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#b622f119896aeb1c549bfa784972abd2c0f437a5"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -3801,7 +3801,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.5",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4051,7 +4051,7 @@ dependencies = [
  "pin-project-lite",
  "rustls",
  "rustls-pki-types",
- "rustls-platform-verifier 0.7.0",
+ "rustls-platform-verifier 0.6.2",
  "serde",
  "serde_json",
  "sync_wrapper",
@@ -4237,7 +4237,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4305,7 +4305,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4326,7 +4326,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4702,7 +4702,7 @@ version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
 dependencies = [
- "dirs 6.0.0",
+ "dirs 4.0.0",
 ]
 
 [[package]]
@@ -5038,7 +5038,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5932,7 +5932,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/core-node-internal/src/services/action_loop.rs
+++ b/crates/core-node-internal/src/services/action_loop.rs
@@ -73,7 +73,9 @@ pub(crate) async fn accept_goal(
 pub(crate) async fn reject_goal(pending: PendingGoal, encoded: PeppyResult<Payload>) {
     match encoded {
         Ok(payload) => {
-            let _ = pending.reject(payload).await;
+            // The core-node action protocol carries its rejection reason in
+            // the structured payload, so the envelope reason stays empty.
+            let _ = pending.reject(None, payload).await;
         }
         Err(err) => {
             debug!("failed to encode goal rejection: {err}");

--- a/crates/core-node-internal/tests/common/actions.rs
+++ b/crates/core-node-internal/tests/common/actions.rs
@@ -158,7 +158,7 @@ async fn send_node_run_goal(
     .await
     .map_err(|e| format!("Failed to send goal: {}", e))?;
 
-    let goal_response = NodeRunGoalResponse::decode(&action_handle.goal_response().payload())
+    let goal_response = NodeRunGoalResponse::decode(&action_handle.goal_reply().body)
         .map_err(|e| format!("Failed to decode goal response: {}", e))?;
 
     // A rejected goal never streams feedback or produces a result, so callers
@@ -462,7 +462,7 @@ async fn send_node_add_and_wait_internal<'a>(
     // Check if the goal was rejected - if so, return a failure result immediately.
     // This matches the behavior of the CLI client which doesn't poll for results
     // when the goal is rejected.
-    let goal_response_payload = action_handle.goal_response().payload();
+    let goal_response_payload = action_handle.goal_reply().body.clone();
     let goal_response = NodeAddGoalResponse::decode(&goal_response_payload)
         .map_err(|e| format!("Failed to decode goal response: {}", e))?;
 
@@ -603,7 +603,7 @@ async fn send_node_build_and_wait_internal(
     .await
     .map_err(|e| format!("Failed to send build goal: {}", e))?;
 
-    let goal_response_payload = action_handle.goal_response().payload();
+    let goal_response_payload = action_handle.goal_reply().body.clone();
     let goal_response = NodeBuildGoalResponse::decode(&goal_response_payload)
         .map_err(|e| format!("Failed to decode build goal response: {}", e))?;
 

--- a/crates/core-node-internal/tests/listen_for_launch.rs
+++ b/crates/core-node-internal/tests/listen_for_launch.rs
@@ -415,7 +415,7 @@ async fn send_launch_origin_and_wait(
     .await
     .map_err(|e| format!("Failed to send launch goal: {e}"))?;
 
-    let goal_response_payload = action_handle.goal_response().payload();
+    let goal_response_payload = action_handle.goal_reply().body.clone();
     let goal_response = LaunchGoalResponse::decode(&goal_response_payload)
         .map_err(|e| format!("Failed to decode goal response: {e}"))?;
 

--- a/crates/core-node-internal/tests/listen_for_node_add/concurrency_and_force.rs
+++ b/crates/core-node-internal/tests/listen_for_node_add/concurrency_and_force.rs
@@ -43,7 +43,7 @@ async fn listen_for_node_add_rejects_second_goal_when_action_in_progress() {
     .await
     .expect("first goal should be sent");
 
-    let first_response_payload = first_action_handle.goal_response().payload();
+    let first_response_payload = first_action_handle.goal_reply().body.clone();
     let first_response = NodeAddGoalResponse::decode(&first_response_payload)
         .expect("failed to decode first goal response");
     assert!(first_response.accepted, "first goal should be accepted");
@@ -126,7 +126,7 @@ async fn listen_for_node_add_force_overrides_in_progress_action() {
     .await
     .expect("first goal should be sent");
 
-    let first_response_payload = first_action_handle.goal_response().payload();
+    let first_response_payload = first_action_handle.goal_reply().body.clone();
     let first_response = NodeAddGoalResponse::decode(&first_response_payload)
         .expect("failed to decode first goal response");
     assert!(first_response.accepted, "first goal should be accepted");

--- a/crates/core-node-internal/tests/listen_for_node_add/replacement_and_lifecycle.rs
+++ b/crates/core-node-internal/tests/listen_for_node_add/replacement_and_lifecycle.rs
@@ -527,7 +527,7 @@ async fn listen_for_node_add_abandoned_action_does_not_block_next_goal() {
     .expect("first goal should be sent");
 
     // Verify first goal was accepted
-    let first_goal_response_payload = first_action_handle.goal_response().payload();
+    let first_goal_response_payload = first_action_handle.goal_reply().body.clone();
     let first_goal_response = NodeAddGoalResponse::decode(&first_goal_response_payload)
         .expect("failed to decode first goal response");
     assert!(

--- a/crates/core-node-internal/tests/listen_for_node_run.rs
+++ b/crates/core-node-internal/tests/listen_for_node_run.rs
@@ -984,7 +984,7 @@ async fn listen_for_node_run_abandoned_action_does_not_block_next_goal() {
     .expect("first goal should be sent");
 
     // Verify first goal was accepted
-    let first_goal_response_payload = first_action_handle.goal_response().payload();
+    let first_goal_response_payload = first_action_handle.goal_reply().body.clone();
     let first_goal_response =
         core_node_api::encoding::NodeRunGoalResponse::decode(&first_goal_response_payload)
             .expect("failed to decode first goal response");

--- a/crates/core-node-internal/tests/listen_for_repo_refresh.rs
+++ b/crates/core-node-internal/tests/listen_for_repo_refresh.rs
@@ -101,7 +101,7 @@ async fn send_refresh_inner(
     .await
     .expect("send goal should succeed");
 
-    let goal_response_payload = action_handle.goal_response().payload();
+    let goal_response_payload = action_handle.goal_reply().body.clone();
     let goal_response =
         RepoRefreshGoalResponse::decode(&goal_response_payload).expect("decode goal response");
 

--- a/crates/core-node-internal/tests/listen_for_stack_benchmark.rs
+++ b/crates/core-node-internal/tests/listen_for_stack_benchmark.rs
@@ -34,9 +34,8 @@ async fn run_benchmark_goal(
     .await
     .expect("send stack_benchmark goal");
 
-    let goal_response =
-        StackBenchmarkGoalResponse::decode(&action_handle.goal_response().payload())
-            .expect("decode goal response");
+    let goal_response = StackBenchmarkGoalResponse::decode(&action_handle.goal_reply().body)
+        .expect("decode goal response");
     assert!(goal_response.accepted, "benchmark goal should be accepted");
 
     // Drain feedback to end-of-stream with a generous overall deadline.

--- a/crates/generator-internal/src/generator/python/actions.rs
+++ b/crates/generator-internal/src/generator/python/actions.rs
@@ -100,30 +100,39 @@ pub fn build_exposed_action(
         emit_format_as_dataclass(&mut builder, "GoalResponse", fmt)?;
     }
 
-    // GoalDecision controls framework acceptance independently of the response
-    // payload. Both branches carry the declared GoalResponse when one exists.
+    // GoalDecision controls framework admission, carried by the goal-ack
+    // envelope independently of the declared response payload. An accept
+    // carries the declared GoalResponse when one exists; a reject carries an
+    // optional human-readable reason and an optional response.
     builder.line("class GoalDecision:");
     builder.indent();
     if has_goal_response {
-        builder.line("def __init__(self, accepted: bool, response):");
+        builder.line("def __init__(self, accepted: bool, reason=None, response=None):");
         builder.indent();
         builder.line("self.accepted = accepted");
+        builder.line("self.reason = reason");
         builder.line("self.response = response");
         builder.dedent();
         builder.line("@staticmethod");
         builder.line("def accept(response):");
         builder.indent();
-        builder.line("return GoalDecision(True, response)");
+        builder.line("if response is None:");
+        builder.indent();
+        builder
+            .line("raise ValueError(\"GoalDecision.accept requires the declared GoalResponse\")");
+        builder.dedent();
+        builder.line("return GoalDecision(True, response=response)");
         builder.dedent();
         builder.line("@staticmethod");
-        builder.line("def reject(response):");
+        builder.line("def reject(reason=None, response=None):");
         builder.indent();
-        builder.line("return GoalDecision(False, response)");
+        builder.line("return GoalDecision(False, reason=reason, response=response)");
         builder.dedent();
     } else {
-        builder.line("def __init__(self, accepted: bool):");
+        builder.line("def __init__(self, accepted: bool, reason=None):");
         builder.indent();
         builder.line("self.accepted = accepted");
+        builder.line("self.reason = reason");
         builder.dedent();
         builder.line("@staticmethod");
         builder.line("def accept():");
@@ -131,9 +140,9 @@ pub fn build_exposed_action(
         builder.line("return GoalDecision(True)");
         builder.dedent();
         builder.line("@staticmethod");
-        builder.line("def reject():");
+        builder.line("def reject(reason=None):");
         builder.indent();
-        builder.line("return GoalDecision(False)");
+        builder.line("return GoalDecision(False, reason=reason)");
         builder.dedent();
     }
     builder.dedent();
@@ -237,9 +246,12 @@ pub fn build_exposed_action(
     builder.indent();
     builder.line("decision = await decision");
     builder.dedent();
-    // Serialize the GoalResponse once; both accept and reject reply with it.
+    // Serialize the declared GoalResponse when the decision carries one; a
+    // reject without a response replies with an empty body.
     if let Some((fmt, info)) = goal_response_format.zip(goal_response_schema_info) {
         builder.line("response = decision.response");
+        builder.line("if response is not None:");
+        builder.indent();
         let loader_fn_name = capnp_loader_fn_name(info);
         builder.line(&format!(
             "capnp_msg = {loader_fn_name}().{}.new_message()",
@@ -254,6 +266,11 @@ pub fn build_exposed_action(
             &mut counter,
         );
         builder.line("response_bytes = capnp_msg.to_bytes()");
+        builder.dedent();
+        builder.line("else:");
+        builder.indent();
+        builder.line("response_bytes = b\"\"");
+        builder.dedent();
     } else {
         builder.line("response_bytes = b\"\"");
     }
@@ -264,7 +281,7 @@ pub fn build_exposed_action(
     builder.dedent();
     // Rejected: answer the client and keep polling for the next goal (the
     // accept branch above returns, so this runs only when not accepted).
-    builder.line("await pending.reject(response_bytes)");
+    builder.line("await pending.reject(decision.reason, response_bytes)");
     builder.dedent(); // end while loop
     builder.dedent(); // end handle_goal_next_request
 
@@ -604,14 +621,19 @@ pub fn build_consumed_action(
     builder.dedent();
     builder.line(")");
 
-    // Construct ActionHandle instance
+    // Construct ActionHandle instance. Admission and the optional rejection
+    // reason come from the framework goal-ack envelope, decoded engine-side.
     builder.line("handle = cls()");
     builder.line("handle._messenger = node_runner.messenger()");
     builder.line("handle._inner = action_handle");
+    builder.line("handle.accepted = action_handle.accepted");
+    builder.line("handle.reason = action_handle.reason");
     if has_goal_response {
-        builder.line("payload = action_handle.goal_response.payload");
-        builder.line("goal_response_data = _deserialize_goal_response(payload)");
-        builder.line("handle.data = goal_response_data");
+        // An empty body means no response was supplied (a declared response
+        // serializes to a non-empty capnp message), which only a reject can
+        // produce.
+        builder.line("body = action_handle.goal_reply_body");
+        builder.line("handle.data = _deserialize_goal_response(body) if body else None");
     }
     builder.line("return handle");
 

--- a/crates/generator-internal/src/generator/python/tests/actions.rs
+++ b/crates/generator-internal/src/generator/python/tests/actions.rs
@@ -211,8 +211,9 @@ fn exposed_action() {
     );
 
     // GoalResponse mirrors response_message_format exactly. GoalDecision
-    // controls framework acceptance independently and carries that payload in
-    // both branches.
+    // controls framework admission independently: an accept carries the
+    // declared payload, a reject carries an optional reason and optional
+    // payload.
     assert_contains_all(
         &rendered,
         &[
@@ -220,7 +221,7 @@ fn exposed_action() {
             "accepted: bool",
             "class GoalDecision:",
             "def accept(response):",
-            "def reject(response):",
+            "def reject(reason=None, response=None):",
         ],
     );
 
@@ -270,9 +271,10 @@ fn exposed_action() {
             "pending = await self._inner.recv_next_goal()",
             "request = GoalRequest(instance_id=pending.instance_id, core_node=pending.core_node, data=request_data)",
             "response = decision.response",
+            "if response is not None:",
             "ctx = await pending.accept(response_bytes)",
             "return GoalContext(ctx, request)",
-            "await pending.reject(response_bytes)",
+            "await pending.reject(decision.reason, response_bytes)",
         ],
     );
 
@@ -315,7 +317,7 @@ fn expose_action_without_request_body() {
             "class GoalResponse:",
             "class GoalDecision:",
             "def accept(response):",
-            "def reject(response):",
+            "def reject(reason=None, response=None):",
             "async def handle_goal_next_request(",
         ],
     );
@@ -638,8 +640,10 @@ fn consumed_action() {
             "handle = cls()",
             "handle._messenger = node_runner.messenger()",
             "handle._inner = action_handle",
-            "goal_response_data = _deserialize_goal_response(payload)",
-            "handle.data = goal_response_data",
+            "handle.accepted = action_handle.accepted",
+            "handle.reason = action_handle.reason",
+            "body = action_handle.goal_reply_body",
+            "handle.data = _deserialize_goal_response(body) if body else None",
             "return handle",
         ],
     );

--- a/crates/generator-internal/src/generator/rust.rs
+++ b/crates/generator-internal/src/generator/rust.rs
@@ -267,19 +267,35 @@ impl RustGenerator {
             helper_items.push(deserialize_helper);
 
             quote! {
-                let payload = action_handle.goal_response().payload();
-                let response_data = deserialize_goal_response(payload.as_ref())?;
+                let reply = action_handle.goal_reply();
+                let accepted = reply.accepted;
+                let reason = reply.reason.clone();
+                // An empty body means no response was supplied (a declared
+                // response serializes to a non-empty capnp message), which
+                // only a reject can produce.
+                let data = if reply.body.is_empty() {
+                    None
+                } else {
+                    Some(deserialize_goal_response(reply.body.as_ref())?)
+                };
                 Ok(Self {
                     messenger: node_runner.messenger().clone(),
                     inner: action_handle,
-                    data: response_data,
+                    accepted,
+                    reason,
+                    data,
                 })
             }
         } else {
             quote! {
+                let reply = action_handle.goal_reply();
+                let accepted = reply.accepted;
+                let reason = reply.reason.clone();
                 Ok(Self {
                     messenger: node_runner.messenger().clone(),
                     inner: action_handle,
+                    accepted,
+                    reason,
                 })
             }
         };
@@ -1679,7 +1695,17 @@ impl LanguageGenerator for RustGenerator {
                 pub struct ActionHandle {
                     messenger: peppylib::MessengerHandle,
                     inner: peppylib::messaging::ActionGoalHandle,
-                    pub data: #goal_response_data_ident,
+                    /// Whether the producer admitted the goal, decoded from
+                    /// the framework goal-ack envelope.
+                    pub accepted: bool,
+                    /// Optional human-readable rejection reason from the
+                    /// goal-ack envelope. `None` for accepted goals and for
+                    /// rejections sent without a reason.
+                    pub reason: Option<String>,
+                    /// The declared goal response. Always present for
+                    /// accepted goals; `None` when a rejection carried no
+                    /// response payload.
+                    pub data: Option<#goal_response_data_ident>,
                 }
             }
         } else {
@@ -1687,6 +1713,13 @@ impl LanguageGenerator for RustGenerator {
                 pub struct ActionHandle {
                     messenger: peppylib::MessengerHandle,
                     inner: peppylib::messaging::ActionGoalHandle,
+                    /// Whether the producer admitted the goal, decoded from
+                    /// the framework goal-ack envelope.
+                    pub accepted: bool,
+                    /// Optional human-readable rejection reason from the
+                    /// goal-ack envelope. `None` for accepted goals and for
+                    /// rejections sent without a reason.
+                    pub reason: Option<String>,
                 }
             }
         };

--- a/crates/generator-internal/src/generator/rust/actions.rs
+++ b/crates/generator-internal/src/generator/rust/actions.rs
@@ -50,16 +50,40 @@ pub fn build_action_expose_method(
     }
 }
 
-/// The framework decision returned by a goal handler. Accept and reject both
-/// carry the declared `GoalResponse` when one exists, keeping control flow
-/// independent of the response payload's fields.
+/// The framework decision returned by a goal handler. Admission travels in
+/// the framework goal-ack envelope, so it stays independent of the declared
+/// `GoalResponse` fields: an accept carries the declared response when one
+/// exists, and a reject carries an optional human-readable reason plus an
+/// optional response. The `accept` / `reject` constructors cover the common
+/// paths; construct the `Reject` variant directly for full control.
 pub fn build_goal_decision_enum(has_response: bool) -> TokenStream {
     if has_response {
         quote! {
             #[allow(dead_code)]
             pub enum GoalDecision {
                 Accept(GoalResponse),
-                Reject(GoalResponse),
+                Reject {
+                    reason: Option<String>,
+                    response: Option<GoalResponse>,
+                },
+            }
+
+            #[allow(dead_code)]
+            impl GoalDecision {
+                /// Admit the goal and reply with the declared response.
+                pub fn accept(response: GoalResponse) -> Self {
+                    Self::Accept(response)
+                }
+
+                /// Decline the goal with a human-readable reason and no
+                /// response payload. Construct `GoalDecision::Reject`
+                /// directly to attach a response as well.
+                pub fn reject(reason: impl Into<String>) -> Self {
+                    Self::Reject {
+                        reason: Some(reason.into()),
+                        response: None,
+                    }
+                }
             }
         }
     } else {
@@ -67,7 +91,26 @@ pub fn build_goal_decision_enum(has_response: bool) -> TokenStream {
             #[allow(dead_code)]
             pub enum GoalDecision {
                 Accept,
-                Reject,
+                Reject {
+                    reason: Option<String>,
+                },
+            }
+
+            #[allow(dead_code)]
+            impl GoalDecision {
+                /// Admit the goal.
+                pub fn accept() -> Self {
+                    Self::Accept
+                }
+
+                /// Decline the goal with a human-readable reason. Construct
+                /// `GoalDecision::Reject { reason: None }` directly for a
+                /// silent reject.
+                pub fn reject(reason: impl Into<String>) -> Self {
+                    Self::Reject {
+                        reason: Some(reason.into()),
+                    }
+                }
             }
         }
     }
@@ -117,9 +160,12 @@ pub fn build_handle_goal_next_request(
                 quote! {
                     // Rejected: answer the client and keep polling for the
                     // next goal. A reject never ends the accept loop.
-                    GoalDecision::Reject(response) => {
-                        let response_payload = #serialize_reject;
-                        pending.reject(response_payload).await?;
+                    GoalDecision::Reject { reason, response } => {
+                        let response_payload = match response {
+                            Some(response) => #serialize_reject,
+                            None => peppylib::Payload::new(),
+                        };
+                        pending.reject(reason.as_deref(), response_payload).await?;
                     }
                 },
             )
@@ -134,8 +180,8 @@ pub fn build_handle_goal_next_request(
             quote! {
                 // Rejected: answer the client and keep polling for the next
                 // goal. A reject never ends the accept loop.
-                GoalDecision::Reject => {
-                    pending.reject(peppylib::Payload::new()).await?;
+                GoalDecision::Reject { reason } => {
+                    pending.reject(reason.as_deref(), peppylib::Payload::new()).await?;
                 }
             },
         ),

--- a/crates/generator-internal/src/generator/rust/tests/actions.rs
+++ b/crates/generator-internal/src/generator/rust/tests/actions.rs
@@ -234,7 +234,8 @@ fn exposed_action() {
     );
 
     // GoalResponse mirrors the declared response_message_format exactly. The
-    // framework decision is a separate enum whose branches both carry it.
+    // framework decision is a separate enum: an accept carries the declared
+    // response, a reject carries an optional reason and optional response.
     assert_contains_all(
         &rendered,
         &[
@@ -243,7 +244,10 @@ fn exposed_action() {
             "pub fn new(accepted: bool) -> Self",
             "pub enum GoalDecision",
             "Accept(GoalResponse)",
-            "Reject(GoalResponse)",
+            "reason: Option<String>",
+            "response: Option<GoalResponse>",
+            "pub fn accept(response: GoalResponse) -> Self",
+            "pub fn reject(reason: impl Into<String>) -> Self",
         ],
     );
 
@@ -277,8 +281,8 @@ fn exposed_action() {
             "recv_next_goal",
             "GoalDecision::Accept(response)",
             "pending.accept(response_payload).await?",
-            "GoalDecision::Reject(response)",
-            "pending.reject(response_payload).await?",
+            "GoalDecision::Reject { reason, response }",
+            "pending.reject(reason.as_deref(), response_payload).await?",
         ],
     );
 
@@ -325,7 +329,8 @@ fn expose_action_without_request_body() {
             "pub struct GoalResponse",
             "pub enum GoalDecision",
             "Accept(GoalResponse)",
-            "Reject(GoalResponse)",
+            "reason: Option<String>",
+            "response: Option<GoalResponse>",
             "pub async fn handle_goal_next_request",
             "F: Fn(&GoalRequest) -> crate::Result<GoalDecision>",
         ],
@@ -419,6 +424,9 @@ fn expose_feedback_only_action() {
             "pub enum GoalDecision",
             "Accept",
             "Reject",
+            "reason: Option<String>",
+            "pub fn reject(reason: impl Into<String>) -> Self",
+            "pending.reject(reason.as_deref(), peppylib::Payload::new()).await?",
             "pub struct GoalContext",
             "pub async fn publish_feedback",
         ],
@@ -554,7 +562,9 @@ fn consumed_action() {
             "pub struct ActionHandle",
             "messenger: peppylib::MessengerHandle",
             "inner: peppylib::messaging::ActionGoalHandle",
-            "pub data: GoalResponseData",
+            "pub accepted: bool",
+            "pub reason: Option<String>",
+            "pub data: Option<GoalResponseData>",
             "impl ActionHandle",
         ],
     );
@@ -901,13 +911,16 @@ fn consumed_action_without_response_payload() {
     let rendered = artifacts.into_iter().next().expect("artifact is present");
 
     // No declared goal response means the client handle carries no response
-    // data and needs no goal-response deserializer.
+    // data and needs no goal-response deserializer. The admission ack fields
+    // are still present.
     assert_contains_all(
         &rendered,
         &[
             "pub struct ActionHandle",
             "messenger: peppylib::MessengerHandle",
             "inner: peppylib::messaging::ActionGoalHandle",
+            "pub accepted: bool",
+            "pub reason: Option<String>",
             "impl ActionHandle",
             "pub async fn fire_goal",
             "pub async fn get_result",

--- a/crates/generator-internal/tests/python/actions_communication.rs
+++ b/crates/generator-internal/tests/python/actions_communication.rs
@@ -155,12 +155,24 @@ from peppygen.exposed_services import move_arm_flow_done
 from peppygen.consumed_actions.brain import move_arm as brain_move_arm
 
 async def run_consumer(node_runner):
-    request = brain_move_arm.GoalRequest(arm_id=7, desired_position=[10, 20, 30])
     arm = brain_move_arm.bound_producer(node_runner)
+
+    # A goal for the reserved arm is rejected through the framework
+    # admission ack; no declared response payload rides along.
+    reserved = brain_move_arm.GoalRequest(arm_id=99, desired_position=[0, 0, 0])
+    rejected = await brain_move_arm.ActionHandle.fire_goal(
+        node_runner, arm, reserved, 5.0, QoSProfile.SensorData
+    )
+    print(
+        f"rejected goal accepted={rejected.accepted} reason={rejected.reason} data_present={rejected.data is not None}",
+        flush=True,
+    )
+
+    request = brain_move_arm.GoalRequest(arm_id=7, desired_position=[10, 20, 30])
     goal = await brain_move_arm.ActionHandle.fire_goal(
         node_runner, arm, request, 5.0, QoSProfile.SensorData
     )
-    print(f"goal accepted={goal.data.accepted}", flush=True)
+    print(f"goal accepted={goal.accepted} data_accepted={goal.data.accepted}", flush=True)
 
     feedback = await goal.on_next_feedback_message()
     assert feedback.new_position == [7, 31, 43], "unexpected feedback message"
@@ -234,6 +246,8 @@ async def run_exposer(node_runner):
             f"server received goal arm_id={request.data.arm_id} desired={request.data.desired_position}",
             flush=True,
         )
+        if request.data.arm_id == 99:
+            return move_arm.GoalDecision.reject("arm 99 is reserved")
         return move_arm.GoalDecision.accept(move_arm.GoalResponse(True))
 
     while True:
@@ -387,7 +401,9 @@ if __name__ == "__main__":
         consumer_stderr
     );
     assert!(
-        consumer_stdout.contains("goal accepted=True")
+        consumer_stdout
+            .contains("rejected goal accepted=False reason=arm 99 is reserved data_present=False")
+            && consumer_stdout.contains("goal accepted=True data_accepted=True")
             && consumer_stdout.contains("feedback message received new_position=[7, 31, 43]")
             && consumer_stdout
                 .contains("result success=True error=None final_position=[98, 4, 26]"),

--- a/crates/generator-internal/tests/rust/actions_communication.rs
+++ b/crates/generator-internal/tests/rust/actions_communication.rs
@@ -498,6 +498,25 @@ use peppygen::Result;
 use std::time::Duration;
 
 async fn consume_action(node_runner: &peppygen::NodeRunner) -> Result<()> {
+    // A goal for the reserved arm is rejected through the framework
+    // admission ack; no declared response payload rides along.
+    let rejected = brain_move_arm::ActionHandle::fire_goal(
+        &node_runner,
+        brain_move_arm::bound_producer(&node_runner),
+        Duration::from_secs(5),
+        brain_move_arm::GoalRequest {
+            arm_id: 99,
+            desired_position: [0, 0, 0],
+        },
+        peppygen::QoSProfile::SensorData,
+    ).await?;
+    println!(
+        "rejected goal accepted={} reason={:?} data_present={}",
+        rejected.accepted,
+        rejected.reason.as_deref(),
+        rejected.data.is_some()
+    );
+
     let request = brain_move_arm::GoalRequest {
         arm_id: 7,
         desired_position: [10, 20, 30],
@@ -509,7 +528,8 @@ async fn consume_action(node_runner: &peppygen::NodeRunner) -> Result<()> {
         request,
         peppygen::QoSProfile::SensorData,
     ).await?;
-    println!("goal accepted={}", action_handle.data.accepted);
+    let data = action_handle.data.as_ref().expect("accepted goal carries the declared response");
+    println!("goal accepted={} data_accepted={}", action_handle.accepted, data.accepted);
 
     let feedback = action_handle.on_next_feedback_message().await?;
     assert_eq!(feedback.new_position, [7, 31, 43], "unexpected feedback message");
@@ -592,6 +612,9 @@ async fn expose_action(node_runner: &peppygen::NodeRunner) -> Result<()> {
                         "server received goal arm_id={} desired={:?}",
                         request.data.arm_id, request.data.desired_position
                     );
+                    if request.data.arm_id == 99 {
+                        return Ok(move_arm::GoalDecision::reject("arm 99 is reserved"));
+                    }
                     Ok(move_arm::GoalDecision::Accept(move_arm::GoalResponse::new(true)))
                 })
                 .await;
@@ -732,7 +755,9 @@ fn main() -> Result<()> {
         consumer_stderr
     );
     assert!(
-        consumer_stdout.contains("goal accepted=true")
+        consumer_stdout.contains(
+            "rejected goal accepted=false reason=Some(\"arm 99 is reserved\") data_present=false"
+        ) && consumer_stdout.contains("goal accepted=true data_accepted=true")
             && consumer_stdout.contains("feedback message received new_position=[7, 31, 43]")
             && consumer_stdout
                 .contains("result success=true error=None final_position=[98, 4, 26]"),
@@ -850,7 +875,7 @@ async fn consume_action(node_runner: &peppygen::NodeRunner) -> Result<()> {
         request,
         peppygen::QoSProfile::SensorData,
     ).await?;
-    println!("goal accepted={}", action_handle.data.accepted);
+    println!("goal accepted={}", action_handle.data.as_ref().expect("accepted goal carries the declared response").accepted);
 
     let cancel_response = action_handle.cancel_goal(Duration::from_secs(5)).await?;
     let accepted = matches!(
@@ -1200,7 +1225,7 @@ async fn consume_action(node_runner: &peppygen::NodeRunner) -> Result<()> {
         request,
         peppygen::QoSProfile::SensorData,
     ).await?;
-    println!("goal accepted={}", action_handle.data.accepted);
+    println!("goal accepted={}", action_handle.data.as_ref().expect("accepted goal carries the declared response").accepted);
     println!("draining feedback...");
 
     // Drain-loop pattern: keep reading feedback until the server signals
@@ -1594,7 +1619,7 @@ async fn consume_action(node_runner: &peppygen::NodeRunner) -> Result<()> {
         request,
         peppygen::QoSProfile::SensorData,
     ).await?;
-    println!("goal accepted={}", action_handle.data.accepted);
+    println!("goal accepted={}", action_handle.data.as_ref().expect("accepted goal carries the declared response").accepted);
 
     // Server emits a single warmup feedback before the cancel arrives so
     // we can verify it's received before the close signal.
@@ -1972,7 +1997,7 @@ async fn consume_action(node_runner: &peppygen::NodeRunner) -> Result<()> {
         request,
         peppygen::QoSProfile::SensorData,
     ).await?;
-    println!("goal accepted={}", action_handle.data.accepted);
+    println!("goal accepted={}", action_handle.data.as_ref().expect("accepted goal carries the declared response").accepted);
 
     let pre_cancel = action_handle.on_next_feedback_message().await?;
     println!("pre_cancel feedback new_position={:?}", pre_cancel.new_position);
@@ -2368,7 +2393,7 @@ async fn consume_action(node_runner: &peppygen::NodeRunner) -> Result<()> {
         request,
         peppygen::QoSProfile::SensorData,
     ).await?;
-    println!("goal accepted={}", action_handle.data.accepted);
+    println!("goal accepted={}", action_handle.data.as_ref().expect("accepted goal carries the declared response").accepted);
 
     let first = action_handle.on_next_feedback_message().await?;
     println!("first feedback received new_position={:?}", first.new_position);

--- a/crates/peppy/src/commands/action_poll.rs
+++ b/crates/peppy/src/commands/action_poll.rs
@@ -49,7 +49,7 @@ where
     Fb: ActionFeedbackLike,
     Res: ActionResultLike,
 {
-    let goal_response_payload = action_handle.goal_response().payload();
+    let goal_response_payload = action_handle.goal_reply().body.clone();
     let goal_response = Resp::decode_payload(&goal_response_payload)
         .map_err(|e| Error::ExecutionFailed(format!("Failed to decode goal response: {}", e)))?;
 

--- a/crates/peppy/src/commands/repo/refresh.rs
+++ b/crates/peppy/src/commands/repo/refresh.rs
@@ -34,7 +34,7 @@ async fn repo_refresh_async(ctx: &Arc<AppContext>) -> Result<()> {
     .await
     .map_err(|e| Error::ExecutionFailed(format!("Failed to send repo refresh goal: {}", e)))?;
 
-    let goal_response_payload = action_handle.goal_response().payload();
+    let goal_response_payload = action_handle.goal_reply().body.clone();
     let goal_response = RepoRefreshGoalResponse::decode(&goal_response_payload)
         .map_err(|e| Error::ExecutionFailed(format!("Failed to decode goal response: {}", e)))?;
 

--- a/crates/peppy/src/commands/stack/benchmark.rs
+++ b/crates/peppy/src/commands/stack/benchmark.rs
@@ -94,10 +94,8 @@ async fn benchmark_async(
     .await
     .map_err(|e| Error::ExecutionFailed(format!("Failed to send benchmark goal: {}", e)))?;
 
-    let goal_response = StackBenchmarkGoalResponse::decode(
-        &action_handle.goal_response().payload(),
-    )
-    .map_err(|e| Error::ExecutionFailed(format!("Failed to decode goal response: {}", e)))?;
+    let goal_response = StackBenchmarkGoalResponse::decode(&action_handle.goal_reply().body)
+        .map_err(|e| Error::ExecutionFailed(format!("Failed to decode goal response: {}", e)))?;
 
     if !goal_response.accepted {
         let reason = goal_response

--- a/crates/peppy/src/commands/stack/launch.rs
+++ b/crates/peppy/src/commands/stack/launch.rs
@@ -269,7 +269,7 @@ async fn launch_async(
     .await
     .map_err(|e| Error::ExecutionFailed(format!("Failed to send launch goal: {}", e)))?;
 
-    let goal_response = LaunchGoalResponse::decode(&action_handle.goal_response().payload())
+    let goal_response = LaunchGoalResponse::decode(&action_handle.goal_reply().body)
         .map_err(|e| Error::ExecutionFailed(format!("Failed to decode goal response: {}", e)))?;
 
     if !goal_response.accepted {

--- a/docs/src/content/docs/advanced_guides/actions.mdx
+++ b/docs/src/content/docs/advanced_guides/actions.mdx
@@ -28,7 +28,7 @@ Additionally, the client can issue a **cancel** request at any time to abort an 
 Client                              Server
   │                                    │
   │──── fire_goal (request) ──────────>│
-  │<─── GoalResponse (accepted) ───────│
+  │<─── goal ack (+ GoalResponse) ─────│
   │                                    │
   │<─── feedback ──────────────────────│  (repeated)
   │<─── feedback ──────────────────────│
@@ -64,9 +64,6 @@ Each action defines a `goal_service`, a `feedback_topic`, and a `result_service`
                     $items: "i32",
                     $length: 3
                   }
-                },
-                response_message_format: {
-                  accepted: "bool"
                 }
               },
               feedback_topic: {
@@ -126,9 +123,6 @@ Each action defines a `goal_service`, a `feedback_topic`, and a `result_service`
                     $items: "i32",
                     $length: 3
                   }
-                },
-                response_message_format: {
-                  accepted: "bool"
                 }
               },
               feedback_topic: {
@@ -204,9 +198,7 @@ fn main() -> Result<()> {
                     );
                     // The decider sets the concurrency policy: e.g. reject a
                     // goal for a busy `arm_id`.
-                    Ok(move_arm::GoalDecision::Accept(
-                        move_arm::GoalResponse::new(true),
-                    ))
+                    Ok(move_arm::GoalDecision::accept())
                 })
                 .await
             {
@@ -255,7 +247,7 @@ async def run_action(node_runner):
             f"desired={request.data.desired_position}",
             flush=True,
         )
-        return move_arm.GoalDecision.accept(move_arm.GoalResponse(True))
+        return move_arm.GoalDecision.accept()
 
     while True:
         ctx = await action.handle_goal_next_request(decide)
@@ -279,12 +271,11 @@ if __name__ == "__main__":
   </TabItem>
 </Tabs>
 
-`GoalResponse` contains exactly the fields declared in `goal_service.response_message_format`. The framework never adds an `accepted` or error field. `GoalDecision` controls admission independently of that payload:
+`GoalDecision` controls admission. The decision and its optional rejection reason travel in a framework-owned envelope wrapped around the goal reply, so they never appear in your schema: `GoalResponse` contains exactly the fields declared in `goal_service.response_message_format`, and the framework never adds an `accepted` or error field to it.
 
-- `GoalDecision::Accept(response)` (`GoalDecision.accept(response)` in Python) admits the goal, sends `response` to the client, and yields a `GoalContext`.
-- `GoalDecision::Reject(response)` (`GoalDecision.reject(response)` in Python) declines it: the client receives the supplied response, no context is created, and the accept loop transparently moves on to the next goal. This is where you enforce per-resource concurrency limits.
-
-Both decisions send the response, including `Reject`. If `response_message_format` is omitted, use the corresponding decision without a response argument. The framework decision remains separate and still works with an empty response payload.
+- `GoalDecision::accept()` (`GoalDecision.accept()` in Python) admits the goal, replies to the client, and yields a `GoalContext`. When the action declares a `response_message_format`, the constructor takes the declared response instead: `GoalDecision::accept(response)`.
+- `GoalDecision::reject(reason)` (`GoalDecision.reject(reason)` in Python) declines it: the client sees `accepted == false` and the reason on its handle, no context is created, and the accept loop transparently moves on to the next goal. This is where you enforce per-resource concurrency limits.
+- A reject can also carry the declared response payload: construct `GoalDecision::Reject { reason, response }` directly in Rust, or pass both arguments in Python with `GoalDecision.reject(reason, response)`. The client's `data` is absent when a rejection carried no payload.
 
 The `GoalRequest` passed to the decider contains:
 - `instance_id`: the client instance that sent the goal. The producer is binding-agnostic; it doesn't know which slot on the client this goal is heading to.
@@ -317,13 +308,13 @@ while let Ok(Some(ctx)) = action
         move |request| -> Result<move_arm::GoalDecision> {
             // `HashSet::insert` returns false when the arm is already busy.
             if busy.lock().unwrap().insert(request.data.arm_id) {
-                Ok(move_arm::GoalDecision::Accept(
-                    move_arm::GoalResponse::new(true),
-                ))
+                Ok(move_arm::GoalDecision::accept())
             } else {
-                Ok(move_arm::GoalDecision::Reject(
-                    move_arm::GoalResponse::new(false),
-                ))
+                // The reason rides back to the client in the goal ack.
+                Ok(move_arm::GoalDecision::reject(format!(
+                    "arm {} is already moving",
+                    request.data.arm_id
+                )))
             }
         }
     })
@@ -356,9 +347,10 @@ async def drive(ctx):
 def decide(request):
     arm_id = request.data.arm_id
     if arm_id in busy:
-        return move_arm.GoalDecision.reject(move_arm.GoalResponse(False))
+        # The reason rides back to the client in the goal ack.
+        return move_arm.GoalDecision.reject(f"arm {arm_id} is already moving")
     busy.add(arm_id)
-    return move_arm.GoalDecision.accept(move_arm.GoalResponse(True))
+    return move_arm.GoalDecision.accept()
 
 
 while True:
@@ -523,7 +515,10 @@ fn main() -> Result<()> {
         )
         .await?;
 
-        println!("goal accepted={}", action_handle.data.accepted);
+        println!(
+            "goal accepted={} reason={:?}",
+            action_handle.accepted, action_handle.reason
+        );
 
         Ok(())
     })
@@ -549,7 +544,10 @@ async def run(node_runner):
         5.0,                    # timeout (seconds)
         QoSProfile.SensorData,  # QoS for the feedback topic
     )
-    print(f"goal accepted={action_handle.data.accepted}", flush=True)
+    print(
+        f"goal accepted={action_handle.accepted} reason={action_handle.reason}",
+        flush=True,
+    )
 
 
 async def setup(parameters, node_runner):
@@ -568,7 +566,7 @@ if __name__ == "__main__":
 
 `fire_goal` requires the caller to pass one explicit target for every [cardinality](/advanced_guides/topics#dependency-cardinality), including the default `one`; obtain it from the slot's cardinality-typed accessor (the singular, infallible `bound_producer()` on a `one` slot, `bound_producers()` on the multi cardinalities, never empty for `one_or_more`). The target must belong to the slot's own set; anything else fails with a runtime error before the goal reaches the wire. Firing a goal at every bound producer of a multi-cardinality slot is a plain loop over `bound_producers()`; each returned handle drives its own feedback stream, cancel, and result, exactly as a single goal does.
 
-`fire_goal` returns an `ActionHandle` whose `data` field holds the goal response (e.g. `data.accepted`). The handle retains the selected target: goal submission, feedback, result retrieval, and cancellation all stay pinned to that same producer; no stage uses a wildcard, fallback producer, discovery, or automatic retargeting. The handle is what you use for subsequent feedback, result, and cancel calls. You can fire multiple goals concurrently, and each returns its own handle, so the server can drive them in parallel.
+`fire_goal` returns an `ActionHandle`. Its `accepted` flag and optional rejection `reason` are decoded from the framework goal ack, and, when the action declares a `response_message_format`, its `data` field holds the declared goal response (absent when a rejection carried no payload). The handle retains the selected target: goal submission, feedback, result retrieval, and cancellation all stay pinned to that same producer; no stage uses a wildcard, fallback producer, discovery, or automatic retargeting. The handle is what you use for subsequent feedback, result, and cancel calls. You can fire multiple goals concurrently, and each returns its own handle, so the server can drive them in parallel.
 
 ### Receiving feedback
 
@@ -804,5 +802,5 @@ This makes the "one server, many resources" pattern natural: include a
 discriminator in the goal request (e.g. `arm_id` or `device_id`) and route to a
 per-resource worker. Your goal handler is responsible for the concurrency
 policy: accept goals to run them in parallel, or reject a goal (with
-`GoalDecision::Reject(response)`) when its target resource is already busy. A goal
+`GoalDecision::reject(reason)`) when its target resource is already busy. A goal
 that is not accepted yields no `GoalContext` and cannot be cancelled or completed.


### PR DESCRIPTION
## Summary

Companion to Peppy-bot/public-peppy-libs#63 (merge that first, see sequencing below). peppylib now frames every goal reply in a framework admission ack (`accepted` + optional human-readable `reason`) wrapped around the declared response body. This PR adopts it across the generators, CLI clients, daemon, tests, and docs:

- **Generated producer API**: `GoalDecision` keeps admission out of the declared payload and regains the old ergonomics. `GoalDecision::accept()` / `GoalDecision.accept()` (taking the declared `GoalResponse` when one is declared) and `GoalDecision::reject("arm 3 is already moving")` / `GoalDecision.reject(reason)`. A reject can optionally carry the declared response too (`GoalDecision::Reject { reason, response }` in Rust, `reject(reason, response)` in Python).
- **Generated consumer API**: `fire_goal` handles expose the decoded ack: `accepted: bool`, `reason: Option<String>`, and `data` (the declared `GoalResponse`, `Option`al: absent when a rejection carried no payload). Contracts no longer need to duplicate an `accepted` field for clients to see admission.
- **CLI/daemon**: action clients decode `goal_reply().body`; the daemon's `reject_goal` passes no envelope reason because the core-node action protocol keeps its structured reason in its own payload.
- **Docs**: the `move_arm` examples drop their redundant `accepted: "bool"` response schema and read as they did before the split, with the reason restored (`reject("arm N is already moving")`), while the contract-honesty guarantees from #320 are kept: declared schemas generate exactly the declared fields and the framework never injects any.

## Why

After #320 the admission flag no longer reached the wire at all: accept and reject sent identical bytes, so a client could not distinguish an admitted goal from a rejected one unless the contract duplicated the flag in its own schema (which the examples were forced to do, producing `GoalDecision.accept(GoalResponse(True))`). Admission is framework semantics (it decides whether a `GoalContext` and cancel/result routing exist), so it now travels as protocol, like the `goal_id` request envelope and the framework-owned cancel ack, and the redundancy in the examples disappears.

This is an intentional breaking change with no legacy shims, consistent with #320.

## Sequencing

~~Blocked on Peppy-bot/public-peppy-libs#63.~~ **Resolved:** #63 is merged and `Cargo.lock` now pins the merged libs rev (`b622f119`), so this branch builds against the libs default branch. Re-validated against the pinned git deps: `cargo check --workspace --all-targets`, `cargo test -p generator --lib` (159), and the daemon action e2e suites (`listen_for_repo_refresh` 15, `listen_for_stack_benchmark` 14, `listen_for_launch` 4). The full generator e2e suites below ran earlier against byte-identical libs sources via the local co-dev toggle (restored to OFF).

## Test plan

- `cargo fmt --all -- --check`, `git diff --check`
- `cargo test -p generator --lib` (159 unit/generated-code tests)
- `cargo test -p generator --test python` (42 e2e, incl. a new cross-node rejected-goal round asserting `accepted=False`, the reason string, and the absent payload)
- `cargo test -p generator --test rust` (39 e2e, incl. the same new rejected-goal round)
- `cargo test -p core-node --lib` (245) and the daemon action e2e suites `listen_for_repo_refresh` (15), `listen_for_stack_benchmark` (14), `listen_for_launch` (4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Goal decisions now support optional human-readable rejection reasons and response payloads.
  * Action handles now expose acceptance status and rejection reasons directly.
  * Goal response data is correctly treated as optional when no payload is provided.

* **Documentation**
  * Updated action-handling examples and guidance for the revised decision and response behavior.

* **Tests**
  * Added coverage for rejected goals with reasons and reserved-action scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
