### PR TITLE
Add per-instance env_vars support to launcher files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1088,6 +1088,7 @@ name = "daemon-config"
 version = "0.0.1"
 dependencies = [
  "const_format",
+ "core-node-api",
  "dirs 6.0.0",
  "peppy-config-model",
  "serde",

--- a/crates/core-node-internal/src/services/stack/launch.rs
+++ b/crates/core-node-internal/src/services/stack/launch.rs
@@ -502,6 +502,36 @@ fn mount_source(mount: &str) -> &str {
     mount.split(':').next().unwrap_or(mount)
 }
 
+/// The environment one launched instance is started with: the caller
+/// environment the launch goal forwards to every node, with the instance's own
+/// `env_vars` layered on top so a deployment can pin what differs per instance
+/// (a device path, a board id) without depending on whoever ran the launch.
+///
+/// A key declared by the instance replaces the forwarded one rather than
+/// appearing twice: the spawn paths differ on duplicates (a process node's
+/// `Command::env` keeps the last, apptainer's `--env` flags are order-dependent
+/// in their own way), so the ambiguity is resolved here, once. Forwarded order
+/// is preserved and the instance's own entries follow in name order, which
+/// keeps the resulting command line stable for a given launcher file.
+///
+/// Only `node_run` takes this: `env_vars` belong to an instance, while adding
+/// and building a node happen once for every instance that deploys it.
+fn instance_environment(
+    forwarded: &[(String, String)],
+    instance_env: &std::collections::BTreeMap<String, String>,
+) -> Vec<(String, String)> {
+    forwarded
+        .iter()
+        .filter(|(key, _)| !instance_env.contains_key(key))
+        .cloned()
+        .chain(
+            instance_env
+                .iter()
+                .map(|(key, value)| (key.clone(), value.clone())),
+        )
+        .collect()
+}
+
 /// Step 7: Start every instance in dependency order.
 async fn start_node_instances(
     ctx: &ProcessLaunchContext,
@@ -652,7 +682,7 @@ async fn start_node_instances(
                 item.node_name.as_str(),
                 item.node_tag.as_str(),
             )
-            .with_env_vars(ctx.env_vars.clone())
+            .with_env_vars(instance_environment(&ctx.env_vars, &instance.env_vars))
             .with_requested_pairs(
                 requested_by_instance
                     .remove(instance_id)
@@ -1179,6 +1209,46 @@ mod tests {
 
         assert_eq!(resolved, vec!["/tmp/video_reconstruction:/frames:rw"]);
         assert_eq!(mount_source(&resolved[0]), "/tmp/video_reconstruction");
+    }
+
+    /// An instance's `env_vars` are added to the forwarded caller environment
+    /// and win on a shared key, leaving exactly one entry per key so the spawn
+    /// path has nothing to disambiguate.
+    #[test]
+    fn instance_env_vars_override_the_forwarded_caller_environment() {
+        let forwarded = vec![
+            ("PATH".to_string(), "/usr/bin".to_string()),
+            ("ESP32_DEVICE".to_string(), "/dev/from_caller".to_string()),
+        ];
+        let mut instance_env = BTreeMap::new();
+        instance_env.insert("ESP32_DEVICE".to_string(), "/dev/ttyUSB0".to_string());
+        instance_env.insert("BOARD_ID".to_string(), "3".to_string());
+
+        let merged = instance_environment(&forwarded, &instance_env);
+
+        assert_eq!(
+            merged,
+            vec![
+                ("PATH".to_string(), "/usr/bin".to_string()),
+                ("BOARD_ID".to_string(), "3".to_string()),
+                ("ESP32_DEVICE".to_string(), "/dev/ttyUSB0".to_string()),
+            ]
+        );
+    }
+
+    /// An instance that declares nothing is started with the forwarded
+    /// environment unchanged, in the order it arrived.
+    #[test]
+    fn instance_without_env_vars_keeps_the_forwarded_environment() {
+        let forwarded = vec![
+            ("PATH".to_string(), "/usr/bin".to_string()),
+            ("HOME".to_string(), "/home/user".to_string()),
+        ];
+
+        assert_eq!(
+            instance_environment(&forwarded, &BTreeMap::new()),
+            forwarded
+        );
     }
 
     #[test]

--- a/crates/core-node-internal/tests/listen_for_launch.rs
+++ b/crates/core-node-internal/tests/listen_for_launch.rs
@@ -1859,6 +1859,102 @@ sleep \"${1:-60}\"
     );
 }
 
+/// A launcher instance's `env_vars` reach the process the daemon spawns, and a
+/// key it declares wins over the caller environment the launch forwards. The
+/// node writes what it actually received to a file, so the assertion is on the
+/// value in the spawned process rather than on anything the daemon reports.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn listen_for_launch_applies_per_instance_env_vars() {
+    const NODE_NAME: &str = "env_probe_node";
+    const NODE_TAG: &str = "v1";
+    const INSTANCE_ID: &str = "probe_1";
+    const INSTANCE_DEVICE: &str = "/dev/ttyUSB0";
+    const CALLER_DEVICE: &str = "/dev/from_caller";
+
+    let started_core_node = start_core_node_with_mock_messenger().await;
+
+    let nodes_dir = tempdir().expect("failed to create temp nodes directory");
+    let probe_path = nodes_dir.path().join("received_env.txt");
+    // Records the value the process was started with, then stays alive so the
+    // instance can reach Running like any other node.
+    let probe_script = format!(
+        "printf '%s' \"$ESP32_DEVICE\" > {}; exec sleep 60",
+        probe_path.display()
+    );
+    let _node_path = write_node_config(
+        nodes_dir.path(),
+        NODE_NAME,
+        NODE_TAG,
+        "test-hash",
+        &["sh", "-c", probe_script.as_str()],
+        false,
+        false,
+    );
+
+    let launcher_json5 = format!(
+        r#"{{ peppy_schema: "launcher/v1", deployments: [ {{ source: {{ local: "./{NODE_NAME}" }}, instances: [ {{ instance_id: "{INSTANCE_ID}", env_vars: {{ ESP32_DEVICE: "{INSTANCE_DEVICE}" }} }} ] }} ] }}"#
+    );
+    let launch_file_path = nodes_dir.path().join("peppy_launcher.json5");
+    fs::write(&launch_file_path, &launcher_json5).expect("failed to write launch file");
+
+    let node_messenger =
+        MessengerHandle::from_shared(Arc::clone(&started_core_node.shared_messenger));
+    let _ready = AbortOnDrop(
+        listen_for_node_ready(
+            &node_messenger,
+            &started_core_node.core_node_name,
+            INSTANCE_ID,
+            common::test_node_target(NODE_NAME),
+        )
+        .await
+        .expect("ready service should start"),
+    );
+    let _health = AbortOnDrop(
+        listen_for_node_health(
+            &node_messenger,
+            &started_core_node.core_node_name,
+            INSTANCE_ID,
+            common::test_node_target(NODE_NAME),
+        )
+        .await
+        .expect("health service should start"),
+    );
+
+    // Allow listeners to establish.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // The caller environment carries the same key with a different value, so a
+    // matching probe can only come from the instance's own declaration.
+    let (_goal_response, result) = send_node_launch_and_wait_with_env(
+        &started_core_node.caller_handle,
+        &started_core_node.core_node_name,
+        &launch_file_path,
+        GOAL_TIMEOUT,
+        RESULT_TIMEOUT,
+        vec![("ESP32_DEVICE".to_string(), CALLER_DEVICE.to_string())],
+    )
+    .await
+    .expect("launch request should complete");
+
+    assert!(
+        result.success,
+        "launch should succeed, got error: {:?}",
+        result.error_message
+    );
+
+    let received = poll_until(
+        Duration::from_secs(10),
+        "the launched node should have recorded the env var it was started with",
+        || fs::read_to_string(&probe_path).ok(),
+    )
+    .await;
+    assert_eq!(
+        received, INSTANCE_DEVICE,
+        "the instance's `env_vars` value must reach the spawned process and \
+         override the forwarded caller environment"
+    );
+}
+
 /// `LauncherOrigin::Repository` resolves the launcher name through `launchers.json5`
 /// (the launcher repo cache) and uses the on-disk path it points at. The deployment
 /// itself uses a local source so we don't need to spin up a fake git repo.

