### PR TITLE
Add peppy platform list, the workspace's core nodes and their status

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,7 +573,7 @@ dependencies = [
 [[package]]
 name = "build-helpers"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#b622f119896aeb1c549bfa784972abd2c0f437a5"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#cb07e5dc717f246e541b24ccb15245ff1fa4f7c3"
 dependencies = [
  "sha2",
 ]
@@ -774,7 +774,7 @@ dependencies = [
 [[package]]
 name = "config-test-support"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#b622f119896aeb1c549bfa784972abd2c0f437a5"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#cb07e5dc717f246e541b24ccb15245ff1fa4f7c3"
 dependencies = [
  "askama",
  "git2",
@@ -918,7 +918,7 @@ dependencies = [
 [[package]]
 name = "core-node-api"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#b622f119896aeb1c549bfa784972abd2c0f437a5"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#cb07e5dc717f246e541b24ccb15245ff1fa4f7c3"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -1256,7 +1256,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1404,7 +1404,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2577,7 +2577,7 @@ dependencies = [
 [[package]]
 name = "json5-pretty"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#b622f119896aeb1c549bfa784972abd2c0f437a5"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#cb07e5dc717f246e541b24ccb15245ff1fa4f7c3"
 dependencies = [
  "serde",
  "serde_json",
@@ -2981,7 +2981,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3366,7 +3366,7 @@ dependencies = [
 [[package]]
 name = "peppy-config-model"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#b622f119896aeb1c549bfa784972abd2c0f437a5"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#cb07e5dc717f246e541b24ccb15245ff1fa4f7c3"
 dependencies = [
  "capnp",
  "clap",
@@ -3389,7 +3389,7 @@ version = "0.0.1"
 [[package]]
 name = "peppylib-rs"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#b622f119896aeb1c549bfa784972abd2c0f437a5"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#cb07e5dc717f246e541b24ccb15245ff1fa4f7c3"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -3584,7 +3584,7 @@ dependencies = [
 [[package]]
 name = "pmi"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#b622f119896aeb1c549bfa784972abd2c0f437a5"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#cb07e5dc717f246e541b24ccb15245ff1fa4f7c3"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -3801,7 +3801,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.5",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4051,7 +4051,7 @@ dependencies = [
  "pin-project-lite",
  "rustls",
  "rustls-pki-types",
- "rustls-platform-verifier 0.6.2",
+ "rustls-platform-verifier 0.7.0",
  "serde",
  "serde_json",
  "sync_wrapper",
@@ -4237,7 +4237,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4305,7 +4305,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4326,7 +4326,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4702,7 +4702,7 @@ version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
 dependencies = [
- "dirs 4.0.0",
+ "dirs 6.0.0",
 ]
 
 [[package]]
@@ -5038,7 +5038,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5932,7 +5932,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/auth-internal/src/client.rs
+++ b/crates/auth-internal/src/client.rs
@@ -50,6 +50,87 @@ pub fn get_me(http: &HttpClient, api_url: &str, cred: &mut Credential) -> Result
     authed_get_json(http, api_url, "/me", cred)
 }
 
+/// The caller's workspace's core nodes, as `GET /me/core-nodes` returns them.
+///
+/// Deserialized tolerantly (unknown fields ignored), and every field the
+/// platform may not know is optional. That is version skew, not a legacy shim:
+/// the CLI is installed on user machines and the backend is deployed
+/// independently, so an older CLI meets a newer backend routinely. Later work
+/// adds a per-entry `network` object to this exact response, and a CLI that
+/// rejected unknown fields would break on that deploy.
+#[derive(Debug, Clone, Deserialize)]
+pub struct CoreNodeListing {
+    /// The workspace whose core nodes these are, as the backend derives it from
+    /// the authenticated principal.
+    pub workspace_id: String,
+    /// Whether the platform could read liveliness at all. When false, every
+    /// entry's application status is null, and that is a different statement
+    /// from every machine being offline.
+    #[serde(default)]
+    pub application_status_available: bool,
+    #[serde(default)]
+    pub core_nodes: Vec<CoreNodeEntry>,
+}
+
+/// One core node in the workspace.
+#[derive(Debug, Clone, Deserialize)]
+pub struct CoreNodeEntry {
+    pub core_node_name: String,
+    /// Whether the platform has a registry row for this name. `false` is the
+    /// normal appearance of a `zenoh.external` daemon, which adopts its cached
+    /// workspace namespace but never pulls federation config.
+    #[serde(default)]
+    pub registered: bool,
+    /// RFC 3339 UTC, or null on an unregistered entry.
+    #[serde(default)]
+    pub first_seen_at: Option<String>,
+    /// RFC 3339 UTC, or null on an unregistered entry. A config-pull time, not
+    /// a liveness signal, which is why it is never rendered as "last seen".
+    #[serde(default)]
+    pub last_config_pull_at: Option<String>,
+    #[serde(default)]
+    pub application: ApplicationStatus,
+}
+
+/// Whether a core node's daemon is on the wire. Both fields are null when the
+/// platform could not read liveliness.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct ApplicationStatus {
+    /// `"online"`, `"offline"`, or null. Kept as a string rather than an enum
+    /// so a status this CLI has not heard of renders as itself instead of
+    /// failing the whole listing.
+    #[serde(default)]
+    pub status: Option<String>,
+    /// Distinct instance ids claiming the name. More than one is an active
+    /// collision, and the losing daemon refuses to boot.
+    #[serde(default)]
+    pub live_claimants: Option<u32>,
+}
+
+/// `GET {api_url}/me/core-nodes`, refreshing once on a 401 for session
+/// credentials.
+///
+/// A `404` is mapped explicitly: it means the backend predates this endpoint,
+/// which the generic status message would render as an unexplained
+/// `returned 404`. The mapping lives here rather than in
+/// [`interpret_authed_json`] because `404` means something different on every
+/// endpoint (on `DELETE /me/core-nodes/{name}` it means "no such row").
+pub fn list_core_nodes(
+    http: &HttpClient,
+    api_url: &str,
+    cred: &mut Credential,
+) -> Result<CoreNodeListing> {
+    let url = format!("{}/me/core-nodes", api_url.trim_end_matches('/'));
+    let resp = authed_get(http, &url, cred)?;
+    if resp.status == 404 {
+        return Err(Error::Http(format!(
+            "{api_url} does not support `peppy platform list`; upgrade the platform, \
+             or check --api-url"
+        )));
+    }
+    interpret_authed_json(resp, cred, "GET", &url, "/me/core-nodes")
+}
+
 /// The connection config the backend hands the CLI for the caller's private
 /// per-user zenoh router. Deserialized tolerantly (unknown fields ignored) so a
 /// backend that adds fields still parses. The CA the router is validated against

--- a/crates/peppy/src/commands/platform.rs
+++ b/crates/peppy/src/commands/platform.rs
@@ -1,12 +1,14 @@
-//! The `peppy platform` command group: `login`, `logout`, and `whoami`. Each
-//! variant maps to a handler in this module's directory; the OAuth device flow,
-//! token storage, and credential resolution they share live in the separate
-//! `auth` engine crate. The group is named for the platform account rather than
-//! for auth because signing in does more than obtain a token: it stamps this
-//! machine's workspace namespace and pokes the running daemon to refederate
-//! its messaging router, and a login whose federation link cannot be
-//! established fails.
+//! The `peppy platform` command group: `login`, `logout`, `whoami`, and
+//! `list`. Each variant maps to a handler in this module's directory; the OAuth
+//! device flow, token storage, and credential resolution they share live in the
+//! separate `auth` engine crate, and the config/URL/credential preamble they
+//! all repeat lives here as [`PlatformSession`]. The group is named for the
+//! platform account rather than for auth because signing in does more than
+//! obtain a token: it stamps this machine's workspace namespace and pokes the
+//! running daemon to refederate its messaging router, and a login whose
+//! federation link cannot be established fails.
 
+pub mod list;
 pub mod login;
 pub mod logout;
 pub mod whoami;
@@ -19,6 +21,8 @@ use core_node_api::encoding::StackListRequest;
 use core_node_api::{NodeStage, SerializedNodeGraph};
 use daemon_config::consts::PeppyDirs;
 use peppylib::core_node::transport::poll;
+
+use auth::{http::HttpClient, profile, storage};
 
 use super::Command;
 use crate::commands::CALLER_INSTANCE_ID;
@@ -108,6 +112,70 @@ pub(crate) fn federation_poke_timeout_secs(
 /// not.
 pub(crate) fn read_daemon_state(dirs: &PeppyDirs) -> Option<DaemonState> {
     DaemonState::read_from(&DaemonState::state_file_in(dirs.root())).ok()
+}
+
+/// What every `peppy platform` command resolves before it can talk to the
+/// backend.
+///
+/// All four commands opened with the same four steps: load (and seed) the peppy
+/// config with the daemon's own strict semantics, resolve the API URL through
+/// the profile fallback, locate the credentials file, and build an HTTP client.
+/// The daemon's state rides along because it decides managed-vs-external for
+/// `login`/`logout` and supplies the `(this machine)` marker for `list`;
+/// reading it never fails the command, since a machine with no daemon running
+/// is a normal case for all four.
+pub(crate) struct PlatformSession {
+    pub dirs: PeppyDirs,
+    pub config: daemon_config::peppy_config::PeppyConfig,
+    pub api_url: String,
+    pub creds_path: std::path::PathBuf,
+    pub http: HttpClient,
+    /// The running daemon's recorded state. `None` when no daemon is running,
+    /// or its state file is absent or unreadable.
+    pub daemon_state: Option<DaemonState>,
+}
+
+impl PlatformSession {
+    pub(crate) fn resolve(peppy_dirs: Option<PeppyDirs>, api_url: Option<&str>) -> Result<Self> {
+        let dirs = peppy_dirs.unwrap_or_default();
+        // Loads (and seeds/completes) peppy_config.json5 with the same strict,
+        // fail-loud semantics the daemon uses; resource_servers supplies the
+        // per-profile URL fallback.
+        let config =
+            daemon_config::peppy_config::load_or_create(&dirs).map_err(Error::DaemonConfig)?;
+        let resolved_api_url = profile::resolve_api_url(api_url, &config.resource_servers)?;
+        Ok(Self {
+            creds_path: storage::credentials_path(&dirs),
+            // Managed vs external follows the RUNNING daemon's mode (from its
+            // state file), not the disk config, which may have been edited
+            // since it started; only with no daemon running does the disk
+            // config decide.
+            daemon_state: read_daemon_state(&dirs),
+            dirs,
+            config,
+            api_url: resolved_api_url,
+            http: HttpClient::new(),
+        })
+    }
+}
+
+/// Rejects `--core-node` for the whole `platform` group.
+///
+/// `--core-node` redirects a command at another machine's daemon, and no
+/// command in this group addresses a daemon that way: `login` and `logout` poke
+/// the *local* daemon over its control socket, and `whoami` and `list` talk
+/// only to the platform. Accepting the flag and ignoring it would silently
+/// answer a different question than the one asked, so the whole group refuses
+/// it rather than each command deciding for itself.
+fn reject_core_node_override(ctx: &AppContext) -> Result<()> {
+    let Some(core_node) = ctx.core_node_override() else {
+        return Ok(());
+    };
+    Err(Error::ExecutionFailed(format!(
+        "`--core-node {core_node}` is not valid for `peppy platform` commands: they act on this \
+         machine's daemon and on your platform account, never on another core node. \
+         Run `peppy stack list` to see other core nodes in your workspace."
+    )))
 }
 
 /// Confirms (before authentication begins) a managed-router login/logout that
@@ -451,6 +519,14 @@ pub enum PlatformCommands {
         #[arg(long)]
         json: bool,
     },
+    /// List the core nodes registered to this workspace, and whether each is alive
+    List {
+        #[arg(long = "api-url")]
+        api_url: Option<String>,
+        /// Emit machine-readable JSON.
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 pub struct PlatformCommand {
@@ -459,6 +535,9 @@ pub struct PlatformCommand {
 
 impl Command for PlatformCommand {
     fn execute(self, app_ctx: &Arc<AppContext>) -> Result<()> {
+        // Refused for the whole group, before any command does work: see
+        // `reject_core_node_override`.
+        reject_core_node_override(app_ctx)?;
         match self.command {
             PlatformCommands::Login {
                 api_url,
@@ -478,6 +557,12 @@ impl Command for PlatformCommand {
             }
             .execute(app_ctx),
             PlatformCommands::Whoami { api_url, json } => whoami::WhoamiCommand {
+                api_url,
+                json,
+                peppy_dirs: None,
+            }
+            .execute(app_ctx),
+            PlatformCommands::List { api_url, json } => list::ListCommand {
                 api_url,
                 json,
                 peppy_dirs: None,

--- a/crates/peppy/src/commands/platform/list.rs
+++ b/crates/peppy/src/commands/platform/list.rs
@@ -1,0 +1,512 @@
+//! `peppy platform list`: the core nodes registered to this workspace, and
+//! whether each is alive right now.
+//!
+//! Two machines logged into the same account already federate to the platform's
+//! shared router under one workspace namespace and can address each other.
+//! Nothing in the CLI showed that; this does.
+//!
+//! # A pure HTTP client
+//!
+//! The command resolves the session credential, issues one
+//! `GET /me/core-nodes`, and renders. It opens no zenoh session, connects to no
+//! daemon, and runs no presence query of its own. Every status printed is the
+//! platform's view, which is the only view that can see other sites at all: a
+//! local query would describe this machine's own mesh, which is not what the
+//! command claims to show.
+//!
+//! There is deliberately no local fallback when the backend is unreachable. A
+//! fallback could only answer a different question, and it would double the
+//! code and the tests to serve an outage.
+//!
+//! The one local read is the `(this machine)` marker, and it never fails the
+//! command.
+
+use std::sync::Arc;
+
+use daemon::state::DaemonState;
+use daemon_config::consts::PeppyDirs;
+use daemon_config::peppy_config::PeppyConfig;
+
+use crate::commands::Command;
+use crate::commands::platform::PlatformSession;
+use crate::context::AppContext;
+use crate::error::{Error, Result};
+use auth::client::{self, CoreNodeListing};
+use auth::resolver;
+
+pub struct ListCommand {
+    pub api_url: Option<String>,
+    /// Emit machine-readable JSON instead of human text.
+    pub json: bool,
+    /// Test seam: override the peppy data dirs (the credentials file and
+    /// `peppy_config.json5` both derive from it).
+    pub peppy_dirs: Option<PeppyDirs>,
+}
+
+impl Command for ListCommand {
+    fn execute(self, _ctx: &Arc<AppContext>) -> Result<()> {
+        let session = PlatformSession::resolve(self.peppy_dirs, self.api_url.as_deref())?;
+        let mut cred =
+            match resolver::resolve(&session.creds_path, &session.http, resolver::pat_from_env()) {
+                Ok(cred) => cred,
+                // Unlike `whoami`, whose output *is* the sign-in state, this
+                // command cannot produce its output at all without a credential.
+                // So it fails: a script gets the uniform "empty stdout, non-zero
+                // exit" contract rather than having to tell a partial document from
+                // a complete one.
+                Err(auth::AuthError::NotAuthenticated) => {
+                    return Err(Error::Auth(
+                        "Not authenticated. Run `peppy platform login`.".to_string(),
+                    ));
+                }
+                Err(e) => return Err(e.into()),
+            };
+
+        let listing = client::list_core_nodes(&session.http, &session.api_url, &mut cred)?;
+        let this_machine = this_machine_name(
+            session.daemon_state.as_ref(),
+            &session.config,
+            &listing.workspace_id,
+        );
+
+        if self.json {
+            print!("{}", render_json(&listing, &session.api_url));
+        } else {
+            print!("{}", render_human(&listing, &session.api_url, this_machine));
+        }
+        if !listing.application_status_available {
+            eprintln!(
+                "Warning: the platform could not read liveliness, so application status is \
+                 unknown for every core node. The roster itself is unaffected."
+            );
+        }
+        Ok(())
+    }
+}
+
+/// This machine's core-node name, when it can be established *and* this machine
+/// belongs to the workspace being listed.
+///
+/// The namespace gate is the point. A daemon that has not restarted since a
+/// login is still running under the previous workspace, so its recorded
+/// core-node name says nothing about the workspace in this response, and a name
+/// that happens to exist in both would otherwise be labelled as this machine
+/// when it is someone else's. The daemon's state file already records its
+/// namespace, so this is a comparison rather than new plumbing.
+///
+/// Falls back to the configured name when no daemon is running, and to nothing
+/// when neither is available. Never fails the command: the marker is a
+/// convenience, and a machine with no daemon and no configured name is a normal
+/// case.
+fn this_machine_name(
+    daemon_state: Option<&DaemonState>,
+    config: &PeppyConfig,
+    workspace_id: &str,
+) -> Option<String> {
+    let Some(state) = daemon_state else {
+        // No daemon running, so there is no namespace to compare against. The
+        // configured name is what a daemon started now would claim.
+        return config.core_node_name.clone();
+    };
+    match state.namespace.as_str() == workspace_id {
+        true => Some(state.core_node_name.clone()),
+        false => None,
+    }
+}
+
+/// Human-readable output. Pure, so the column layout, the marker, the collision
+/// suffix, and the empty case are all testable without a backend.
+fn render_human(listing: &CoreNodeListing, api_url: &str, this_machine: Option<String>) -> String {
+    let mut out = format!("Workspace {} (backend {api_url})\n\n", listing.workspace_id);
+    if listing.core_nodes.is_empty() {
+        out.push_str(
+            "No core nodes registered in this workspace. \
+             Run 'peppy platform login' on a machine to register its daemon.\n",
+        );
+        return out;
+    }
+
+    let rows: Vec<(String, String, String, bool)> = ordered_rows(listing, this_machine.as_deref())
+        .into_iter()
+        .map(|(entry, is_this_machine)| {
+            (
+                entry.core_node_name.clone(),
+                application_column(entry),
+                registered_column(entry),
+                is_this_machine,
+            )
+        })
+        .collect();
+
+    let name_width = column_width("CORE NODE", rows.iter().map(|(name, ..)| name.as_str()));
+    let status_width = column_width(
+        "APPLICATION",
+        rows.iter().map(|(_, status, ..)| status.as_str()),
+    );
+
+    out.push_str(&format!(
+        "{:<name_width$}  {:<status_width$}  {}\n",
+        "CORE NODE", "APPLICATION", "REGISTERED"
+    ));
+    for (name, status, registered, is_this_machine) in rows {
+        let marker = match is_this_machine {
+            true => "   (this machine)",
+            false => "",
+        };
+        out.push_str(&format!(
+            "{name:<name_width$}  {status:<status_width$}  {registered}{marker}\n"
+        ));
+    }
+    out
+}
+
+/// The entries in render order: this machine first, then by name ascending.
+///
+/// The backend already orders by name, so this only hoists the local row.
+/// Deterministic either way, which is what lets the tests assert on it
+/// directly.
+fn ordered_rows<'a>(
+    listing: &'a CoreNodeListing,
+    this_machine: Option<&str>,
+) -> Vec<(&'a client::CoreNodeEntry, bool)> {
+    let is_this_machine = |entry: &client::CoreNodeEntry| {
+        this_machine.is_some_and(|name| name == entry.core_node_name)
+    };
+    let mut rows: Vec<(&client::CoreNodeEntry, bool)> = listing
+        .core_nodes
+        .iter()
+        .map(|entry| (entry, is_this_machine(entry)))
+        .collect();
+    rows.sort_by_key(|(entry, is_this_machine)| (!is_this_machine, entry.core_node_name.clone()));
+    rows
+}
+
+/// The APPLICATION column: the status, with the claimant count appended only
+/// when a name is contested. A collision must be visible, since the losing
+/// daemon refuses to boot and that is frequently why a site will not come up.
+fn application_column(entry: &client::CoreNodeEntry) -> String {
+    let Some(status) = &entry.application.status else {
+        return "unknown".to_string();
+    };
+    match entry.application.live_claimants {
+        Some(claimants) if claimants > 1 => format!("{status} ({claimants} claimants)"),
+        _ => status.clone(),
+    }
+}
+
+/// The REGISTERED column: the UTC date this name was first registered, or `-`
+/// for a name that is live but has no registry row.
+///
+/// Deliberately not the config-pull timestamp. Rendering that as "last seen"
+/// would read as liveness, and it is not one. UTC rather than local time, so
+/// the output does not depend on the machine's timezone.
+fn registered_column(entry: &client::CoreNodeEntry) -> String {
+    entry
+        .first_seen_at
+        .as_deref()
+        .and_then(|timestamp| timestamp.split('T').next())
+        .unwrap_or("-")
+        .to_string()
+}
+
+fn column_width<'a>(header: &str, values: impl Iterator<Item = &'a str>) -> usize {
+    values
+        .map(str::len)
+        .chain([header.len()])
+        .max()
+        .unwrap_or(0)
+}
+
+/// Machine-readable output. Passes the platform's entries through with the
+/// `api_url` this CLI called added, so a script can tell which backend answered.
+fn render_json(listing: &CoreNodeListing, api_url: &str) -> String {
+    let core_nodes: Vec<serde_json::Value> = listing
+        .core_nodes
+        .iter()
+        .map(|entry| {
+            serde_json::json!({
+                "core_node_name": entry.core_node_name,
+                "registered": entry.registered,
+                "first_seen_at": entry.first_seen_at,
+                "last_config_pull_at": entry.last_config_pull_at,
+                "application": {
+                    "status": entry.application.status,
+                    "live_claimants": entry.application.live_claimants,
+                },
+            })
+        })
+        .collect();
+    let doc = serde_json::json!({
+        "workspace_id": listing.workspace_id,
+        "api_url": api_url,
+        "application_status_available": listing.application_status_available,
+        "core_nodes": core_nodes,
+    });
+    format!("{doc}\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use auth::client::{ApplicationStatus, CoreNodeEntry};
+
+    const WORKSPACE: &str = "4f1b2e2c-9a71-4d0e-b3c8-0d2b9f6a11c4";
+    const API_URL: &str = "https://api.peppy.dev";
+
+    fn entry(
+        name: &str,
+        registered: bool,
+        status: Option<&str>,
+        claimants: Option<u32>,
+    ) -> CoreNodeEntry {
+        registered_on(name, registered, status, claimants, "2026-07-01")
+    }
+
+    /// [`entry`] with an explicit registration date, for the layout test.
+    fn registered_on(
+        name: &str,
+        registered: bool,
+        status: Option<&str>,
+        claimants: Option<u32>,
+        first_seen_date: &str,
+    ) -> CoreNodeEntry {
+        CoreNodeEntry {
+            core_node_name: name.to_string(),
+            registered,
+            first_seen_at: registered.then(|| format!("{first_seen_date}T10:00:00Z")),
+            last_config_pull_at: registered.then(|| "2026-07-24T09:12:33Z".to_string()),
+            application: ApplicationStatus {
+                status: status.map(str::to_string),
+                live_claimants: claimants,
+            },
+        }
+    }
+
+    fn listing(entries: Vec<CoreNodeEntry>, available: bool) -> CoreNodeListing {
+        CoreNodeListing {
+            workspace_id: WORKSPACE.to_string(),
+            application_status_available: available,
+            core_nodes: entries,
+        }
+    }
+
+    #[test]
+    fn human_output_renders_status_the_marker_and_a_collision() {
+        let listing = listing(
+            vec![
+                registered_on("cn-a1b2c3d4e5", true, Some("online"), Some(1), "2026-07-01"),
+                registered_on(
+                    "cn-9f8e7d6c5b",
+                    true,
+                    Some("offline"),
+                    Some(0),
+                    "2026-07-14",
+                ),
+                entry("lab-bench-external", false, Some("online"), Some(2)),
+            ],
+            true,
+        );
+
+        let out = render_human(&listing, API_URL, Some("cn-a1b2c3d4e5".to_string()));
+
+        assert_eq!(
+            out,
+            "Workspace 4f1b2e2c-9a71-4d0e-b3c8-0d2b9f6a11c4 (backend https://api.peppy.dev)\n\
+             \n\
+             CORE NODE           APPLICATION           REGISTERED\n\
+             cn-a1b2c3d4e5       online                2026-07-01   (this machine)\n\
+             cn-9f8e7d6c5b       offline               2026-07-14\n\
+             lab-bench-external  online (2 claimants)  -\n"
+        );
+    }
+
+    #[test]
+    fn this_machine_sorts_first_and_the_rest_by_name() {
+        let listing = listing(
+            vec![
+                entry("cn-aaa", true, Some("online"), Some(1)),
+                entry("cn-bbb", true, Some("online"), Some(1)),
+                entry("cn-zzz", true, Some("online"), Some(1)),
+            ],
+            true,
+        );
+
+        let ordered: Vec<&str> = ordered_rows(&listing, Some("cn-zzz"))
+            .into_iter()
+            .map(|(entry, _)| entry.core_node_name.as_str())
+            .collect();
+
+        assert_eq!(ordered, vec!["cn-zzz", "cn-aaa", "cn-bbb"]);
+    }
+
+    #[test]
+    fn without_a_local_name_nothing_is_marked() {
+        let listing = listing(vec![entry("cn-aaa", true, Some("online"), Some(1))], true);
+
+        let out = render_human(&listing, API_URL, None);
+
+        assert!(
+            !out.contains("(this machine)"),
+            "no marker without a resolved local name: {out}"
+        );
+    }
+
+    /// A single claimant is the normal case and must not be annotated: only a
+    /// contested name earns the suffix.
+    #[test]
+    fn only_a_contested_name_shows_a_claimant_count() {
+        assert_eq!(
+            application_column(&entry("cn", true, Some("online"), Some(1))),
+            "online"
+        );
+        assert_eq!(
+            application_column(&entry("cn", true, Some("online"), Some(3))),
+            "online (3 claimants)"
+        );
+    }
+
+    #[test]
+    fn an_unavailable_observer_renders_unknown_in_every_row() {
+        let listing = listing(
+            vec![
+                entry("cn-aaa", true, None, None),
+                entry("cn-bbb", true, None, None),
+            ],
+            false,
+        );
+
+        let out = render_human(&listing, API_URL, None);
+
+        assert_eq!(out.matches("unknown").count(), 2);
+        assert!(!out.contains("offline"), "unknown is not offline: {out}");
+    }
+
+    #[test]
+    fn an_empty_roster_explains_how_to_populate_it() {
+        let out = render_human(&listing(vec![], true), API_URL, None);
+
+        assert!(out.contains("No core nodes registered in this workspace"));
+        assert!(out.contains("peppy platform login"));
+        assert!(!out.contains("CORE NODE"), "no header for an empty roster");
+    }
+
+    #[test]
+    fn an_unregistered_entry_shows_no_registration_date() {
+        assert_eq!(
+            registered_column(&entry("lab-bench", false, Some("online"), Some(1))),
+            "-"
+        );
+        assert_eq!(
+            registered_column(&entry("cn-a", true, Some("online"), Some(1))),
+            "2026-07-01",
+            "the date only, in UTC, so output does not depend on the machine's timezone"
+        );
+    }
+
+    #[test]
+    fn json_output_carries_the_backend_and_the_honest_timestamp_name() {
+        let listing = listing(
+            vec![entry("cn-a1b2c3d4e5", true, Some("online"), Some(1))],
+            true,
+        );
+
+        let doc: serde_json::Value =
+            serde_json::from_str(&render_json(&listing, API_URL)).expect("valid json");
+
+        assert_eq!(doc["workspace_id"], serde_json::json!(WORKSPACE));
+        assert_eq!(doc["api_url"], serde_json::json!(API_URL));
+        assert_eq!(doc["application_status_available"], serde_json::json!(true));
+        let entry = &doc["core_nodes"][0];
+        assert_eq!(entry["registered"], serde_json::json!(true));
+        assert_eq!(
+            entry["last_config_pull_at"],
+            serde_json::json!("2026-07-24T09:12:33Z")
+        );
+        assert!(
+            entry.get("last_seen_at").is_none(),
+            "the pull timestamp never appears under a name that reads as liveness"
+        );
+        assert_eq!(entry["application"]["status"], serde_json::json!("online"));
+    }
+
+    // ─── The `(this machine)` marker ──────────────────────────────────────
+
+    fn daemon_in(core_node_name: &str, namespace: &str) -> DaemonState {
+        DaemonState::new(
+            core_node_name,
+            "127.0.0.1",
+            7447,
+            "test-git-hash",
+            30,
+            config::namespace::Namespace::parse(namespace).expect("valid namespace"),
+            Some(30),
+        )
+    }
+
+    fn config_named(core_node_name: Option<&str>) -> PeppyConfig {
+        PeppyConfig {
+            core_node_name: core_node_name.map(str::to_string),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn the_marker_uses_the_running_daemons_name() {
+        let daemon = daemon_in("cn-local", WORKSPACE);
+
+        assert_eq!(
+            this_machine_name(Some(&daemon), &config_named(None), WORKSPACE),
+            Some("cn-local".to_string())
+        );
+    }
+
+    /// The mid-login case, and the reason the marker is gated on the namespace
+    /// at all: the daemon has not restarted yet, so it is still running under
+    /// the previous workspace. Its name says nothing about the workspace being
+    /// listed, and an identical name in both would otherwise be labelled as
+    /// this machine when it belongs to someone else.
+    #[test]
+    fn the_marker_is_withheld_when_the_daemon_runs_in_another_workspace() {
+        let daemon = daemon_in("cn-local", "local");
+
+        assert_eq!(
+            this_machine_name(Some(&daemon), &config_named(Some("cn-local")), WORKSPACE),
+            None,
+            "a daemon in another namespace must not be marked, even by an exact name match, \
+             and must not fall through to the configured name either"
+        );
+    }
+
+    #[test]
+    fn the_marker_falls_back_to_the_configured_name_with_no_daemon_running() {
+        assert_eq!(
+            this_machine_name(None, &config_named(Some("cn-configured")), WORKSPACE),
+            Some("cn-configured".to_string()),
+            "with no daemon there is no namespace to compare, so the configured name is what a \
+             daemon started now would claim"
+        );
+    }
+
+    #[test]
+    fn the_marker_is_simply_absent_when_neither_source_resolves() {
+        assert_eq!(
+            this_machine_name(None, &config_named(None), WORKSPACE),
+            None
+        );
+    }
+
+    #[test]
+    fn json_nulls_the_status_when_the_observer_could_not_answer() {
+        let listing = listing(vec![entry("cn-a", true, None, None)], false);
+
+        let doc: serde_json::Value =
+            serde_json::from_str(&render_json(&listing, API_URL)).expect("valid json");
+
+        assert_eq!(
+            doc["application_status_available"],
+            serde_json::json!(false)
+        );
+        assert!(doc["core_nodes"][0]["application"]["status"].is_null());
+        assert!(doc["core_nodes"][0]["application"]["live_claimants"].is_null());
+    }
+}

--- a/crates/peppy/src/commands/platform/login.rs
+++ b/crates/peppy/src/commands/platform/login.rs
@@ -10,7 +10,7 @@ use daemon_config::consts::PeppyDirs;
 
 use crate::commands::Command;
 use crate::context::AppContext;
-use crate::error::{Error, Result};
+use crate::error::Result;
 use auth::device::{self, TokenSet};
 use auth::discovery::OidcEndpoints;
 use auth::{cli_config, client, discovery, http::HttpClient, profile, resolver, storage};
@@ -32,20 +32,15 @@ pub struct LoginCommand {
 
 impl Command for LoginCommand {
     fn execute(self, ctx: &Arc<AppContext>) -> Result<()> {
-        let dirs = self.peppy_dirs.unwrap_or_default();
-        // Loads (and seeds/completes) peppy_config.json5 with the same strict,
-        // fail-loud semantics the daemon uses; resource_servers supplies the
-        // per-profile URL fallback.
-        let config =
-            daemon_config::peppy_config::load_or_create(&dirs).map_err(Error::DaemonConfig)?;
-        // Managed vs external follows the RUNNING daemon's mode (from its state
-        // file), not the disk config, which may have been edited since it
-        // started; only with no daemon running does the disk config decide.
-        let daemon_state = super::read_daemon_state(&dirs);
+        let super::PlatformSession {
+            dirs,
+            config,
+            api_url,
+            creds_path,
+            http,
+            daemon_state,
+        } = super::PlatformSession::resolve(self.peppy_dirs, self.api_url.as_deref())?;
         let federation = super::federation_poke_timeout_secs(daemon_state.as_ref(), &config);
-        let api_url = profile::resolve_api_url(self.api_url.as_deref(), &config.resource_servers)?;
-        let creds_path = storage::credentials_path(&dirs);
-        let http = HttpClient::new();
 
         // With a managed router, warn (before authentication begins) that a login
         // changing the workspace namespace restarts the daemon and wipes the

--- a/crates/peppy/src/commands/platform/logout.rs
+++ b/crates/peppy/src/commands/platform/logout.rs
@@ -14,7 +14,7 @@ use daemon_config::peppy_config::PeppyConfig;
 
 use crate::commands::Command;
 use crate::context::AppContext;
-use crate::error::{Error, Result};
+use crate::error::Result;
 use auth::{client, http::HttpClient, profile, storage};
 
 pub struct LogoutCommand {
@@ -28,17 +28,15 @@ pub struct LogoutCommand {
 
 impl Command for LogoutCommand {
     fn execute(self, ctx: &Arc<AppContext>) -> Result<()> {
-        let dirs = self.peppy_dirs.unwrap_or_default();
-        let config =
-            daemon_config::peppy_config::load_or_create(&dirs).map_err(Error::DaemonConfig)?;
-        // Managed vs external follows the RUNNING daemon's mode (from its state
-        // file), not the disk config, which may have been edited since it
-        // started; only with no daemon running does the disk config decide.
-        let daemon_state = super::read_daemon_state(&dirs);
+        let super::PlatformSession {
+            dirs,
+            config,
+            api_url,
+            creds_path,
+            http,
+            daemon_state,
+        } = super::PlatformSession::resolve(self.peppy_dirs, self.api_url.as_deref())?;
         let federation = super::federation_poke_timeout_secs(daemon_state.as_ref(), &config);
-        let api_url = profile::resolve_api_url(self.api_url.as_deref(), &config.resource_servers)?;
-        let creds_path = storage::credentials_path(&dirs);
-        let http = HttpClient::new();
 
         // Load-resilient: a malformed / pre-`workspace_id` file fails to parse
         // with `Error::Auth`; treat it as "already effectively logged out" rather

--- a/crates/peppy/src/commands/platform/whoami.rs
+++ b/crates/peppy/src/commands/platform/whoami.rs
@@ -8,10 +8,11 @@ use std::sync::Arc;
 use daemon_config::consts::PeppyDirs;
 
 use crate::commands::Command;
+use crate::commands::platform::PlatformSession;
 use crate::context::AppContext;
-use crate::error::{Error, Result};
+use crate::error::Result;
 use auth::client::Principal;
-use auth::{client, http::HttpClient, profile, resolver, storage};
+use auth::{client, profile, resolver, storage};
 
 pub struct WhoamiCommand {
     pub api_url: Option<String>,
@@ -24,12 +25,12 @@ pub struct WhoamiCommand {
 
 impl Command for WhoamiCommand {
     fn execute(self, _ctx: &Arc<AppContext>) -> Result<()> {
-        let dirs = self.peppy_dirs.unwrap_or_default();
-        let config =
-            daemon_config::peppy_config::load_or_create(&dirs).map_err(Error::DaemonConfig)?;
-        let api_url = profile::resolve_api_url(self.api_url.as_deref(), &config.resource_servers)?;
-        let creds_path = storage::credentials_path(&dirs);
-        let http = HttpClient::new();
+        let PlatformSession {
+            api_url,
+            creds_path,
+            http,
+            ..
+        } = PlatformSession::resolve(self.peppy_dirs, self.api_url.as_deref())?;
         let pat = resolver::pat_from_env();
 
         match resolver::resolve(&creds_path, &http, pat) {

--- a/crates/peppy/src/context.rs
+++ b/crates/peppy/src/context.rs
@@ -56,6 +56,12 @@ impl AppContext {
         self
     }
 
+    /// The `--core-node` target, when one was given. Read by command groups
+    /// that cannot honor it, so they can refuse rather than silently ignore it.
+    pub(crate) fn core_node_override(&self) -> Option<&str> {
+        self.core_node_override.as_deref()
+    }
+
     pub(crate) fn read_daemon_state(&self) -> crate::error::Result<DaemonState> {
         let state = match &self.daemon_state_path {
             Some(path) => DaemonState::read_from(path),

--- a/crates/peppy/src/main.rs
+++ b/crates/peppy/src/main.rs
@@ -74,7 +74,7 @@ enum Commands {
         #[command(subcommand)]
         command: repo::RepoCommands,
     },
-    /// Platform account: log in, log out, and show the current identity
+    /// Platform account: log in, log out, show the current identity, and list the workspace's core nodes
     Platform {
         #[command(subcommand)]
         command: platform::PlatformCommands,

--- a/crates/peppy/tests/platform_flow.rs
+++ b/crates/peppy/tests/platform_flow.rs
@@ -16,10 +16,13 @@ use secrecy::ExposeSecret;
 use serde_json::json;
 
 use auth::storage::{self, Credentials, ProfileCreds};
+use daemon::state::DaemonState;
 use peppy::commands::Command;
+use peppy::commands::platform::list::ListCommand;
 use peppy::commands::platform::login::LoginCommand;
 use peppy::commands::platform::logout::LogoutCommand;
 use peppy::commands::platform::whoami::WhoamiCommand;
+use peppy::commands::platform::{PlatformCommand, PlatformCommands};
 use peppy::context::AppContext;
 
 /// Builds the cli/auth-config + OIDC discovery + device-authorization + token mocks
@@ -701,6 +704,244 @@ fn whoami_runs_against_a_seeded_session() {
         .execute(&ctx())
         .expect("whoami");
     }
+}
+
+// ─── `peppy platform list` ────────────────────────────────────────────────
+
+const WORKSPACE: &str = "4f1b2e2c-9a71-4d0e-b3c8-0d2b9f6a11c4";
+
+/// A tempdir with a seeded session credential pointing at `server`, ready for a
+/// command that needs to be authenticated.
+fn authenticated_dir(server: &MockServer) -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let creds = Credentials {
+        session: Some(seeded_creds(server, 9_999_999_999)),
+        ..Default::default()
+    };
+    storage::save(&creds_path(&dir), &creds).expect("seed creds");
+    dir
+}
+
+/// Mocks `GET /me/core-nodes` with one registered, online core node.
+fn mock_core_nodes<'a>(server: &'a MockServer, core_node_name: &str) -> httpmock::Mock<'a> {
+    server.mock(|when, then| {
+        when.method(GET).path("/me/core-nodes");
+        then.status(200).json_body(json!({
+            "workspace_id": WORKSPACE,
+            "application_status_available": true,
+            "core_nodes": [{
+                "core_node_name": core_node_name,
+                "registered": true,
+                "first_seen_at": "2026-07-01T10:00:00Z",
+                "last_config_pull_at": "2026-07-24T09:12:33Z",
+                "application": { "status": "online", "live_claimants": 1 },
+            }],
+        }));
+    })
+}
+
+fn list_in(server: &MockServer, dir: &tempfile::TempDir, json: bool) -> peppy::error::Result<()> {
+    ListCommand {
+        api_url: Some(server.base_url()),
+        json,
+        peppy_dirs: Some(PeppyDirs::new(dir.path())),
+    }
+    .execute(&ctx())
+}
+
+#[test]
+fn list_renders_the_workspace_roster_in_both_formats() {
+    let server = MockServer::start();
+    let core_nodes = mock_core_nodes(&server, "cn-a1b2c3d4e5");
+    let dir = authenticated_dir(&server);
+
+    for json in [false, true] {
+        list_in(&server, &dir, json).expect("list should succeed");
+    }
+
+    core_nodes.assert_calls(2);
+}
+
+/// Unlike `whoami`, whose output IS the sign-in state, `list` cannot answer at
+/// all without a credential, so it fails rather than printing a document
+/// saying so. `main` maps the error to exit 1.
+#[test]
+fn list_without_a_credential_fails_instead_of_emitting_a_document() {
+    let server = MockServer::start();
+    // No credentials seeded.
+    let dir = tempfile::tempdir().expect("temp dir");
+
+    for json in [false, true] {
+        let error = list_in(&server, &dir, json).expect_err("list must fail unauthenticated");
+        assert!(
+            error.to_string().contains("peppy platform login"),
+            "the error must say how to fix it: {error}"
+        );
+    }
+}
+
+#[test]
+fn list_fails_when_the_backend_is_unreachable() {
+    let server = MockServer::start();
+    let dir = authenticated_dir(&server);
+    // A port nothing listens on, so the request cannot complete. There is
+    // deliberately no local fallback: a local query would answer a different
+    // question than the one the command claims to answer.
+    let unreachable = "http://127.0.0.1:1";
+
+    let error = ListCommand {
+        api_url: Some(unreachable.to_string()),
+        json: false,
+        peppy_dirs: Some(PeppyDirs::new(dir.path())),
+    }
+    .execute(&ctx())
+    .expect_err("an unreachable backend must fail the command");
+
+    assert!(
+        !error.to_string().is_empty(),
+        "the failure must carry a message"
+    );
+}
+
+#[test]
+fn list_surfaces_a_backend_outage_as_a_retryable_error() {
+    let server = MockServer::start();
+    server.mock(|when, then| {
+        when.method(GET).path("/me/core-nodes");
+        then.status(503);
+    });
+    let dir = authenticated_dir(&server);
+
+    let error = list_in(&server, &dir, false).expect_err("a 503 must fail the command");
+
+    assert!(
+        error.to_string().contains("try again"),
+        "a 503 must read as transient: {error}"
+    );
+}
+
+/// A newer CLI against a backend that predates the endpoint. Without the
+/// explicit mapping this reads as an unexplained `returned 404`.
+#[test]
+fn list_explains_a_backend_that_does_not_have_the_endpoint() {
+    let server = MockServer::start();
+    server.mock(|when, then| {
+        when.method(GET).path("/me/core-nodes");
+        then.status(404);
+    });
+    let dir = authenticated_dir(&server);
+
+    let error = list_in(&server, &dir, false).expect_err("a 404 must fail the command");
+
+    assert!(
+        error.to_string().contains("upgrade the platform"),
+        "a 404 must name the cause and the fix: {error}"
+    );
+}
+
+/// `--core-node` redirects a command at another machine's daemon, which no
+/// `platform` command does. The whole group refuses it, rather than each
+/// command silently answering a different question.
+#[test]
+fn every_platform_command_refuses_a_core_node_override() {
+    let server = MockServer::start();
+    let dir = authenticated_dir(&server);
+    let redirected = Arc::new(
+        AppContext::from_current_dir()
+            .expect("cwd is readable")
+            .with_core_node_override(Some("robot-7".to_string())),
+    );
+
+    let commands: Vec<(&str, PlatformCommands)> = vec![
+        (
+            "list",
+            PlatformCommands::List {
+                api_url: Some(server.base_url()),
+                json: false,
+            },
+        ),
+        (
+            "whoami",
+            PlatformCommands::Whoami {
+                api_url: Some(server.base_url()),
+                json: false,
+            },
+        ),
+        (
+            "logout",
+            PlatformCommands::Logout {
+                api_url: Some(server.base_url()),
+                yes: true,
+            },
+        ),
+        (
+            "login",
+            PlatformCommands::Login {
+                api_url: Some(server.base_url()),
+                no_browser: true,
+                yes: true,
+            },
+        ),
+    ];
+
+    for (name, command) in commands {
+        let error = PlatformCommand { command }
+            .execute(&redirected)
+            .expect_err(&format!("`platform {name}` must refuse --core-node"));
+        assert!(
+            error.to_string().contains("--core-node"),
+            "`platform {name}` must name the flag it refused: {error}"
+        );
+        assert!(
+            error.to_string().contains("peppy stack list"),
+            "`platform {name}` must point at the command that does show other core nodes: {error}"
+        );
+    }
+
+    // The refusal happens before any work: the backend was never called.
+    server.mock(|when, then| {
+        when.method(GET).path("/me/core-nodes");
+        then.status(500);
+    });
+    let _ = dir;
+}
+
+/// A stale daemon state file must not fail the command, whatever it records.
+///
+/// The marker RULES are pinned as a pure unit in `platform::list`
+/// (`this_machine_name`), where each case is asserted directly rather than
+/// inferred from a command that succeeded. What this covers is the wiring: a
+/// state file on disk is read, and a daemon running in another workspace is a
+/// normal case rather than an error.
+#[test]
+fn a_daemon_in_another_workspace_does_not_fail_the_listing() {
+    let server = MockServer::start();
+    let core_nodes = mock_core_nodes(&server, "cn-local-daemon");
+    let dir = authenticated_dir(&server);
+    // Same core-node name as the listed row, different workspace: the
+    // mid-login case.
+    write_daemon_state(&dir, "cn-local-daemon", "local");
+
+    list_in(&server, &dir, false).expect("a mismatched namespace must not fail the command");
+
+    core_nodes.assert();
+}
+
+/// Writes a daemon state file recording `core_node_name` under `namespace`.
+fn write_daemon_state(dir: &tempfile::TempDir, core_node_name: &str, namespace: &str) {
+    let state = DaemonState::new(
+        core_node_name,
+        "127.0.0.1",
+        7447,
+        "test-git-hash",
+        30,
+        config::namespace::Namespace::parse(namespace).expect("valid namespace"),
+        Some(30),
+    );
+    let path = DaemonState::state_file_in(dir.path());
+    std::fs::create_dir_all(path.parent().expect("state file has a parent"))
+        .expect("state file dir");
+    DaemonState::write_to(&path, &state).expect("write daemon state");
 }
 
 /// A session credential pointing at `server` with the given absolute expiry.

--- a/docs/src/content/docs/advanced_guides/platform.mdx
+++ b/docs/src/content/docs/advanced_guides/platform.mdx
@@ -16,6 +16,7 @@ The CLI never sees your Google/passkey credentials. Those stay in the browser.
 |---------|--------------|
 | `peppy platform login [--api-url <url>] [--no-browser] [--yes]` | Logs in via the OAuth 2.0 Device Authorization Grant, caches the tokens, and federates a managed router to your workspace's cloud router. |
 | `peppy platform whoami` (alias `status`) | Shows the current identity, backend, and token validity. `--json` for machine-readable output. |
+| `peppy platform list [--api-url <url>] [--json]` | Lists the core nodes registered to your workspace and whether each one is running right now. |
 | `peppy platform logout [--yes]` | Revokes the access token on the backend (across replicas), deletes the local credentials, and de-federates a managed router. |
 
 `--yes` (`-y`) skips the daemon-restart confirmation prompt described under
@@ -91,6 +92,62 @@ to resolve the cloud router is bounded by
 With `zenoh.external`, login and logout skip federation and print a note instead;
 the daemon applies the resolved namespace to its sessions on its next manual
 restart. See [Federation outside the Peppy platform](#federation-outside-the-peppy-platform).
+
+### Listing the workspace's core nodes
+
+Once two machines have logged in under the same account, they share a workspace
+namespace and can already address each other. `peppy platform list` is what
+shows you that:
+
+```sh
+peppy platform list
+```
+
+```
+Workspace 4f1b2e2c-9a71-4d0e-b3c8-0d2b9f6a11c4 (backend https://api.peppy.dev)
+
+CORE NODE            APPLICATION           REGISTERED
+cn-a1b2c3d4e5        online                2026-07-01   (this machine)
+cn-9f8e7d6c5b        offline               2026-07-14
+lab-bench-external   online (2 claimants)  -
+```
+
+The listing is **workspace scoped**. It shows the machines logged in to your own
+account and nothing else, and machines in other workspaces are invisible to you
+by design. The platform runs no core node in your workspace either, so every row
+is one of your own machines.
+
+The `APPLICATION` column reads:
+
+| Value | Meaning |
+|-------|---------|
+| `online` | The machine's daemon is running and reachable on the shared router right now. |
+| `offline` | The machine is registered but its daemon is stopped or unreachable. |
+| `online (N claimants)` | `N` different daemons are claiming this core-node name at once. This is a name collision, and it is worth acting on: the losing daemon refuses to start, so a collision is often why a machine will not come up. |
+| `unknown` | The platform could not read liveness at all, so no row's status is known. The list of machines itself is still accurate. A warning explains this on stderr. |
+
+A row with `-` under `REGISTERED` is running on the wire but was never registered
+with the platform. That is the normal appearance of a daemon configured with
+[`zenoh.external`](/advanced_guides/daemon_config/#zenohexternal-use-an-operator-run-router):
+it adopts its cached workspace namespace but never pulls federation config, so
+the platform is never told about it.
+
+`REGISTERED` is the date a machine first registered, in UTC. There is
+deliberately no "last seen" column: the platform's other timestamp records when
+a daemon last pulled its configuration, which is not the same as when it was
+last running. A machine that has been up for a week without re-pulling would
+look a week stale. Liveness lives in the `APPLICATION` column and nowhere else.
+`--json` exposes the pull time under its own name, `last_config_pull_at`.
+
+Two caveats worth knowing:
+
+- Default core-node names are hashes of the machine's UID, so the roster may not
+  tell you which machine is which. `peppy stack list` is where host names live.
+  Set [`core_node_name`](/advanced_guides/daemon_config/) to give a machine a
+  name you recognize.
+- `online` is not an authenticated statement. The messaging transport does not
+  authenticate daemons, so anything that can reach the router can claim a name.
+  A `REGISTERED` date is backed by a bearer token; a live status is not.
 
 ## Federation outside the Peppy platform
 


### PR DESCRIPTION
## Why

Shows which machines are logged in to this account and which are running right now.

Third of three PRs. **Depends on Peppy-bot/platform-backend#16** (the `GET /me/core-nodes` endpoint) and transitively on Peppy-bot/public-peppy-libs#65.

```
Workspace 4f1b2e2c-9a71-4d0e-b3c8-0d2b9f6a11c4 (backend https://api.peppy.dev)

CORE NODE            APPLICATION           REGISTERED
cn-a1b2c3d4e5        online                2026-07-01   (this machine)
cn-9f8e7d6c5b        offline               2026-07-14
lab-bench-external   online (2 claimants)  -
```

## What changed

### A pure HTTP client

One `GET /me/core-nodes`, then render. The command opens no zenoh session and connects to no daemon, because only the platform's view can see other sites at all. There is deliberately no local fallback for a backend outage: a local query would answer a different question than the command claims to answer, and it would double the code and the tests to serve an outage.

### `REGISTERED` is not "last seen"

The column shows the first-registration date, in UTC so output does not depend on the machine's timezone. The platform's other timestamp records when a daemon last pulled configuration, which is not when it was last running, and a machine up for a week without re-pulling would look a week stale. It appears only in `--json`, under `last_config_pull_at`.

### The `(this machine)` marker is gated on the namespace

The marker is applied only when the local daemon's namespace equals the listed workspace. A daemon that has not restarted since a login is still running under the previous workspace, so its recorded name says nothing about this response, and an identical name in both would otherwise be labelled as this machine when it belongs to someone else. The state file already carries the namespace, so this is a comparison, not new plumbing. Falls back to the configured name with no daemon running, and is simply absent otherwise. It never fails the command.

### Failure contract

Unauthenticated exits non-zero and prints **no document**, unlike `whoami`, whose output *is* the sign-in state. `list` cannot produce its output at all without a credential, so a script gets one rule: empty stdout means non-zero exit.

A `404` is mapped explicitly. An older backend without the endpoint would otherwise surface as an unexplained `returned 404`; the mapping is local to this call because `404` means something different on `DELETE /me/core-nodes/{name}`. The response is deserialized tolerantly for the same version-skew reason in the other direction: the CLI is installed on user machines and the backend deploys independently, and later work adds a `network` object to this exact shape.

### Two group-level cleanups

`--core-node` is now refused across the **whole** `platform` group, not just this command. No platform command addresses another machine's daemon (`login`/`logout` poke the *local* daemon over its control socket), so accepting the flag and ignoring it would silently answer a different question, and refusing it in one of four would be its own surprise.

The config → URL → credentials preamble that `login`, `logout`, and `whoami` each repeated is now `PlatformSession`, applied to all four commands rather than leaving two of the three original duplicators in place.

## Test plan

Rendering is pure, so the exact column layout, the marker, the collision suffix, the `unknown` column, ordering, the empty roster, and both `--json` shapes are asserted directly. The marker rules are a pure function too, so each case is pinned rather than inferred from a command that happened to succeed, including the mid-login case where the daemon's name matches a row exactly but its namespace does not.

```
cargo test -p peppy --lib commands::platform::list
test result: ok. 13 passed; 0 failed
```

`platform_flow.rs` covers the happy path in both formats, unauthenticated, an unreachable backend, a `503`, a `404`, `--core-node` refused by all four commands, and a daemon in another workspace not failing the listing.

```
cargo test -p peppy --test integration platform_flow
test result: ok. 21 passed; 0 failed

cargo test -p peppy -p auth --lib
test result: ok. 57 passed; 0 failed
test result: ok. 189 passed; 0 failed
```

Three pre-existing integration failures (`daemon_singleton` ×2, `service_install`) and the `container::*` tests fail identically on the clean tree in my sandbox; I verified that by stashing. They need systemd, process-lock behaviour, and apt respectively.

## Docs

`advanced_guides/platform.mdx` gains a "Listing the workspace's core nodes" section covering what each status means, that an unregistered row is the normal appearance of a `zenoh.external` daemon, that every row is one of the user's own machines since the platform runs no core node, why the registry timestamp is not liveness, that `peppy stack list` is where host names live (default names are machine-UID hashes), and that `online` is not an authenticated statement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `peppy platform list` to display workspace core nodes.
  - Supports human-readable and JSON output, registration dates, application status, claimant counts, and current-machine identification.
  - Provides clear handling for empty rosters, unavailable status information, authentication errors, and unsupported backends.

- **Documentation**
  - Added usage guidance, output examples, status definitions, and registration-time explanations for the new command.

- **Bug Fixes**
  - Standardized platform session setup across login, logout, and identity commands.
  - Prevented unsupported `--core-node` overrides for platform commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->