### PR TITLE
Release v0.20.0

### DIFF
--- a/.claude/skills/plan-review/SKILL.md
+++ b/.claude/skills/plan-review/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: plan-review
+description: Staged review of a plan, architecture, design, or set of code changes, covering architecture, code quality, tests, and performance. Use when reviewing a plan before implementation, when working in plan mode, or when asked to review a design, an approach, or pending changes.
+---
+
+# Plan review
+
+Review this plan thoroughly before making any code changes. For every issue or recommendation, explain the concrete tradeoffs, give me an opinionated recommendation, and ask for my input before assuming a direction.
+
+The engineering preferences in `Claude.md` govern every recommendation below.
+
+---
+
+## 1. Architecture review
+
+**Evaluate:**
+
+- Overall system design and component boundaries.
+- Dependency graph and coupling concerns.
+- Data flow patterns and potential bottlenecks.
+- Scaling characteristics and single points of failure.
+
+---
+
+## 2. Code quality review
+
+**Evaluate:**
+
+- Code organization and module structure.
+- DRY violations—be aggressive here.
+- Error handling patterns and missing edge cases (call these out explicitly).
+- Technical debt hotspots.
+- Areas that are over-engineered or under-engineered relative to my preferences.
+
+---
+
+## 3. Test review
+
+**Evaluate:**
+
+- Test coverage gaps (unit, integration).
+- Test quality and assertion strength.
+- Missing edge case coverage—be thorough.
+- Untested failure modes and error paths.
+- Tests must be human readable, prefer code clarity here over optimisation.
+- When you modify code, add or update tests only if the change materially affects behavior, correctness, edge cases, interfaces, regression risk, or business logic.
+- DO NOT add tests for trivial, cosmetic, or low-signal changes unless existing tests must be adjusted to stay consistent.
+- DO NOT create test backdoors or escape hatches where you create functions in the business logic that are only meant to be used by tests
+
+---
+
+## 4. Performance review
+
+**Evaluate:**
+
+- N+1 queries and database access patterns.
+- Memory-usage concerns.
+- Caching opportunities.
+- Slow or high-complexity code paths.
+
+---
+
+## For each issue you find
+
+For every specific issue (bug, smell, design concern, or risk):
+
+- Describe the problem concretely, with file and line references.
+- Present 2–3 options, including “do nothing” where that’s reasonable.
+- For each option, specify:
+  - Implementation effort
+  - Risk
+  - Impact on other code
+  - Maintenance burden
+- Give me your recommended option and why, mapped to my preferences above.
+- Then explicitly ask whether I agree or want to choose a different direction before proceeding.
+
+---
+
+## FOR EACH STAGE OF REVIEW
+
+- Output:
+  - The explanation
+  - Pros and cons of each stage’s questions
+  - Your opinionated recommendation and why
+- Then use **AskUserQuestion**.
+
+Additional rules:
+
+- **NUMBER issues**.
+- **Use LETTERS for options**.
+- When using **AskUserQuestion**, clearly label:
+  - Issue **NUMBER**
+  - Option **LETTER**
+- Make the **recommended option always the 1st option**.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,9 +13,15 @@ on:
   issues:
     types: [opened]
 
-# Keyed per issue/PR so two mentions on the same thread queue instead of racing
-# on the same branch. `cancel-in-progress` stays false on purpose: killing a run
-# mid-flight leaves a half-written comment and, worse, a half-pushed branch.
+# Keyed per issue/PR so mentions on the same thread cannot run concurrently and
+# race on the same branch. `cancel-in-progress` stays false on purpose: killing a
+# run mid-flight leaves a half-written comment and, worse, a half-pushed branch.
+#
+# Caveat: GitHub holds at most ONE pending run per group. With a run active and
+# one already pending, a third mention displaces the pending one rather than
+# lining up behind it. Actions has no `queue:` setting to change that, and a real
+# durable queue would need external machinery that a human-paced trigger does not
+# justify. If a mention is ever dropped this way, post it again.
 concurrency:
   group: claude-${{ github.event.issue.number || github.event.pull_request.number }}
   cancel-in-progress: false
@@ -29,11 +35,25 @@ jobs:
   authorize:
     # Cheap pre-filter so an unrelated comment does not boot a runner just to be
     # discarded. The action re-checks the trigger phrase itself afterwards.