--- a/crates/daemon-config-internal/Cargo.toml
+++ b/crates/daemon-config-internal/Cargo.toml
@@ -10,6 +10,11 @@ edition.workspace = true
 
 [dependencies]
 config = { workspace = true }
+# `FORBIDDEN_ENV_KEYS`, the protocol policy both sides of the core-node wire
+# enforce on environment variables. `env::check_env_var` applies it where a
+# launcher's `env_vars` are parsed so a rejected key is reported against the
+# file the user wrote, not at spawn time.
+core-node-api = { workspace = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_json5 = "0.2"

--- a/crates/daemon-config-internal/src/env.rs
+++ b/crates/daemon-config-internal/src/env.rs
@@ -1,0 +1,193 @@
+//! Shape rules for the environment variables a spawned node receives.
+//!
+//! Two callers share them. The CLI filters the caller environment it forwards
+//! with a launch or run goal, and the launcher parser rejects a per-instance
+//! `env_vars` entry a node could not receive intact. One definition keeps the
+//! two in step: what the CLI silently drops from the ambient environment is not
+//! something a launcher file can smuggle through.
+//!
+//! The rules follow the strictest consumer, a container node. Apptainer writes
+//! every `--env NAME=value` unquoted into a generated
+//! `/.inject-apptainer-env.sh` that the container sources at startup, so a name
+//! that is not a shell identifier, or a value carrying whitespace or shell
+//! metacharacters, aborts that script with "invalid var name". Every later
+//! variable is dropped with it, `PEPPY_RUNTIME_CONFIG` included, and the node
+//! then falls back to its standalone defaults instead of the parameters the
+//! daemon meant to hand it. A value holding shell metacharacters is also a
+//! command-injection vector inside the container. A process node is more
+//! forgiving, but a node gains or loses a `container` block over its life while
+//! the launcher file that deploys it stays the same, so one rule covers both.
+
+use core_node_api::FORBIDDEN_ENV_KEYS;
+use thiserror::Error;
+
+/// Whether `name` is a valid POSIX shell identifier (`[A-Za-z_][A-Za-z0-9_]*`).
+///
+/// The caller environment routinely holds names that are not: bash exports
+/// shell functions under keys like `BASH_FUNC_foo%%`, and other tooling uses
+/// keys with `%`, `(`, or `.`. None are meaningful to a node.
+pub fn is_valid_env_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    match chars.next() {
+        Some(first) if first == '_' || first.is_ascii_alphabetic() => {}
+        _ => return false,
+    }
+    chars.all(|c| c == '_' || c.is_ascii_alphanumeric())
+}
+
+/// Whether `value` survives an unquoted shell assignment unchanged: letters,
+/// digits, and the punctuation that appears in the values nodes actually take
+/// (device paths, hosts, ports, search paths, log filters, tokens).
+pub fn is_safe_env_value(value: &str) -> bool {
+    value.chars().all(|c| {
+        c.is_ascii_alphanumeric()
+            || matches!(c, '_' | '-' | '.' | '/' | ':' | ',' | '=' | '@' | '+' | '%')
+    })
+}
+
+/// Whether `name` is one of the [`FORBIDDEN_ENV_KEYS`]: dynamic-linker and
+/// shell hooks that turn an environment entry into code execution inside the
+/// node. Case-insensitive, so a lowercase spelling cannot slip past.
+pub fn is_forbidden_env_name(name: &str) -> bool {
+    FORBIDDEN_ENV_KEYS.contains(&name.trim().to_ascii_uppercase().as_str())
+}
+
+/// Why an explicitly declared environment variable cannot be given to a node.
+/// Only declarations a human wrote (a launcher instance's `env_vars`) produce
+/// this: the ambient caller environment is filtered, not rejected, because it
+/// carries entries the user never asked a node to see.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum InvalidEnvVar {
+    #[error(
+        "env var name `{name}` is not a valid shell identifier: a name must start with a letter \
+         or `_` and contain only letters, digits, and `_`"
+    )]
+    Name { name: String },
+    #[error(
+        "env var `{name}` is reserved: it is a dynamic-linker or shell hook that would let an \
+         environment entry run code inside the node"
+    )]
+    Forbidden { name: String },
+    #[error(
+        "value of env var `{name}` contains characters a node cannot receive intact: a value may \
+         hold letters, digits, and `_ - . / : , = @ + %` (no whitespace, quotes, or shell \
+         metacharacters)"
+    )]
+    Value { name: String },
+}
+
+/// Checks one explicitly declared environment variable against the rules above.
+/// Callers run this at their parse boundary so an entry that could not reach a
+/// node is rejected where the user wrote it, not at spawn time with the node
+/// half-deployed.
+pub fn check_env_var(name: &str, value: &str) -> Result<(), InvalidEnvVar> {
+    if !is_valid_env_name(name) {
+        return Err(InvalidEnvVar::Name {
+            name: name.to_string(),
+        });
+    }
+    if is_forbidden_env_name(name) {
+        return Err(InvalidEnvVar::Forbidden {
+            name: name.to_string(),
+        });
+    }
+    if !is_safe_env_value(value) {
+        return Err(InvalidEnvVar::Value {
+            name: name.to_string(),
+        });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn env_names_must_be_shell_identifiers() {
+        for name in [
+            "PATH",
+            "_underscore",
+            "ESP32_DEVICE",
+            "PEPPY_RUNTIME_CONFIG",
+            "X1",
+        ] {
+            assert!(is_valid_env_name(name), "`{name}` should be valid");
+        }
+        // `BASH_FUNC_foo%%` is how bash exports a shell function; the rest are
+        // the punctuation other tooling puts in keys.
+        for name in [
+            "",
+            "1foo",
+            "BASH_FUNC_foo%%",
+            "foo bar",
+            "foo.bar",
+            "foo(",
+            " PADDED",
+        ] {
+            assert!(!is_valid_env_name(name), "`{name}` should be rejected");
+        }
+    }
+
+    #[test]
+    fn env_values_must_survive_unquoted_assignment() {
+        // Real-world values: paths, endpoints, log filters, tokens, urls.
+        for value in [
+            "",
+            "/dev/ttyUSB0",
+            "/opt/node/.venv/bin:/usr/bin",
+            "127.0.0.1:7448",
+            "info,my_node=debug",
+            "sentry-release=app%401.2,public_key=abc",
+            "https://example.com/path",
+            "42",
+        ] {
+            assert!(is_safe_env_value(value), "`{value}` should be accepted");
+        }
+        // Whitespace splits an unquoted `export X=a b`, aborting the injection
+        // script; metacharacters would run inside the container.
+        for value in [
+            "user:inference user:file_upload",
+            "a\tb",
+            "line1\nline2",
+            "a;rm -rf /",
+            "$(whoami)",
+            "`id`",
+            "a|b",
+        ] {
+            assert!(!is_safe_env_value(value), "`{value}` should be rejected");
+        }
+    }
+
+    #[test]
+    fn forbidden_names_are_matched_case_insensitively() {
+        assert!(is_forbidden_env_name("LD_PRELOAD"));
+        assert!(is_forbidden_env_name("ld_preload"));
+        assert!(!is_forbidden_env_name("LD_PRELOADED"));
+    }
+
+    /// Each rejection names the offending variable and states its own rule, so
+    /// the message a user sees points at what to change.
+    #[test]
+    fn check_reports_the_rule_that_failed() {
+        assert_eq!(
+            check_env_var("has-dash", "ok"),
+            Err(InvalidEnvVar::Name {
+                name: "has-dash".to_string()
+            })
+        );
+        assert_eq!(
+            check_env_var("LD_PRELOAD", "/tmp/evil.so"),
+            Err(InvalidEnvVar::Forbidden {
+                name: "LD_PRELOAD".to_string()
+            })
+        );
+        assert_eq!(
+            check_env_var("GREETING", "hello world"),
+            Err(InvalidEnvVar::Value {
+                name: "GREETING".to_string()
+            })
+        );
+        assert_eq!(check_env_var("ESP32_DEVICE", "/dev/ttyUSB0"), Ok(()));
+    }
+}

--- a/crates/daemon-config-internal/src/launcher/types.rs
+++ b/crates/daemon-config-internal/src/launcher/types.rs
@@ -292,7 +292,12 @@ pub struct DeploymentInstance {
     pub instance_id: Name,
     #[serde(default)]
     pub arguments: BTreeMap<String, AnyType>,
-    #[serde(default)]
+    /// Environment variables handed to this instance's process, layered over
+    /// the caller environment the daemon forwards to every node (the instance
+    /// wins on a shared key). Validated at parse time against [`crate::env`],
+    /// so a launcher that parses carries only entries a node can actually
+    /// receive.
+    #[serde(default, deserialize_with = "deserialize_env_vars")]
     pub env_vars: BTreeMap<String, String>,
     #[serde(default)]
     pub framework: FrameworkOverrides,
@@ -371,6 +376,22 @@ where
         out.insert(key, value);
     }
     Ok(out)
+}
+
+/// The per-instance `env_vars` map. Every entry is checked here rather than at
+/// spawn time: `peppy stack launch` clears the running stack before it starts
+/// anything, so a name or value a node could not receive must fail while the
+/// file is being read (the CLI parses it locally first) instead of halfway
+/// through a launch that already tore the previous stack down.
+fn deserialize_env_vars<'de, D>(deserializer: D) -> Result<BTreeMap<String, String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let env_vars = BTreeMap::<String, String>::deserialize(deserializer)?;
+    for (name, value) in &env_vars {
+        crate::internal::env::check_env_var(name, value).map_err(de::Error::custom)?;
+    }
+    Ok(env_vars)
 }
 
 /// Splits a launcher `links` scalar target (or CLI `--link` right-hand side)
