### PR TITLE
Deregister this machine's core node on `peppy platform logout`

### DIFF
--- a/crates/auth-internal/src/client.rs
+++ b/crates/auth-internal/src/client.rs
@@ -139,6 +139,32 @@ pub fn logout(http: &HttpClient, api_url: &str, access_token: &str) -> Result<u1
     Ok(resp.status)
 }
 
+/// `DELETE {api_url}/me/core-nodes/{core_node_name}`: remove this machine's core
+/// node from the caller's registry on the platform. Returns the status code so
+/// the caller can decide what to print (`204` removed, `404` nothing to remove).
+///
+/// Never refreshes, deliberately, exactly like [`logout`]. `peppy platform
+/// logout` calls this immediately before revoking the very token it holds: a
+/// refresh here would mint a token that the revocation which follows does not
+/// cover, leaving it valid until its own expiry.
+///
+/// The name goes into the path unencoded because the backend accepts only
+/// `[A-Za-z0-9_-]`, which is the daemon's own charset, so a core-node name is
+/// always a literal path segment.
+pub fn deregister_core_node(
+    http: &HttpClient,
+    api_url: &str,
+    access_token: &str,
+    core_node_name: &str,
+) -> Result<u16> {
+    let url = format!(
+        "{}/me/core-nodes/{core_node_name}",
+        api_url.trim_end_matches('/')
+    );
+    let resp = http.delete(&url, Some(access_token))?;
+    Ok(resp.status)
+}
+
 /// A GET that, on 401 with a session credential, refreshes (and persists) the
 /// token and retries exactly once.
 fn authed_get(http: &HttpClient, url: &str, cred: &mut Credential) -> Result<HttpResponse> {

--- a/crates/auth-internal/src/http.rs
+++ b/crates/auth-internal/src/http.rs
@@ -145,6 +145,14 @@ impl HttpClient {
             .map_err(|e| Error::Http(format!("POST {} failed: {e}", redact(url))))?;
         finish("POST", url, resp)
     }
+
+    /// `DELETE url` (used for `/me/core-nodes/{core_node_name}`).
+    pub fn delete(&self, url: &str, bearer: Option<&str>) -> Result<HttpResponse> {
+        let resp = with_bearer(self.agent.delete(url), bearer)
+            .call()
+            .map_err(|e| Error::Http(format!("DELETE {} failed: {e}", redact(url))))?;
+        finish("DELETE", url, resp)
+    }
 }
 
 /// Strips the query string from a URL for error messages, so a `verification_uri_complete`

--- a/crates/daemon-internal/src/router_federation.rs
+++ b/crates/daemon-internal/src/router_federation.rs
@@ -27,18 +27,19 @@
 //!   *verifies* the federation link with a real TLS handshake
 //!   ([`pmi::probe_tls_reachable`]) so a silent UnknownCA loop is reported as
 //!   [`FederationOutcome::Unreachable`] rather than a false success.
-//! * **Liveness (backend-driven).** There is no client-side keepalive poll. Once
-//!   federated, the local router holds its link to the cloud router open on its
-//!   own (`reconnect: true`); the backend actively probes this daemon's `/health`
-//!   service over the federated link and tears the cloud router down when the
-//!   daemon stops answering. The config pull on startup/login tells the backend
-//!   this daemon's `core_node` name so it knows which `/health` service to probe.
+//! * **Liveness.** There is no keepalive poll in either direction. Once
+//!   federated, the local router holds its link to the shared router open on its
+//!   own (`reconnect: true`), and the backend neither probes this daemon nor
+//!   tears anything down: the router it hands back is a single shared one, not a
+//!   per-user resource with a lifetime.
 //! * **Registration cadence.** Every config pull's POST carries this daemon's
 //!   core-node name, upserting it into the backend's per-principal core-node
 //!   registry. The POST fires on cache-stale pulls and on login/logout pokes —
 //!   login clears the router cache, so every login re-registers — never on a
 //!   timer. The backend's `last_seen_at` for a core node therefore means "last
