### PR TITLE
docs: add the quickstart video to the quickstart page

### DIFF
--- a/crates/auth-internal/src/client.rs
+++ b/crates/auth-internal/src/client.rs
@@ -167,9 +167,10 @@ pub struct ZenohRouterConfig {
     /// Transport scheme, `"tls"` today.
     pub protocol: String,
     /// How long this config may be reused before re-resolving it. A cache-freshness
-    /// hint only: the backend now actively health-checks the daemon, so reusing a
-    /// still-fresh config (rather than re-pulling) never risks the router being torn
-    /// down.
+    /// hint only: the router the backend hands back is a single shared one, not a
+    /// per-user resource with a lifetime, and nothing on the backend probes this
+    /// daemon or tears that router down. Reusing a still-fresh config therefore only
+    /// delays this daemon's next re-registration, never the loss of a router.
     pub reconnect_after_secs: u64,
     /// The daemon's session namespace, deserialized directly from the backend's
     /// `workspace_id`. Typed at the HTTP boundary: an invalid workspace id fails

--- a/crates/auth-internal/src/router.rs
+++ b/crates/auth-internal/src/router.rs
@@ -121,7 +121,9 @@ fn materialize_embedded(cache_dir: &Path, filename: &str, bytes: &[u8]) -> Optio
 /// tags the cache, so a resolve under a different name (a renamed daemon) always
 /// re-pulls and re-registers rather than reusing a still-fresh cache.
 /// `router_zid` is the managed router's pinned transport identity, carried in
-/// the same POST and tagging the cache the same way.
+/// the same POST so the registered row can be matched against the shared
+/// router's live session list. Unlike the name, it deliberately does not
+/// participate in cache reuse (see the cache comment below).
 ///
 /// Only the pull path needs a credential, so a fresh cache is reused without
 /// touching the token at all.

--- a/crates/peppy/src/commands/platform/logout.rs
+++ b/crates/peppy/src/commands/platform/logout.rs
@@ -166,7 +166,7 @@ fn deregister_core_node(
     core_node_name: Option<&str>,
 ) {
     let Some(core_node_name) = core_node_name else {
-        eprintln!(
+        println!(
             "Warning: could not determine this machine's core-node name; it stays listed in \
              the platform's core-node registry."
         );
@@ -176,8 +176,8 @@ fn deregister_core_node(
         format!("core node {core_node_name} may stay listed in the platform's core-node registry");
     match client::deregister_core_node(http, api_url, access_token, core_node_name) {
         Ok(204) | Ok(404) => {}
-        Ok(status) => eprintln!("Warning: deregistering returned {status}; {leak}."),
-        Err(e) => eprintln!("Warning: could not reach the backend ({e}); {leak}."),
+        Ok(status) => println!("Warning: deregistering returned {status}; {leak}."),
+        Err(e) => println!("Warning: could not reach the backend ({e}); {leak}."),
     }
 }
 

--- a/crates/peppy/tests/platform_flow.rs
+++ b/crates/peppy/tests/platform_flow.rs
@@ -845,7 +845,12 @@ fn list_explains_a_backend_that_does_not_have_the_endpoint() {
 #[test]
 fn every_platform_command_refuses_a_core_node_override() {
     let server = MockServer::start();
-    let dir = authenticated_dir(&server);
+    // Registered before the commands run, so the call count below is evidence.
+    // A mock added afterwards could not have been hit whatever the guard does.
+    let core_nodes = server.mock(|when, then| {
+        when.method(GET).path("/me/core-nodes");
+        then.status(500);
+    });
     let redirected = Arc::new(
         AppContext::from_current_dir()
             .expect("cwd is readable")
@@ -899,11 +904,11 @@ fn every_platform_command_refuses_a_core_node_override() {
     }
 
     // The refusal happens before any work: the backend was never called.
-    server.mock(|when, then| {
-        when.method(GET).path("/me/core-nodes");
-        then.status(500);
-    });
-    let _ = dir;
+    assert_eq!(
+        core_nodes.calls(),
+        0,
+        "the override must be refused before any command reaches the backend"
+    );
 }
 
 /// A stale daemon state file must not fail the command, whatever it records.

--- a/docs/src/components/YouTubeEmbed.astro
+++ b/docs/src/components/YouTubeEmbed.astro
@@ -2,8 +2,9 @@
 /*
  * Responsive YouTube player. The iframe fills a 16:9 wrapper instead of
  * carrying fixed width/height attributes, so it tracks the content column at
- * every breakpoint, and it is served from youtube-nocookie.com so watching a
- * video from the docs does not plant tracking cookies. The frame borrows the
+ * every breakpoint, and it is served from youtube-nocookie.com, YouTube's
+ * privacy-enhanced embed, which holds back the identifiers a plain embed
+ * stores until a visitor actually plays the video. The frame borrows the
  * hairline and 12px radius the code windows and asides use, so an embed reads
  * as one of the page's own blocks rather than a foreign panel.
  */

--- a/docs/src/components/YouTubeEmbed.astro
+++ b/docs/src/components/YouTubeEmbed.astro
@@ -1,0 +1,44 @@
+---
+/*
+ * Responsive YouTube player. The iframe fills a 16:9 wrapper instead of
+ * carrying fixed width/height attributes, so it tracks the content column at
+ * every breakpoint, and it is served from youtube-nocookie.com so watching a
+ * video from the docs does not plant tracking cookies. The frame borrows the
+ * hairline and 12px radius the code windows and asides use, so an embed reads
+ * as one of the page's own blocks rather than a foreign panel.
+ */
+interface Props {
+	/** The `v` parameter of the video's watch URL. */
+	id: string;
+	/** Accessible name for the player frame; use the video's title. */
+	title: string;
+}
+
+const { id, title } = Astro.props;
+---
+
+<div class="video-embed">
+	<iframe
+		src={`https://www.youtube-nocookie.com/embed/${id}`}
+		title={title}
+		loading="lazy"
+		referrerpolicy="strict-origin-when-cross-origin"
+		allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+		allowfullscreen></iframe>
+</div>
+
+<style>
+	.video-embed {
+		aspect-ratio: 16 / 9;
+		overflow: hidden;
+		border: 1px solid var(--sl-color-hairline);
+		border-radius: 12px;
+	}
+
+	.video-embed iframe {
+		display: block;
+		width: 100%;
+		height: 100%;
+		border: 0;
+	}
+</style>

--- a/docs/src/content/docs/quickstart.mdx
+++ b/docs/src/content/docs/quickstart.mdx
@@ -5,12 +5,19 @@ description: Install peppy and drive a simulated bimanual OpenArm from your brow
 
 import { Steps } from '@astrojs/starlight/components';
 import OpenArmStackGraph from '../../components/OpenArmStackGraph.astro';
+import YouTubeEmbed from '../../components/YouTubeEmbed.astro';
 
 Three steps take you from nothing installed to a bimanual [OpenArm](https://openarm.dev/) you can drive from your browser. There is no repository to clone and no robot hardware to plug in: the arms, the grippers, and the physics all run in a MuJoCo simulation on your machine.
 
 This page is a demo, not a tutorial. It exists so you can watch a peppy stack work end to end before you learn how one is put together. To learn how one is put together, start at [Installation](/guides/installation/) and work through the [guides](/guides/first_node/), which build a stack up node by node from an empty directory.
 
 Peppy runs on Linux (x86_64/aarch64, tested on Ubuntu 24.04, Fedora, and Arch Linux) and macOS (aarch64).
+
+## Watch it instead
+
+The video below is this page in video form: the same three steps, run start to finish on a real machine. Watch it first if you would rather see where you are headed, then follow the written steps to do it yourself.
+
+<YouTubeEmbed id="dqvAvyugaeA" title="Peppy framework quickstart" />
 
 ## Step 1: Install peppy
 

--- a/scripts/tests/test_lima.py
+++ b/scripts/tests/test_lima.py
@@ -199,7 +199,12 @@ def test_vm_resources_caps_memory_at_half_host_ram(tmp_path: Path) -> None:
 def test_ensure_lima_vm_create_failure_raises(tmp_path: Path) -> None:
     limactl = tmp_path / "limactl"
 
-    with patch("functions.lima._run_limactl") as mock_run:
+    # `_vm_resources` is stubbed for the same reason the success case above
+    # stubs it: it reads the host's RAM through `sysctl`, which exists only on
+    # macOS, so the real one raises its own ReleaseError on the Linux CI runner
+    # before the create call under test is ever reached.
+    with patch("functions.lima._run_limactl") as mock_run, \
+         patch("functions.lima._vm_resources", return_value=(8, 12)):
         # First call: list (empty = not found), second call: create fails
         mock_run.side_effect = [
             MagicMock(stdout=""),


### PR DESCRIPTION
## Summary

Adds the [Peppy framework quickstart video](https://www.youtube.com/watch?v=dqvAvyugaeA) to the written Quickstart page, as a **Watch it instead** section between the intro and Step 1.

The player is a new `YouTubeEmbed` component: the iframe fills a 16:9 wrapper instead of carrying fixed `width`/`height`, so it tracks the content column at every breakpoint. It is served from `youtube-nocookie.com`, YouTube's privacy-enhanced embed, which holds back the identifiers a plain embed stores until a visitor actually plays the video. The frame borrows the hairline border and 12px radius the code windows and asides use so it reads as one of the page's own blocks.

## Test plan

- `npm run build` in `docs/` completes (154 pages).
- The built `dist/quickstart/index.html` contains the `youtube-nocookie.com/embed/dqvAvyugaeA` iframe and the `watch-it-instead` heading; the component's scoped styles ship in `dist/_astro/quickstart.*.css`.
- No em-dashes in the added prose, and the added heading is sentence case, per the docs style pass.

Note: this branch also carries unrelated commits from concurrent work in the same worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)