@@ -513,6 +534,35 @@ mod tests {
             with_env.env_vars.get("ESP32_DEVICE").map(String::as_str),
             Some("/dev/ttyUSB0")
         );
+    }
+
+    /// An `env_vars` entry a node could not receive intact is rejected while
+    /// the launcher is being parsed, and the message names the variable so the
+    /// user knows which line to fix.
+    #[test]
+    fn env_vars_reject_entries_a_node_cannot_receive() {
+        let cases = [
+            (
+                "{ \"has-dash\": \"ok\" }",
+                "`has-dash` is not a valid shell identifier",
+            ),
+            (
+                "{ LD_PRELOAD: \"/tmp/evil.so\" }",
+                "`LD_PRELOAD` is reserved",
+            ),
+            (
+                "{ GREETING: \"hello world\" }",
+                "value of env var `GREETING`",
+            ),
+            ("{ \"\": \"ok\" }", "not a valid shell identifier"),
+        ];
+        for (env_vars, expected) in cases {
+            let json5 = format!("{{ instance_id: \"esp32_1\", env_vars: {env_vars} }}");
+            let err = serde_json5::from_str::<DeploymentInstance>(&json5)
+                .expect_err(&format!("`{env_vars}` must be rejected"));
+            let msg = err.to_string();
+            assert!(msg.contains(expected), "expected `{expected}`, got: {msg}");
+        }
     }
 
     /// Per-instance framework overrides parse cleanly and round-trip back