-//!   federation config pull", not liveness.
+//!   federation config pull", not liveness. `peppy platform logout` removes the
+//!   row outright (`DELETE /me/core-nodes/{core_node_name}`), since a logged-out
+//!   machine stops federating and stops pulling config.
 //! * **Live (re)federation.** When the resolved upstream changes (the user logs
 //!   in, logs out, or the endpoint moves) the local router's zenohd config is
 //!   re-rendered and the router restarted, so the change takes effect without a

--- a/crates/peppy/src/commands/platform.rs
+++ b/crates/peppy/src/commands/platform.rs
@@ -81,16 +81,33 @@ pub(crate) enum FederationPokeAction {
 /// nor skip the poke a managed daemon needs to (de)federate immediately
 /// (managed daemon, external config on disk). Only when no daemon is running,
 /// so there is nothing to poke or restart either way, does the on-disk `config`
-/// decide, matching what the next daemon start will do. The state file is read
-/// from the same `dirs` the command resolved, so a test seam isolates it.
+/// decide, matching what the next daemon start will do.
+///
+/// Takes the already-parsed `state` rather than reading the file itself, so a
+/// command that needs more than one field from it (logout needs the core-node
+/// name too) reads it exactly once and cannot see two different daemon
+/// generations within one invocation.
 pub(crate) fn federation_poke_timeout_secs(
-    dirs: &PeppyDirs,
+    state: Option<&DaemonState>,
     config: &daemon_config::peppy_config::PeppyConfig,
 ) -> Option<u64> {
-    match DaemonState::read_from(&DaemonState::state_file_in(dirs.root())) {
-        Ok(state) if state.is_running() => state.federation_connect_timeout_secs,
+    match state {
+        Some(state) if state.is_running() => state.federation_connect_timeout_secs,
         _ => config.zenoh.federation().map(|f| f.connect_timeout_secs),
     }
+}
+
+/// The daemon state file under `dirs`, or `None` when it is absent or
+/// unreadable. Read from the same `dirs` the command resolved, so a test seam
+/// isolates it.
+///
+/// The file outlives the daemon process, so a successful read is not proof of
+/// liveness; consumers that need "is a daemon actually up" check
+/// [`DaemonState::is_running`] themselves, and consumers that only need what the
+/// last daemon generation recorded (the core-node name it registered under) do
+/// not.
+pub(crate) fn read_daemon_state(dirs: &PeppyDirs) -> Option<DaemonState> {
+    DaemonState::read_from(&DaemonState::state_file_in(dirs.root())).ok()
 }
 
 /// Confirms (before authentication begins) a managed-router login/logout that
@@ -472,7 +489,10 @@ impl Command for PlatformCommand {
 
 #[cfg(test)]
 mod tests {
-    use super::{federation_poke_timeout_secs, report_login, report_logout, stack_has_user_nodes};
+    use super::{
+        federation_poke_timeout_secs, read_daemon_state, report_login, report_logout,
+        stack_has_user_nodes,
+    };
     use core_node_api::{
         InstanceState, NodeStage, SerializedInstance, SerializedNode, SerializedNodeGraph,
     };
@@ -522,12 +542,12 @@ mod tests {
         let dirs = PeppyDirs::new(dir.path());
         let managed = managed_config();
         assert_eq!(
-            federation_poke_timeout_secs(&dirs, &managed),
+            federation_poke_timeout_secs(read_daemon_state(&dirs).as_ref(), &managed),
             managed.zenoh.federation().map(|f| f.connect_timeout_secs),
             "no state file: a managed disk config supplies the poke timeout"
         );
         assert_eq!(
-            federation_poke_timeout_secs(&dirs, &external_config()),
+            federation_poke_timeout_secs(read_daemon_state(&dirs).as_ref(), &external_config()),
             None,
             "no state file: an external disk config means no poke"
         );
@@ -542,7 +562,7 @@ mod tests {
         // with the daemon's own timeout.
         write_running_state(&dirs, Some(7));
         assert_eq!(
-            federation_poke_timeout_secs(&dirs, &external_config()),
+            federation_poke_timeout_secs(read_daemon_state(&dirs).as_ref(), &external_config()),
             Some(7),
             "a running managed daemon must be poked even if the disk config went external"
         );
@@ -551,7 +571,7 @@ mod tests {
         // so login/logout must not warn about a restart or poke anything.
         write_running_state(&dirs, None);
         assert_eq!(
-            federation_poke_timeout_secs(&dirs, &managed_config()),
+            federation_poke_timeout_secs(read_daemon_state(&dirs).as_ref(), &managed_config()),
             None,
             "a running external daemon has no control socket to poke"
         );
@@ -578,7 +598,7 @@ mod tests {
 
         let managed = managed_config();
         assert_eq!(
-            federation_poke_timeout_secs(&dirs, &managed),
+            federation_poke_timeout_secs(read_daemon_state(&dirs).as_ref(), &managed),
             managed.zenoh.federation().map(|f| f.connect_timeout_secs),
             "a dead daemon's state must not override the disk config"
         );

--- a/crates/peppy/src/commands/platform/login.rs
+++ b/crates/peppy/src/commands/platform/login.rs
@@ -41,7 +41,8 @@ impl Command for LoginCommand {
         // Managed vs external follows the RUNNING daemon's mode (from its state
         // file), not the disk config, which may have been edited since it
         // started; only with no daemon running does the disk config decide.
-        let federation = super::federation_poke_timeout_secs(&dirs, &config);
+        let daemon_state = super::read_daemon_state(&dirs);
+        let federation = super::federation_poke_timeout_secs(daemon_state.as_ref(), &config);
         let api_url = profile::resolve_api_url(self.api_url.as_deref(), &config.resource_servers)?;
         let creds_path = storage::credentials_path(&dirs);
         let http = HttpClient::new();

--- a/crates/peppy/src/commands/platform/logout.rs
+++ b/crates/peppy/src/commands/platform/logout.rs
@@ -1,13 +1,16 @@
-//! `peppy platform logout`: kill the access token on the backend (cross-replica) and
-//! delete the local session credentials. Does not revoke the refresh token at
-//! Zitadel (out of scope for v1); a backend that's unreachable or returns
-//! 401/503 still results in the local credentials being cleared.
+//! `peppy platform logout`: deregister this machine's core node, kill the access
+//! token on the backend (cross-replica), and delete the local session
+//! credentials. Does not revoke the refresh token at Zitadel (out of scope for
+//! v1); a backend that's unreachable or returns 401/503 still results in the
+//! local credentials being cleared.
 
 use std::sync::Arc;
 
 use secrecy::ExposeSecret;
 
+use daemon::state::DaemonState;
 use daemon_config::consts::PeppyDirs;
+use daemon_config::peppy_config::PeppyConfig;
 
 use crate::commands::Command;
 use crate::context::AppContext;
@@ -31,7 +34,8 @@ impl Command for LogoutCommand {
         // Managed vs external follows the RUNNING daemon's mode (from its state
         // file), not the disk config, which may have been edited since it
         // started; only with no daemon running does the disk config decide.
-        let federation = super::federation_poke_timeout_secs(&dirs, &config);
+        let daemon_state = super::read_daemon_state(&dirs);
+        let federation = super::federation_poke_timeout_secs(daemon_state.as_ref(), &config);
         let api_url = profile::resolve_api_url(self.api_url.as_deref(), &config.resource_servers)?;
         let creds_path = storage::credentials_path(&dirs);
         let http = HttpClient::new();
@@ -68,6 +72,20 @@ impl Command for LogoutCommand {
         }
 
         let access_token = pc.access_token.expose_secret().to_string();
+
+        // Leave the platform's core-node registry before the revocation below
+        // kills the token this call needs, and after the `confirm_restart` prompt
+        // above, so an aborted logout deregisters nothing. Logging out is what
+        // removes a machine from the registry: it stops federating, drops to the
+        // `local` namespace, and stops pulling config, so leaving its row behind
+        // would be a lie.
+        deregister_core_node(
+            &http,
+            &api_url,
+            &access_token,
+            registered_core_node_name(daemon_state.as_ref(), &config).as_deref(),
+        );
+
         match client::logout(&http, &api_url, &access_token) {
             Ok(202) | Ok(401) => {}
             Ok(503) => println!(
@@ -103,5 +121,136 @@ impl Command for LogoutCommand {
             None => println!("{}", super::EXTERNAL_ROUTER_NOTE),
         }
         Ok(())
+    }
+}
+
+/// The core-node name this machine registered with the platform, for
+/// deregistration.
+///
+/// The daemon state file wins, and is used REGARDLESS of whether the pid it
+/// records is still alive: the file outlives the daemon process, so a machine
+/// whose daemon is already stopped still knows the name it registered under,
+/// which is the ordinary case for a logout rather than the exception. An
+/// explicitly configured `peppy_config.core_node_name` is the fallback for a
+/// wiped state file.
+///
+/// `None` when neither resolves, which leaves one row behind. The residual leak
+/// is narrow: the state file would have to be gone while the credentials
+/// survive, and a wiped `PEPPY_HOME` takes both, so logout exits early with "not
+/// logged in". The daemon's private `derive_core_node_name` is deliberately not
+/// exported to close that last sliver, because recomputing a machine-UID hash to
+/// guess which row to delete is a worse failure mode than leaving one behind.
+fn registered_core_node_name(
+    daemon_state: Option<&DaemonState>,
+    config: &PeppyConfig,
+) -> Option<String> {
+    [
+        daemon_state.map(|state| state.core_node_name.as_str()),
+        config.core_node_name.as_deref(),
+    ]
+    .into_iter()
+    .flatten()
+    .map(str::trim)
+    .find(|name| !name.is_empty())
+    .map(str::to_owned)
+}
+
+/// Remove this machine's row from the platform's core-node registry, best
+/// effort. Every failure warns and lets logout complete, matching what logout
+/// already does for the token revocation itself.
+///
+/// A `404` is silent success: an external-mode daemon that never registered, and
+/// a repeated logout, both find nothing to remove.
+fn deregister_core_node(
+    http: &HttpClient,
+    api_url: &str,
+    access_token: &str,
+    core_node_name: Option<&str>,
+) {
+    let Some(core_node_name) = core_node_name else {
+        eprintln!(
+            "Warning: could not determine this machine's core-node name; it stays listed in \
+             the platform's core-node registry."
+        );
+        return;
+    };
+    let leak =
+        format!("core node {core_node_name} may stay listed in the platform's core-node registry");
+    match client::deregister_core_node(http, api_url, access_token, core_node_name) {
+        Ok(204) | Ok(404) => {}
+        Ok(status) => eprintln!("Warning: deregistering returned {status}; {leak}."),
+        Err(e) => eprintln!("Warning: could not reach the backend ({e}); {leak}."),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn state_with(core_node_name: &str, pid: Option<u32>) -> DaemonState {
+        let mut state = DaemonState::new(
+            core_node_name,
+            "127.0.0.1",
+            7447,
+            "test",
+            5,
+            config::namespace::Namespace::local(),
+            None,
+        );
+        state.daemon_pid = pid;
+        state
+    }
+
+    fn config_with(core_node_name: Option<&str>) -> PeppyConfig {
+        PeppyConfig {
+            core_node_name: core_node_name.map(str::to_owned),
+            ..PeppyConfig::default()
+        }
+    }
+
+    #[test]
+    fn the_daemon_state_name_wins_over_the_configured_one() {
+        let state = state_with("cn-from-state", Some(std::process::id()));
+        assert_eq!(
+            registered_core_node_name(Some(&state), &config_with(Some("cn-from-config"))),
+            Some("cn-from-state".to_string()),
+            "the running daemon registered under the name it recorded, not the disk config's"
+        );
+    }
+
+    #[test]
+    fn a_dead_daemons_state_file_still_resolves_the_name() {
+        // The ordinary case: logging out on a machine whose daemon is already
+        // stopped. The state file outlives the process, and it still names the
+        // core node this machine registered under, so `is_running` must not gate
+        // this the way it gates the federation poke.
+        let state = state_with("cn-from-dead-daemon", Some(u32::MAX));
+        assert!(!state.is_running(), "u32::MAX names no live process");
+        assert_eq!(
+            registered_core_node_name(Some(&state), &config_with(None)),
+            Some("cn-from-dead-daemon".to_string())
+        );
+    }
+
+    #[test]
+    fn the_configured_name_is_the_fallback_for_a_wiped_state_file() {
+        assert_eq!(
+            registered_core_node_name(None, &config_with(Some("cn-from-config"))),
+            Some("cn-from-config".to_string())
+        );
+        // A state file that somehow carries no name falls through to the config
+        // rather than deregistering an empty name.
+        let blank = state_with("   ", Some(std::process::id()));
+        assert_eq!(
+            registered_core_node_name(Some(&blank), &config_with(Some("cn-from-config"))),
+            Some("cn-from-config".to_string())
+        );
+    }
+
+    #[test]
+    fn neither_source_yields_no_name() {
+        // Nothing is guessed here: recomputing the machine-UID hash to pick a row
+        // to delete would be a worse failure mode than leaving one behind.
+        assert_eq!(registered_core_node_name(None, &config_with(None)), None);
     }
 }

--- a/crates/peppy/tests/platform_flow.rs
+++ b/crates/peppy/tests/platform_flow.rs
@@ -416,7 +416,8 @@ fn deregistration_never_refreshes_the_token_logout_is_about_to_revoke() {
     let dir = tempfile::tempdir().expect("temp dir");
     let path = logout_with_core_node(&server, &dir, "cn-stale-token");
 
-    assert_eq!(deregister.calls(), 1);
+    // Asserted before the call count, so a refreshing implementation reports the
+    // property it broke rather than the retry that broke it.
     assert_eq!(
         discovery.calls(),
         0,
@@ -426,6 +427,11 @@ fn deregistration_never_refreshes_the_token_logout_is_about_to_revoke() {
         token.calls(),
         0,
         "deregistration must not mint a token the revocation that follows would not cover"
+    );
+    assert_eq!(
+        deregister.calls(),
+        1,
+        "the 401 is reported, not retried under a new token"
     );
     assert!(logout.calls() >= 1, "a 401 must not stop the revocation");
     assert!(

--- a/crates/peppy/tests/platform_flow.rs
+++ b/crates/peppy/tests/platform_flow.rs
@@ -338,9 +338,14 @@ fn logout_with_core_node(
 #[test]
 fn logout_deregisters_this_machines_core_node() {
     let server = MockServer::start();
-    // Scoped to the exact path and to the bearer the session holds: the DELETE
-    // must go out under the token logout is about to revoke, which is only true
-    // if it runs before the revocation and never refreshes.
+    // Matching on the header as well as the path means an unauthenticated DELETE
+    // (or one under some other token) does not match, and `calls()` reads 0.
+    // Ordering against the revocation is deliberately NOT asserted here: the
+    // `/logout` mock is stateless, so a DELETE sent after it would look
+    // identical, and httpmock exposes no ordered request log to tell them apart.
+    // What ordering exists for, keeping a live token under the DELETE, is
+    // covered from the other side by
+    // `deregistration_never_refreshes_the_token_logout_is_about_to_revoke`.
     let deregister = server.mock(|when, then| {
         when.method(DELETE)
             .path("/me/core-nodes/cn-logout-me")
@@ -364,6 +369,68 @@ fn logout_deregisters_this_machines_core_node() {
     assert!(
         storage::load(&path).expect("load creds").session.is_none(),
         "local credentials must be removed after logout"
+    );
+}
+
+#[test]
+fn deregistration_never_refreshes_the_token_logout_is_about_to_revoke() {
+    // A 401 is the one trigger the refreshing `authed_*` helpers act on. If
+    // `deregister_core_node` ever routes through them, it mints and persists a
+    // NEW access token here, and the revocation immediately after would still
+    // revoke the old one, leaving the new token valid until its own expiry. That
+    // fires whenever the access token has expired but the refresh token has not,
+    // which is the ordinary state of an idle CLI.
+    //
+    // A refresh does OIDC discovery and then posts to the token endpoint, so
+    // mounting both and asserting neither is touched catches it. The type
+    // signature (`&str`, not `&mut Credential`) is what makes it impossible;
+    // this is the behavioral guard that fails if the signature is widened.
+    let server = MockServer::start();
+    let base = server.base_url();
+    let discovery = server.mock(|when, then| {
+        when.method(GET).path("/.well-known/openid-configuration");
+        then.status(200).json_body(json!({
+            "device_authorization_endpoint": format!("{base}/oauth/v2/device_authorization"),
+            "token_endpoint": format!("{base}/oauth/v2/token"),
+        }));
+    });
+    let token = server.mock(|when, then| {
+        when.method(POST).path("/oauth/v2/token");
+        then.status(200).json_body(json!({
+            "access_token": "refreshed-access",
+            "refresh_token": "refreshed-refresh",
+            "expires_in": 3600,
+            "token_type": "Bearer",
+            "scope": "openid",
+        }));
+    });
+    let deregister = server.mock(|when, then| {
+        when.method(DELETE).path("/me/core-nodes/cn-stale-token");
+        then.status(401);
+    });
+    let logout = server.mock(|when, then| {
+        when.method(POST).path("/logout");
+        then.status(202);
+    });
+
+    let dir = tempfile::tempdir().expect("temp dir");
+    let path = logout_with_core_node(&server, &dir, "cn-stale-token");
+
+    assert_eq!(deregister.calls(), 1);
+    assert_eq!(
+        discovery.calls(),
+        0,
+        "deregistration must not begin a token refresh"
+    );
+    assert_eq!(
+        token.calls(),
+        0,
+        "deregistration must not mint a token the revocation that follows would not cover"
+    );
+    assert!(logout.calls() >= 1, "a 401 must not stop the revocation");
+    assert!(
+        storage::load(&path).expect("load creds").session.is_none(),
+        "a 401 must not stop the local credentials being cleared"
     );
 }
 

--- a/crates/peppy/tests/platform_flow.rs
+++ b/crates/peppy/tests/platform_flow.rs
@@ -292,6 +292,176 @@ fn login_writes_credentials_file_0600() {
     assert_eq!(mode, 0o600, "credentials must be owner-only");
 }
 
+/// Writes a config that pins `core_node_name`, so logout can resolve the name to
+/// deregister without a daemon ever having run in the tempdir. The daemon state
+/// file takes precedence over this in production; the precedence itself is unit
+/// tested next to the resolver.
+fn write_core_node_name_config(dir: &tempfile::TempDir, core_node_name: &str) {
+    let config_dir = dir.path().join("conf");
+    std::fs::create_dir_all(&config_dir).expect("config dir");
+    std::fs::write(
+        config_dir.join("peppy_config.json5"),
+        format!("{{ core_node_name: \"{core_node_name}\" }}"),
+    )
+    .expect("write peppy config");
+}
+
+/// Seed a logged-in session under `dir` and run logout against `server`, with
+/// `core_node_name` pinned in the config so the deregistration has a name.
+/// Returns the credentials path so the caller can assert the session was cleared.
+fn logout_with_core_node(
+    server: &MockServer,
+    dir: &tempfile::TempDir,
+    core_node_name: &str,
+) -> PathBuf {
+    write_core_node_name_config(dir, core_node_name);
+    let path = creds_path(dir);
+    storage::save(
+        &path,
+        &Credentials {
+            session: Some(seeded_creds(server, 9_999_999_999)),
+            ..Default::default()
+        },
+    )
+    .expect("seed creds");
+
+    LogoutCommand {
+        api_url: Some(server.base_url()),
+        yes: true,
+        peppy_dirs: Some(PeppyDirs::new(dir.path())),
+    }
+    .execute(&ctx())
+    .expect("logout");
+    path
+}
+
+#[test]
+fn logout_deregisters_this_machines_core_node() {
+    let server = MockServer::start();
+    // Scoped to the exact path and to the bearer the session holds: the DELETE
+    // must go out under the token logout is about to revoke, which is only true
+    // if it runs before the revocation and never refreshes.
+    let deregister = server.mock(|when, then| {
+        when.method(DELETE)
+            .path("/me/core-nodes/cn-logout-me")
+            .header("Authorization", "Bearer seeded-access");
+        then.status(204);
+    });
+    let logout = server.mock(|when, then| {
+        when.method(POST).path("/logout");
+        then.status(202);
+    });
+
+    let dir = tempfile::tempdir().expect("temp dir");
+    let path = logout_with_core_node(&server, &dir, "cn-logout-me");
+
+    assert_eq!(
+        deregister.calls(),
+        1,
+        "logout must deregister this machine's core node"
+    );
+    assert!(logout.calls() >= 1, "POST /logout should have been called");
+    assert!(
+        storage::load(&path).expect("load creds").session.is_none(),
+        "local credentials must be removed after logout"
+    );
+}
+
+#[test]
+fn logout_completes_when_deregistration_finds_nothing_to_remove() {
+    // A 404 is silent success: a daemon in external mode never registered, and a
+    // repeated logout has nothing left to remove.
+    let server = MockServer::start();
+    let deregister = server.mock(|when, then| {
+        when.method(DELETE)
+            .path("/me/core-nodes/cn-never-registered");
+        then.status(404);
+    });
+    let logout = server.mock(|when, then| {
+        when.method(POST).path("/logout");
+        then.status(202);
+    });
+
+    let dir = tempfile::tempdir().expect("temp dir");
+    let path = logout_with_core_node(&server, &dir, "cn-never-registered");
+
+    assert_eq!(deregister.calls(), 1);
+    assert!(logout.calls() >= 1, "a 404 must not stop the revocation");
+    assert!(
+        storage::load(&path).expect("load creds").session.is_none(),
+        "a 404 must not stop the local credentials being cleared"
+    );
+}
+
+#[test]
+fn logout_completes_when_deregistration_fails() {
+    // Every deregistration failure is best effort, exactly like the revocation
+    // itself: the row is left behind and logout still finishes.
+    let server = MockServer::start();
+    let deregister = server.mock(|when, then| {
+        when.method(DELETE).path("/me/core-nodes/cn-backend-down");
+        then.status(503);
+    });
+    let logout = server.mock(|when, then| {
+        when.method(POST).path("/logout");
+        then.status(202);
+    });
+
+    let dir = tempfile::tempdir().expect("temp dir");
+    let path = logout_with_core_node(&server, &dir, "cn-backend-down");
+
+    assert_eq!(deregister.calls(), 1);
+    assert!(logout.calls() >= 1, "a 503 must not stop the revocation");
+    assert!(
+        storage::load(&path).expect("load creds").session.is_none(),
+        "a 503 must not stop the local credentials being cleared"
+    );
+}
+
+#[test]
+fn logout_without_a_resolvable_core_node_name_sends_no_deregistration() {
+    // No daemon state file and no configured name: there is nothing to delete by,
+    // and nothing is guessed. The row is left behind and logout still completes.
+    let server = MockServer::start();
+    let deregister = server.mock(|when, then| {
+        // Any DELETE at all, so the assertion covers a guessed name as well as
+        // the right one.
+        when.method(DELETE);
+        then.status(204);
+    });
+    let logout = server.mock(|when, then| {
+        when.method(POST).path("/logout");
+        then.status(202);
+    });
+
+    let dir = tempfile::tempdir().expect("temp dir");
+    let path = creds_path(&dir);
+    storage::save(
+        &path,
+        &Credentials {
+            session: Some(seeded_creds(&server, 9_999_999_999)),
+            ..Default::default()
+        },
+    )
+    .expect("seed creds");
+
+    LogoutCommand {
+        api_url: Some(server.base_url()),
+        yes: true,
+        peppy_dirs: Some(PeppyDirs::new(dir.path())),
+    }
+    .execute(&ctx())
+    .expect("logout");
+
+    assert_eq!(
+        deregister.calls(),
+        0,
+        "an unresolvable name must not produce a guessed DELETE"
+    );
+    assert!(logout.calls() >= 1);
+    assert!(storage::load(&path).expect("load creds").session.is_none());
+}
+
 #[test]
 fn logout_calls_backend_and_clears_local_credentials() {
     let server = MockServer::start();


### PR DESCRIPTION
## Why

A machine leaves the platform's core-node registry by logging out on that machine. That is what logout already means: it stops federating, drops to the `local` namespace, and stops pulling config, so leaving its row behind would be a lie.

This is the only removal path in the CLI. `DELETE /me/core-nodes/{core_node_name}` gets no CLI verb of its own; it exists because logout needs it, and it doubles as the escape hatch for the row of a machine that died without logging out.

## What

**Ordering.** The DELETE runs before `client::logout` revokes the access token, since it needs that token, and after the `confirm_restart` prompt, so an aborted logout deregisters nothing.

**`deregister_core_node` takes the access token by value and never refreshes**, exactly like `client::logout`. This matters: routing it through the refreshing `authed_*` helpers would, on a 401, mint and persist a new token that the revocation immediately following does not cover, leaving it valid until its own expiry. That fires whenever the access token has expired but the refresh token has not, which is the ordinary state of an idle CLI. The signature is what enforces it, not a comment.

**Name resolution.** The daemon state file wins and is read regardless of whether the recorded pid is alive. The file outlives the daemon process, so a machine whose daemon is already stopped still knows the name it registered under, which is the ordinary case for a logout rather than the exception. An explicitly configured `peppy_config.core_node_name` covers a wiped state file.

If neither resolves, the CLI warns and continues. Nothing is guessed: the daemon's private `derive_core_node_name` is deliberately not exported, because recomputing a machine-UID hash to pick a row to delete is a worse failure mode than leaving one behind. The residual leak is narrow, since a wiped `PEPPY_HOME` takes the credentials too and logout then exits early with "not logged in".

**Best effort throughout.** Every failure warns and lets logout finish, matching what logout already does for the revocation. A `404` is silent success, covering external-mode daemons that never registered and repeated logouts.

**`federation_poke_timeout_secs` now takes the already-parsed `DaemonState`** rather than reading the file itself, so login and logout read it once per invocation instead of once per field and cannot observe two daemon generations within one command.

**Doc fix.** Drops `router_federation`'s claim that the backend probes each daemon's `/health` over the federated link and tears the cloud router down when it stops answering. The backend has no such probe, and the router it hands back is a single shared one, not a per-user resource with a lifetime.

## Test plan

All green locally:

- 4 new unit tests on the name resolver in `logout.rs`: the daemon state name wins over the configured one; **a dead daemon's state file still resolves** (the case `is_running` must not gate); the config is the fallback for a wiped or blank-named state file; neither source yields `None`.
- 5 new `platform_flow.rs` integration tests (`httpmock`): the DELETE goes to the right path under the session's bearer and logout clears credentials; a `404` is silent and does not stop the revocation; a `503` does not stop it either; an unresolvable name sends **no DELETE at all** (the mock matches any DELETE, so a guessed name would fail it); and `deregistration_never_refreshes_the_token_logout_is_about_to_revoke` returns a `401` (the sole refresh trigger) and asserts OIDC discovery and the token endpoint are never touched.

  That last one is **verified by mutation**: routing `deregister_core_node` through a refreshing `&mut Credential` path does make it fail. Worth stating because an earlier version of this PR had a comment claiming the plain DELETE test proved the same property, and it did not: with a `204` response no `401` ever occurs, so the refresh branch was unreachable and the assertion passed against either implementation. That comment is corrected.
- Existing suites: 13 `platform_flow`, 57 + 15 `auth`, 176 peppy lib, 41 daemon lib.
- `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` clean.

One gap worth naming: there is no test that an aborted `confirm_restart` sends no DELETE. `confirm_restart` returns `true` whenever stdin is not a TTY, so the abort branch is unreachable from the test harness. Code placement (deregistration after the prompt) is what enforces it.

## Sequencing

Depends on Peppy-bot/platform-backend#15, which adds the endpoint this calls. Merge that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