+    #
+    # `author_association` is read straight from the event payload, so a drive-by
+    # comment from outside the org is rejected without starting a runner at all.
+    # It is deliberately wider than the admin test below (an admin here reports
+    # MEMBER, not OWNER), so it filters noise rather than granting anything; the
+    # `is_admin` lookup remains the actual authorization boundary.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude'))
-      || (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude'))
-      || (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
-      || (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issue_comment'
+        && contains(github.event.comment.body, '@claude')
+        && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
+      || (github.event_name == 'pull_request_review_comment'
+        && contains(github.event.comment.body, '@claude')
+        && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
+      || (github.event_name == 'pull_request_review'
+        && contains(github.event.review.body, '@claude')
+        && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association))
+      || (github.event_name == 'issues'
+        && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude'))
+        && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))
 
     runs-on: ubuntu-latest
     permissions:
@@ -94,15 +114,24 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v6
+      # Both actions below are pinned to a commit rather than a tag. Tags are
+      # mutable, and this job holds contents: write plus the Claude credential,
+      # so a retagged release would run with them. Bump deliberately.
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           # Full history so Claude can read blame and prior commits rather than
           # reasoning from a single shallow snapshot.
           fetch-depth: 0
 
-      - uses: anthropics/claude-code-action@v1
+      - uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # The job-level `actions: read` above scopes GITHUB_TOKEN, which this
+          # action does not use: it works through an App token minted by the OIDC
+          # exchange, and that token's scope comes from this input. Without it the
+          # log-reading grant lands on a token nothing reads logs with.
+          additional_permissions: |
+            actions: read
           # The `[1m]` suffix selects the 1M-context variant of Opus 5. Without
           # it the model runs at its standard context window, which matters here
           # because the checkout is a full-history clone of a large Rust repo.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -21,15 +21,57 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  claude:
-    # The action does its own trigger-phrase matching, but that happens after a
-    # runner is already up. This job-level filter keeps every unrelated comment
-    # in the repo from booting a runner just to be discarded.
+  # Gate. The action has its own built-in check, but it admits anyone with
+  # *write* access, and this repo is public with a job that can push branches.
+  # Admin is the narrower bar we actually want, and it has to be read at run
+  # time rather than hardcoded so that admins added later are covered without
+  # editing this file.
+  authorize:
+    # Cheap pre-filter so an unrelated comment does not boot a runner just to be
+    # discarded. The action re-checks the trigger phrase itself afterwards.
     if: |
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude'))
       || (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude'))
       || (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
       || (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      is_admin: ${{ steps.check.outputs.is_admin }}
+
+    steps:
+      - id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Passed through the environment rather than interpolated into the
+          # script body, so no field controlled by the event can be parsed as
+          # shell.
+          ACTOR: ${{ github.actor }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # `.user.permissions.admin` is a boolean, unlike `role_name`, which an
+          # org can override with a custom role whose name we cannot predict.
+          # On failure gh writes its error body to stdout, so `raw` is only
+          # trusted when it is exactly "true"; anything else (API error, actor
+          # not a collaborator, token lacking the read) denies. The failure mode
+          # is a refusal to run, never an unintended grant.
+          raw="$(gh api "repos/$REPO/collaborators/$ACTOR/permission" \
+            --jq '.user.permissions.admin' 2>/dev/null || true)"
+
+          if [ "$raw" = "true" ]; then
+            echo "is_admin=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_admin=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Ignoring @claude from '$ACTOR': restricted to repository admins."
+          fi
+
+  claude:
+    needs: authorize
+    if: needs.authorize.outputs.is_admin == 'true'
 
     # GitHub-hosted rather than the self-hosted runner the other workflows use.
     # This job installs its own toolchain and would otherwise contend with the
@@ -41,6 +83,15 @@ jobs:
       pull-requests: write # post review comments, open PRs
       issues: write # reply on the issue thread
       actions: read # read failing CI logs when asked why a run broke
+      # Required. With no `github_token` input the action mints its credential
+      # by exchanging an OIDC token for a GitHub App token, and without this it
+      # cannot read ACTIONS_ID_TOKEN_REQUEST_URL and fails outright.
+      #
+      # Worth keeping over the simpler `github_token: ${{ secrets.GITHUB_TOKEN }}`
+      # route: pushes made with GITHUB_TOKEN deliberately do not start other
+      # workflows, so a fix Claude pushed to a PR would never run tests.yml.
+      # The App token has no such restriction.
+      id-token: write
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,65 @@
+name: Claude
+
+# Interactive only: nothing runs unless a human writes `@claude` in an issue, a
+# PR comment, or a review. There is no automatic per-push review, so this costs
+# nothing on ordinary PR traffic.
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened]
+
+# Keyed per issue/PR so two mentions on the same thread queue instead of racing
+# on the same branch. `cancel-in-progress` stays false on purpose: killing a run
+# mid-flight leaves a half-written comment and, worse, a half-pushed branch.
+concurrency:
+  group: claude-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  claude:
+    # The action does its own trigger-phrase matching, but that happens after a
+    # runner is already up. This job-level filter keeps every unrelated comment
+    # in the repo from booting a runner just to be discarded.
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude'))
+      || (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude'))
+      || (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
+      || (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+
+    # GitHub-hosted rather than the self-hosted runner the other workflows use.
+    # This job installs its own toolchain and would otherwise contend with the
+    # long cargo and container builds that already occupy the self-hosted box.
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write # push the branch when Claude is asked to make a change
+      pull-requests: write # post review comments, open PRs
+      issues: write # reply on the issue thread
+      actions: read # read failing CI logs when asked why a run broke
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Full history so Claude can read blame and prior commits rather than
+          # reasoning from a single shallow snapshot.
+          fetch-depth: 0
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # The `[1m]` suffix selects the 1M-context variant of Opus 5. Without
+          # it the model runs at its standard context window, which matters here
+          # because the checkout is a full-history clone of a large Rust repo.
+          #
+          # `xhigh` rather than `high`: this job reviews and edits Rust, and
+          # xhigh is the recommended level for coding and agentic work on Opus 5.
+          # Both are pinned for the same reason, so a change in either default
+          # does not silently change what CI runs.
+          claude_args: >-
+            --model claude-opus-5[1m]
+            --effort xhigh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,7 +573,7 @@ dependencies = [
 [[package]]
 name = "build-helpers"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#b622f119896aeb1c549bfa784972abd2c0f437a5"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#cb07e5dc717f246e541b24ccb15245ff1fa4f7c3"
 dependencies = [
  "sha2",
 ]
@@ -774,7 +774,7 @@ dependencies = [
 [[package]]
 name = "config-test-support"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#b622f119896aeb1c549bfa784972abd2c0f437a5"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#cb07e5dc717f246e541b24ccb15245ff1fa4f7c3"
 dependencies = [
  "askama",
  "git2",
@@ -918,7 +918,7 @@ dependencies = [
 [[package]]
 name = "core-node-api"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#b622f119896aeb1c549bfa784972abd2c0f437a5"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#cb07e5dc717f246e541b24ccb15245ff1fa4f7c3"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -1256,7 +1256,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1404,7 +1404,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2577,7 +2577,7 @@ dependencies = [
 [[package]]
 name = "json5-pretty"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#b622f119896aeb1c549bfa784972abd2c0f437a5"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#cb07e5dc717f246e541b24ccb15245ff1fa4f7c3"
 dependencies = [
  "serde",
  "serde_json",
@@ -2981,7 +2981,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3366,7 +3366,7 @@ dependencies = [
 [[package]]
 name = "peppy-config-model"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#b622f119896aeb1c549bfa784972abd2c0f437a5"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#cb07e5dc717f246e541b24ccb15245ff1fa4f7c3"
 dependencies = [
  "capnp",
  "clap",
@@ -3389,7 +3389,7 @@ version = "0.0.1"
 [[package]]
 name = "peppylib-rs"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#b622f119896aeb1c549bfa784972abd2c0f437a5"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#cb07e5dc717f246e541b24ccb15245ff1fa4f7c3"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -3584,7 +3584,7 @@ dependencies = [
 [[package]]
 name = "pmi"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#b622f119896aeb1c549bfa784972abd2c0f437a5"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#cb07e5dc717f246e541b24ccb15245ff1fa4f7c3"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -3801,7 +3801,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.5",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4051,7 +4051,7 @@ dependencies = [
  "pin-project-lite",
  "rustls",
  "rustls-pki-types",
- "rustls-platform-verifier 0.6.2",
+ "rustls-platform-verifier 0.7.0",
  "serde",
  "serde_json",
  "sync_wrapper",
@@ -4237,7 +4237,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4305,7 +4305,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4326,7 +4326,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4702,7 +4702,7 @@ version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
 dependencies = [
- "dirs 4.0.0",
+ "dirs 6.0.0",
 ]
 
 [[package]]
@@ -5038,7 +5038,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5932,7 +5932,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,7 +573,7 @@ dependencies = [
 [[package]]
 name = "build-helpers"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#cb07e5dc717f246e541b24ccb15245ff1fa4f7c3"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#7197afea34a6f1d3e148b7472f319af0b7bf5904"
 dependencies = [
  "sha2",
 ]
@@ -625,9 +625,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -774,7 +774,7 @@ dependencies = [
 [[package]]
 name = "config-test-support"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#cb07e5dc717f246e541b24ccb15245ff1fa4f7c3"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#7197afea34a6f1d3e148b7472f319af0b7bf5904"
 dependencies = [
  "askama",
  "git2",
@@ -918,7 +918,7 @@ dependencies = [
 [[package]]
 name = "core-node-api"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#cb07e5dc717f246e541b24ccb15245ff1fa4f7c3"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#7197afea34a6f1d3e148b7472f319af0b7bf5904"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -1331,9 +1331,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "email_address"
@@ -1709,7 +1709,7 @@ dependencies = [
  "rust-embed",
  "serde_json5",
  "sha2",
- "syn 2.0.119",
+ "syn 3.0.3",
  "tempfile",
  "thiserror 2.0.19",
  "tokio",
@@ -1806,9 +1806,9 @@ dependencies = [
 
 [[package]]
 name = "gix-path"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbbecb0f8dc5cdf6cbde69133f7072064dfc9da4cf0046913afb6857b07300fa"
+checksum = "1ed3e8d7a82e886e17a72e03d4ba0c13db6f2219b6cd4e2900b4cae426ec20c9"
 dependencies = [
  "bstr",
  "gix-trace",
@@ -1818,27 +1818,40 @@ dependencies = [
 
 [[package]]
 name = "gix-trace"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44dc45eae785c0eb14173e0f152e6e224dcf4d45b6a6999a3aed22af541ad678"
+checksum = "be3eb81d9dc914335923e50d52829c551feefd6a72d176c4130c546b67a60814"
 
 [[package]]
 name = "gix-url"
-version = "0.36.2"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d68e70e96da0e5f9c871f1566349e0fd0e1a20bb483c7f54af1dd0b85b4b29"
+checksum = "42d10e53b8eae21ee601687f47bbbd6cb2ed7162cb4c1cafdd422fb7ec64cbee"
 dependencies = [
  "bstr",
  "gix-path",
+ "gix-utils",
  "percent-encoding",
  "thiserror 2.0.19",
 ]
 
 [[package]]
-name = "gix-validate"
-version = "0.11.2"
+name = "gix-utils"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bc6fc771c4063ba7cd2f47b91fb6076251c6a823b64b7fe7b8874b0fe4afae3"
+checksum = "b1795bd2a970ca8b2185318c2abb97d955c71992f1cf28de73ad3b593a9f3ce8"
+dependencies = [
+ "bstr",
+ "fastrand",
+ "getrandom 0.4.3",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "gix-validate"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a034e84d1e04e1b1f20f51f12491da230b6ac8b925d0c8e1b89bcd87a7c5ccc"
 dependencies = [
  "bstr",
 ]
@@ -2577,7 +2590,7 @@ dependencies = [
 [[package]]
 name = "json5-pretty"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#cb07e5dc717f246e541b24ccb15245ff1fa4f7c3"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#7197afea34a6f1d3e148b7472f319af0b7bf5904"
 dependencies = [
  "serde",
  "serde_json",
@@ -2585,9 +2598,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.48.5"
+version = "0.49.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05a6cff806294a7699d48761d4ae2bdebab7fa2eef05e4a0b83320f0ff46901"
+checksum = "9cc9116a0f75b7336e55eb2a2a0ddef86c37cadf02924a571751aa123d5a0290"
 dependencies = [
  "ahash",
  "bytecount",
@@ -2616,18 +2629,18 @@ dependencies = [
 
 [[package]]
 name = "jsonschema-regex"
-version = "0.48.5"
+version = "0.49.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84708dd3f6c5327478a96f37378adb27deed6a626cf84d19de780d9e8ae84b17"
+checksum = "628a1f02bda4651d9a6088ee6386a92f0ee96255b0c99e9dfe1be91bf83bd838"
 dependencies = [
  "regex-syntax",
 ]
 
 [[package]]
 name = "jsonschema-value"
-version = "0.48.5"
+version = "0.49.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd8c04ab4ce60e42c4e302d3bd9d184652bb56f212495d2eea23573bcbf72556"
+checksum = "75d94a372f8d81d070fd405065c6b1168d8248d1d6adad073ac708de254698c6"
 dependencies = [
  "ahash",
  "bytecount",
@@ -2691,9 +2704,9 @@ checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.18.5+1.9.4"
+version = "0.18.7+1.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "005d6ae6eac1912906073e069f7db60b1fa98e052a68227824afe3e3a1c59ca2"
+checksum = "23c7391e4b9f4ffab1a624223cc1d7385ff9a678f490768add717de7ea2f4d89"
 dependencies = [
  "cc",
  "libc",
@@ -3366,7 +3379,7 @@ dependencies = [
 [[package]]
 name = "peppy-config-model"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#cb07e5dc717f246e541b24ccb15245ff1fa4f7c3"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#7197afea34a6f1d3e148b7472f319af0b7bf5904"
 dependencies = [
  "capnp",
  "clap",
@@ -3389,7 +3402,7 @@ version = "0.0.1"
 [[package]]
 name = "peppylib-rs"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#cb07e5dc717f246e541b24ccb15245ff1fa4f7c3"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#7197afea34a6f1d3e148b7472f319af0b7bf5904"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -3584,13 +3597,14 @@ dependencies = [
 [[package]]
 name = "pmi"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#cb07e5dc717f246e541b24ccb15245ff1fa4f7c3"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#7197afea34a6f1d3e148b7472f319af0b7bf5904"
 dependencies = [
  "build-helpers",
  "bytes",
  "derive_more",
  "flume 0.12.0",
  "peppy-config-model",
+ "rand 0.10.2",
  "rustls-native-certs",
  "rustls-pemfile",
  "serde_json",
@@ -3665,12 +3679,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.37"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+checksum = "2bfe0f4c752e450fc2faf62654f1c134747922825d5b04ca717b8874f41a40c0"
 dependencies = [
  "proc-macro2",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3977,9 +3991,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.48.5"
+version = "0.49.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "980e77f5cfffc592c0e7dfb6d20770a0b96a6ab94d403de7454ed9799505e4ba"
+checksum = "978badf4419c9d0e1bc6e7466e99277f829d768257670c46d88121ca75e34bf7"
 dependencies = [
  "ahash",
  "fluent-uri",
@@ -4279,9 +4293,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -5581,6 +5595,15 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-segmentation"

--- a/Claude.md
+++ b/Claude.md
@@ -1,6 +1,4 @@
-# Claude Code Prompt for Plan Mode
-
-Review this plan thoroughly before making any code changes. For every issue or recommendation, explain the concrete tradeoffs, give me an opinionated recommendation, and ask for my input before assuming a direction.
+# Project instructions
 
 ## My engineering preferences (use these to guide your recommendations)
 
@@ -18,75 +16,11 @@ Review this plan thoroughly before making any code changes. For every issue or r
 
 ---
 
-## 1. Architecture review
-
-**Evaluate:**
-
-- Overall system design and component boundaries.
-- Dependency graph and coupling concerns.
-- Data flow patterns and potential bottlenecks.
-- Scaling characteristics and single points of failure.
-
----
-
-## 2. Code quality review
-
-**Evaluate:**
-
-- Code organization and module structure.
-- DRY violations—be aggressive here.
-- Error handling patterns and missing edge cases (call these out explicitly).
-- Technical debt hotspots.
-- Areas that are over-engineered or under-engineered relative to my preferences.
-
----
-
-## 3. Test review
-
-**Evaluate:**
-
-- Test coverage gaps (unit, integration).
-- Test quality and assertion strength.
-- Missing edge case coverage—be thorough.
-- Untested failure modes and error paths.
-- Tests must be human readable, prefer code clarity here over optimisation.
-- When you modify code, add or update tests only if the change materially affects behavior, correctness, edge cases, interfaces, regression risk, or business logic.
-- DO NOT add tests for trivial, cosmetic, or low-signal changes unless existing tests must be adjusted to stay consistent.
-- DO NOT create test backdoors or escape hatches where you create functions in the business logic that are only meant to be used by tests
-
----
-
-## 4. Performance review
-
-**Evaluate:**
-
-- N+1 queries and database access patterns.
-- Memory-usage concerns.
-- Caching opportunities.
-- Slow or high-complexity code paths.
-
----
-
-## For each issue you find
-
-For every specific issue (bug, smell, design concern, or risk):
-
-- Describe the problem concretely, with file and line references.
-- Present 2–3 options, including “do nothing” where that’s reasonable.
-- For each option, specify:
-  - Implementation effort
-  - Risk
-  - Impact on other code
-  - Maintenance burden
-- Give me your recommended option and why, mapped to my preferences above.
-- Then explicitly ask whether I agree or want to choose a different direction before proceeding.
-
----
-
 ## Workflow and interaction style
 
 - Do not assume my priorities on timeline or scale.
-- After each section, pause and ask for my feedback before moving on.
+- Review this plan thoroughly before making any code changes. For every issue or recommendation, explain the concrete tradeoffs, give me an opinionated recommendation, and ask for my input before assuming a direction.
+- When reviewing a plan, a design, or pending changes, follow the `plan-review` skill (`.claude/skills/plan-review/SKILL.md`).
 
 ---
 
@@ -102,27 +36,3 @@ For every specific issue (bug, smell, design concern, or risk):
 - If unsure: say so and ask user questions in doubt.
 - Never guess or invent file paths.
 - User instructions always override this file.
-
-## Efficiency
-
-- Read before writing. Understand the problem before coding.
-- No redundant file reads. Read each file once.
-- One focused coding pass. Avoid write-delete-rewrite cycles.
-- Test once, fix if needed, verify once. No unnecessary iterations.
-
-## FOR EACH STAGE OF REVIEW
-
-- Output:
-  - The explanation
-  - Pros and cons of each stage’s questions
-  - Your opinionated recommendation and why
-- Then use **AskUserQuestion**.
-
-Additional rules:
-
-- **NUMBER issues**.
-- **Use LETTERS for options**.
-- When using **AskUserQuestion**, clearly label:
-  - Issue **NUMBER**
-  - Option **LETTER**
-- Make the **recommended option always the 1st option**.

--- a/Claude.md
+++ b/Claude.md
@@ -12,8 +12,8 @@
 - Do not leave legacy code behind or code that is meant to support previous version of the code.
 - When you write comments or documentation, stop using em-dash `—`, this is a recurring pattern that you make and immediately jumps at users as being your coding style.
 - Push back hard against design implementation that you think are fundamentally wrong and explain your reasoning
-- Never open or merge PRs in the remote repository without my consent
-
+- Never merge PRs in the remote repository without my consent
+- When tests are written, never make them time-based, they should be deterministic and should not depend on the speed of the host
 ---
 
 ## Workflow and interaction style
@@ -33,6 +33,6 @@
 - Test your code before declaring done.
 - No sycophantic openers or closing fluff.
 - Keep solutions simple and direct. No over-engineering, but if a big refactor is needed to keep code easier to reason about, proceed.
-- If unsure: say so and ask user questions in doubt.
+- When unsure about a big design decision: say so and AskUserQuestion, do not ask those questions if it's about a small implementation detail.
 - Never guess or invent file paths.
 - User instructions always override this file.

--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
 # Peppy
 
-[![Tests](https://github.com/Peppy-bot/peppy/actions/workflows/tests.yml/badge.svg)](https://github.com/Peppy-bot/peppy/actions/workflows/tests.yml)
+[![Tests](https://github.com/Peppy-bot/peppy/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/Peppy-bot/peppy/actions/workflows/tests.yml?query=branch%3Amain)
 
 Peppy is a modern robotics middleware framework designed for robots. Similar to ROS 2, it provides a distributed communication layer for robotic systems with a big focus on ease of use and explicit configuration.
 

--- a/crates/auth-internal/src/client.rs
+++ b/crates/auth-internal/src/client.rs
@@ -50,6 +50,87 @@ pub fn get_me(http: &HttpClient, api_url: &str, cred: &mut Credential) -> Result
     authed_get_json(http, api_url, "/me", cred)
 }
 
+/// The caller's workspace's core nodes, as `GET /me/core-nodes` returns them.
+///
+/// Deserialized tolerantly (unknown fields ignored), and every field the
+/// platform may not know is optional. That is version skew, not a legacy shim:
+/// the CLI is installed on user machines and the backend is deployed
+/// independently, so an older CLI meets a newer backend routinely. Later work
+/// adds a per-entry `network` object to this exact response, and a CLI that
+/// rejected unknown fields would break on that deploy.
+#[derive(Debug, Clone, Deserialize)]
+pub struct CoreNodeListing {
+    /// The workspace whose core nodes these are, as the backend derives it from
+    /// the authenticated principal.
+    pub workspace_id: String,
+    /// Whether the platform could read liveliness at all. When false, every
+    /// entry's application status is null, and that is a different statement
+    /// from every machine being offline.
+    #[serde(default)]
+    pub application_status_available: bool,
+    #[serde(default)]
+    pub core_nodes: Vec<CoreNodeEntry>,
+}
+
+/// One core node in the workspace.
+#[derive(Debug, Clone, Deserialize)]
+pub struct CoreNodeEntry {
+    pub core_node_name: String,
+    /// Whether the platform has a registry row for this name. `false` is the
+    /// normal appearance of a `zenoh.external` daemon, which adopts its cached
+    /// workspace namespace but never pulls federation config.
+    #[serde(default)]
+    pub registered: bool,
+    /// RFC 3339 UTC, or null on an unregistered entry.
+    #[serde(default)]
+    pub first_seen_at: Option<String>,
+    /// RFC 3339 UTC, or null on an unregistered entry. A config-pull time, not
+    /// a liveness signal, which is why it is never rendered as "last seen".
+    #[serde(default)]
+    pub last_config_pull_at: Option<String>,
+    #[serde(default)]
+    pub application: ApplicationStatus,
+}
+
+/// Whether a core node's daemon is on the wire. Both fields are null when the
+/// platform could not read liveliness.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct ApplicationStatus {
+    /// `"online"`, `"offline"`, or null. Kept as a string rather than an enum
+    /// so a status this CLI has not heard of renders as itself instead of
+    /// failing the whole listing.
+    #[serde(default)]
+    pub status: Option<String>,
+    /// Distinct instance ids claiming the name. More than one is an active
+    /// collision, and the losing daemon refuses to boot.
+    #[serde(default)]
+    pub live_claimants: Option<u32>,
+}
+
+/// `GET {api_url}/me/core-nodes`, refreshing once on a 401 for session
+/// credentials.
+///
+/// A `404` is mapped explicitly: it means the backend predates this endpoint,
+/// which the generic status message would render as an unexplained
+/// `returned 404`. The mapping lives here rather than in
+/// [`interpret_authed_json`] because `404` means something different on every
+/// endpoint (on `DELETE /me/core-nodes/{name}` it means "no such row").
+pub fn list_core_nodes(
+    http: &HttpClient,
+    api_url: &str,
+    cred: &mut Credential,
+) -> Result<CoreNodeListing> {
+    let url = format!("{}/me/core-nodes", api_url.trim_end_matches('/'));
+    let resp = authed_get(http, &url, cred)?;
+    if resp.status == 404 {
+        return Err(Error::Http(format!(
+            "{api_url} does not support `peppy platform list`; upgrade the platform, \
+             or check --api-url"
+        )));
+    }
+    interpret_authed_json(resp, cred, "GET", &url, "/me/core-nodes")
+}
+
 /// The connection config the backend hands the CLI for the caller's private
 /// per-user zenoh router. Deserialized tolerantly (unknown fields ignored) so a
 /// backend that adds fields still parses. The CA the router is validated against

--- a/crates/auth-internal/src/client.rs
+++ b/crates/auth-internal/src/client.rs
@@ -139,6 +139,32 @@ pub fn logout(http: &HttpClient, api_url: &str, access_token: &str) -> Result<u1
     Ok(resp.status)
 }
 
+/// `DELETE {api_url}/me/core-nodes/{core_node_name}`: remove this machine's core
+/// node from the caller's registry on the platform. Returns the status code so
+/// the caller can decide what to print (`204` removed, `404` nothing to remove).
+///
+/// Never refreshes, deliberately, exactly like [`logout`]. `peppy platform
+/// logout` calls this immediately before revoking the very token it holds: a
+/// refresh here would mint a token that the revocation which follows does not
+/// cover, leaving it valid until its own expiry.
+///
+/// The name goes into the path unencoded because the backend accepts only
+/// `[A-Za-z0-9_-]`, which is the daemon's own charset, so a core-node name is
+/// always a literal path segment.
+pub fn deregister_core_node(
+    http: &HttpClient,
+    api_url: &str,
+    access_token: &str,
+    core_node_name: &str,
+) -> Result<u16> {
+    let url = format!(
+        "{}/me/core-nodes/{core_node_name}",
+        api_url.trim_end_matches('/')
+    );
+    let resp = http.delete(&url, Some(access_token))?;
+    Ok(resp.status)
+}
+
 /// A GET that, on 401 with a session credential, refreshes (and persists) the
 /// token and retries exactly once.
 fn authed_get(http: &HttpClient, url: &str, cred: &mut Credential) -> Result<HttpResponse> {

--- a/crates/auth-internal/src/client.rs
+++ b/crates/auth-internal/src/client.rs
@@ -89,7 +89,29 @@ pub struct CoreNodeEntry {
     #[serde(default)]
     pub last_config_pull_at: Option<String>,
     #[serde(default)]
+    pub network: NetworkStatus,
+    #[serde(default)]
     pub application: ApplicationStatus,
+}
+
+/// Whether this core node's site holds a live transport session with the
+/// platform's shared router.
+///
+/// The network layer and the application layer fail separately, which is the
+/// whole reason both are reported: `linked` with an offline application layer is
+/// a dead daemon behind a healthy uplink (debug the machine), while `unlinked`
+/// with an offline application layer is an unreachable site (debug the network).
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct NetworkStatus {
+    /// `"linked"`, `"indirect"`, `"unlinked"`, or `"unknown"`. Kept as a string
+    /// rather than an enum, like [`ApplicationStatus::status`], so a status this
+    /// CLI has not heard of renders as itself instead of failing the listing.
+    #[serde(default)]
+    pub status: Option<String>,
+    /// The transport identity this site's daemon reported, or null for a name
+    /// that is live on the wire but has no registry row (nothing to join on).
+    #[serde(default)]
+    pub router_zid: Option<String>,
 }
 
 /// Whether a core node's daemon is on the wire. Both fields are null when the
@@ -195,19 +217,32 @@ pub fn split_locator(endpoint: &str) -> Result<(String, u16)> {
 /// `POST {api_url}/me/cli/federation`: fetch the shared router's
 /// connection config (the daemon's discovery point), refreshing the access token
 /// once on a 401 for session credentials (the same reactive-refresh contract as
-/// [`get_me`]). The
-/// body always carries the daemon's core-node name — the backend requires it and
-/// upserts the name into its per-principal core-node registry (its `last_seen_at`
-/// tracks config pulls, not liveness). The daemon dials the returned endpoint
-/// over one-way TLS, verifying the router's certificate and presenting none of
-/// its own.
+/// [`get_me`]). The daemon dials the returned endpoint over one-way TLS,
+/// verifying the router's certificate and presenting none of its own.
+///
+/// The body always carries two required fields, both upserted into the backend's
+/// per-principal core-node registry:
+///
+/// * `core_node_name`, the daemon's application-layer identity (its
+///   `last_seen_at` tracks config pulls, not liveness).
+/// * `router_zid`, the transport identity this daemon's managed router pins.
+///   The platform joins it against the shared router's live session list, which
+///   is what separates "the uplink is up, the daemon is not" from "this site is
+///   unreachable". Only a managed daemon pulls federation config, and a managed
+///   daemon always owns a router, so there is no caller that legitimately lacks
+///   one and the backend rejects a request without it.
 pub fn establish_federation(
     http: &HttpClient,
     api_url: &str,
     cred: &mut Credential,
     core_node_name: &str,
+    router_zid: &pmi::RouterId,
 ) -> Result<ZenohRouterConfig> {
-    let body = serde_json::json!({ "core_node_name": core_node_name }).to_string();
+    let body = serde_json::json!({
+        "core_node_name": core_node_name,
+        "router_zid": router_zid.as_str(),
+    })
+    .to_string();
     authed_post_json(http, api_url, "/me/cli/federation", &body, cred)
 }
 

--- a/crates/auth-internal/src/client.rs
+++ b/crates/auth-internal/src/client.rs
@@ -167,9 +167,10 @@ pub struct ZenohRouterConfig {
     /// Transport scheme, `"tls"` today.
     pub protocol: String,
     /// How long this config may be reused before re-resolving it. A cache-freshness
-    /// hint only: the backend now actively health-checks the daemon, so reusing a
-    /// still-fresh config (rather than re-pulling) never risks the router being torn
-    /// down.
+    /// hint only: the router the backend hands back is a single shared one, not a
+    /// per-user resource with a lifetime, and nothing on the backend probes this
+    /// daemon or tears that router down. Reusing a still-fresh config therefore only
+    /// delays this daemon's next re-registration, never the loss of a router.
     pub reconnect_after_secs: u64,
     /// The daemon's session namespace, deserialized directly from the backend's
     /// `workspace_id`. Typed at the HTTP boundary: an invalid workspace id fails

--- a/crates/auth-internal/src/http.rs
+++ b/crates/auth-internal/src/http.rs
@@ -145,6 +145,14 @@ impl HttpClient {
             .map_err(|e| Error::Http(format!("POST {} failed: {e}", redact(url))))?;
         finish("POST", url, resp)
     }
+
+    /// `DELETE url` (used for `/me/core-nodes/{core_node_name}`).
+    pub fn delete(&self, url: &str, bearer: Option<&str>) -> Result<HttpResponse> {
+        let resp = with_bearer(self.agent.delete(url), bearer)
+            .call()
+            .map_err(|e| Error::Http(format!("DELETE {} failed: {e}", redact(url))))?;
+        finish("DELETE", url, resp)
+    }
 }
 
 /// Strips the query string from a URL for error messages, so a `verification_uri_complete`

--- a/crates/auth-internal/src/router.rs
+++ b/crates/auth-internal/src/router.rs
@@ -120,6 +120,8 @@ fn materialize_embedded(cache_dir: &Path, filename: &str, bytes: &[u8]) -> Optio
 /// core-node registry (see [`client::establish_federation`]); it also
 /// tags the cache, so a resolve under a different name (a renamed daemon) always
 /// re-pulls and re-registers rather than reusing a still-fresh cache.
+/// `router_zid` is the managed router's pinned transport identity, carried in
+/// the same POST and tagging the cache the same way.
 ///
 /// Only the pull path needs a credential, so a fresh cache is reused without
 /// touching the token at all.
@@ -130,6 +132,7 @@ pub fn resolve_router_endpoint(
     pat: Option<String>,
     ca_certificate: Option<PathBuf>,
     core_node_name: &str,
+    router_zid: &pmi::RouterId,
 ) -> Result<RouterEndpoint> {
     let now = storage::now_unix();
     // Load once: the cached router config and the active session's subject come
@@ -157,6 +160,14 @@ pub fn resolve_router_endpoint(
     // collision-fix workflow: set `core_node_name`, restart) must re-pull — and
     // thereby register its new name — instead of reusing a still-fresh cache and
     // staying absent from the registry until the cache goes stale.
+    //
+    // The router zid deliberately does NOT tag the cache. It changes only when
+    // the workspace changes (which clears this cache with the session) or when
+    // the identity record is lost, and adding it to the cached `RouterSession`
+    // would invalidate every credentials file on disk to close that second,
+    // narrow case. A re-minted identity simply re-registers on the next stale
+    // pull; until then the row reads `indirect`, which is a less specific answer
+    // rather than a wrong one.
     let reuse_cache = pat.is_none() && !active_subject.is_empty();
     let (endpoint, namespace) = match creds.router {
         Some(rs)
@@ -167,7 +178,15 @@ pub fn resolve_router_endpoint(
         {
             (rs.endpoint, rs.namespace)
         }
-        _ => pull_and_cache(creds_path, http, api_url, pat, now, core_node_name)?,
+        _ => pull_and_cache(
+            creds_path,
+            http,
+            api_url,
+            pat,
+            now,
+            core_node_name,
+            router_zid,
+        )?,
     };
 
     let (host, port) = client::split_locator(&endpoint)?;
@@ -184,8 +203,8 @@ pub fn resolve_router_endpoint(
 /// cached `repull_after` uses the same clock reading as the freshness check. The
 /// trust anchor is resolved fresh at connect time (see [`resolve_router_ca`]), so
 /// it is deliberately not part of the cached `RouterSession`. The pull identifies
-/// the daemon by `core_node_name` (the POST body), upserting it into the
-/// backend's core-node registry.
+/// the daemon by `core_node_name` and `router_zid` (the POST body), upserting
+/// both into the backend's core-node registry.
 fn pull_and_cache(
     creds_path: &Path,
     http: &HttpClient,
@@ -193,6 +212,7 @@ fn pull_and_cache(
     pat: Option<String>,
     now: i64,
     core_node_name: &str,
+    router_zid: &pmi::RouterId,
 ) -> Result<(String, config::namespace::Namespace)> {
     let mut cred = resolver::resolve(creds_path, http, pat)?;
     // The identity this pull is actually authenticated as drives the cache tag
@@ -200,7 +220,7 @@ fn pull_and_cache(
     // session subject; doing so would let the session reuse the PAT's workspace once the
     // PAT is gone (a cross-identity leak).
     let is_pat = matches!(cred.kind, resolver::CredentialKind::Pat);
-    let cfg = client::establish_federation(http, api_url, &mut cred, core_node_name)?;
+    let cfg = client::establish_federation(http, api_url, &mut cred, core_node_name, router_zid)?;
 
     // Validate the config *before* it is written to `creds.router`: a malformed
     // endpoint or an unsupported transport must not poison the on-disk
@@ -265,9 +285,10 @@ fn pull_and_cache(
 /// backend can't stall the caller (federation at startup / on a login-poke)
 /// beyond it; on timeout the pull errors and this returns `None`.
 ///
-/// `core_node_name` is the daemon's core-node name, sent in every pull's POST
-/// body so the backend registry records which daemon federated (and when it
-/// last pulled).
+/// `core_node_name` is the daemon's core-node name and `router_zid` its managed
+/// router's pinned transport identity; both are sent in every pull's POST body
+/// so the backend registry records which daemon federated (and when it last
+/// pulled), and can match this site against the shared router's session list.
 ///
 /// `peppy_dirs` is the caller's resolved peppy data root: the credentials file
 /// and the materialized dev TLS material both derive from it, so a daemon
@@ -279,6 +300,7 @@ pub fn resolve_federation_target(
     api_url: &str,
     connect_timeout: Duration,
     core_node_name: &str,
+    router_zid: &pmi::RouterId,
 ) -> Option<(String, pmi::TlsConfig)> {
     let cache_dir = peppy_dirs.cache_dir();
     resolve_federation_target_at(
@@ -288,6 +310,7 @@ pub fn resolve_federation_target(
         resolve_router_ca(&cache_dir),
         connect_timeout,
         core_node_name,
+        router_zid,
     )
 }
 
@@ -302,6 +325,7 @@ pub fn resolve_federation_target_at(
     ca_certificate: Option<PathBuf>,
     connect_timeout: Duration,
     core_node_name: &str,
+    router_zid: &pmi::RouterId,
 ) -> Option<(String, pmi::TlsConfig)> {
     // Skip the network entirely when there is plainly no identity to pull for, so
     // an un-provisioned dev box does not log a spurious auth error every poll. Take
@@ -330,6 +354,7 @@ pub fn resolve_federation_target_at(
         pat,
         ca_certificate,
         core_node_name,
+        router_zid,
     ) {
         // Fail-closed gate, single source: only a validated, non-local namespace
         // federates. The daemon session is resolved from the same cached value.

--- a/crates/auth-internal/src/router.rs
+++ b/crates/auth-internal/src/router.rs
@@ -121,7 +121,9 @@ fn materialize_embedded(cache_dir: &Path, filename: &str, bytes: &[u8]) -> Optio
 /// tags the cache, so a resolve under a different name (a renamed daemon) always
 /// re-pulls and re-registers rather than reusing a still-fresh cache.
 /// `router_zid` is the managed router's pinned transport identity, carried in
-/// the same POST and tagging the cache the same way.
+/// the same POST so the registered row can be matched against the shared
+/// router's live session list. Unlike the name, it deliberately does not
+/// participate in cache reuse (see the cache comment below).
 ///
 /// Only the pull path needs a credential, so a fresh cache is reused without
 /// touching the token at all.

--- a/crates/auth-internal/tests/auth_flow.rs
+++ b/crates/auth-internal/tests/auth_flow.rs
@@ -168,6 +168,12 @@ fn get_me_parses_principal_with_unknown_fields() {
 /// pull mocks *require* it as the POST body (`json_body`), so a pull that
 /// drops or malforms the body gets no mock response and fails its test.
 const CORE_NODE: &str = "core-node-test-1";
+/// The managed router identity every federation pull in these tests reports.
+const ROUTER_ZID: &str = "7f3a9c1e";
+
+fn router_zid() -> pmi::RouterId {
+    pmi::RouterId::parse(ROUTER_ZID).expect("a valid router id literal")
+}
 
 fn workspace_namespace() -> config::namespace::Namespace {
     config::namespace::Namespace::parse("550e8400-e29b-41d4-a716-446655440000").unwrap()
@@ -177,12 +183,14 @@ fn workspace_namespace() -> config::namespace::Namespace {
 fn establish_federation_parses_the_contract() {
     let server = MockServer::start();
     // The shared router is static, so the POST provisions nothing — but its body
-    // must always identify the daemon by core-node name (the backend registry
-    // requires it). The matcher rejects any other body.
+    // must always identify the daemon by BOTH its core-node name (the
+    // application layer) and its router zid (the transport layer); the backend
+    // registry requires both. The matcher rejects any other body, so this is the
+    // wire-contract check for the pair.
     let cfg_mock = server.mock(|when, then| {
         when.method(POST)
             .path("/me/cli/federation")
-            .json_body(json!({ "core_node_name": CORE_NODE }));
+            .json_body(json!({ "core_node_name": CORE_NODE, "router_zid": ROUTER_ZID }));
         then.status(200).json_body(json!({
             "endpoint": "tls/localhost:7447",
             "protocol": "tls",
@@ -199,8 +207,14 @@ fn establish_federation_parses_the_contract() {
         token: storage::secret("any-token".to_string()),
         kind: CredentialKind::Pat,
     };
-    let cfg = client::establish_federation(&http, &server.base_url(), &mut cred, CORE_NODE)
-        .expect("fetch shared router config");
+    let cfg = client::establish_federation(
+        &http,
+        &server.base_url(),
+        &mut cred,
+        CORE_NODE,
+        &router_zid(),
+    )
+    .expect("fetch shared router config");
     assert_eq!(cfg.protocol, "tls");
     assert_eq!(cfg.reconnect_after_secs, 3000);
     assert_eq!(cfg.namespace, workspace_namespace());
@@ -237,20 +251,20 @@ fn router_config_pull_refreshes_on_401_then_re_pulls() {
         }));
     });
     // First pull (seeded token) is rejected; the retry (rotated token) succeeds.
-    // Both matchers require the core-node-name body, so the retry provably
-    // re-sends it.
+    // Both matchers require the full identity body, so the retry provably
+    // re-sends it rather than dropping a field on the way through.
     let pull_rejected = server.mock(|when, then| {
         when.method(POST)
             .path("/me/cli/federation")
             .header("Authorization", "Bearer seeded-access")
-            .json_body(json!({ "core_node_name": CORE_NODE }));
+            .json_body(json!({ "core_node_name": CORE_NODE, "router_zid": ROUTER_ZID }));
         then.status(401);
     });
     let pull_ok = server.mock(|when, then| {
         when.method(POST)
             .path("/me/cli/federation")
             .header("Authorization", "Bearer refreshed-access")
-            .json_body(json!({ "core_node_name": CORE_NODE }));
+            .json_body(json!({ "core_node_name": CORE_NODE, "router_zid": ROUTER_ZID }));
         then.status(200).json_body(json!({
             "endpoint": "tls/cap.zenoh.localhost:7443",
             "protocol": "tls",
@@ -280,8 +294,14 @@ fn router_config_pull_refreshes_on_401_then_re_pulls() {
         }),
     };
 
-    let cfg = client::establish_federation(&http, &server.base_url(), &mut cred, CORE_NODE)
-        .expect("pull after refresh");
+    let cfg = client::establish_federation(
+        &http,
+        &server.base_url(),
+        &mut cred,
+        CORE_NODE,
+        &router_zid(),
+    )
+    .expect("pull after refresh");
     assert_eq!(
         cfg.host_port().unwrap(),
         ("cap.zenoh.localhost".to_string(), 7443)
@@ -337,9 +357,16 @@ fn resolve_router_endpoint_reuses_a_fresh_cache_without_pulling() {
     storage::save(&path, &creds).expect("seed creds");
 
     let http = HttpClient::new();
-    let endpoint =
-        router::resolve_router_endpoint(&path, &http, &server.base_url(), None, None, CORE_NODE)
-            .expect("resolve from cache");
+    let endpoint = router::resolve_router_endpoint(
+        &path,
+        &http,
+        &server.base_url(),
+        None,
+        None,
+        CORE_NODE,
+        &router_zid(),
+    )
+    .expect("resolve from cache");
     assert_eq!(endpoint.host, "cached.zenoh.localhost");
     assert_eq!(endpoint.port, 7443);
     assert!(endpoint.tls.verify_name_on_connect);
@@ -354,11 +381,11 @@ fn resolve_federation_target_derives_the_upstream_tls_locator() {
     // the `RouterFederation` task both rely on.
     let server = MockServer::start();
     // The body matcher doubles as the C1 wire-contract check: the daemon's
-    // federation pull must always identify itself by core-node name.
+    // federation pull must always identify itself by core-node name and router zid.
     let pull = server.mock(|when, then| {
         when.method(POST)
             .path("/me/cli/federation")
-            .json_body(json!({ "core_node_name": CORE_NODE }));
+            .json_body(json!({ "core_node_name": CORE_NODE, "router_zid": ROUTER_ZID }));
         then.status(200).json_body(json!({
             "endpoint": "tls/cap.zenoh.localhost:7443",
             "protocol": "tls",
@@ -383,6 +410,7 @@ fn resolve_federation_target_derives_the_upstream_tls_locator() {
         Some(ca.clone()),
         SECS_30,
         CORE_NODE,
+        &router_zid(),
     )
     .expect("logged in ⇒ a federation target");
     assert_eq!(target.0, "tls/cap.zenoh.localhost:7443");
@@ -419,6 +447,7 @@ fn resolve_federation_target_is_none_when_not_logged_in() {
         None,
         SECS_30,
         CORE_NODE,
+        &router_zid(),
     );
     assert!(target.is_none(), "not logged in ⇒ no federation target");
     assert_eq!(pull.calls(), 0, "not logged in ⇒ the backend is never hit");
@@ -457,6 +486,7 @@ fn resolve_federation_target_fails_closed_on_an_invalid_workspace_namespace() {
         None,
         SECS_30,
         CORE_NODE,
+        &router_zid(),
     );
     assert!(
         target.is_none(),
@@ -506,6 +536,7 @@ fn resolve_federation_target_honors_a_short_connect_timeout() {
         None,
         Duration::from_millis(100),
         CORE_NODE,
+        &router_zid(),
     );
     assert!(
         too_slow.is_none(),
@@ -520,6 +551,7 @@ fn resolve_federation_target_honors_a_short_connect_timeout() {
         None,
         SECS_30,
         CORE_NODE,
+        &router_zid(),
     );
     assert!(
         in_time.is_some(),
@@ -534,12 +566,12 @@ fn resolve_federation_target_honors_a_short_connect_timeout() {
 #[test]
 fn resolve_router_endpoint_re_pulls_and_caches_when_stale() {
     let server = MockServer::start();
-    // The stale re-pull must also carry the core-node-name body (the matcher
+    // The stale re-pull must also carry both identity fields (the matcher
     // rejects anything else).
     let pull = server.mock(|when, then| {
         when.method(POST)
             .path("/me/cli/federation")
-            .json_body(json!({ "core_node_name": CORE_NODE }));
+            .json_body(json!({ "core_node_name": CORE_NODE, "router_zid": ROUTER_ZID }));
         then.status(200).json_body(json!({
             "endpoint": "tls/fresh.zenoh.localhost:7443",
             "protocol": "tls",
@@ -574,6 +606,7 @@ fn resolve_router_endpoint_re_pulls_and_caches_when_stale() {
         None,
         Some(ca.clone()),
         CORE_NODE,
+        &router_zid(),
     )
     .expect("re-pull");
     assert_eq!(endpoint.host, "fresh.zenoh.localhost");
@@ -608,7 +641,7 @@ fn resolve_router_endpoint_re_pulls_when_the_core_node_name_changed() {
     let pull = server.mock(|when, then| {
         when.method(POST)
             .path("/me/cli/federation")
-            .json_body(json!({ "core_node_name": CORE_NODE }));
+            .json_body(json!({ "core_node_name": CORE_NODE, "router_zid": ROUTER_ZID }));
         then.status(200).json_body(json!({
             "endpoint": "tls/cap.zenoh.localhost:7443",
             "protocol": "tls",
@@ -635,9 +668,16 @@ fn resolve_router_endpoint_re_pulls_when_the_core_node_name_changed() {
     storage::save(&path, &creds).expect("seed creds");
 
     let http = HttpClient::new();
-    let endpoint =
-        router::resolve_router_endpoint(&path, &http, &server.base_url(), None, None, CORE_NODE)
-            .expect("resolve re-pulls under the new name");
+    let endpoint = router::resolve_router_endpoint(
+        &path,
+        &http,
+        &server.base_url(),
+        None,
+        None,
+        CORE_NODE,
+        &router_zid(),
+    )
+    .expect("resolve re-pulls under the new name");
     assert_eq!(endpoint.host, "cap.zenoh.localhost");
     assert_eq!(
         pull.calls(),
@@ -696,6 +736,7 @@ fn router_cache_is_bound_to_the_pull_identity_not_the_on_disk_session() {
         Some("the-pat".to_string()),
         None,
         CORE_NODE,
+        &router_zid(),
     )
     .expect("PAT pull resolves");
     assert_eq!(ep.host, "pat-workspace.zenoh.localhost");
@@ -718,9 +759,16 @@ fn router_cache_is_bound_to_the_pull_identity_not_the_on_disk_session() {
 
     // With the PAT gone, a session resolve must NOT reuse the PAT's cache: the
     // subjects differ, so it re-pulls rather than leaking the PAT's workspace.
-    let _ =
-        router::resolve_router_endpoint(&path, &http, &server.base_url(), None, None, CORE_NODE)
-            .expect("session resolve");
+    let _ = router::resolve_router_endpoint(
+        &path,
+        &http,
+        &server.base_url(),
+        None,
+        None,
+        CORE_NODE,
+        &router_zid(),
+    )
+    .expect("session resolve");
     assert_eq!(
         pull.calls(),
         2,

--- a/crates/core-node-internal/Cargo.toml
+++ b/crates/core-node-internal/Cargo.toml
@@ -39,7 +39,7 @@ tokio-util = "0.7"
 tracing = "0.1"
 askama = "0.16"
 rust-embed = { version = "8", features = ["include-exclude"] }
-gix-url = "0.36"
+gix-url = "0.37"
 git2 = { version = "0.21", features = ["https", "vendored-openssl"] }
 url = "2"
 ureq = "3.1"

--- a/crates/daemon-config-internal/src/consts.rs
+++ b/crates/daemon-config-internal/src/consts.rs
@@ -147,6 +147,15 @@ impl PeppyDirs {
         self.root.join("stack_log.log")
     }
 
+    /// Path to the daemon's persisted zenoh router identity.
+    ///
+    /// Sits at the data root beside `daemon_state.json5`, which it resembles:
+    /// daemon-owned state, not user-editable configuration, so it deliberately
+    /// does not live under [`Self::conf_dir`].
+    pub fn router_identity_path(&self) -> PathBuf {
+        self.root.join("router_identity.json5")
+    }
+
     /// Shared Rust crate cache directory for a given cache key.
     pub fn rust_libs_cache_dir(&self, cache_key: &str) -> PathBuf {
         self.root.join("libs").join("rust").join(cache_key)

--- a/crates/daemon-internal/src/builder.rs
+++ b/crates/daemon-internal/src/builder.rs
@@ -4,6 +4,7 @@ use super::messaging_router::{MessagingRouter, teardown_budget_for};
 use super::router_federation::RouterFederation;
 use super::serve::{CompositeCommand, Serve};
 use crate::error::{Error, Result};
+use crate::router_identity;
 use crate::state::DaemonState;
 use daemon_config::consts::PeppyDirs;
 use daemon_config::peppy_config::PeppyConfig;
@@ -69,6 +70,13 @@ pub struct ServeCommandBuilder {
     /// [`RouterFederation`] task (which compares against it to decide restart vs
     /// live re-federate). A single source for the whole generation.
     namespace: config::namespace::Namespace,
+    /// The managed router's persisted transport identity, resolved alongside
+    /// [`Self::namespace`] in [`with_messaging_router`](Self::with_messaging_router)
+    /// and pinned into the router's config. `None` for an external router (the
+    /// operator owns its identity) and for the non-zenoh engines. Threaded into
+    /// [`RouterFederation`], which reports it to the backend so the platform can
+    /// match this site against the shared router's live session list.
+    router_id: Option<pmi::RouterId>,
     /// The shared coordinator token for this generation: cloned into every serve
     /// task (so a restart/stop unparks them for graceful teardown) and handed to
     /// [`Serve`] (which cancels it on its way out). Created per generation.
@@ -101,6 +109,7 @@ impl ServeCommandBuilder {
             // Default for the mock/other engines that never resolve a namespace;
             // the zenoh path overwrites this in `with_messaging_router`.
             namespace: config::namespace::Namespace::local(),
+            router_id: None,
             teardown_token: CancellationToken::new(),
         })
     }
@@ -179,21 +188,46 @@ impl ServeCommandBuilder {
                 self.namespace = namespace.clone();
 
                 let gossip = self.peppy_config.zenoh.gossip();
-                let adapter = match self.peppy_config.zenoh.external_endpoint() {
+                // Taken by value so the identity resolve below can borrow `self`
+                // mutably without contending with this read.
+                let external_endpoint = self
+                    .peppy_config
+                    .zenoh
+                    .external_endpoint()
+                    .map(str::to_string);
+                let adapter = match external_endpoint {
+                    // An operator-run router keeps its own identity, and an
+                    // external daemon never federates or registers
+                    // (`zenoh.federation()` is `None` in this mode), so there is
+                    // nothing here for peppy to pin or report.
                     Some(endpoint) => {
-                        ZenohAdapter::with_external_router(endpoint, gossip, subscriber_buffers)?
+                        ZenohAdapter::with_external_router(&endpoint, gossip, subscriber_buffers)?
                     }
-                    None => ZenohAdapter::with_router(
-                        ZenohNetProtocol::Tcp,
-                        "0.0.0.0",
-                        listening_port,
-                        gossip,
-                        subscriber_buffers,
-                        // Standalone: local nodes reach this router over plaintext
-                        // loopback TCP. The federation task adds TLS upstream later.
-                        Vec::new(),
-                        None,
-                    )?,
+                    None => {
+                        // This generation's router identity, scoped to the same
+                        // namespace and persisted under this run's data root, so
+                        // the managed router keeps one zid across restarts and
+                        // the platform can attribute its transport session in the
+                        // shared router's session list to this site.
+                        let router_id = router_identity::resolve(
+                            &self.peppy_dirs.router_identity_path(),
+                            &namespace,
+                        )?;
+                        self.router_id = Some(router_id.clone());
+                        ZenohAdapter::with_router(
+                            ZenohNetProtocol::Tcp,
+                            "0.0.0.0",
+                            listening_port,
+                            gossip,
+                            subscriber_buffers,
+                            // Standalone: local nodes reach this router over
+                            // plaintext loopback TCP. The federation task adds
+                            // the TLS upstream later, keeping this same identity.
+                            Vec::new(),
+                            None,
+                            router_id,
+                        )?
+                    }
                 }
                 .with_session_reconnect()
                 .with_namespace(Some(namespace));
@@ -373,9 +407,13 @@ impl ServeCommandBuilder {
             // name, so with none materialized there is nothing to register.
             warn!("Router federation requires a core node; staying standalone");
         }
+        // `router_id` is `Some` for exactly the configurations that also set
+        // `federation_api_url` (managed zenoh), so this arm never narrows what
+        // federates; it just makes the identity available without an `expect`.
         if let Some(api_url) = self.federation_api_url.take()
             && let Some(messenger) = self.messenger.clone()
             && let Some(messaging_ready) = self.messaging_ready.clone()
+            && let Some(router_id) = self.router_id.clone()
             && let Some(core_node_name) = federation_core_node_name
         {
             let connect_timeout = self.federation_connect_timeout;
@@ -396,6 +434,10 @@ impl ServeCommandBuilder {
                         // federation POST so the backend registry knows which
                         // daemon pulled the config.
                         core_node_name,
+                        // The managed router's pinned identity, reported in the
+                        // same POST so the backend can match this site against
+                        // the shared router's live session list.
+                        router_id,
                         // The data root the loop's per-poll credential reads
                         // and materialized dev TLS derive from.
                         self.peppy_dirs.clone(),

--- a/crates/daemon-internal/src/builder.rs
+++ b/crates/daemon-internal/src/builder.rs
@@ -695,12 +695,19 @@ mod tests {
             ..PeppyConfig::default()
         };
 
-        let builder =
-            ServeCommandBuilder::new("/unused", "regression-git-hash", PeppyDirs::new("/unused"))
-                .expect("create builder")
-                .with_peppy_config(peppy_config)
-                .with_messaging_router("zenoh".to_string())
-                .expect("build managed messaging adapter without starting it");
+        // Unlike the external case, the managed path persists the router
+        // identity under the data root, so this one needs a root it may
+        // actually write to.
+        let data_root = tempfile::tempdir().expect("temp data root");
+        let builder = ServeCommandBuilder::new(
+            "/unused",
+            "regression-git-hash",
+            PeppyDirs::new(data_root.path()),
+        )
+        .expect("create builder")
+        .with_peppy_config(peppy_config)
+        .with_messaging_router("zenoh".to_string())
+        .expect("build managed messaging adapter without starting it");
 
         assert!(
             builder.federation_api_url.is_some(),

--- a/crates/daemon-internal/src/lib.rs
+++ b/crates/daemon-internal/src/lib.rs
@@ -27,6 +27,7 @@ mod error;
 mod federation_control;
 mod messaging_router;
 mod router_federation;
+mod router_identity;
 mod serve;
 mod shutdown_signal;
 

--- a/crates/daemon-internal/src/router_federation.rs
+++ b/crates/daemon-internal/src/router_federation.rs
@@ -33,8 +33,11 @@
 //!   tears anything down: the router it hands back is a single shared one, not a
 //!   per-user resource with a lifetime.
 //! * **Registration cadence.** Every config pull's POST carries this daemon's
-//!   core-node name, upserting it into the backend's per-principal core-node
-//!   registry. The POST fires on cache-stale pulls and on login/logout pokes —
+//!   core-node name *and* its managed router's pinned transport identity
+//!   (`router_zid`), upserting both into the backend's per-principal core-node
+//!   registry. The zid is what lets the platform tell a site whose uplink is
+//!   healthy but whose daemon is dead from one that is simply unreachable: it
+//!   matches the row against the shared router's live session list. The POST fires on cache-stale pulls and on login/logout pokes —
 //!   login clears the router cache, so every login re-registers — never on a
 //!   timer. The backend's `last_seen_at` for a core node therefore means "last
 //!   federation config pull", not liveness. `peppy platform logout` removes the
@@ -213,6 +216,7 @@ impl RouterFederation {
         messenger: Arc<Mutex<Messenger>>,
         api_url: String,
         core_node_name: String,
+        router_id: pmi::RouterId,
         peppy_dirs: PeppyDirs,
         messaging_ready: watch::Receiver<bool>,
         trigger_rx: TriggerReceiver,
@@ -232,6 +236,7 @@ impl RouterFederation {
                 &api_url,
                 connect_timeout,
                 &core_node_name,
+                &router_id,
             )
         });
         Self {

--- a/crates/daemon-internal/src/router_federation.rs
+++ b/crates/daemon-internal/src/router_federation.rs
@@ -27,18 +27,19 @@
 //!   *verifies* the federation link with a real TLS handshake
 //!   ([`pmi::probe_tls_reachable`]) so a silent UnknownCA loop is reported as
 //!   [`FederationOutcome::Unreachable`] rather than a false success.
-//! * **Liveness (backend-driven).** There is no client-side keepalive poll. Once
-//!   federated, the local router holds its link to the cloud router open on its
-//!   own (`reconnect: true`); the backend actively probes this daemon's `/health`
-//!   service over the federated link and tears the cloud router down when the
-//!   daemon stops answering. The config pull on startup/login tells the backend
-//!   this daemon's `core_node` name so it knows which `/health` service to probe.
+//! * **Liveness.** There is no keepalive poll in either direction. Once
+//!   federated, the local router holds its link to the shared router open on its
+//!   own (`reconnect: true`), and the backend neither probes this daemon nor
+//!   tears anything down: the router it hands back is a single shared one, not a
+//!   per-user resource with a lifetime.
 //! * **Registration cadence.** Every config pull's POST carries this daemon's
 //!   core-node name, upserting it into the backend's per-principal core-node
 //!   registry. The POST fires on cache-stale pulls and on login/logout pokes —
 //!   login clears the router cache, so every login re-registers — never on a
 //!   timer. The backend's `last_seen_at` for a core node therefore means "last
-//!   federation config pull", not liveness.
+//!   federation config pull", not liveness. `peppy platform logout` removes the
+//!   row outright (`DELETE /me/core-nodes/{core_node_name}`), since a logged-out
+//!   machine stops federating and stops pulling config.
 //! * **Live (re)federation.** When the resolved upstream changes (the user logs
 //!   in, logs out, or the endpoint moves) the local router's zenohd config is
 //!   re-rendered and the router restarted, so the change takes effect without a

--- a/crates/daemon-internal/src/router_identity.rs
+++ b/crates/daemon-internal/src/router_identity.rs
@@ -1,0 +1,252 @@
+//! The daemon's persisted zenoh router identity, scoped to its workspace.
+//!
+//! The managed router's config pins a [`RouterId`] (see [`pmi::RouterId`]),
+//! which is what lets the platform attribute a transport session in the shared
+//! router's session list to a particular site. That only works if the id
+//! survives a restart, so it is persisted here rather than minted per boot.
+//!
+//! # Why the identity is scoped to the workspace, not the machine
+//!
+//! The record on disk is a `(namespace, router_id)` pair, and a resolved
+//! namespace that differs from the stored one mints a fresh id. That falls out
+//! of how namespaces already work: a namespace is resolved once per daemon
+//! generation and fixed for that generation's whole lifetime, and changing it
+//! restarts the daemon into a new generation. A router identity that outlived
+//! that boundary would be the only thing on the machine that did.
+//!
+//! It also removes a class of wrong answer. A machine that logs into a
+//! different account without logging out first leaves a registry row behind in
+//! its old workspace. If the id persisted across the switch, that abandoned row
+//! would keep matching the shared router's live session list and read as a
+//! healthy uplink behind a dead daemon, rather than as a machine that left.
+//! With a workspace-scoped id the old row's id is simply no longer connected,
+//! which is exactly what happened.
+
+use std::path::Path;
+
+use config::namespace::Namespace;
+use pmi::RouterId;
+use serde::{Deserialize, Serialize};
+use tracing::{info, warn};
+
+use crate::error::{Error, Result};
+
+/// The on-disk record: which workspace this router identity belongs to, and
+/// what it is.
+///
+/// The namespace is stored rather than inferred so a workspace change is
+/// detectable from the file alone. Both fields are required: a record that
+/// cannot say which workspace it is for cannot be trusted for either answer,
+/// and is re-minted (see [`resolve`]).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct StoredIdentity {
+    namespace: String,
+    router_id: String,
+}
+
+/// This generation's router identity: the stored one when it belongs to
+/// `namespace`, otherwise a freshly minted one, persisted before returning.
+///
+/// A record that is absent, unreadable, unparseable, or holds an id zenoh would
+/// not accept is treated the same as one for a different workspace: warn and
+/// re-mint. Losing an identity costs one re-registration on the next federation
+/// pull, whereas refusing to start would take the daemon down over a file it
+/// can simply rewrite.
+///
+/// A *write* failure is a hard error, and deliberately not symmetric with the
+/// read side. Continuing with an id that was never persisted would mint a new
+/// one on every boot, which is precisely the anonymity this module exists to
+/// remove, and it would do so silently: the daemon would look healthy while its
+/// registry row pointed at an identity that no longer connects.
+pub(crate) fn resolve(path: &Path, namespace: &Namespace) -> Result<RouterId> {
+    if let Some(existing) = stored_for(path, namespace) {
+        return Ok(existing);
+    }
+
+    let minted = RouterId::generate();
+    let record = StoredIdentity {
+        namespace: namespace.as_str().to_string(),
+        router_id: minted.to_string(),
+    };
+    let document = serde_json::to_string_pretty(&record).map_err(|e| {
+        Error::ExecutionFailed(format!("could not serialize the router identity: {e}"))
+    })?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| {
+            Error::ExecutionFailed(format!(
+                "could not create {} to persist the daemon's router identity: {e}",
+                parent.display()
+            ))
+        })?;
+    }
+    std::fs::write(path, document).map_err(|e| {
+        Error::ExecutionFailed(format!(
+            "could not persist the daemon's router identity to {}: {e}. Without a persisted \
+             identity the router would take a new one on every restart, so the platform could \
+             not tell this site apart from a new machine.",
+            path.display()
+        ))
+    })?;
+    info!(
+        namespace = %namespace,
+        router_id = %minted,
+        "minted a new zenoh router identity for this workspace"
+    );
+    Ok(minted)
+}
+
+/// The stored identity when it exists, parses, and belongs to `namespace`.
+///
+/// Every rejection is logged with its reason, so a re-mint is never silent: it
+/// changes how this site appears in the platform's roster until the next
+/// federation pull re-registers it.
+fn stored_for(path: &Path, namespace: &Namespace) -> Option<RouterId> {
+    let raw = match std::fs::read_to_string(path) {
+        Ok(raw) => raw,
+        // First boot under this data root is the overwhelmingly common case, so
+        // it must not warn.
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return None,
+        Err(error) => {
+            warn!(
+                path = %path.display(), %error,
+                "could not read the stored zenoh router identity; minting a new one"
+            );
+            return None;
+        }
+    };
+
+    let stored: StoredIdentity = match serde_json5::from_str(&raw) {
+        Ok(stored) => stored,
+        Err(error) => {
+            warn!(
+                path = %path.display(), %error,
+                "the stored zenoh router identity is unreadable; minting a new one"
+            );
+            return None;
+        }
+    };
+
+    if stored.namespace != namespace.as_str() {
+        info!(
+            stored_namespace = %stored.namespace,
+            namespace = %namespace,
+            "the stored zenoh router identity belongs to another workspace; minting a new one"
+        );
+        return None;
+    }
+
+    match RouterId::parse(&stored.router_id) {
+        Ok(router_id) => Some(router_id),
+        Err(error) => {
+            warn!(
+                path = %path.display(), %error,
+                "the stored zenoh router identity is not a valid zenoh id; minting a new one"
+            );
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn workspace(raw: &str) -> Namespace {
+        Namespace::parse(raw).expect("a valid namespace literal")
+    }
+
+    const WORKSPACE_A: &str = "550e8400-e29b-41d4-a716-446655440000";
+    const WORKSPACE_B: &str = "6ba7b810-9dad-11d1-80b4-00c04fd430c8";
+
+    /// The whole point: a restart in the same workspace keeps the identity, so
+    /// the platform sees one continuous router rather than a new machine per
+    /// boot.
+    #[test]
+    fn the_identity_survives_a_restart_in_the_same_workspace() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("router_identity.json5");
+
+        let first = resolve(&path, &workspace(WORKSPACE_A)).expect("first resolve");
+        let second = resolve(&path, &workspace(WORKSPACE_A)).expect("second resolve");
+
+        assert_eq!(
+            first, second,
+            "a restart under the same workspace must reuse the persisted identity"
+        );
+    }
+
+    /// And the other half of the rule: a workspace change re-mints, so an
+    /// abandoned registry row in the old workspace stops matching the shared
+    /// router's session list instead of reporting a healthy uplink forever.
+    #[test]
+    fn the_identity_is_reminted_when_the_workspace_changes_and_only_then() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("router_identity.json5");
+
+        let in_a = resolve(&path, &workspace(WORKSPACE_A)).expect("resolve in workspace A");
+        let in_b = resolve(&path, &workspace(WORKSPACE_B)).expect("resolve in workspace B");
+        assert_ne!(in_a, in_b, "a workspace change must mint a new identity");
+
+        // The new one is now the persisted one, and is itself stable.
+        let again_in_b =
+            resolve(&path, &workspace(WORKSPACE_B)).expect("re-resolve in workspace B");
+        assert_eq!(in_b, again_in_b);
+
+        // Returning to A does not resurrect A's old identity: only one record is
+        // kept, so the machine reads as a new arrival there, which it is.
+        let back_in_a =
+            resolve(&path, &workspace(WORKSPACE_A)).expect("resolve back in workspace A");
+        assert_ne!(back_in_a, in_a);
+    }
+
+    #[test]
+    fn a_logged_out_daemon_gets_a_local_scoped_identity() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("router_identity.json5");
+
+        let local = resolve(&path, &Namespace::local()).expect("resolve while logged out");
+        let again = resolve(&path, &Namespace::local()).expect("re-resolve while logged out");
+        assert_eq!(local, again);
+
+        // Logging in is a workspace change like any other.
+        let logged_in = resolve(&path, &workspace(WORKSPACE_A)).expect("resolve after login");
+        assert_ne!(local, logged_in);
+    }
+
+    #[test]
+    fn an_unreadable_record_is_replaced_rather_than_failing_the_daemon() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("router_identity.json5");
+
+        for corrupt in [
+            "not json at all",
+            // Parses as JSON but is not a record.
+            "{}",
+            // A well-formed record holding an id zenoh would reject (uppercase).
+            &format!(r#"{{ "namespace": "{WORKSPACE_A}", "router_id": "ABCDEF" }}"#),
+        ] {
+            std::fs::write(&path, corrupt).expect("write a corrupt record");
+
+            let resolved = resolve(&path, &workspace(WORKSPACE_A))
+                .unwrap_or_else(|e| panic!("a corrupt record must be replaced, not fatal: {e}"));
+            // And the replacement is persisted, so the next boot is stable again.
+            assert_eq!(
+                resolved,
+                resolve(&path, &workspace(WORKSPACE_A)).expect("re-resolve"),
+                "the replacement must be written back"
+            );
+        }
+    }
+
+    #[test]
+    fn the_record_is_created_under_a_data_root_that_does_not_exist_yet() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("fresh").join("root").join("id.json5");
+
+        let minted = resolve(&path, &workspace(WORKSPACE_A)).expect("first boot creates the root");
+        assert_eq!(
+            minted,
+            resolve(&path, &workspace(WORKSPACE_A)).expect("re-resolve")
+        );
+    }
+}

--- a/crates/generator-internal/Cargo.toml
+++ b/crates/generator-internal/Cargo.toml
@@ -11,8 +11,8 @@ daemon-config = { workspace = true }
 encoding = { workspace = true }
 quote = "1.0"
 proc-macro2 = "1.0"
-prettyplease = "0.2"
-syn = { version = "2.0", features = ["full"] }
+prettyplease = "0.3"
+syn = { version = "3.0", features = ["full"] }
 thiserror = "2"
 askama = "0.16"
 toml = "1"

--- a/crates/generator-internal/src/generator/rust/scaffold.rs
+++ b/crates/generator-internal/src/generator/rust/scaffold.rs
@@ -585,6 +585,7 @@ fn write_leaf_module(
     }
     let module_file = File {
         shebang: None,
+        frontmatter: None,
         attrs,
         items,
     };
@@ -606,6 +607,7 @@ fn render_module_file(module_file: File) -> String {
     if !module_file.attrs.is_empty() {
         let attr_file = File {
             shebang: None,
+            frontmatter: None,
             attrs: module_file.attrs,
             items: Vec::new(),
         };
@@ -618,6 +620,7 @@ fn render_module_file(module_file: File) -> String {
     while let Some(item) = items_iter.next() {
         let item_file = File {
             shebang: None,
+            frontmatter: None,
             attrs: Vec::new(),
             items: vec![item],
         };
@@ -675,6 +678,7 @@ fn as_function_item(item: ImplItem) -> Option<Item> {
     let ImplItemFn {
         attrs,
         vis,
+        modifiers,
         sig,
         block,
         ..
@@ -683,6 +687,7 @@ fn as_function_item(item: ImplItem) -> Option<Item> {
     Some(Item::Fn(ItemFn {
         attrs,
         vis,
+        modifiers,
         sig,
         block: Box::new(block),
     }))

--- a/crates/peppy/Cargo.toml
+++ b/crates/peppy/Cargo.toml
@@ -20,7 +20,7 @@ json5-pretty = { workspace = true }
 bytes = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-gix-url = "0.36"
+gix-url = "0.37"
 url = "2"
 # https://docs.rs/quote/latest/quote/
 clap = { version = "4.5", features = ["derive"] }

--- a/crates/peppy/src/commands/platform.rs
+++ b/crates/peppy/src/commands/platform.rs
@@ -81,16 +81,33 @@ pub(crate) enum FederationPokeAction {
 /// nor skip the poke a managed daemon needs to (de)federate immediately
 /// (managed daemon, external config on disk). Only when no daemon is running,
 /// so there is nothing to poke or restart either way, does the on-disk `config`
-/// decide, matching what the next daemon start will do. The state file is read
-/// from the same `dirs` the command resolved, so a test seam isolates it.
+/// decide, matching what the next daemon start will do.
+///
+/// Takes the already-parsed `state` rather than reading the file itself, so a
+/// command that needs more than one field from it (logout needs the core-node
+/// name too) reads it exactly once and cannot see two different daemon
+/// generations within one invocation.
 pub(crate) fn federation_poke_timeout_secs(
-    dirs: &PeppyDirs,
+    state: Option<&DaemonState>,
     config: &daemon_config::peppy_config::PeppyConfig,
 ) -> Option<u64> {
-    match DaemonState::read_from(&DaemonState::state_file_in(dirs.root())) {
-        Ok(state) if state.is_running() => state.federation_connect_timeout_secs,
+    match state {
+        Some(state) if state.is_running() => state.federation_connect_timeout_secs,
         _ => config.zenoh.federation().map(|f| f.connect_timeout_secs),
     }
+}
+
+/// The daemon state file under `dirs`, or `None` when it is absent or
+/// unreadable. Read from the same `dirs` the command resolved, so a test seam
+/// isolates it.
+///
+/// The file outlives the daemon process, so a successful read is not proof of
+/// liveness; consumers that need "is a daemon actually up" check
+/// [`DaemonState::is_running`] themselves, and consumers that only need what the
+/// last daemon generation recorded (the core-node name it registered under) do
+/// not.
+pub(crate) fn read_daemon_state(dirs: &PeppyDirs) -> Option<DaemonState> {
+    DaemonState::read_from(&DaemonState::state_file_in(dirs.root())).ok()
 }
 
 /// Confirms (before authentication begins) a managed-router login/logout that
@@ -472,7 +489,10 @@ impl Command for PlatformCommand {
 
 #[cfg(test)]
 mod tests {
-    use super::{federation_poke_timeout_secs, report_login, report_logout, stack_has_user_nodes};
+    use super::{
+        federation_poke_timeout_secs, read_daemon_state, report_login, report_logout,
+        stack_has_user_nodes,
+    };
     use core_node_api::{
         InstanceState, NodeStage, SerializedInstance, SerializedNode, SerializedNodeGraph,
     };
@@ -522,12 +542,12 @@ mod tests {
         let dirs = PeppyDirs::new(dir.path());
         let managed = managed_config();
         assert_eq!(
-            federation_poke_timeout_secs(&dirs, &managed),
+            federation_poke_timeout_secs(read_daemon_state(&dirs).as_ref(), &managed),
             managed.zenoh.federation().map(|f| f.connect_timeout_secs),
             "no state file: a managed disk config supplies the poke timeout"
         );
         assert_eq!(
-            federation_poke_timeout_secs(&dirs, &external_config()),
+            federation_poke_timeout_secs(read_daemon_state(&dirs).as_ref(), &external_config()),
             None,
             "no state file: an external disk config means no poke"
         );
@@ -542,7 +562,7 @@ mod tests {
         // with the daemon's own timeout.
         write_running_state(&dirs, Some(7));
         assert_eq!(
-            federation_poke_timeout_secs(&dirs, &external_config()),
+            federation_poke_timeout_secs(read_daemon_state(&dirs).as_ref(), &external_config()),
             Some(7),
             "a running managed daemon must be poked even if the disk config went external"
         );
@@ -551,7 +571,7 @@ mod tests {
         // so login/logout must not warn about a restart or poke anything.
         write_running_state(&dirs, None);
         assert_eq!(
-            federation_poke_timeout_secs(&dirs, &managed_config()),
+            federation_poke_timeout_secs(read_daemon_state(&dirs).as_ref(), &managed_config()),
             None,
             "a running external daemon has no control socket to poke"
         );
@@ -578,7 +598,7 @@ mod tests {
 
         let managed = managed_config();
         assert_eq!(
-            federation_poke_timeout_secs(&dirs, &managed),
+            federation_poke_timeout_secs(read_daemon_state(&dirs).as_ref(), &managed),
             managed.zenoh.federation().map(|f| f.connect_timeout_secs),
             "a dead daemon's state must not override the disk config"
         );

--- a/crates/peppy/src/commands/platform.rs
+++ b/crates/peppy/src/commands/platform.rs
@@ -1,12 +1,14 @@
-//! The `peppy platform` command group: `login`, `logout`, and `whoami`. Each
-//! variant maps to a handler in this module's directory; the OAuth device flow,
-//! token storage, and credential resolution they share live in the separate
-//! `auth` engine crate. The group is named for the platform account rather than
-//! for auth because signing in does more than obtain a token: it stamps this
-//! machine's workspace namespace and pokes the running daemon to refederate
-//! its messaging router, and a login whose federation link cannot be
-//! established fails.
+//! The `peppy platform` command group: `login`, `logout`, `whoami`, and
+//! `list`. Each variant maps to a handler in this module's directory; the OAuth
+//! device flow, token storage, and credential resolution they share live in the
+//! separate `auth` engine crate, and the config/URL/credential preamble they
+//! all repeat lives here as [`PlatformSession`]. The group is named for the
+//! platform account rather than for auth because signing in does more than
+//! obtain a token: it stamps this machine's workspace namespace and pokes the
+//! running daemon to refederate its messaging router, and a login whose
+//! federation link cannot be established fails.
 
+pub mod list;
 pub mod login;
 pub mod logout;
 pub mod whoami;
@@ -19,6 +21,8 @@ use core_node_api::encoding::StackListRequest;
 use core_node_api::{NodeStage, SerializedNodeGraph};
 use daemon_config::consts::PeppyDirs;
 use peppylib::core_node::transport::poll;
+
+use auth::{http::HttpClient, profile, storage};
 
 use super::Command;
 use crate::commands::CALLER_INSTANCE_ID;
@@ -108,6 +112,70 @@ pub(crate) fn federation_poke_timeout_secs(
 /// not.
 pub(crate) fn read_daemon_state(dirs: &PeppyDirs) -> Option<DaemonState> {
     DaemonState::read_from(&DaemonState::state_file_in(dirs.root())).ok()
+}
+
+/// What every `peppy platform` command resolves before it can talk to the
+/// backend.
+///
+/// All four commands opened with the same four steps: load (and seed) the peppy
+/// config with the daemon's own strict semantics, resolve the API URL through
+/// the profile fallback, locate the credentials file, and build an HTTP client.
+/// The daemon's state rides along because it decides managed-vs-external for
+/// `login`/`logout` and supplies the `(this machine)` marker for `list`;
+/// reading it never fails the command, since a machine with no daemon running
+/// is a normal case for all four.
+pub(crate) struct PlatformSession {
+    pub dirs: PeppyDirs,
+    pub config: daemon_config::peppy_config::PeppyConfig,
+    pub api_url: String,
+    pub creds_path: std::path::PathBuf,
+    pub http: HttpClient,
+    /// The running daemon's recorded state. `None` when no daemon is running,
+    /// or its state file is absent or unreadable.
+    pub daemon_state: Option<DaemonState>,
+}
+
+impl PlatformSession {
+    pub(crate) fn resolve(peppy_dirs: Option<PeppyDirs>, api_url: Option<&str>) -> Result<Self> {
+        let dirs = peppy_dirs.unwrap_or_default();
+        // Loads (and seeds/completes) peppy_config.json5 with the same strict,
+        // fail-loud semantics the daemon uses; resource_servers supplies the
+        // per-profile URL fallback.
+        let config =
+            daemon_config::peppy_config::load_or_create(&dirs).map_err(Error::DaemonConfig)?;
+        let resolved_api_url = profile::resolve_api_url(api_url, &config.resource_servers)?;
+        Ok(Self {
+            creds_path: storage::credentials_path(&dirs),
+            // Managed vs external follows the RUNNING daemon's mode (from its
+            // state file), not the disk config, which may have been edited
+            // since it started; only with no daemon running does the disk
+            // config decide.
+            daemon_state: read_daemon_state(&dirs),
+            dirs,
+            config,
+            api_url: resolved_api_url,
+            http: HttpClient::new(),
+        })
+    }
+}
+
+/// Rejects `--core-node` for the whole `platform` group.
+///
+/// `--core-node` redirects a command at another machine's daemon, and no
+/// command in this group addresses a daemon that way: `login` and `logout` poke
+/// the *local* daemon over its control socket, and `whoami` and `list` talk
+/// only to the platform. Accepting the flag and ignoring it would silently
+/// answer a different question than the one asked, so the whole group refuses
+/// it rather than each command deciding for itself.
+fn reject_core_node_override(ctx: &AppContext) -> Result<()> {
+    let Some(core_node) = ctx.core_node_override() else {
+        return Ok(());
+    };
+    Err(Error::ExecutionFailed(format!(
+        "`--core-node {core_node}` is not valid for `peppy platform` commands: they act on this \
+         machine's daemon and on your platform account, never on another core node. \
+         Run `peppy stack list` to see other core nodes in your workspace."
+    )))
 }
 
 /// Confirms (before authentication begins) a managed-router login/logout that
@@ -451,6 +519,14 @@ pub enum PlatformCommands {
         #[arg(long)]
         json: bool,
     },
+    /// List the core nodes registered to this workspace, and whether each is alive
+    List {
+        #[arg(long = "api-url")]
+        api_url: Option<String>,
+        /// Emit machine-readable JSON.
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 pub struct PlatformCommand {
@@ -459,6 +535,9 @@ pub struct PlatformCommand {
 
 impl Command for PlatformCommand {
     fn execute(self, app_ctx: &Arc<AppContext>) -> Result<()> {
+        // Refused for the whole group, before any command does work: see
+        // `reject_core_node_override`.
+        reject_core_node_override(app_ctx)?;
         match self.command {
             PlatformCommands::Login {
                 api_url,
@@ -478,6 +557,12 @@ impl Command for PlatformCommand {
             }
             .execute(app_ctx),
             PlatformCommands::Whoami { api_url, json } => whoami::WhoamiCommand {
+                api_url,
+                json,
+                peppy_dirs: None,
+            }
+            .execute(app_ctx),
+            PlatformCommands::List { api_url, json } => list::ListCommand {
                 api_url,
                 json,
                 peppy_dirs: None,

--- a/crates/peppy/src/commands/platform/list.rs
+++ b/crates/peppy/src/commands/platform/list.rs
@@ -1,0 +1,512 @@
+//! `peppy platform list`: the core nodes registered to this workspace, and
+//! whether each is alive right now.
+//!
+//! Two machines logged into the same account already federate to the platform's
+//! shared router under one workspace namespace and can address each other.
+//! Nothing in the CLI showed that; this does.
+//!
+//! # A pure HTTP client
+//!
+//! The command resolves the session credential, issues one
+//! `GET /me/core-nodes`, and renders. It opens no zenoh session, connects to no
+//! daemon, and runs no presence query of its own. Every status printed is the
+//! platform's view, which is the only view that can see other sites at all: a
+//! local query would describe this machine's own mesh, which is not what the
+//! command claims to show.
+//!
+//! There is deliberately no local fallback when the backend is unreachable. A
+//! fallback could only answer a different question, and it would double the
+//! code and the tests to serve an outage.
+//!
+//! The one local read is the `(this machine)` marker, and it never fails the
+//! command.
+
+use std::sync::Arc;
+
+use daemon::state::DaemonState;
+use daemon_config::consts::PeppyDirs;
+use daemon_config::peppy_config::PeppyConfig;
+
+use crate::commands::Command;
+use crate::commands::platform::PlatformSession;
+use crate::context::AppContext;
+use crate::error::{Error, Result};
+use auth::client::{self, CoreNodeListing};
+use auth::resolver;
+
+pub struct ListCommand {
+    pub api_url: Option<String>,
+    /// Emit machine-readable JSON instead of human text.
+    pub json: bool,
+    /// Test seam: override the peppy data dirs (the credentials file and
+    /// `peppy_config.json5` both derive from it).
+    pub peppy_dirs: Option<PeppyDirs>,
+}
+
+impl Command for ListCommand {
+    fn execute(self, _ctx: &Arc<AppContext>) -> Result<()> {
+        let session = PlatformSession::resolve(self.peppy_dirs, self.api_url.as_deref())?;
+        let mut cred =
+            match resolver::resolve(&session.creds_path, &session.http, resolver::pat_from_env()) {
+                Ok(cred) => cred,
+                // Unlike `whoami`, whose output *is* the sign-in state, this
+                // command cannot produce its output at all without a credential.
+                // So it fails: a script gets the uniform "empty stdout, non-zero
+                // exit" contract rather than having to tell a partial document from
+                // a complete one.
+                Err(auth::AuthError::NotAuthenticated) => {
+                    return Err(Error::Auth(
+                        "Not authenticated. Run `peppy platform login`.".to_string(),
+                    ));
+                }
+                Err(e) => return Err(e.into()),
+            };
+
+        let listing = client::list_core_nodes(&session.http, &session.api_url, &mut cred)?;
+        let this_machine = this_machine_name(
+            session.daemon_state.as_ref(),
+            &session.config,
+            &listing.workspace_id,
+        );
+
+        if self.json {
+            print!("{}", render_json(&listing, &session.api_url));
+        } else {
+            print!("{}", render_human(&listing, &session.api_url, this_machine));
+        }
+        if !listing.application_status_available {
+            eprintln!(
+                "Warning: the platform could not read liveliness, so application status is \
+                 unknown for every core node. The roster itself is unaffected."
+            );
+        }
+        Ok(())
+    }
+}
+
+/// This machine's core-node name, when it can be established *and* this machine
+/// belongs to the workspace being listed.
+///
+/// The namespace gate is the point. A daemon that has not restarted since a
+/// login is still running under the previous workspace, so its recorded
+/// core-node name says nothing about the workspace in this response, and a name
+/// that happens to exist in both would otherwise be labelled as this machine
+/// when it is someone else's. The daemon's state file already records its
+/// namespace, so this is a comparison rather than new plumbing.
+///
+/// Falls back to the configured name when no daemon is running, and to nothing
+/// when neither is available. Never fails the command: the marker is a
+/// convenience, and a machine with no daemon and no configured name is a normal
+/// case.
+fn this_machine_name(
+    daemon_state: Option<&DaemonState>,
+    config: &PeppyConfig,
+    workspace_id: &str,
+) -> Option<String> {
+    let Some(state) = daemon_state else {
+        // No daemon running, so there is no namespace to compare against. The
+        // configured name is what a daemon started now would claim.
+        return config.core_node_name.clone();
+    };
+    match state.namespace.as_str() == workspace_id {
+        true => Some(state.core_node_name.clone()),
+        false => None,
+    }
+}
+
+/// Human-readable output. Pure, so the column layout, the marker, the collision
+/// suffix, and the empty case are all testable without a backend.
+fn render_human(listing: &CoreNodeListing, api_url: &str, this_machine: Option<String>) -> String {
+    let mut out = format!("Workspace {} (backend {api_url})\n\n", listing.workspace_id);
+    if listing.core_nodes.is_empty() {
+        out.push_str(
+            "No core nodes registered in this workspace. \
+             Run 'peppy platform login' on a machine to register its daemon.\n",
+        );
+        return out;
+    }
+
+    let rows: Vec<(String, String, String, bool)> = ordered_rows(listing, this_machine.as_deref())
+        .into_iter()
+        .map(|(entry, is_this_machine)| {
+            (
+                entry.core_node_name.clone(),
+                application_column(entry),
+                registered_column(entry),
+                is_this_machine,
+            )
+        })
+        .collect();
+
+    let name_width = column_width("CORE NODE", rows.iter().map(|(name, ..)| name.as_str()));
+    let status_width = column_width(
+        "APPLICATION",
+        rows.iter().map(|(_, status, ..)| status.as_str()),
+    );
+
+    out.push_str(&format!(
+        "{:<name_width$}  {:<status_width$}  {}\n",
+        "CORE NODE", "APPLICATION", "REGISTERED"
+    ));
+    for (name, status, registered, is_this_machine) in rows {
+        let marker = match is_this_machine {
+            true => "   (this machine)",
+            false => "",
+        };
+        out.push_str(&format!(
+            "{name:<name_width$}  {status:<status_width$}  {registered}{marker}\n"
+        ));
+    }
+    out
+}
+
+/// The entries in render order: this machine first, then by name ascending.
+///
+/// The backend already orders by name, so this only hoists the local row.
+/// Deterministic either way, which is what lets the tests assert on it
+/// directly.
+fn ordered_rows<'a>(
+    listing: &'a CoreNodeListing,
+    this_machine: Option<&str>,
+) -> Vec<(&'a client::CoreNodeEntry, bool)> {
+    let is_this_machine = |entry: &client::CoreNodeEntry| {
+        this_machine.is_some_and(|name| name == entry.core_node_name)
+    };
+    let mut rows: Vec<(&client::CoreNodeEntry, bool)> = listing
+        .core_nodes
+        .iter()
+        .map(|entry| (entry, is_this_machine(entry)))
+        .collect();
+    rows.sort_by_key(|(entry, is_this_machine)| (!is_this_machine, entry.core_node_name.clone()));
+    rows
+}
+
+/// The APPLICATION column: the status, with the claimant count appended only
+/// when a name is contested. A collision must be visible, since the losing
+/// daemon refuses to boot and that is frequently why a site will not come up.
+fn application_column(entry: &client::CoreNodeEntry) -> String {
+    let Some(status) = &entry.application.status else {
+        return "unknown".to_string();
+    };
+    match entry.application.live_claimants {
+        Some(claimants) if claimants > 1 => format!("{status} ({claimants} claimants)"),
+        _ => status.clone(),
+    }
+}
+
+/// The REGISTERED column: the UTC date this name was first registered, or `-`
+/// for a name that is live but has no registry row.
+///
+/// Deliberately not the config-pull timestamp. Rendering that as "last seen"
+/// would read as liveness, and it is not one. UTC rather than local time, so
+/// the output does not depend on the machine's timezone.
+fn registered_column(entry: &client::CoreNodeEntry) -> String {
+    entry
+        .first_seen_at
+        .as_deref()
+        .and_then(|timestamp| timestamp.split('T').next())
+        .unwrap_or("-")
+        .to_string()
+}
+
+fn column_width<'a>(header: &str, values: impl Iterator<Item = &'a str>) -> usize {
+    values
+        .map(str::len)
+        .chain([header.len()])
+        .max()
+        .unwrap_or(0)
+}
+
+/// Machine-readable output. Passes the platform's entries through with the
+/// `api_url` this CLI called added, so a script can tell which backend answered.
+fn render_json(listing: &CoreNodeListing, api_url: &str) -> String {
+    let core_nodes: Vec<serde_json::Value> = listing
+        .core_nodes
+        .iter()
+        .map(|entry| {
+            serde_json::json!({
+                "core_node_name": entry.core_node_name,
+                "registered": entry.registered,
+                "first_seen_at": entry.first_seen_at,
+                "last_config_pull_at": entry.last_config_pull_at,
+                "application": {
+                    "status": entry.application.status,
+                    "live_claimants": entry.application.live_claimants,
+                },
+            })
+        })
+        .collect();
+    let doc = serde_json::json!({
+        "workspace_id": listing.workspace_id,
+        "api_url": api_url,
+        "application_status_available": listing.application_status_available,
+        "core_nodes": core_nodes,
+    });
+    format!("{doc}\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use auth::client::{ApplicationStatus, CoreNodeEntry};
+
+    const WORKSPACE: &str = "4f1b2e2c-9a71-4d0e-b3c8-0d2b9f6a11c4";
+    const API_URL: &str = "https://api.peppy.dev";
+
+    fn entry(
+        name: &str,
+        registered: bool,
+        status: Option<&str>,
+        claimants: Option<u32>,
+    ) -> CoreNodeEntry {
+        registered_on(name, registered, status, claimants, "2026-07-01")
+    }
+
+    /// [`entry`] with an explicit registration date, for the layout test.
+    fn registered_on(
+        name: &str,
+        registered: bool,
+        status: Option<&str>,
+        claimants: Option<u32>,
+        first_seen_date: &str,
+    ) -> CoreNodeEntry {
+        CoreNodeEntry {
+            core_node_name: name.to_string(),
+            registered,
+            first_seen_at: registered.then(|| format!("{first_seen_date}T10:00:00Z")),
+            last_config_pull_at: registered.then(|| "2026-07-24T09:12:33Z".to_string()),
+            application: ApplicationStatus {
+                status: status.map(str::to_string),
+                live_claimants: claimants,
+            },
+        }
+    }
+
+    fn listing(entries: Vec<CoreNodeEntry>, available: bool) -> CoreNodeListing {
+        CoreNodeListing {
+            workspace_id: WORKSPACE.to_string(),
+            application_status_available: available,
+            core_nodes: entries,
+        }
+    }
+
+    #[test]
+    fn human_output_renders_status_the_marker_and_a_collision() {
+        let listing = listing(
+            vec![
+                registered_on("cn-a1b2c3d4e5", true, Some("online"), Some(1), "2026-07-01"),
+                registered_on(
+                    "cn-9f8e7d6c5b",
+                    true,
+                    Some("offline"),
+                    Some(0),
+                    "2026-07-14",
+                ),
+                entry("lab-bench-external", false, Some("online"), Some(2)),
+            ],
+            true,
+        );
+
+        let out = render_human(&listing, API_URL, Some("cn-a1b2c3d4e5".to_string()));
+
+        assert_eq!(
+            out,
+            "Workspace 4f1b2e2c-9a71-4d0e-b3c8-0d2b9f6a11c4 (backend https://api.peppy.dev)\n\
+             \n\
+             CORE NODE           APPLICATION           REGISTERED\n\
+             cn-a1b2c3d4e5       online                2026-07-01   (this machine)\n\
+             cn-9f8e7d6c5b       offline               2026-07-14\n\
+             lab-bench-external  online (2 claimants)  -\n"
+        );
+    }
+
+    #[test]
+    fn this_machine_sorts_first_and_the_rest_by_name() {
+        let listing = listing(
+            vec![
+                entry("cn-aaa", true, Some("online"), Some(1)),
+                entry("cn-bbb", true, Some("online"), Some(1)),
+                entry("cn-zzz", true, Some("online"), Some(1)),
+            ],
+            true,
+        );
+
+        let ordered: Vec<&str> = ordered_rows(&listing, Some("cn-zzz"))
+            .into_iter()
+            .map(|(entry, _)| entry.core_node_name.as_str())
+            .collect();
+
+        assert_eq!(ordered, vec!["cn-zzz", "cn-aaa", "cn-bbb"]);
+    }
+
+    #[test]
+    fn without_a_local_name_nothing_is_marked() {
+        let listing = listing(vec![entry("cn-aaa", true, Some("online"), Some(1))], true);
+
+        let out = render_human(&listing, API_URL, None);
+
+        assert!(
+            !out.contains("(this machine)"),
+            "no marker without a resolved local name: {out}"
+        );
+    }
+
+    /// A single claimant is the normal case and must not be annotated: only a
+    /// contested name earns the suffix.
+    #[test]
+    fn only_a_contested_name_shows_a_claimant_count() {
+        assert_eq!(
+            application_column(&entry("cn", true, Some("online"), Some(1))),
+            "online"
+        );
+        assert_eq!(
+            application_column(&entry("cn", true, Some("online"), Some(3))),
+            "online (3 claimants)"
+        );
+    }
+
+    #[test]
+    fn an_unavailable_observer_renders_unknown_in_every_row() {
+        let listing = listing(
+            vec![
+                entry("cn-aaa", true, None, None),
+                entry("cn-bbb", true, None, None),
+            ],
+            false,
+        );
+
+        let out = render_human(&listing, API_URL, None);
+
+        assert_eq!(out.matches("unknown").count(), 2);
+        assert!(!out.contains("offline"), "unknown is not offline: {out}");
+    }
+
+    #[test]
+    fn an_empty_roster_explains_how_to_populate_it() {
+        let out = render_human(&listing(vec![], true), API_URL, None);
+
+        assert!(out.contains("No core nodes registered in this workspace"));
+        assert!(out.contains("peppy platform login"));
+        assert!(!out.contains("CORE NODE"), "no header for an empty roster");
+    }
+
+    #[test]
+    fn an_unregistered_entry_shows_no_registration_date() {
+        assert_eq!(
+            registered_column(&entry("lab-bench", false, Some("online"), Some(1))),
+            "-"
+        );
+        assert_eq!(
+            registered_column(&entry("cn-a", true, Some("online"), Some(1))),
+            "2026-07-01",
+            "the date only, in UTC, so output does not depend on the machine's timezone"
+        );
+    }
+
+    #[test]
+    fn json_output_carries_the_backend_and_the_honest_timestamp_name() {
+        let listing = listing(
+            vec![entry("cn-a1b2c3d4e5", true, Some("online"), Some(1))],
+            true,
+        );
+
+        let doc: serde_json::Value =
+            serde_json::from_str(&render_json(&listing, API_URL)).expect("valid json");
+
+        assert_eq!(doc["workspace_id"], serde_json::json!(WORKSPACE));
+        assert_eq!(doc["api_url"], serde_json::json!(API_URL));
+        assert_eq!(doc["application_status_available"], serde_json::json!(true));
+        let entry = &doc["core_nodes"][0];
+        assert_eq!(entry["registered"], serde_json::json!(true));
+        assert_eq!(
+            entry["last_config_pull_at"],
+            serde_json::json!("2026-07-24T09:12:33Z")
+        );
+        assert!(
+            entry.get("last_seen_at").is_none(),
+            "the pull timestamp never appears under a name that reads as liveness"
+        );
+        assert_eq!(entry["application"]["status"], serde_json::json!("online"));
+    }
+
+    // ─── The `(this machine)` marker ──────────────────────────────────────
+
+    fn daemon_in(core_node_name: &str, namespace: &str) -> DaemonState {
+        DaemonState::new(
+            core_node_name,
+            "127.0.0.1",
+            7447,
+            "test-git-hash",
+            30,
+            config::namespace::Namespace::parse(namespace).expect("valid namespace"),
+            Some(30),
+        )
+    }
+
+    fn config_named(core_node_name: Option<&str>) -> PeppyConfig {
+        PeppyConfig {
+            core_node_name: core_node_name.map(str::to_string),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn the_marker_uses_the_running_daemons_name() {
+        let daemon = daemon_in("cn-local", WORKSPACE);
+
+        assert_eq!(
+            this_machine_name(Some(&daemon), &config_named(None), WORKSPACE),
+            Some("cn-local".to_string())
+        );
+    }
+
+    /// The mid-login case, and the reason the marker is gated on the namespace
+    /// at all: the daemon has not restarted yet, so it is still running under
+    /// the previous workspace. Its name says nothing about the workspace being
+    /// listed, and an identical name in both would otherwise be labelled as
+    /// this machine when it belongs to someone else.
+    #[test]
+    fn the_marker_is_withheld_when_the_daemon_runs_in_another_workspace() {
+        let daemon = daemon_in("cn-local", "local");
+
+        assert_eq!(
+            this_machine_name(Some(&daemon), &config_named(Some("cn-local")), WORKSPACE),
+            None,
+            "a daemon in another namespace must not be marked, even by an exact name match, \
+             and must not fall through to the configured name either"
+        );
+    }
+
+    #[test]
+    fn the_marker_falls_back_to_the_configured_name_with_no_daemon_running() {
+        assert_eq!(
+            this_machine_name(None, &config_named(Some("cn-configured")), WORKSPACE),
+            Some("cn-configured".to_string()),
+            "with no daemon there is no namespace to compare, so the configured name is what a \
+             daemon started now would claim"
+        );
+    }
+
+    #[test]
+    fn the_marker_is_simply_absent_when_neither_source_resolves() {
+        assert_eq!(
+            this_machine_name(None, &config_named(None), WORKSPACE),
+            None
+        );
+    }
+
+    #[test]
+    fn json_nulls_the_status_when_the_observer_could_not_answer() {
+        let listing = listing(vec![entry("cn-a", true, None, None)], false);
+
+        let doc: serde_json::Value =
+            serde_json::from_str(&render_json(&listing, API_URL)).expect("valid json");
+
+        assert_eq!(
+            doc["application_status_available"],
+            serde_json::json!(false)
+        );
+        assert!(doc["core_nodes"][0]["application"]["status"].is_null());
+        assert!(doc["core_nodes"][0]["application"]["live_claimants"].is_null());
+    }
+}

--- a/crates/peppy/src/commands/platform/list.rs
+++ b/crates/peppy/src/commands/platform/list.rs
@@ -1,9 +1,21 @@
-//! `peppy platform list`: the core nodes registered to this workspace, and
-//! whether each is alive right now.
+//! `peppy platform list`: the core nodes registered to this workspace, and, for
+//! each, whether its site is reachable and whether its daemon is alive.
 //!
 //! Two machines logged into the same account already federate to the platform's
 //! shared router under one workspace namespace and can address each other.
 //! Nothing in the CLI showed that; this does.
+//!
+//! # Two layers, two columns
+//!
+//! The system has two layers that fail separately, so the output reports both.
+//! NETWORK is the transport: does this site's `zenohd` hold a live session with
+//! the platform's shared `zenohd`? APPLICATION is the workspace namespace: is
+//! this site's core node declaring presence? The pairing is the diagnostic.
+//! `linked` beside `offline` is a dead daemon behind a healthy uplink, so debug
+//! the machine; `unlinked` beside `offline` is an unreachable site, so debug the
+//! network. Reporting only the second, as this command originally did, cannot
+//! tell those apart, because the absence of an application signal is exactly as
+//! consistent with a severed link as with a stopped daemon.
 //!
 //! # A pure HTTP client
 //!
@@ -126,38 +138,52 @@ fn render_human(listing: &CoreNodeListing, api_url: &str, this_machine: Option<S
         return out;
     }
 
-    let rows: Vec<(String, String, String, bool)> = ordered_rows(listing, this_machine.as_deref())
+    let rows: Vec<Row> = ordered_rows(listing, this_machine.as_deref())
         .into_iter()
-        .map(|(entry, is_this_machine)| {
-            (
-                entry.core_node_name.clone(),
-                application_column(entry),
-                registered_column(entry),
-                is_this_machine,
-            )
+        .map(|(entry, is_this_machine)| Row {
+            name: entry.core_node_name.clone(),
+            network: network_column(entry),
+            application: application_column(entry),
+            registered: registered_column(entry),
+            is_this_machine,
         })
         .collect();
 
-    let name_width = column_width("CORE NODE", rows.iter().map(|(name, ..)| name.as_str()));
-    let status_width = column_width(
+    let name_width = column_width("CORE NODE", rows.iter().map(|row| row.name.as_str()));
+    let network_width = column_width("NETWORK", rows.iter().map(|row| row.network.as_str()));
+    let application_width = column_width(
         "APPLICATION",
-        rows.iter().map(|(_, status, ..)| status.as_str()),
+        rows.iter().map(|row| row.application.as_str()),
     );
 
+    // NETWORK sits before APPLICATION because that is the order a reader
+    // diagnoses in: the transport has to be up before the application layer's
+    // silence means anything about the daemon.
     out.push_str(&format!(
-        "{:<name_width$}  {:<status_width$}  {}\n",
-        "CORE NODE", "APPLICATION", "REGISTERED"
+        "{:<name_width$}  {:<network_width$}  {:<application_width$}  {}\n",
+        "CORE NODE", "NETWORK", "APPLICATION", "REGISTERED"
     ));
-    for (name, status, registered, is_this_machine) in rows {
-        let marker = match is_this_machine {
+    for row in rows {
+        let marker = match row.is_this_machine {
             true => "   (this machine)",
             false => "",
         };
         out.push_str(&format!(
-            "{name:<name_width$}  {status:<status_width$}  {registered}{marker}\n"
+            "{:<name_width$}  {:<network_width$}  {:<application_width$}  {}{marker}\n",
+            row.name, row.network, row.application, row.registered
         ));
     }
     out
+}
+
+/// One rendered line. A struct rather than a tuple: with four columns plus the
+/// marker flag, positional access stops carrying its own meaning.
+struct Row {
+    name: String,
+    network: String,
+    application: String,
+    registered: String,
+    is_this_machine: bool,
 }
 
 /// The entries in render order: this machine first, then by name ascending.
@@ -179,6 +205,21 @@ fn ordered_rows<'a>(
         .collect();
     rows.sort_by_key(|(entry, is_this_machine)| (!is_this_machine, entry.core_node_name.clone()));
     rows
+}
+
+/// The NETWORK column: whether the platform's shared router holds a live
+/// transport session with this site's router.
+///
+/// Rendered verbatim, including a status this CLI does not recognise, for the
+/// same reason [`application_column`] does: a newer platform must not fail the
+/// whole listing. A row the platform said nothing about reads `unknown`, which
+/// is the honest answer rather than a guess in either direction.
+fn network_column(entry: &client::CoreNodeEntry) -> String {
+    entry
+        .network
+        .status
+        .clone()
+        .unwrap_or_else(|| "unknown".to_string())
 }
 
 /// The APPLICATION column: the status, with the claimant count appended only
@@ -229,6 +270,10 @@ fn render_json(listing: &CoreNodeListing, api_url: &str) -> String {
                 "registered": entry.registered,
                 "first_seen_at": entry.first_seen_at,
                 "last_config_pull_at": entry.last_config_pull_at,
+                "network": {
+                    "status": entry.network.status,
+                    "router_zid": entry.network.router_zid,
+                },
                 "application": {
                     "status": entry.application.status,
                     "live_claimants": entry.application.live_claimants,
@@ -248,7 +293,7 @@ fn render_json(listing: &CoreNodeListing, api_url: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use auth::client::{ApplicationStatus, CoreNodeEntry};
+    use auth::client::{ApplicationStatus, CoreNodeEntry, NetworkStatus};
 
     const WORKSPACE: &str = "4f1b2e2c-9a71-4d0e-b3c8-0d2b9f6a11c4";
     const API_URL: &str = "https://api.peppy.dev";
@@ -275,11 +320,25 @@ mod tests {
             registered,
             first_seen_at: registered.then(|| format!("{first_seen_date}T10:00:00Z")),
             last_config_pull_at: registered.then(|| "2026-07-24T09:12:33Z".to_string()),
+            // The two columns are set independently so a test can pair any
+            // network status with any application status, which is the whole
+            // point of reporting them separately.
+            network: NetworkStatus {
+                status: Some("linked".to_string()),
+                router_zid: registered.then(|| "7f3a9c1e".to_string()),
+            },
             application: ApplicationStatus {
                 status: status.map(str::to_string),
                 live_claimants: claimants,
             },
         }
+    }
+
+    /// [`entry`] with an explicit network status, for the tests that pair the
+    /// two columns.
+    fn linked_as(mut entry: CoreNodeEntry, network: Option<&str>) -> CoreNodeEntry {
+        entry.network.status = network.map(str::to_string);
+        entry
     }
 
     fn listing(entries: Vec<CoreNodeEntry>, available: bool) -> CoreNodeListing {
@@ -291,10 +350,12 @@ mod tests {
     }
 
     #[test]
-    fn human_output_renders_status_the_marker_and_a_collision() {
+    fn human_output_renders_both_layers_the_marker_and_a_collision() {
         let listing = listing(
             vec![
                 registered_on("cn-a1b2c3d4e5", true, Some("online"), Some(1), "2026-07-01"),
+                // A healthy uplink behind a dead daemon: the pairing the NETWORK
+                // column exists to make visible.
                 registered_on(
                     "cn-9f8e7d6c5b",
                     true,
@@ -302,7 +363,22 @@ mod tests {
                     Some(0),
                     "2026-07-14",
                 ),
-                entry("lab-bench-external", false, Some("online"), Some(2)),
+                // An unreachable site: both layers down.
+                linked_as(
+                    registered_on(
+                        "cn-113355aabb",
+                        true,
+                        Some("offline"),
+                        Some(0),
+                        "2026-06-02",
+                    ),
+                    Some("unlinked"),
+                ),
+                // Reaching the platform through a router peppy does not manage.
+                linked_as(
+                    entry("lab-bench-external", false, Some("online"), Some(2)),
+                    Some("indirect"),
+                ),
             ],
             true,
         );
@@ -313,10 +389,46 @@ mod tests {
             out,
             "Workspace 4f1b2e2c-9a71-4d0e-b3c8-0d2b9f6a11c4 (backend https://api.peppy.dev)\n\
              \n\
-             CORE NODE           APPLICATION           REGISTERED\n\
-             cn-a1b2c3d4e5       online                2026-07-01   (this machine)\n\
-             cn-9f8e7d6c5b       offline               2026-07-14\n\
-             lab-bench-external  online (2 claimants)  -\n"
+             CORE NODE           NETWORK   APPLICATION           REGISTERED\n\
+             cn-a1b2c3d4e5       linked    online                2026-07-01   (this machine)\n\
+             cn-113355aabb       unlinked  offline               2026-06-02\n\
+             cn-9f8e7d6c5b       linked    offline               2026-07-14\n\
+             lab-bench-external  indirect  online (2 claimants)  -\n"
+        );
+    }
+
+    /// Every network status renders as itself, including one this CLI does not
+    /// know: a newer platform must not fail the listing.
+    #[test]
+    fn every_network_status_renders_verbatim() {
+        for status in [
+            "linked",
+            "indirect",
+            "unlinked",
+            "unknown",
+            "some-future-state",
+        ] {
+            assert_eq!(
+                network_column(&linked_as(
+                    entry("cn-a", true, Some("online"), Some(1)),
+                    Some(status)
+                )),
+                status
+            );
+        }
+    }
+
+    /// A row the platform said nothing about reads `unknown`, never a guess in
+    /// either direction: `unlinked` there would be wrong exactly when a site is
+    /// healthy and the observer is not.
+    #[test]
+    fn an_absent_network_status_reads_unknown() {
+        assert_eq!(
+            network_column(&linked_as(
+                entry("cn-a", true, Some("online"), Some(1)),
+                None
+            )),
+            "unknown"
         );
     }
 
@@ -427,6 +539,32 @@ mod tests {
             "the pull timestamp never appears under a name that reads as liveness"
         );
         assert_eq!(entry["application"]["status"], serde_json::json!("online"));
+        assert_eq!(entry["network"]["status"], serde_json::json!("linked"));
+        assert_eq!(
+            entry["network"]["router_zid"],
+            serde_json::json!("7f3a9c1e")
+        );
+    }
+
+    /// An unregistered row has no identity to join on, so its network object
+    /// carries a null zid rather than being absent: a script reading the shape
+    /// must not have to tell "no zid" from "no network object".
+    #[test]
+    fn json_nulls_the_router_zid_on_an_unregistered_row() {
+        let listing = listing(
+            vec![linked_as(
+                entry("lab-bench", false, Some("online"), Some(1)),
+                Some("indirect"),
+            )],
+            true,
+        );
+
+        let doc: serde_json::Value =
+            serde_json::from_str(&render_json(&listing, API_URL)).expect("valid json");
+
+        let entry = &doc["core_nodes"][0];
+        assert_eq!(entry["network"]["status"], serde_json::json!("indirect"));
+        assert!(entry["network"]["router_zid"].is_null());
     }
 
     // ─── The `(this machine)` marker ──────────────────────────────────────

--- a/crates/peppy/src/commands/platform/login.rs
+++ b/crates/peppy/src/commands/platform/login.rs
@@ -10,7 +10,7 @@ use daemon_config::consts::PeppyDirs;
 
 use crate::commands::Command;
 use crate::context::AppContext;
-use crate::error::{Error, Result};
+use crate::error::Result;
 use auth::device::{self, TokenSet};
 use auth::discovery::OidcEndpoints;
 use auth::{cli_config, client, discovery, http::HttpClient, profile, resolver, storage};
@@ -32,20 +32,15 @@ pub struct LoginCommand {
 
 impl Command for LoginCommand {
     fn execute(self, ctx: &Arc<AppContext>) -> Result<()> {
-        let dirs = self.peppy_dirs.unwrap_or_default();
-        // Loads (and seeds/completes) peppy_config.json5 with the same strict,
-        // fail-loud semantics the daemon uses; resource_servers supplies the
-        // per-profile URL fallback.
-        let config =
-            daemon_config::peppy_config::load_or_create(&dirs).map_err(Error::DaemonConfig)?;
-        // Managed vs external follows the RUNNING daemon's mode (from its state
-        // file), not the disk config, which may have been edited since it
-        // started; only with no daemon running does the disk config decide.
-        let daemon_state = super::read_daemon_state(&dirs);
+        let super::PlatformSession {
+            dirs,
+            config,
+            api_url,
+            creds_path,
+            http,
+            daemon_state,
+        } = super::PlatformSession::resolve(self.peppy_dirs, self.api_url.as_deref())?;
         let federation = super::federation_poke_timeout_secs(daemon_state.as_ref(), &config);
-        let api_url = profile::resolve_api_url(self.api_url.as_deref(), &config.resource_servers)?;
-        let creds_path = storage::credentials_path(&dirs);
-        let http = HttpClient::new();
 
         // With a managed router, warn (before authentication begins) that a login
         // changing the workspace namespace restarts the daemon and wipes the

--- a/crates/peppy/src/commands/platform/login.rs
+++ b/crates/peppy/src/commands/platform/login.rs
@@ -41,7 +41,8 @@ impl Command for LoginCommand {
         // Managed vs external follows the RUNNING daemon's mode (from its state
         // file), not the disk config, which may have been edited since it
         // started; only with no daemon running does the disk config decide.
-        let federation = super::federation_poke_timeout_secs(&dirs, &config);
+        let daemon_state = super::read_daemon_state(&dirs);
+        let federation = super::federation_poke_timeout_secs(daemon_state.as_ref(), &config);
         let api_url = profile::resolve_api_url(self.api_url.as_deref(), &config.resource_servers)?;
         let creds_path = storage::credentials_path(&dirs);
         let http = HttpClient::new();

--- a/crates/peppy/src/commands/platform/logout.rs
+++ b/crates/peppy/src/commands/platform/logout.rs
@@ -166,7 +166,7 @@ fn deregister_core_node(
     core_node_name: Option<&str>,
 ) {
     let Some(core_node_name) = core_node_name else {
-        eprintln!(
+        println!(
             "Warning: could not determine this machine's core-node name; it stays listed in \
              the platform's core-node registry."
         );
@@ -176,8 +176,8 @@ fn deregister_core_node(
         format!("core node {core_node_name} may stay listed in the platform's core-node registry");
     match client::deregister_core_node(http, api_url, access_token, core_node_name) {
         Ok(204) | Ok(404) => {}
-        Ok(status) => eprintln!("Warning: deregistering returned {status}; {leak}."),
-        Err(e) => eprintln!("Warning: could not reach the backend ({e}); {leak}."),
+        Ok(status) => println!("Warning: deregistering returned {status}; {leak}."),
+        Err(e) => println!("Warning: could not reach the backend ({e}); {leak}."),
     }
 }
 

--- a/crates/peppy/src/commands/platform/logout.rs
+++ b/crates/peppy/src/commands/platform/logout.rs
@@ -14,7 +14,7 @@ use daemon_config::peppy_config::PeppyConfig;
 
 use crate::commands::Command;
 use crate::context::AppContext;
-use crate::error::{Error, Result};
+use crate::error::Result;
 use auth::{client, http::HttpClient, profile, storage};
 
 pub struct LogoutCommand {
@@ -28,17 +28,15 @@ pub struct LogoutCommand {
 
 impl Command for LogoutCommand {
     fn execute(self, ctx: &Arc<AppContext>) -> Result<()> {
-        let dirs = self.peppy_dirs.unwrap_or_default();
-        let config =
-            daemon_config::peppy_config::load_or_create(&dirs).map_err(Error::DaemonConfig)?;
-        // Managed vs external follows the RUNNING daemon's mode (from its state
-        // file), not the disk config, which may have been edited since it
-        // started; only with no daemon running does the disk config decide.
-        let daemon_state = super::read_daemon_state(&dirs);
+        let super::PlatformSession {
+            dirs,
+            config,
+            api_url,
+            creds_path,
+            http,
+            daemon_state,
+        } = super::PlatformSession::resolve(self.peppy_dirs, self.api_url.as_deref())?;
         let federation = super::federation_poke_timeout_secs(daemon_state.as_ref(), &config);
-        let api_url = profile::resolve_api_url(self.api_url.as_deref(), &config.resource_servers)?;
-        let creds_path = storage::credentials_path(&dirs);
-        let http = HttpClient::new();
 
         // Load-resilient: a malformed / pre-`workspace_id` file fails to parse
         // with `Error::Auth`; treat it as "already effectively logged out" rather

--- a/crates/peppy/src/commands/platform/logout.rs
+++ b/crates/peppy/src/commands/platform/logout.rs
@@ -1,13 +1,16 @@
-//! `peppy platform logout`: kill the access token on the backend (cross-replica) and
-//! delete the local session credentials. Does not revoke the refresh token at
-//! Zitadel (out of scope for v1); a backend that's unreachable or returns
-//! 401/503 still results in the local credentials being cleared.
+//! `peppy platform logout`: deregister this machine's core node, kill the access
+//! token on the backend (cross-replica), and delete the local session
+//! credentials. Does not revoke the refresh token at Zitadel (out of scope for
+//! v1); a backend that's unreachable or returns 401/503 still results in the
+//! local credentials being cleared.
 
 use std::sync::Arc;
 
 use secrecy::ExposeSecret;
 
+use daemon::state::DaemonState;
 use daemon_config::consts::PeppyDirs;
+use daemon_config::peppy_config::PeppyConfig;
 
 use crate::commands::Command;
 use crate::context::AppContext;
@@ -31,7 +34,8 @@ impl Command for LogoutCommand {
         // Managed vs external follows the RUNNING daemon's mode (from its state
         // file), not the disk config, which may have been edited since it
         // started; only with no daemon running does the disk config decide.
-        let federation = super::federation_poke_timeout_secs(&dirs, &config);
+        let daemon_state = super::read_daemon_state(&dirs);
+        let federation = super::federation_poke_timeout_secs(daemon_state.as_ref(), &config);
         let api_url = profile::resolve_api_url(self.api_url.as_deref(), &config.resource_servers)?;
         let creds_path = storage::credentials_path(&dirs);
         let http = HttpClient::new();
@@ -68,6 +72,20 @@ impl Command for LogoutCommand {
         }
 
         let access_token = pc.access_token.expose_secret().to_string();
+
+        // Leave the platform's core-node registry before the revocation below
+        // kills the token this call needs, and after the `confirm_restart` prompt
+        // above, so an aborted logout deregisters nothing. Logging out is what
+        // removes a machine from the registry: it stops federating, drops to the
+        // `local` namespace, and stops pulling config, so leaving its row behind
+        // would be a lie.
+        deregister_core_node(
+            &http,
+            &api_url,
+            &access_token,
+            registered_core_node_name(daemon_state.as_ref(), &config).as_deref(),
+        );
+
         match client::logout(&http, &api_url, &access_token) {
             Ok(202) | Ok(401) => {}
             Ok(503) => println!(
@@ -103,5 +121,136 @@ impl Command for LogoutCommand {
             None => println!("{}", super::EXTERNAL_ROUTER_NOTE),
         }
         Ok(())
+    }
+}
+
+/// The core-node name this machine registered with the platform, for
+/// deregistration.
+///
+/// The daemon state file wins, and is used REGARDLESS of whether the pid it
+/// records is still alive: the file outlives the daemon process, so a machine
+/// whose daemon is already stopped still knows the name it registered under,
+/// which is the ordinary case for a logout rather than the exception. An
+/// explicitly configured `peppy_config.core_node_name` is the fallback for a
+/// wiped state file.
+///
+/// `None` when neither resolves, which leaves one row behind. The residual leak
+/// is narrow: the state file would have to be gone while the credentials
+/// survive, and a wiped `PEPPY_HOME` takes both, so logout exits early with "not
+/// logged in". The daemon's private `derive_core_node_name` is deliberately not
+/// exported to close that last sliver, because recomputing a machine-UID hash to
+/// guess which row to delete is a worse failure mode than leaving one behind.
+fn registered_core_node_name(
+    daemon_state: Option<&DaemonState>,
+    config: &PeppyConfig,
+) -> Option<String> {
+    [
+        daemon_state.map(|state| state.core_node_name.as_str()),
+        config.core_node_name.as_deref(),
+    ]
+    .into_iter()
+    .flatten()
+    .map(str::trim)
+    .find(|name| !name.is_empty())
+    .map(str::to_owned)
+}
+
+/// Remove this machine's row from the platform's core-node registry, best
+/// effort. Every failure warns and lets logout complete, matching what logout
+/// already does for the token revocation itself.
+///
+/// A `404` is silent success: an external-mode daemon that never registered, and
+/// a repeated logout, both find nothing to remove.
+fn deregister_core_node(
+    http: &HttpClient,
+    api_url: &str,
+    access_token: &str,
+    core_node_name: Option<&str>,
+) {
+    let Some(core_node_name) = core_node_name else {
+        eprintln!(
+            "Warning: could not determine this machine's core-node name; it stays listed in \
+             the platform's core-node registry."
+        );
+        return;
+    };
+    let leak =
+        format!("core node {core_node_name} may stay listed in the platform's core-node registry");
+    match client::deregister_core_node(http, api_url, access_token, core_node_name) {
+        Ok(204) | Ok(404) => {}
+        Ok(status) => eprintln!("Warning: deregistering returned {status}; {leak}."),
+        Err(e) => eprintln!("Warning: could not reach the backend ({e}); {leak}."),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn state_with(core_node_name: &str, pid: Option<u32>) -> DaemonState {
+        let mut state = DaemonState::new(
+            core_node_name,
+            "127.0.0.1",
+            7447,
+            "test",
+            5,
+            config::namespace::Namespace::local(),
+            None,
+        );
+        state.daemon_pid = pid;
+        state
+    }
+
+    fn config_with(core_node_name: Option<&str>) -> PeppyConfig {
+        PeppyConfig {
+            core_node_name: core_node_name.map(str::to_owned),
+            ..PeppyConfig::default()
+        }
+    }
+
+    #[test]
+    fn the_daemon_state_name_wins_over_the_configured_one() {
+        let state = state_with("cn-from-state", Some(std::process::id()));
+        assert_eq!(
+            registered_core_node_name(Some(&state), &config_with(Some("cn-from-config"))),
+            Some("cn-from-state".to_string()),
+            "the running daemon registered under the name it recorded, not the disk config's"
+        );
+    }
+
+    #[test]
+    fn a_dead_daemons_state_file_still_resolves_the_name() {
+        // The ordinary case: logging out on a machine whose daemon is already
+        // stopped. The state file outlives the process, and it still names the
+        // core node this machine registered under, so `is_running` must not gate
+        // this the way it gates the federation poke.
+        let state = state_with("cn-from-dead-daemon", Some(u32::MAX));
+        assert!(!state.is_running(), "u32::MAX names no live process");
+        assert_eq!(
+            registered_core_node_name(Some(&state), &config_with(None)),
+            Some("cn-from-dead-daemon".to_string())
+        );
+    }
+
+    #[test]
+    fn the_configured_name_is_the_fallback_for_a_wiped_state_file() {
+        assert_eq!(
+            registered_core_node_name(None, &config_with(Some("cn-from-config"))),
+            Some("cn-from-config".to_string())
+        );
+        // A state file that somehow carries no name falls through to the config
+        // rather than deregistering an empty name.
+        let blank = state_with("   ", Some(std::process::id()));
+        assert_eq!(
+            registered_core_node_name(Some(&blank), &config_with(Some("cn-from-config"))),
+            Some("cn-from-config".to_string())
+        );
+    }
+
+    #[test]
+    fn neither_source_yields_no_name() {
+        // Nothing is guessed here: recomputing the machine-UID hash to pick a row
+        // to delete would be a worse failure mode than leaving one behind.
+        assert_eq!(registered_core_node_name(None, &config_with(None)), None);
     }
 }

--- a/crates/peppy/src/commands/platform/whoami.rs
+++ b/crates/peppy/src/commands/platform/whoami.rs
@@ -8,10 +8,11 @@ use std::sync::Arc;
 use daemon_config::consts::PeppyDirs;
 
 use crate::commands::Command;
+use crate::commands::platform::PlatformSession;
 use crate::context::AppContext;
-use crate::error::{Error, Result};
+use crate::error::Result;
 use auth::client::Principal;
-use auth::{client, http::HttpClient, profile, resolver, storage};
+use auth::{client, profile, resolver, storage};
 
 pub struct WhoamiCommand {
     pub api_url: Option<String>,
@@ -24,12 +25,12 @@ pub struct WhoamiCommand {
 
 impl Command for WhoamiCommand {
     fn execute(self, _ctx: &Arc<AppContext>) -> Result<()> {
-        let dirs = self.peppy_dirs.unwrap_or_default();
-        let config =
-            daemon_config::peppy_config::load_or_create(&dirs).map_err(Error::DaemonConfig)?;
-        let api_url = profile::resolve_api_url(self.api_url.as_deref(), &config.resource_servers)?;
-        let creds_path = storage::credentials_path(&dirs);
-        let http = HttpClient::new();
+        let PlatformSession {
+            api_url,
+            creds_path,
+            http,
+            ..
+        } = PlatformSession::resolve(self.peppy_dirs, self.api_url.as_deref())?;
         let pat = resolver::pat_from_env();
 
         match resolver::resolve(&creds_path, &http, pat) {

--- a/crates/peppy/src/context.rs
+++ b/crates/peppy/src/context.rs
@@ -56,6 +56,12 @@ impl AppContext {
         self
     }
 
+    /// The `--core-node` target, when one was given. Read by command groups
+    /// that cannot honor it, so they can refuse rather than silently ignore it.
+    pub(crate) fn core_node_override(&self) -> Option<&str> {
+        self.core_node_override.as_deref()
+    }
+
     pub(crate) fn read_daemon_state(&self) -> crate::error::Result<DaemonState> {
         let state = match &self.daemon_state_path {
             Some(path) => DaemonState::read_from(path),

--- a/crates/peppy/src/main.rs
+++ b/crates/peppy/src/main.rs
@@ -74,7 +74,7 @@ enum Commands {
         #[command(subcommand)]
         command: repo::RepoCommands,
     },
-    /// Platform account: log in, log out, and show the current identity
+    /// Platform account: log in, log out, show the current identity, and list the workspace's core nodes
     Platform {
         #[command(subcommand)]
         command: platform::PlatformCommands,

--- a/crates/peppy/tests/multi_daemon_e2e.rs
+++ b/crates/peppy/tests/multi_daemon_e2e.rs
@@ -8,7 +8,7 @@ use config::consts::{PEPPY_CONFIG_ENV, PEPPY_HOME_ENV};
 use daemon_config::peppy_config::{
     ExternalZenohConfig, ManagedZenohConfig, PeppyConfig, ZenohConfig,
 };
-use pmi::{ZenohAdapter, ZenohNetProtocol, render_router_config};
+use pmi::{RouterId, ZenohAdapter, ZenohNetProtocol, render_router_config};
 use testcontainers::core::client::docker_client_instance;
 use testcontainers::core::{AccessMode, CmdWaitFor, ExecCommand, Host, Mount};
 use testcontainers::runners::AsyncRunner;
@@ -84,6 +84,9 @@ fn write_router_pin(path: &Path, connect_endpoints: Vec<String>) {
         true,
         connect_endpoints,
         None,
+        // A pinned config is the operator's, identity included; the daemon's own
+        // persisted identity is never rendered over it.
+        &RouterId::generate(),
     );
     std::fs::write(path, config).expect("write pinned zenohd config");
 }

--- a/crates/peppy/tests/platform_flow.rs
+++ b/crates/peppy/tests/platform_flow.rs
@@ -416,7 +416,8 @@ fn deregistration_never_refreshes_the_token_logout_is_about_to_revoke() {
     let dir = tempfile::tempdir().expect("temp dir");
     let path = logout_with_core_node(&server, &dir, "cn-stale-token");
 
-    assert_eq!(deregister.calls(), 1);
+    // Asserted before the call count, so a refreshing implementation reports the
+    // property it broke rather than the retry that broke it.
     assert_eq!(
         discovery.calls(),
         0,
@@ -426,6 +427,11 @@ fn deregistration_never_refreshes_the_token_logout_is_about_to_revoke() {
         token.calls(),
         0,
         "deregistration must not mint a token the revocation that follows would not cover"
+    );
+    assert_eq!(
+        deregister.calls(),
+        1,
+        "the 401 is reported, not retried under a new token"
     );
     assert!(logout.calls() >= 1, "a 401 must not stop the revocation");
     assert!(

--- a/crates/peppy/tests/platform_flow.rs
+++ b/crates/peppy/tests/platform_flow.rs
@@ -338,9 +338,14 @@ fn logout_with_core_node(
 #[test]
 fn logout_deregisters_this_machines_core_node() {
     let server = MockServer::start();
-    // Scoped to the exact path and to the bearer the session holds: the DELETE
-    // must go out under the token logout is about to revoke, which is only true
-    // if it runs before the revocation and never refreshes.
+    // Matching on the header as well as the path means an unauthenticated DELETE
+    // (or one under some other token) does not match, and `calls()` reads 0.
+    // Ordering against the revocation is deliberately NOT asserted here: the
+    // `/logout` mock is stateless, so a DELETE sent after it would look
+    // identical, and httpmock exposes no ordered request log to tell them apart.
+    // What ordering exists for, keeping a live token under the DELETE, is
+    // covered from the other side by
+    // `deregistration_never_refreshes_the_token_logout_is_about_to_revoke`.
     let deregister = server.mock(|when, then| {
         when.method(DELETE)
             .path("/me/core-nodes/cn-logout-me")
@@ -364,6 +369,68 @@ fn logout_deregisters_this_machines_core_node() {
     assert!(
         storage::load(&path).expect("load creds").session.is_none(),
         "local credentials must be removed after logout"
+    );
+}
+
+#[test]
+fn deregistration_never_refreshes_the_token_logout_is_about_to_revoke() {
+    // A 401 is the one trigger the refreshing `authed_*` helpers act on. If
+    // `deregister_core_node` ever routes through them, it mints and persists a
+    // NEW access token here, and the revocation immediately after would still
+    // revoke the old one, leaving the new token valid until its own expiry. That
+    // fires whenever the access token has expired but the refresh token has not,
+    // which is the ordinary state of an idle CLI.
+    //
+    // A refresh does OIDC discovery and then posts to the token endpoint, so
+    // mounting both and asserting neither is touched catches it. The type
+    // signature (`&str`, not `&mut Credential`) is what makes it impossible;
+    // this is the behavioral guard that fails if the signature is widened.
+    let server = MockServer::start();
+    let base = server.base_url();
+    let discovery = server.mock(|when, then| {
+        when.method(GET).path("/.well-known/openid-configuration");
+        then.status(200).json_body(json!({
+            "device_authorization_endpoint": format!("{base}/oauth/v2/device_authorization"),
+            "token_endpoint": format!("{base}/oauth/v2/token"),
+        }));
+    });
+    let token = server.mock(|when, then| {
+        when.method(POST).path("/oauth/v2/token");
+        then.status(200).json_body(json!({
+            "access_token": "refreshed-access",
+            "refresh_token": "refreshed-refresh",
+            "expires_in": 3600,
+            "token_type": "Bearer",
+            "scope": "openid",
+        }));
+    });
+    let deregister = server.mock(|when, then| {
+        when.method(DELETE).path("/me/core-nodes/cn-stale-token");
+        then.status(401);
+    });
+    let logout = server.mock(|when, then| {
+        when.method(POST).path("/logout");
+        then.status(202);
+    });
+
+    let dir = tempfile::tempdir().expect("temp dir");
+    let path = logout_with_core_node(&server, &dir, "cn-stale-token");
+
+    assert_eq!(deregister.calls(), 1);
+    assert_eq!(
+        discovery.calls(),
+        0,
+        "deregistration must not begin a token refresh"
+    );
+    assert_eq!(
+        token.calls(),
+        0,
+        "deregistration must not mint a token the revocation that follows would not cover"
+    );
+    assert!(logout.calls() >= 1, "a 401 must not stop the revocation");
+    assert!(
+        storage::load(&path).expect("load creds").session.is_none(),
+        "a 401 must not stop the local credentials being cleared"
     );
 }
 

--- a/crates/peppy/tests/platform_flow.rs
+++ b/crates/peppy/tests/platform_flow.rs
@@ -845,7 +845,12 @@ fn list_explains_a_backend_that_does_not_have_the_endpoint() {
 #[test]
 fn every_platform_command_refuses_a_core_node_override() {
     let server = MockServer::start();
-    let dir = authenticated_dir(&server);
+    // Registered before the commands run, so the call count below is evidence.
+    // A mock added afterwards could not have been hit whatever the guard does.
+    let core_nodes = server.mock(|when, then| {
+        when.method(GET).path("/me/core-nodes");
+        then.status(500);
+    });
     let redirected = Arc::new(
         AppContext::from_current_dir()
             .expect("cwd is readable")
@@ -899,11 +904,11 @@ fn every_platform_command_refuses_a_core_node_override() {
     }
 
     // The refusal happens before any work: the backend was never called.
-    server.mock(|when, then| {
-        when.method(GET).path("/me/core-nodes");
-        then.status(500);
-    });
-    let _ = dir;
+    assert_eq!(
+        core_nodes.calls(),
+        0,
+        "the override must be refused before any command reaches the backend"
+    );
 }
 
 /// A stale daemon state file must not fail the command, whatever it records.

--- a/crates/peppy/tests/platform_flow.rs
+++ b/crates/peppy/tests/platform_flow.rs
@@ -292,6 +292,176 @@ fn login_writes_credentials_file_0600() {
     assert_eq!(mode, 0o600, "credentials must be owner-only");
 }
 
+/// Writes a config that pins `core_node_name`, so logout can resolve the name to
+/// deregister without a daemon ever having run in the tempdir. The daemon state
+/// file takes precedence over this in production; the precedence itself is unit
+/// tested next to the resolver.
+fn write_core_node_name_config(dir: &tempfile::TempDir, core_node_name: &str) {
+    let config_dir = dir.path().join("conf");
+    std::fs::create_dir_all(&config_dir).expect("config dir");
+    std::fs::write(
+        config_dir.join("peppy_config.json5"),
+        format!("{{ core_node_name: \"{core_node_name}\" }}"),
+    )
+    .expect("write peppy config");
+}
+
+/// Seed a logged-in session under `dir` and run logout against `server`, with
+/// `core_node_name` pinned in the config so the deregistration has a name.
+/// Returns the credentials path so the caller can assert the session was cleared.
+fn logout_with_core_node(
+    server: &MockServer,
+    dir: &tempfile::TempDir,
+    core_node_name: &str,
+) -> PathBuf {
+    write_core_node_name_config(dir, core_node_name);
+    let path = creds_path(dir);
+    storage::save(
+        &path,
+        &Credentials {
+            session: Some(seeded_creds(server, 9_999_999_999)),
+            ..Default::default()
+        },
+    )
+    .expect("seed creds");
+
+    LogoutCommand {
+        api_url: Some(server.base_url()),
+        yes: true,
+        peppy_dirs: Some(PeppyDirs::new(dir.path())),
+    }
+    .execute(&ctx())
+    .expect("logout");
+    path
+}
+
+#[test]
+fn logout_deregisters_this_machines_core_node() {
+    let server = MockServer::start();
+    // Scoped to the exact path and to the bearer the session holds: the DELETE
+    // must go out under the token logout is about to revoke, which is only true
+    // if it runs before the revocation and never refreshes.
+    let deregister = server.mock(|when, then| {
+        when.method(DELETE)
+            .path("/me/core-nodes/cn-logout-me")
+            .header("Authorization", "Bearer seeded-access");
+        then.status(204);
+    });
+    let logout = server.mock(|when, then| {
+        when.method(POST).path("/logout");
+        then.status(202);
+    });
+
+    let dir = tempfile::tempdir().expect("temp dir");
+    let path = logout_with_core_node(&server, &dir, "cn-logout-me");
+
+    assert_eq!(
+        deregister.calls(),
+        1,
+        "logout must deregister this machine's core node"
+    );
+    assert!(logout.calls() >= 1, "POST /logout should have been called");
+    assert!(
+        storage::load(&path).expect("load creds").session.is_none(),
+        "local credentials must be removed after logout"
+    );
+}
+
+#[test]
+fn logout_completes_when_deregistration_finds_nothing_to_remove() {
+    // A 404 is silent success: a daemon in external mode never registered, and a
+    // repeated logout has nothing left to remove.
+    let server = MockServer::start();
+    let deregister = server.mock(|when, then| {
+        when.method(DELETE)
+            .path("/me/core-nodes/cn-never-registered");
+        then.status(404);
+    });
+    let logout = server.mock(|when, then| {
+        when.method(POST).path("/logout");
+        then.status(202);
+    });
+
+    let dir = tempfile::tempdir().expect("temp dir");
+    let path = logout_with_core_node(&server, &dir, "cn-never-registered");
+
+    assert_eq!(deregister.calls(), 1);
+    assert!(logout.calls() >= 1, "a 404 must not stop the revocation");
+    assert!(
+        storage::load(&path).expect("load creds").session.is_none(),
+        "a 404 must not stop the local credentials being cleared"
+    );
+}
+
+#[test]
+fn logout_completes_when_deregistration_fails() {
+    // Every deregistration failure is best effort, exactly like the revocation
+    // itself: the row is left behind and logout still finishes.
+    let server = MockServer::start();
+    let deregister = server.mock(|when, then| {
+        when.method(DELETE).path("/me/core-nodes/cn-backend-down");
+        then.status(503);
+    });
+    let logout = server.mock(|when, then| {
+        when.method(POST).path("/logout");
+        then.status(202);
+    });
+
+    let dir = tempfile::tempdir().expect("temp dir");
+    let path = logout_with_core_node(&server, &dir, "cn-backend-down");
+
+    assert_eq!(deregister.calls(), 1);
+    assert!(logout.calls() >= 1, "a 503 must not stop the revocation");
+    assert!(
+        storage::load(&path).expect("load creds").session.is_none(),
+        "a 503 must not stop the local credentials being cleared"
+    );
+}
+
+#[test]
+fn logout_without_a_resolvable_core_node_name_sends_no_deregistration() {
+    // No daemon state file and no configured name: there is nothing to delete by,
+    // and nothing is guessed. The row is left behind and logout still completes.
+    let server = MockServer::start();
+    let deregister = server.mock(|when, then| {
+        // Any DELETE at all, so the assertion covers a guessed name as well as
+        // the right one.
+        when.method(DELETE);
+        then.status(204);
+    });
+    let logout = server.mock(|when, then| {
+        when.method(POST).path("/logout");
+        then.status(202);
+    });
+
+    let dir = tempfile::tempdir().expect("temp dir");
+    let path = creds_path(&dir);
+    storage::save(
+        &path,
+        &Credentials {
+            session: Some(seeded_creds(&server, 9_999_999_999)),
+            ..Default::default()
+        },
+    )
+    .expect("seed creds");
+
+    LogoutCommand {
+        api_url: Some(server.base_url()),
+        yes: true,
+        peppy_dirs: Some(PeppyDirs::new(dir.path())),
+    }
+    .execute(&ctx())
+    .expect("logout");
+
+    assert_eq!(
+        deregister.calls(),
+        0,
+        "an unresolvable name must not produce a guessed DELETE"
+    );
+    assert!(logout.calls() >= 1);
+    assert!(storage::load(&path).expect("load creds").session.is_none());
+}
+
 #[test]
 fn logout_calls_backend_and_clears_local_credentials() {
     let server = MockServer::start();

--- a/crates/peppy/tests/platform_flow.rs
+++ b/crates/peppy/tests/platform_flow.rs
@@ -16,10 +16,13 @@ use secrecy::ExposeSecret;
 use serde_json::json;
 
 use auth::storage::{self, Credentials, ProfileCreds};
+use daemon::state::DaemonState;
 use peppy::commands::Command;
+use peppy::commands::platform::list::ListCommand;
 use peppy::commands::platform::login::LoginCommand;
 use peppy::commands::platform::logout::LogoutCommand;
 use peppy::commands::platform::whoami::WhoamiCommand;
+use peppy::commands::platform::{PlatformCommand, PlatformCommands};
 use peppy::context::AppContext;
 
 /// Builds the cli/auth-config + OIDC discovery + device-authorization + token mocks
@@ -701,6 +704,244 @@ fn whoami_runs_against_a_seeded_session() {
         .execute(&ctx())
         .expect("whoami");
     }
+}
+
+// ─── `peppy platform list` ────────────────────────────────────────────────
+
+const WORKSPACE: &str = "4f1b2e2c-9a71-4d0e-b3c8-0d2b9f6a11c4";
+
+/// A tempdir with a seeded session credential pointing at `server`, ready for a
+/// command that needs to be authenticated.
+fn authenticated_dir(server: &MockServer) -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let creds = Credentials {
+        session: Some(seeded_creds(server, 9_999_999_999)),
+        ..Default::default()
+    };
+    storage::save(&creds_path(&dir), &creds).expect("seed creds");
+    dir
+}
+
+/// Mocks `GET /me/core-nodes` with one registered, online core node.
+fn mock_core_nodes<'a>(server: &'a MockServer, core_node_name: &str) -> httpmock::Mock<'a> {
+    server.mock(|when, then| {
+        when.method(GET).path("/me/core-nodes");
+        then.status(200).json_body(json!({
+            "workspace_id": WORKSPACE,
+            "application_status_available": true,
+            "core_nodes": [{
+                "core_node_name": core_node_name,
+                "registered": true,
+                "first_seen_at": "2026-07-01T10:00:00Z",
+                "last_config_pull_at": "2026-07-24T09:12:33Z",
+                "application": { "status": "online", "live_claimants": 1 },
+            }],
+        }));
+    })
+}
+
+fn list_in(server: &MockServer, dir: &tempfile::TempDir, json: bool) -> peppy::error::Result<()> {
+    ListCommand {
+        api_url: Some(server.base_url()),
+        json,
+        peppy_dirs: Some(PeppyDirs::new(dir.path())),
+    }
+    .execute(&ctx())
+}
+
+#[test]
+fn list_renders_the_workspace_roster_in_both_formats() {
+    let server = MockServer::start();
+    let core_nodes = mock_core_nodes(&server, "cn-a1b2c3d4e5");
+    let dir = authenticated_dir(&server);
+
+    for json in [false, true] {
+        list_in(&server, &dir, json).expect("list should succeed");
+    }
+
+    core_nodes.assert_calls(2);
+}
+
+/// Unlike `whoami`, whose output IS the sign-in state, `list` cannot answer at
+/// all without a credential, so it fails rather than printing a document
+/// saying so. `main` maps the error to exit 1.
+#[test]
+fn list_without_a_credential_fails_instead_of_emitting_a_document() {
+    let server = MockServer::start();
+    // No credentials seeded.
+    let dir = tempfile::tempdir().expect("temp dir");
+
+    for json in [false, true] {
+        let error = list_in(&server, &dir, json).expect_err("list must fail unauthenticated");
+        assert!(
+            error.to_string().contains("peppy platform login"),
+            "the error must say how to fix it: {error}"
+        );
+    }
+}
+
+#[test]
+fn list_fails_when_the_backend_is_unreachable() {
+    let server = MockServer::start();
+    let dir = authenticated_dir(&server);
+    // A port nothing listens on, so the request cannot complete. There is
+    // deliberately no local fallback: a local query would answer a different
+    // question than the one the command claims to answer.
+    let unreachable = "http://127.0.0.1:1";
+
+    let error = ListCommand {
+        api_url: Some(unreachable.to_string()),
+        json: false,
+        peppy_dirs: Some(PeppyDirs::new(dir.path())),
+    }
+    .execute(&ctx())
+    .expect_err("an unreachable backend must fail the command");
+
+    assert!(
+        !error.to_string().is_empty(),
+        "the failure must carry a message"
+    );
+}
+
+#[test]
+fn list_surfaces_a_backend_outage_as_a_retryable_error() {
+    let server = MockServer::start();
+    server.mock(|when, then| {
+        when.method(GET).path("/me/core-nodes");
+        then.status(503);
+    });
+    let dir = authenticated_dir(&server);
+
+    let error = list_in(&server, &dir, false).expect_err("a 503 must fail the command");
+
+    assert!(
+        error.to_string().contains("try again"),
+        "a 503 must read as transient: {error}"
+    );
+}
+
+/// A newer CLI against a backend that predates the endpoint. Without the
+/// explicit mapping this reads as an unexplained `returned 404`.
+#[test]
+fn list_explains_a_backend_that_does_not_have_the_endpoint() {
+    let server = MockServer::start();
+    server.mock(|when, then| {
+        when.method(GET).path("/me/core-nodes");
+        then.status(404);
+    });
+    let dir = authenticated_dir(&server);
+
+    let error = list_in(&server, &dir, false).expect_err("a 404 must fail the command");
+
+    assert!(
+        error.to_string().contains("upgrade the platform"),
+        "a 404 must name the cause and the fix: {error}"
+    );
+}
+
+/// `--core-node` redirects a command at another machine's daemon, which no
+/// `platform` command does. The whole group refuses it, rather than each
+/// command silently answering a different question.
+#[test]
+fn every_platform_command_refuses_a_core_node_override() {
+    let server = MockServer::start();
+    let dir = authenticated_dir(&server);
+    let redirected = Arc::new(
+        AppContext::from_current_dir()
+            .expect("cwd is readable")
+            .with_core_node_override(Some("robot-7".to_string())),
+    );
+
+    let commands: Vec<(&str, PlatformCommands)> = vec![
+        (
+            "list",
+            PlatformCommands::List {
+                api_url: Some(server.base_url()),
+                json: false,
+            },
+        ),
+        (
+            "whoami",
+            PlatformCommands::Whoami {
+                api_url: Some(server.base_url()),
+                json: false,
+            },
+        ),
+        (
+            "logout",
+            PlatformCommands::Logout {
+                api_url: Some(server.base_url()),
+                yes: true,
+            },
+        ),
+        (
+            "login",
+            PlatformCommands::Login {
+                api_url: Some(server.base_url()),
+                no_browser: true,
+                yes: true,
+            },
+        ),
+    ];
+
+    for (name, command) in commands {
+        let error = PlatformCommand { command }
+            .execute(&redirected)
+            .expect_err(&format!("`platform {name}` must refuse --core-node"));
+        assert!(
+            error.to_string().contains("--core-node"),
+            "`platform {name}` must name the flag it refused: {error}"
+        );
+        assert!(
+            error.to_string().contains("peppy stack list"),
+            "`platform {name}` must point at the command that does show other core nodes: {error}"
+        );
+    }
+
+    // The refusal happens before any work: the backend was never called.
+    server.mock(|when, then| {
+        when.method(GET).path("/me/core-nodes");
+        then.status(500);
+    });
+    let _ = dir;
+}
+
+/// A stale daemon state file must not fail the command, whatever it records.
+///
+/// The marker RULES are pinned as a pure unit in `platform::list`
+/// (`this_machine_name`), where each case is asserted directly rather than
+/// inferred from a command that succeeded. What this covers is the wiring: a
+/// state file on disk is read, and a daemon running in another workspace is a
+/// normal case rather than an error.
+#[test]
+fn a_daemon_in_another_workspace_does_not_fail_the_listing() {
+    let server = MockServer::start();
+    let core_nodes = mock_core_nodes(&server, "cn-local-daemon");
+    let dir = authenticated_dir(&server);
+    // Same core-node name as the listed row, different workspace: the
+    // mid-login case.
+    write_daemon_state(&dir, "cn-local-daemon", "local");
+
+    list_in(&server, &dir, false).expect("a mismatched namespace must not fail the command");
+
+    core_nodes.assert();
+}
+
+/// Writes a daemon state file recording `core_node_name` under `namespace`.
+fn write_daemon_state(dir: &tempfile::TempDir, core_node_name: &str, namespace: &str) {
+    let state = DaemonState::new(
+        core_node_name,
+        "127.0.0.1",
+        7447,
+        "test-git-hash",
+        30,
+        config::namespace::Namespace::parse(namespace).expect("valid namespace"),
+        Some(30),
+    );
+    let path = DaemonState::state_file_in(dir.path());
+    std::fs::create_dir_all(path.parent().expect("state file has a parent"))
+        .expect("state file dir");
+    DaemonState::write_to(&path, &state).expect("write daemon state");
 }
 
 /// A session credential pointing at `server` with the given absolute expiry.

--- a/docs/src/components/YouTubeEmbed.astro
+++ b/docs/src/components/YouTubeEmbed.astro
@@ -2,8 +2,9 @@
 /*
  * Responsive YouTube player. The iframe fills a 16:9 wrapper instead of
  * carrying fixed width/height attributes, so it tracks the content column at
- * every breakpoint, and it is served from youtube-nocookie.com so watching a
- * video from the docs does not plant tracking cookies. The frame borrows the
+ * every breakpoint, and it is served from youtube-nocookie.com, YouTube's
+ * privacy-enhanced embed, which holds back the identifiers a plain embed
+ * stores until a visitor actually plays the video. The frame borrows the
  * hairline and 12px radius the code windows and asides use, so an embed reads
  * as one of the page's own blocks rather than a foreign panel.
  */

--- a/docs/src/components/YouTubeEmbed.astro
+++ b/docs/src/components/YouTubeEmbed.astro
@@ -1,0 +1,44 @@
+---
+/*
+ * Responsive YouTube player. The iframe fills a 16:9 wrapper instead of
+ * carrying fixed width/height attributes, so it tracks the content column at
+ * every breakpoint, and it is served from youtube-nocookie.com so watching a
+ * video from the docs does not plant tracking cookies. The frame borrows the
+ * hairline and 12px radius the code windows and asides use, so an embed reads
+ * as one of the page's own blocks rather than a foreign panel.
+ */
+interface Props {
+	/** The `v` parameter of the video's watch URL. */
+	id: string;
+	/** Accessible name for the player frame; use the video's title. */
+	title: string;
+}
+
+const { id, title } = Astro.props;
+---
+
+<div class="video-embed">
+	<iframe
+		src={`https://www.youtube-nocookie.com/embed/${id}`}
+		title={title}
+		loading="lazy"
+		referrerpolicy="strict-origin-when-cross-origin"
+		allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+		allowfullscreen></iframe>
+</div>
+
+<style>
+	.video-embed {
+		aspect-ratio: 16 / 9;
+		overflow: hidden;
+		border: 1px solid var(--sl-color-hairline);
+		border-radius: 12px;
+	}
+
+	.video-embed iframe {
+		display: block;
+		width: 100%;
+		height: 100%;
+		border: 0;
+	}
+</style>

--- a/docs/src/content/docs/advanced_guides/platform.mdx
+++ b/docs/src/content/docs/advanced_guides/platform.mdx
@@ -106,16 +106,43 @@ peppy platform list
 ```
 Workspace 4f1b2e2c-9a71-4d0e-b3c8-0d2b9f6a11c4 (backend https://api.peppy.dev)
 
-CORE NODE            APPLICATION           REGISTERED
-cn-a1b2c3d4e5        online                2026-07-01   (this machine)
-cn-9f8e7d6c5b        offline               2026-07-14
-lab-bench-external   online (2 claimants)  -
+CORE NODE            NETWORK    APPLICATION           REGISTERED
+cn-a1b2c3d4e5        linked     online                2026-07-01   (this machine)
+cn-9f8e7d6c5b        linked     offline               2026-07-14
+cn-113355aabb        unlinked   offline               2026-06-02
+lab-bench-external   indirect   online (2 claimants)  -
 ```
 
 The listing is **workspace scoped**. It shows the machines logged in to your own
 account and nothing else, and machines in other workspaces are invisible to you
 by design. The platform runs no core node in your workspace either, so every row
 is one of your own machines.
+
+#### Two layers, reported separately
+
+A machine reaches the platform through two layers, and they fail independently:
+
+- The **network** layer is the transport. Your machine's `zenohd` holds a live
+  session with the platform's shared `zenohd`. This is federation, and it knows
+  nothing about core nodes.
+- The **application** layer is your workspace namespace. Your machine's core node
+  declares its presence there, which is what `APPLICATION` reports.
+
+Both are shown because only one of them cannot tell you what to do about a
+machine that is not answering. `linked` beside `offline` is a healthy uplink with
+a dead daemon behind it, so debug the machine. `unlinked` beside `offline` is a
+site the platform cannot reach at all, so debug the network. Reading the
+application column alone, the absence of a signal is exactly as consistent with a
+severed link as with a stopped daemon.
+
+The `NETWORK` column reads:
+
+| Value | Meaning |
+|-------|---------|
+| `linked` | This machine's router holds a live transport session with the platform's shared router. |
+| `indirect` | That session is absent, but the machine is `online` anyway, so its traffic reaches the platform through a router Peppy does not manage. See below. |
+| `unlinked` | No session, and the machine is `offline`. The site is unreachable. |
+| `unknown` | The platform could not read its router's session list, so no row's network status is known; or the session is absent while the application layer is itself unavailable, in which case `indirect` and `unlinked` cannot be told apart and neither is guessed at. |
 
 The `APPLICATION` column reads:
 
@@ -125,6 +152,19 @@ The `APPLICATION` column reads:
 | `offline` | The machine is registered but its daemon is stopped or unreachable. |
 | `online (N claimants)` | `N` different daemons are claiming this core-node name at once. This is a name collision, and it is worth acting on: the losing daemon refuses to start, so a collision is often why a machine will not come up. |
 | `unknown` | The platform could not read liveness at all, so no row's status is known. The list of machines itself is still accurate. A warning explains this on stderr. |
+
+`indirect` is what a machine configured with
+[`zenoh.external`](/advanced_guides/daemon_config/#zenohexternal-use-an-operator-run-router)
+looks like once it has been registered: Peppy no longer manages the router
+carrying its traffic, so the router identity the platform has on file for it
+stops connecting, while the machine keeps reaching your workspace through the
+router you run. The status exists so the two columns can never contradict each
+other by reporting a machine as both `unlinked` and `online`.
+
+The reverse pairing is real too, and it is the reason the column earns its keep.
+A daemon killed hard enough to leave its `zenohd` running keeps that router
+connected, so the row reads `linked` and `offline`: the uplink is fine, the
+daemon is not.
 
 A row with `-` under `REGISTERED` is running on the wire but was never registered
 with the platform. That is the normal appearance of a daemon configured with
@@ -145,9 +185,11 @@ Two caveats worth knowing:
   tell you which machine is which. `peppy stack list` is where host names live.
   Set [`core_node_name`](/advanced_guides/daemon_config/) to give a machine a
   name you recognize.
-- `online` is not an authenticated statement. The messaging transport does not
-  authenticate daemons, so anything that can reach the router can claim a name.
-  A `REGISTERED` date is backed by a bearer token; a live status is not.
+- Neither `online` nor `linked` is an authenticated statement. The messaging
+  transport does not authenticate daemons, so anything that can reach the router
+  can open a session and claim a name. `NETWORK` reports what the platform's
+  router observes on the wire, not an identity it has vouched for. A `REGISTERED`
+  date is backed by a bearer token; a live status is not.
 
 ## Federation outside the Peppy platform
 

--- a/docs/src/content/docs/advanced_guides/platform.mdx
+++ b/docs/src/content/docs/advanced_guides/platform.mdx
@@ -17,7 +17,7 @@ The CLI never sees your Google/passkey credentials. Those stay in the browser.
 | `peppy platform login [--api-url <url>] [--no-browser] [--yes]` | Logs in via the OAuth 2.0 Device Authorization Grant, caches the tokens, and federates a managed router to your workspace's cloud router. |
 | `peppy platform whoami` (alias `status`) | Shows the current identity, backend, and token validity. `--json` for machine-readable output. |
 | `peppy platform list [--api-url <url>] [--json]` | Lists the core nodes registered to your workspace and whether each one is running right now. |
-| `peppy platform logout [--yes]` | Revokes the access token on the backend (across replicas), deletes the local credentials, and de-federates a managed router. |
+| `peppy platform logout [--yes]` | Removes this machine from the workspace's core-node registry, revokes the access token on the backend (across replicas), deletes the local credentials, and de-federates a managed router. |
 
 `--yes` (`-y`) skips the daemon-restart confirmation prompt described under
 [Workspace federation](#workspace-federation).
@@ -116,7 +116,8 @@ lab-bench-external   indirect   online (2 claimants)  -
 The listing is **workspace scoped**. It shows the machines logged in to your own
 account and nothing else, and machines in other workspaces are invisible to you
 by design. The platform runs no core node in your workspace either, so every row
-is one of your own machines.
+is one of your own machines. A machine is added when it logs in and removed when
+it logs out, so `peppy platform logout` takes a machine off this list.
 
 #### Two layers, reported separately
 
@@ -301,6 +302,14 @@ This calls `POST {api_url}/logout`, which denylists the presented access token
 across all backend replicas (sub-second), then deletes the local credentials.
 The effect is near-immediate for the logged-out token. It revokes only the
 token you presented; a session on another device keeps working.
+
+Logout also deregisters this machine's core node, sending `DELETE
+{api_url}/me/core-nodes/{core_node_name}` so the machine stops appearing in
+`peppy platform list`. A logged-out machine no longer federates or pulls config,
+so leaving its row behind would misrepresent it. This step is best-effort, like
+the token revocation above: if the backend is unreachable the row is left behind
+and logout still completes, and a `zenoh.external` daemon that never registered
+has nothing to remove.
 
 Logout also returns this machine to the `local` namespace. Under `zenoh.managed`,
 it de-federates the router, restarts the daemon, and wipes the running node stack,

--- a/docs/src/content/docs/advanced_guides/platform.mdx
+++ b/docs/src/content/docs/advanced_guides/platform.mdx
@@ -16,6 +16,7 @@ The CLI never sees your Google/passkey credentials. Those stay in the browser.
 |---------|--------------|
 | `peppy platform login [--api-url <url>] [--no-browser] [--yes]` | Logs in via the OAuth 2.0 Device Authorization Grant, caches the tokens, and federates a managed router to your workspace's cloud router. |
 | `peppy platform whoami` (alias `status`) | Shows the current identity, backend, and token validity. `--json` for machine-readable output. |
+| `peppy platform list [--api-url <url>] [--json]` | Lists the core nodes registered to your workspace and whether each one is running right now. |
 | `peppy platform logout [--yes]` | Revokes the access token on the backend (across replicas), deletes the local credentials, and de-federates a managed router. |
 
 `--yes` (`-y`) skips the daemon-restart confirmation prompt described under
@@ -91,6 +92,62 @@ to resolve the cloud router is bounded by
 With `zenoh.external`, login and logout skip federation and print a note instead;
 the daemon applies the resolved namespace to its sessions on its next manual
 restart. See [Federation outside the Peppy platform](#federation-outside-the-peppy-platform).
+
+### Listing the workspace's core nodes
+
+Once two machines have logged in under the same account, they share a workspace
+namespace and can already address each other. `peppy platform list` is what
+shows you that:
+
+```sh
+peppy platform list
+```
+
+```
+Workspace 4f1b2e2c-9a71-4d0e-b3c8-0d2b9f6a11c4 (backend https://api.peppy.dev)
+
+CORE NODE            APPLICATION           REGISTERED
+cn-a1b2c3d4e5        online                2026-07-01   (this machine)
+cn-9f8e7d6c5b        offline               2026-07-14
+lab-bench-external   online (2 claimants)  -
+```
+
+The listing is **workspace scoped**. It shows the machines logged in to your own
+account and nothing else, and machines in other workspaces are invisible to you
+by design. The platform runs no core node in your workspace either, so every row
+is one of your own machines.
+
+The `APPLICATION` column reads:
+
+| Value | Meaning |
+|-------|---------|
+| `online` | The machine's daemon is running and reachable on the shared router right now. |
+| `offline` | The machine is registered but its daemon is stopped or unreachable. |
+| `online (N claimants)` | `N` different daemons are claiming this core-node name at once. This is a name collision, and it is worth acting on: the losing daemon refuses to start, so a collision is often why a machine will not come up. |
+| `unknown` | The platform could not read liveness at all, so no row's status is known. The list of machines itself is still accurate. A warning explains this on stderr. |
+
+A row with `-` under `REGISTERED` is running on the wire but was never registered
+with the platform. That is the normal appearance of a daemon configured with
+[`zenoh.external`](/advanced_guides/daemon_config/#zenohexternal-use-an-operator-run-router):
+it adopts its cached workspace namespace but never pulls federation config, so
+the platform is never told about it.
+
+`REGISTERED` is the date a machine first registered, in UTC. There is
+deliberately no "last seen" column: the platform's other timestamp records when
+a daemon last pulled its configuration, which is not the same as when it was
+last running. A machine that has been up for a week without re-pulling would
+look a week stale. Liveness lives in the `APPLICATION` column and nowhere else.
+`--json` exposes the pull time under its own name, `last_config_pull_at`.
+
+Two caveats worth knowing:
+
+- Default core-node names are hashes of the machine's UID, so the roster may not
+  tell you which machine is which. `peppy stack list` is where host names live.
+  Set [`core_node_name`](/advanced_guides/daemon_config/) to give a machine a
+  name you recognize.
+- `online` is not an authenticated statement. The messaging transport does not
+  authenticate daemons, so anything that can reach the router can claim a name.
+  A `REGISTERED` date is backed by a bearer token; a live status is not.
 
 ## Federation outside the Peppy platform
 

--- a/docs/src/content/docs/quickstart.mdx
+++ b/docs/src/content/docs/quickstart.mdx
@@ -5,12 +5,19 @@ description: Install peppy and drive a simulated bimanual OpenArm from your brow
 
 import { Steps } from '@astrojs/starlight/components';
 import OpenArmStackGraph from '../../components/OpenArmStackGraph.astro';
+import YouTubeEmbed from '../../components/YouTubeEmbed.astro';
 
 Three steps take you from nothing installed to a bimanual [OpenArm](https://openarm.dev/) you can drive from your browser. There is no repository to clone and no robot hardware to plug in: the arms, the grippers, and the physics all run in a MuJoCo simulation on your machine.
 
 This page is a demo, not a tutorial. It exists so you can watch a peppy stack work end to end before you learn how one is put together. To learn how one is put together, start at [Installation](/guides/installation/) and work through the [guides](/guides/first_node/), which build a stack up node by node from an empty directory.
 
 Peppy runs on Linux (x86_64/aarch64, tested on Ubuntu 24.04, Fedora, and Arch Linux) and macOS (aarch64).
+
+## Watch it instead
+
+The video below is this page in video form: the same three steps, run start to finish on a real machine. Watch it first if you would rather see where you are headed, then follow the written steps to do it yourself.
+
+<YouTubeEmbed id="dqvAvyugaeA" title="Peppy framework quickstart" />
 
 ## Step 1: Install peppy
 

--- a/scripts/tests/test_lima.py
+++ b/scripts/tests/test_lima.py
@@ -199,7 +199,12 @@ def test_vm_resources_caps_memory_at_half_host_ram(tmp_path: Path) -> None:
 def test_ensure_lima_vm_create_failure_raises(tmp_path: Path) -> None:
     limactl = tmp_path / "limactl"
 
-    with patch("functions.lima._run_limactl") as mock_run:
+    # `_vm_resources` is stubbed for the same reason the success case above
+    # stubs it: it reads the host's RAM through `sysctl`, which exists only on
+    # macOS, so the real one raises its own ReleaseError on the Linux CI runner
+    # before the create call under test is ever reached.
+    with patch("functions.lima._run_limactl") as mock_run, \
+         patch("functions.lima._vm_resources", return_value=(8, 12)):
         # First call: list (empty = not found), second call: create fails
         mock_run.side_effect = [
             MagicMock(stdout=""),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `peppy platform list` to view workspace core nodes, network/application status, registration times, and machine identification.
  * Added JSON output for platform listings.
  * Added persistent router identity handling to improve federation consistency across restarts.
  * Added automatic core-node deregistration during logout.

* **Bug Fixes**
  * Improved handling and messaging for unavailable, unauthenticated, or unsupported platform services.

* **Documentation**
  * Documented platform core-node listings, status meanings, and workspace scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->