--- a/crates/daemon-config-internal/src/lib.rs
+++ b/crates/daemon-config-internal/src/lib.rs
@@ -29,6 +29,7 @@ mod internal {
     pub mod atomic_write;
     pub mod consts;
     pub mod contract;
+    pub mod env;
     pub mod launcher;
     pub mod pairing;
     pub mod peppy_config;
@@ -44,6 +45,13 @@ pub use error::{
 // -- atomic_write --
 pub mod atomic_write {
     pub use crate::internal::atomic_write::publish_atomic;
+}
+
+// -- env --
+pub mod env {
+    pub use crate::internal::env::{
+        InvalidEnvVar, check_env_var, is_forbidden_env_name, is_safe_env_value, is_valid_env_name,
+    };
 }
 
 // -- consts --

--- a/crates/peppy/src/commands/node/env.rs
+++ b/crates/peppy/src/commands/node/env.rs
@@ -1,4 +1,4 @@
-use core_node_api::FORBIDDEN_ENV_KEYS;
+use daemon_config::env::{is_forbidden_env_name, is_safe_env_value, is_valid_env_name};
 
 /// Env vars that are meaningless or misleading when forwarded to a spawned node
 /// because the node runs somewhere the caller's paths do not describe: a
@@ -18,65 +18,29 @@ use core_node_api::FORBIDDEN_ENV_KEYS;
 /// runs both kinds of node.
 const CALLER_ONLY_ENV_KEYS: [&str; 5] = ["PWD", "OLDPWD", "TMPDIR", "TEMP", "TMP"];
 
-/// Whether `name` is a valid POSIX shell identifier (`[A-Za-z_][A-Za-z0-9_]*`).
+/// Whether a caller env var should be forwarded to a spawned node: it must
+/// carry a name and a value a node can receive intact (see [`daemon_config::env`],
+/// which states why and is the same rule the launcher's `env_vars` are parsed
+/// against), must not be a code injection vector, and must not be a caller-only
+/// var that is wrong in the node's working directory.
 ///
-/// Only such names can be forwarded to a containerized node. A node runs under
-/// apptainer, which writes every forwarded `--env NAME=value` into a generated
-/// `/.inject-apptainer-env.sh` that the container sources at startup. A name
-/// that is not a shell identifier makes that `source` abort with "invalid var
-/// name", and because the abort happens mid-script every later var is dropped,
-/// including `PEPPY_RUNTIME_CONFIG`. The node then silently falls back to its
-/// standalone defaults instead of the daemon-provided parameters.
-///
-/// The caller's environment routinely contains such names: bash exports shell
-/// functions under keys like `BASH_FUNC_foo%%`, and other tooling uses keys
-/// with `%`, `(`, or `.`. None of these are meaningful to a node, so dropping
-/// them is both safe and necessary.
-fn is_valid_env_name(name: &str) -> bool {
-    let mut chars = name.chars();
-    match chars.next() {
-        Some(first) if first == '_' || first.is_ascii_alphabetic() => {}
-        _ => return false,
-    }
-    chars.all(|c| c == '_' || c.is_ascii_alphanumeric())
-}
-
-/// Whether `value` is safe to forward to a containerized node.
-///
-/// Same root cause as [`is_valid_env_name`]: apptainer writes each forwarded
-/// `--env NAME=value` UNQUOTED into the `/.inject-apptainer-env.sh` the
-/// container sources, effectively `export NAME=value`. A value with whitespace
-/// makes the shell read trailing words as further export targets (`export X=a b`
-/// tries to export `b`), which aborts the script with "invalid var name" and
-/// drops every later var, including `PEPPY_RUNTIME_CONFIG`. Worse, a value with
-/// shell metacharacters is a command-injection vector (`X=a;cmd` would run
-/// `cmd` inside the container). Neither shape is meaningful for a node's
-/// environment, so we forward only values built from characters that survive an
-/// unquoted assignment unchanged.
-fn is_safe_env_value(value: &str) -> bool {
-    value.chars().all(|c| {
-        c.is_ascii_alphanumeric()
-            || matches!(c, '_' | '-' | '.' | '/' | ':' | ',' | '=' | '@' | '+' | '%')
-    })
-}
-
-/// Whether a caller env var should be forwarded to a spawned node: it must have
-/// a valid shell-identifier name (see [`is_valid_env_name`]) and a value safe to
-/// inject unquoted (see [`is_safe_env_value`]), not be a code injection vector,
-/// and not be a caller-only var that is wrong in the node's working directory.
+/// This side filters rather than rejects. The caller environment is ambient and
+/// full of entries nobody asked a node to see, so a failing entry is dropped
+/// silently; an `env_vars` entry a user wrote in a launcher file meets the same
+/// rules but fails loudly, while the file is being parsed.
 fn should_forward_env(key: &str, value: &str) -> bool {
     let normalized = key.trim().to_ascii_uppercase();
     is_valid_env_name(key)
         && is_safe_env_value(value)
-        && !FORBIDDEN_ENV_KEYS.contains(&normalized.as_str())
+        && !is_forbidden_env_name(key)
         && !CALLER_ONLY_ENV_KEYS.contains(&normalized.as_str())
 }
 
 /// Collects environment variables from the caller's environment to pass to the daemon.
 /// Filters out forbidden env vars that could be used for code injection,
 /// caller-only vars that would be incorrect in the node's working directory,
-/// vars whose names are not valid shell identifiers (see [`is_valid_env_name`]),
-/// and vars whose values are not safe to inject unquoted (see [`is_safe_env_value`]).
+/// and vars whose name or value a node could not receive intact (see
+/// [`should_forward_env`]).
 pub fn caller_env_overrides() -> Vec<(String, String)> {
     std::env::vars()
         .filter(|(key, value)| should_forward_env(key, value))
@@ -86,18 +50,6 @@ pub fn caller_env_overrides() -> Vec<(String, String)> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn rejects_non_identifier_env_names() {
-        // Bash exports functions under names like this; they break the
-        // container's env-injection script if forwarded.
-        assert!(!is_valid_env_name("BASH_FUNC_foo%%"));
-        assert!(!is_valid_env_name("foo bar"));
-        assert!(!is_valid_env_name("foo.bar"));
-        assert!(!is_valid_env_name("foo("));
-        assert!(!is_valid_env_name("1foo"));
-        assert!(!is_valid_env_name(""));
-    }
 
     /// The caller's temp dir describes the host, not the container. On macOS
     /// it is `/var/folders/…`, which the guest cannot write, so forwarding it
@@ -122,38 +74,6 @@ mod tests {
     fn keeps_env_vars_that_merely_mention_temp() {
         assert!(should_forward_env("TMPDIR_OVERRIDE", "/opt/scratch"));
         assert!(should_forward_env("PEPPY_TMP", "/opt/scratch"));
-    }
-
-    #[test]
-    fn accepts_valid_identifier_env_names() {
-        assert!(is_valid_env_name("PATH"));
-        assert!(is_valid_env_name("PEPPY_RUNTIME_CONFIG"));
-        assert!(is_valid_env_name("_underscore"));
-        assert!(is_valid_env_name("ROS_DOMAIN_ID"));
-        assert!(is_valid_env_name("X1"));
-    }
-
-    #[test]
-    fn rejects_unsafe_env_values() {
-        // Whitespace splits an unquoted `export X=a b` and aborts the script.
-        assert!(!is_safe_env_value("user:inference user:file_upload"));
-        assert!(!is_safe_env_value("a\tb"));
-        assert!(!is_safe_env_value("line1\nline2"));
-        // Shell metacharacters are command-injection vectors.
-        assert!(!is_safe_env_value("a;rm -rf /"));
-        assert!(!is_safe_env_value("$(whoami)"));
-        assert!(!is_safe_env_value("`id`"));
-        assert!(!is_safe_env_value("a|b"));
-    }
-
-    #[test]
-    fn accepts_safe_env_values() {
-        // Real-world safe values: paths, lists, ids, urls, ratios.
-        assert!(is_safe_env_value("/opt/node/.venv/bin:/usr/bin"));
-        assert!(is_safe_env_value("42"));
-        assert!(is_safe_env_value("sentry-release=app%401.2,public_key=abc"));
-        assert!(is_safe_env_value("https://example.com/path"));
-        assert!(is_safe_env_value(""));
     }
 
     #[test]

--- a/docs/src/content/docs/guides/launch_files.mdx
+++ b/docs/src/content/docs/guides/launch_files.mdx
@@ -38,7 +38,7 @@ In the `examples/` directory, you'll find a launcher file for each language. Ope
 
  1. The file is identified by `peppy_schema: "launcher/v1"` at the root: peppy uses this to distinguish launcher files from node `peppy.json5` files (which use `"node/v1"`)
  2. All deployments are defined in the `deployments` array
- 3. Each deployment requires a `source` and `instances` attribute. Besides `instance_id`, an instance can carry `arguments`, `env_vars`, `links` (one map filling every kind of `depends_on` slot, keyed by `link_id`), and `defer_links` (explicitly starting a required pairing or observer slot unresolved). A `links` value is interpreted against the slot it names: a producer slot (`depends_on.{nodes,contracts}`) takes a producer instance (a scalar for a `one` slot, an array for a multi-cardinality slot); a [pairing](/advanced_guides/pairing/) participant slot takes a single peer instance (`"<peer>"` or `"<peer>/<peer_link_id>"` to disambiguate); and an observer slot takes a single source instance to observe (`"<source>"` or `"<source>/<source_link_id>"`)
+ 3. Each deployment requires a `source` (where the node comes from) and an `instances` array (how many copies to start, and how each one is configured). Every entry needs an `instance_id`; `arguments`, `env_vars`, `framework`, `links`, and `defer_links` are optional. See [Instance attributes](#instance-attributes) for what each one does
 
 The `source` attribute supports four formats:
  - **URL**: A link to a `.tar.zst` archive, requiring both `url` and `sha256` attributes. The download is retried automatically on transient network failures (connection errors or `5xx` responses); a mismatch against `sha256`, or a client (`4xx`) error, fails immediately
@@ -153,3 +153,89 @@ $ peppy stack list
 ```
 
 The output confirms that all nodes have been added to the stack along with their dependency relationships. The `Instance bindings` table breaks that down per instance: the consumers (`fake_robot_brain`, `fake_video_reconstruction`) list the `depends_on` slots they resolved, while the producers (`fake_openarm01_controller`, `fake_uvc_camera`) and the core node declare no slots and show `(none)`. A resolved binding shows the chosen producer(s) as `instance_id@core_node`, ordered by link ID; a multi-cardinality slot lists every bound member in binding order, and a `zero_or_more` slot bound to nothing shows `(empty set)`. Every declared slot except `zero_or_more` must be bound (a launcher that leaves one out is rejected at validation); see [dependency cardinality](/advanced_guides/topics/#dependency-cardinality).
+
+## Instance attributes
+
+Every entry in an `instances` array configures one running copy of the deployment's node. Two instances of the same node are independent: they get their own arguments, their own environment, and their own bindings.
+
+```json5 title="peppy_launcher.json5"
+{
+  source: { local: "./uvc_camera" },
+  instances: [
+    {
+      instance_id: "camera_front",
+      arguments: { device: { path: "/dev/video0" }, frame_rate: 30 },
+      env_vars: { GST_DEBUG: "2" },
+      framework: { use_sim_time: false },
+    },
+    {
+      instance_id: "camera_rear",
+      arguments: { device: { path: "/dev/video1" }, frame_rate: 15 },
+    },
+  ],
+}
+```
+
+### `instance_id` (required)
+
+The name this copy runs under. It labels the instance in `peppy stack list`, in its log file, and in every `links` value that points at it.
+
+Allowed characters are letters, digits, `_` and `-`. The id must be unique across the whole stack, not just within its own deployment: two deployments cannot both declare `camera_front`, and no instance may take the core node's own id. A collision is reported before anything starts.
+
+### `arguments` (optional)
+
+Values for the parameters the node declares in its `execution.parameters` block, written with the same nesting as that schema. See the [Parameters reference](/reference/parameters/) for the full syntax.
+
+A parameter that declares a `$default` may be omitted, and the daemon fills it in before the node starts. A required parameter left without a value fails the launch as that instance starts, naming the leaf it is missing (`Missing required parameters: device.serial`). Unknown keys and type mismatches are caught by the node itself as it boots, so they surface as that instance failing to come up.
+
+A [container node](/advanced_guides/containers/) can also reference these values in its `mount_paths` with `${parameters:<path>}`, which is how two instances of one node mount two different host devices.
+
+### `env_vars` (optional)
+
+Environment variables for this instance's process.
+
+`peppy stack launch` forwards your own shell environment to every node it starts, so a node already sees your `PATH` and the rest. `env_vars` is layered on top of that for what differs per instance (a device path, a board serial, a log level), and a name declared here replaces the forwarded value:
+
+```json5
+{
+  source: { local: "./esp32_board" },
+  instances: [
+    { instance_id: "esp32_left",  env_vars: { ESP32_DEVICE: "/dev/ttyUSB0" } },
+    { instance_id: "esp32_right", env_vars: { ESP32_DEVICE: "/dev/ttyUSB1" } },
+  ],
+}
+```
+
+Entries are checked when the launcher file is read, before the running stack is touched:
+
+- **Names** must be shell identifiers: a letter or `_` first, then letters, digits and `_`. `ESP32_DEVICE` is fine, `esp32-device` is not.
+- **Values** may hold letters, digits and `` _ - . / : , = @ + % ``. Whitespace, quotes and shell metacharacters (`;`, `$`, `` ` ``, `|`, and friends) are rejected, so a value like `"--flag other"` has to reach the node another way, typically as an [argument](#arguments-optional).
+- **Injection-prone names** are rejected outright: the dynamic-linker and shell hooks (`LD_PRELOAD`, `LD_LIBRARY_PATH`, `DYLD_INSERT_LIBRARIES`, `BASH_ENV`, `IFS`, and the rest of that family).
+
+:::note
+The name and value rules exist because a container node receives its environment through Apptainer, which writes each variable unquoted into a script the container sources at startup. A name or value that does not survive that step would take `PEPPY_RUNTIME_CONFIG` down with it and leave the node running on its standalone defaults. The same rule applies to process nodes so that adding a `container` block to a node later cannot break the launchers that already deploy it.
+:::
+
+`env_vars` reach the instance when it starts. Fetching and building a node happen once for the node, not once per instance, so a variable your build needs (a registry token, a toolchain path) belongs in the shell you run `peppy stack launch` from, where it is forwarded to those steps too.
+
+### `framework` (optional)
+
+Framework knobs owned by peppylib rather than by the node author, so they mean the same thing for every node. Today the block holds one:
+
+- `use_sim_time`: read the clock from a simulator or bag replay instead of the daemon's wall clock. Setting it here wins over the daemon's `--clock-source` flag; omitting it falls through to that flag (which defaults to `wall`). See [System clock](/advanced_guides/system_clock/#sim-and-replay-clocks).
+
+An unknown key inside `framework` is an error rather than a no-op, so a typo like `use_simulation_time` fails the launch instead of silently leaving the instance on wall time.
+
+### `links` (optional)
+
+One map filling every kind of `depends_on` slot the node declares, keyed by the slot's `link_id`. A value is interpreted against the slot it names:
+
+- a producer slot (`depends_on.nodes` / `depends_on.contracts`) takes the producer instance to bind: a scalar for a `one` slot, an array for a multi-cardinality slot;
+- a [pairing](/advanced_guides/pairing/) participant slot takes a single peer instance, `"<peer>"` or `"<peer>/<peer_link_id>"` to disambiguate which of the peer's slots to use;
+- an observer slot takes the single source instance to observe, `"<source>"` or `"<source>/<source_link_id>"`.
+
+Every target must name an `instance_id` declared somewhere in the same launcher.
+
+### `defer_links` (optional)
+
+The `link_id`s of required pairing or observer slots this instance should start with left unresolved, listed by name. Every required participant slot must either be paired or appear here, and every observer slot must either be linked or appear here; a producer-binding slot cannot be deferred. Use it when the peer arrives later, at runtime, rather than in this launch.


### PR DESCRIPTION
Instance env_vars now layer over the forwarded caller environment (winning on shared keys) when starting a node process. The name/value safety rules previously used only to filter forwarded CLI env vars are extracted into daemon-config-internal::env and reused to validate launcher env_vars at parse time, so an invalid entry fails before the stack is touched. Adds launcher parsing and end-to-end launch tests, and documents the new `env_vars` behavior alongside the other instance attributes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for per-instance environment variables in launch configurations.
  * Per-instance values override forwarded environment values with the same name.
  * Added validation for environment variable names and values, including protection against reserved or unsafe entries.

* **Documentation**
  * Expanded launch-file guidance covering instance attributes, environment variables, arguments, frameworks, links, and deferred links.

* **Bug Fixes**
  * Ensured configured environment variables are consistently passed to spawned node instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->