### PR TITLE
Register the core node explicitly instead of via the config pull

### DIFF
--- a/crates/auth-internal/src/client.rs
+++ b/crates/auth-internal/src/client.rs
@@ -1,9 +1,16 @@
 //! Authenticated calls to the `platform-backend` resource server: `GET /me`,
-//! `POST /logout`, and `POST /me/cli/federation` (fetch the
-//! shared router's connection config). On a `401` with a refreshable session credential the
-//! request is retried once after refreshing (and persisting) the token; a `401`
-//! on a PAT is a hard error (a PAT cannot be refreshed). `502`/`503` map to
-//! distinct messages so an ops problem isn't mistaken for a bad token.
+//! `POST /logout`, `GET /me/cli/router-config` (fetch the shared router's
+//! connection config), and `POST /me/core-nodes` (claim this machine's
+//! identity). On a `401` with a refreshable session credential the request is
+//! retried once after refreshing (and persisting) the token; a `401` on a PAT is
+//! a hard error (a PAT cannot be refreshed). `502`/`503` map to distinct
+//! messages so an ops problem isn't mistaken for a bad token.
+//!
+//! Reading the router config and claiming an identity are separate calls
+//! deliberately. The config is valid for anyone holding the token; the identity
+//! claim is valid only for a daemon generation that has settled its namespace
+//! and owns the router it names. Fusing them let a generation about to be torn
+//! down publish a zid it never ran under.
 
 use config::namespace::Namespace;
 use secrecy::ExposeSecret;
@@ -78,16 +85,17 @@ pub struct CoreNodeEntry {
     pub core_node_name: String,
     /// Whether the platform has a registry row for this name. `false` is the
     /// normal appearance of a `zenoh.external` daemon, which adopts its cached
-    /// workspace namespace but never pulls federation config.
+    /// workspace namespace but never registers.
     #[serde(default)]
     pub registered: bool,
     /// RFC 3339 UTC, or null on an unregistered entry.
     #[serde(default)]
     pub first_seen_at: Option<String>,
-    /// RFC 3339 UTC, or null on an unregistered entry. A config-pull time, not
-    /// a liveness signal, which is why it is never rendered as "last seen".
+    /// RFC 3339 UTC, or null on an unregistered entry. When that machine last
+    /// asserted its identity, not a liveness signal, which is why it is never
+    /// rendered as "last seen".
     #[serde(default)]
-    pub last_config_pull_at: Option<String>,
+    pub last_registered_at: Option<String>,
     #[serde(default)]
     pub network: NetworkStatus,
     #[serde(default)]
@@ -215,36 +223,51 @@ pub fn split_locator(endpoint: &str) -> Result<(String, u16)> {
     Ok((host.to_string(), port))
 }
 
-/// `POST {api_url}/me/cli/federation`: fetch the shared router's
-/// connection config (the daemon's discovery point), refreshing the access token
-/// once on a 401 for session credentials (the same reactive-refresh contract as
+/// `GET {api_url}/me/cli/router-config`: fetch the shared router's connection
+/// config (the daemon's discovery point), refreshing the access token once on a
+/// 401 for session credentials (the same reactive-refresh contract as
 /// [`get_me`]). The daemon dials the returned endpoint over one-way TLS,
 /// verifying the router's certificate and presenting none of its own.
 ///
-/// The body always carries two required fields, both upserted into the backend's
-/// per-principal core-node registry:
+/// Carries no daemon identity, and the call writes nothing on the backend.
+/// Claiming an identity is [`register_core_node`].
+pub fn fetch_router_config(
+    http: &HttpClient,
+    api_url: &str,
+    cred: &mut Credential,
+) -> Result<ZenohRouterConfig> {
+    authed_get_json(http, api_url, "/me/cli/router-config", cred)
+}
+
+/// `POST {api_url}/me/core-nodes`: record that this machine runs
+/// `core_node_name` behind the router `router_zid` pins, refreshing the access
+/// token once on a 401 for session credentials.
 ///
-/// * `core_node_name`, the daemon's application-layer identity (its
-///   `last_seen_at` tracks config pulls, not liveness).
-/// * `router_zid`, the transport identity this daemon's managed router pins.
-///   The platform joins it against the shared router's live session list, which
-///   is what separates "the uplink is up, the daemon is not" from "this site is
-///   unreachable". Only a managed daemon pulls federation config, and a managed
-///   daemon always owns a router, so there is no caller that legitimately lacks
-///   one and the backend rejects a request without it.
-pub fn establish_federation(
+/// The platform joins the zid against the shared router's live session list,
+/// which is what separates "the uplink is up, the daemon is not" from "this site
+/// is unreachable". The caller must therefore pass the identity its live router
+/// actually pins, never one read back from disk after the fact.
+pub fn register_core_node(
     http: &HttpClient,
     api_url: &str,
     cred: &mut Credential,
     core_node_name: &str,
     router_zid: &pmi::RouterId,
-) -> Result<ZenohRouterConfig> {
+) -> Result<()> {
     let body = serde_json::json!({
         "core_node_name": core_node_name,
         "router_zid": router_zid.as_str(),
     })
     .to_string();
-    authed_post_json(http, api_url, "/me/cli/federation", &body, cred)
+    let path = "/me/core-nodes";
+    let url = format!("{}{}", api_url.trim_end_matches('/'), path);
+    let resp = authed_post(http, &url, &body, cred)?;
+    // A registration answers `204`, so there is no body to deserialize; the rest
+    // of the status contract is the one every authed call shares.
+    match resp.status {
+        204 => Ok(()),
+        status => Err(interpret_authed_status(status, cred, "POST", &url)),
+    }
 }
 
 /// `POST {api_url}/logout` with the current access token. Returns the status code
@@ -322,27 +345,10 @@ fn authed_get_json<T: DeserializeOwned>(
     interpret_authed_json(resp, cred, "GET", &url, path)
 }
 
-/// An authenticated `POST {api_url}{path}` with a JSON `body` whose `200` response
-/// deserializes to `T`. See [`interpret_authed_json`] for the shared status
-/// contract.
-fn authed_post_json<T: DeserializeOwned>(
-    http: &HttpClient,
-    api_url: &str,
-    path: &str,
-    body: &str,
-    cred: &mut Credential,
-) -> Result<T> {
-    let url = format!("{}{}", api_url.trim_end_matches('/'), path);
-    let resp = authed_post(http, &url, body, cred)?;
-    interpret_authed_json(resp, cred, "POST", &url, path)
-}
-
 /// The status contract every authenticated `/me*` JSON endpoint shares: a `200`
-/// body deserializes to `T`, a `401` becomes the credential-specific auth error
-/// (after the single reactive refresh the `authed_*` callers already attempt),
-/// `502`/`503` map to distinct ops-vs-token messages, and any other status to a
-/// generic HTTP error. `path` doubles as the deserialization context label, so a
-/// new authed endpoint is one line, not a copied block.
+/// body deserializes to `T`, and every other status goes through
+/// [`interpret_authed_status`]. `path` doubles as the deserialization context
+/// label, so a new authed endpoint is one line, not a copied block.
 fn interpret_authed_json<T: DeserializeOwned>(
     resp: HttpResponse,
     cred: &Credential,
@@ -352,15 +358,27 @@ fn interpret_authed_json<T: DeserializeOwned>(
 ) -> Result<T> {
     match resp.status {
         200 => resp.json(path),
-        401 => Err(unauthorized_error(cred)),
-        502 => Err(Error::Auth(
+        status => Err(interpret_authed_status(status, cred, method, url)),
+    }
+}
+
+/// The failure half of that contract, shared by the JSON endpoints and the
+/// bodyless ones (which cannot go through [`interpret_authed_json`] at all): a
+/// `401` becomes the credential-specific auth error (after the single reactive
+/// refresh the `authed_*` callers already attempt), `502`/`503` map to distinct
+/// ops-vs-token messages, and any other status to a generic HTTP error.
+///
+/// Split out rather than duplicated so the two interpreters cannot drift on what
+/// a `503` means.
+fn interpret_authed_status(status: u16, cred: &Credential, method: &str, url: &str) -> Error {
+    match status {
+        401 => unauthorized_error(cred),
+        502 => Error::Auth(
             "the backend's introspection credentials were rejected (server-side problem)"
                 .to_string(),
-        )),
-        503 => Err(Error::Http(
-            "backend temporarily unavailable, try again shortly".to_string(),
-        )),
-        s => Err(Error::Http(format!("{method} {url} returned {s}"))),
+        ),
+        503 => Error::Http("backend temporarily unavailable, try again shortly".to_string()),
+        s => Error::Http(format!("{method} {url} returned {s}")),
     }
 }
 

--- a/crates/auth-internal/src/router.rs
+++ b/crates/auth-internal/src/router.rs
@@ -2,9 +2,11 @@
 //! session.
 //!
 //! The flow mirrors the OAuth resolver: reuse the cached router config while it
-//! is fresh, otherwise fetch a new one from `POST /me/cli/federation`
-//! (refreshing the access token on a `401` via [`client::establish_federation`])
-//! and cache it beside the session. The CA the router is validated against is
+//! is fresh, otherwise fetch a new one from `GET /me/cli/router-config`
+//! (refreshing the access token on a `401` via [`client::fetch_router_config`])
+//! and cache it beside the session. That fetch is side-effect free: claiming
+//! this machine's identity is [`register_core_node`], a separate call the daemon
+//! makes only once it has settled its namespace and owns its router. The CA the router is validated against is
 //! resolved CLI-side at connect time (see [`resolve_router_ca`]), **not** taken
 //! from the server's response: a debug build trusts the committed dev CA embedded
 //! in the binary; a release build validates against the system trust store. There
@@ -115,15 +117,10 @@ fn materialize_embedded(cache_dir: &Path, filename: &str, bytes: &[u8]) -> Optio
 /// is fresh, else pulls a new config and caches it. `api_url` and `pat` follow the
 /// same resolution the auth commands use; `ca_certificate` (the trust anchor, see
 /// [`resolve_router_ca`]) is applied fresh to the live TLS at connect
-/// time (never cached on disk). `core_node_name` is the daemon's core-node name,
-/// carried in the pull's POST body to register the daemon in the backend's
-/// core-node registry (see [`client::establish_federation`]); it also
-/// tags the cache, so a resolve under a different name (a renamed daemon) always
-/// re-pulls and re-registers rather than reusing a still-fresh cache.
-/// `router_zid` is the managed router's pinned transport identity, carried in
-/// the same POST so the registered row can be matched against the shared
-/// router's live session list. Unlike the name, it deliberately does not
-/// participate in cache reuse (see the cache comment below).
+/// time (never cached on disk).
+///
+/// Carries no daemon identity: the router config is identical for every core
+/// node in a workspace, and registering one is [`register_core_node`]'s job.
 ///
 /// Only the pull path needs a credential, so a fresh cache is reused without
 /// touching the token at all.
@@ -133,8 +130,6 @@ pub fn resolve_router_endpoint(
     api_url: &str,
     pat: Option<String>,
     ca_certificate: Option<PathBuf>,
-    core_node_name: &str,
-    router_zid: &pmi::RouterId,
 ) -> Result<RouterEndpoint> {
     let now = storage::now_unix();
     // Load once: the cached router config and the active session's subject come
@@ -156,39 +151,21 @@ pub fn resolve_router_endpoint(
     // cannot match on this fast path, and re-pulling is cheap (federation resolves
     // only at startup and on a login/logout poke).
     //
-    // The cache is additionally bound to the core-node name it was pulled under
-    // (`rs.core_node_name`): the pull's POST is what registers the daemon in the
-    // backend's core-node registry, so a renamed daemon (the `CoreNodeNameTaken`
-    // collision-fix workflow: set `core_node_name`, restart) must re-pull — and
-    // thereby register its new name — instead of reusing a still-fresh cache and
-    // staying absent from the registry until the cache goes stale.
-    //
-    // The router zid deliberately does NOT tag the cache. It changes only when
-    // the workspace changes (which clears this cache with the session) or when
-    // the identity record is lost, and adding it to the cached `RouterSession`
-    // would invalidate every credentials file on disk to close that second,
-    // narrow case. A re-minted identity simply re-registers on the next stale
-    // pull; until then the row reads `indirect`, which is a less specific answer
-    // rather than a wrong one.
+    // Nothing else tags the cache. Neither the core-node name nor the router zid
+    // changes what the backend answers here (the config is per workspace, not per
+    // daemon), and registration no longer rides on this pull, so a rename or a
+    // re-minted identity has no reason to force one. The `subject` tag stays: it
+    // guards a real cross-identity leak.
     let reuse_cache = pat.is_none() && !active_subject.is_empty();
     let (endpoint, namespace) = match creds.router {
         Some(rs)
             if reuse_cache
                 && !rs.is_stale(now, REPULL_SKEW_SECS)
-                && rs.subject == active_subject
-                && rs.core_node_name == core_node_name =>
+                && rs.subject == active_subject =>
         {
             (rs.endpoint, rs.namespace)
         }
-        _ => pull_and_cache(
-            creds_path,
-            http,
-            api_url,
-            pat,
-            now,
-            core_node_name,
-            router_zid,
-        )?,
+        _ => pull_and_cache(creds_path, http, api_url, pat, now)?,
     };
 
     let (host, port) = client::split_locator(&endpoint)?;
@@ -204,17 +181,13 @@ pub fn resolve_router_endpoint(
 /// the session, and returns the endpoint locator. `now` is threaded in so the
 /// cached `repull_after` uses the same clock reading as the freshness check. The
 /// trust anchor is resolved fresh at connect time (see [`resolve_router_ca`]), so
-/// it is deliberately not part of the cached `RouterSession`. The pull identifies
-/// the daemon by `core_node_name` and `router_zid` (the POST body), upserting
-/// both into the backend's core-node registry.
+/// it is deliberately not part of the cached `RouterSession`.
 fn pull_and_cache(
     creds_path: &Path,
     http: &HttpClient,
     api_url: &str,
     pat: Option<String>,
     now: i64,
-    core_node_name: &str,
-    router_zid: &pmi::RouterId,
 ) -> Result<(String, config::namespace::Namespace)> {
     let mut cred = resolver::resolve(creds_path, http, pat)?;
     // The identity this pull is actually authenticated as drives the cache tag
@@ -222,7 +195,7 @@ fn pull_and_cache(
     // session subject; doing so would let the session reuse the PAT's workspace once the
     // PAT is gone (a cross-identity leak).
     let is_pat = matches!(cred.kind, resolver::CredentialKind::Pat);
-    let cfg = client::establish_federation(http, api_url, &mut cred, core_node_name, router_zid)?;
+    let cfg = client::fetch_router_config(http, api_url, &mut cred)?;
 
     // Validate the config *before* it is written to `creds.router`: a malformed
     // endpoint or an unsupported transport must not poison the on-disk
@@ -265,9 +238,6 @@ fn pull_and_cache(
         repull_after: now.saturating_add(saturating_secs_to_i64(cfg.reconnect_after_secs)),
         namespace: cfg.namespace.clone(),
         subject,
-        // Tag the cache with the name this pull registered, so a rename forces
-        // a re-pull (and re-registration) even while the cache is still fresh.
-        core_node_name: core_node_name.to_string(),
     });
     storage::save(creds_path, &creds)?;
     Ok((cfg.endpoint, cfg.namespace))
@@ -287,11 +257,6 @@ fn pull_and_cache(
 /// backend can't stall the caller (federation at startup / on a login-poke)
 /// beyond it; on timeout the pull errors and this returns `None`.
 ///
-/// `core_node_name` is the daemon's core-node name and `router_zid` its managed
-/// router's pinned transport identity; both are sent in every pull's POST body
-/// so the backend registry records which daemon federated (and when it last
-/// pulled), and can match this site against the shared router's session list.
-///
 /// `peppy_dirs` is the caller's resolved peppy data root: the credentials file
 /// and the materialized dev TLS material both derive from it, so a daemon
 /// running under an injected root (a test) never reads the machine's real
@@ -301,8 +266,6 @@ pub fn resolve_federation_target(
     peppy_dirs: &PeppyDirs,
     api_url: &str,
     connect_timeout: Duration,
-    core_node_name: &str,
-    router_zid: &pmi::RouterId,
 ) -> Option<(String, pmi::TlsConfig)> {
     let cache_dir = peppy_dirs.cache_dir();
     resolve_federation_target_at(
@@ -311,8 +274,6 @@ pub fn resolve_federation_target(
         resolver::pat_from_env(),
         resolve_router_ca(&cache_dir),
         connect_timeout,
-        core_node_name,
-        router_zid,
     )
 }
 
@@ -326,8 +287,6 @@ pub fn resolve_federation_target_at(
     pat: Option<String>,
     ca_certificate: Option<PathBuf>,
     connect_timeout: Duration,
-    core_node_name: &str,
-    router_zid: &pmi::RouterId,
 ) -> Option<(String, pmi::TlsConfig)> {
     // Skip the network entirely when there is plainly no identity to pull for, so
     // an un-provisioned dev box does not log a spurious auth error every poll. Take
@@ -349,15 +308,7 @@ pub fn resolve_federation_target_at(
         }
     }
     let http = HttpClient::with_timeout(connect_timeout);
-    match resolve_router_endpoint(
-        creds_path,
-        &http,
-        api_url,
-        pat,
-        ca_certificate,
-        core_node_name,
-        router_zid,
-    ) {
+    match resolve_router_endpoint(creds_path, &http, api_url, pat, ca_certificate) {
         // Fail-closed gate, single source: only a validated, non-local namespace
         // federates. The daemon session is resolved from the same cached value.
         Ok(ep) if !ep.namespace.is_local() => {
@@ -378,6 +329,34 @@ pub fn resolve_federation_target_at(
             None
         }
     }
+}
+
+/// Claim this machine's identity on the platform: record that `core_node_name`
+/// runs behind the router `router_zid` pins
+/// (`POST /me/core-nodes`, see [`client::register_core_node`]).
+///
+/// Blocking, and errors propagate rather than degrading to `None`: unlike the
+/// federation target, a failure here is not "stay standalone", it is "the
+/// platform's view of this machine is now stale", which the caller reports.
+///
+/// The credential is resolved exactly as [`resolve_federation_target`] resolves
+/// it (`PEPPY_API_KEY` first, else the on-disk session), and that parity is load
+/// bearing. The backend derives the workspace from whichever principal
+/// authenticated, so a session-authenticated registration paired with a
+/// PAT-authenticated config pull would write this row into the **session
+/// owner's** workspace while the daemon runs under the **PAT owner's**
+/// namespace. That is the same class of bug this split exists to remove.
+pub fn register_core_node(
+    peppy_dirs: &PeppyDirs,
+    api_url: &str,
+    connect_timeout: Duration,
+    core_node_name: &str,
+    router_zid: &pmi::RouterId,
+) -> Result<()> {
+    let creds_path = storage::credentials_path(peppy_dirs);
+    let http = HttpClient::with_timeout(connect_timeout);
+    let mut cred = resolver::resolve(&creds_path, &http, resolver::pat_from_env())?;
+    client::register_core_node(&http, api_url, &mut cred, core_node_name, router_zid)
 }
 
 /// Resolve the daemon's session namespace from credentials. A missing file or a

--- a/crates/auth-internal/src/storage.rs
+++ b/crates/auth-internal/src/storage.rs
@@ -80,15 +80,6 @@ pub struct RouterSession {
     /// reused under the wrong workspace. Empty for a PAT pull (no session). Required
     /// for the same clean-break reason as `namespace`.
     pub subject: String,
-    /// The core-node name the config was pulled under (the pull's POST body,
-    /// which registers the daemon in the backend's core-node registry). Tags
-    /// the cache like `subject` does: a fresh cache pulled under a *different*
-    /// name is not reused, so a renamed daemon (e.g. after a
-    /// `CoreNodeNameTaken` collision fix) re-pulls — and re-registers — on its
-    /// next resolve instead of staying absent from the registry until the
-    /// cache goes stale. Required for the same clean-break reason as
-    /// `namespace`.
-    pub core_node_name: String,
 }
 
 impl RouterSession {
@@ -329,7 +320,6 @@ mod tests {
                 )
                 .unwrap(),
                 subject: "auth0|alice".into(),
-                core_node_name: "core-node-alice-1".into(),
             }),
             ..Default::default()
         };
@@ -345,14 +335,17 @@ mod tests {
             "550e8400-e29b-41d4-a716-446655440000"
         );
         assert_eq!(rs.subject, "auth0|alice");
-        assert_eq!(rs.core_node_name, "core-node-alice-1");
     }
 
-    /// A cached router session missing the `core_node_name` tag is rejected
-    /// outright (no back-compat default), the same clean break as
-    /// `namespace`: `auth login`/`logout` start fresh.
+    /// A credentials file written while `RouterSession` still carried a
+    /// `core_node_name` tag keeps parsing: the key is ignored and dropped on the
+    /// next save. No migration, no version bump.
+    ///
+    /// Worth pinning rather than assuming, because it rests entirely on this
+    /// document not being `deny_unknown_fields`: adding that would log out every
+    /// machine on disk without any code here changing.
     #[test]
-    fn rejects_a_router_session_missing_the_core_node_name() {
+    fn a_router_session_carrying_the_removed_name_tag_still_parses() {
         let dir = tempfile::tempdir().expect("temp dir");
         let path = dir.path().join("conf").join("credentials.json5");
         std::fs::create_dir_all(path.parent().unwrap()).expect("mkdir");
@@ -362,15 +355,23 @@ mod tests {
                 r#"{{ version: {CREDENTIALS_VERSION}, router: {{
                     endpoint: "tls/cap:7443", protocol: "tls", repull_after: 1,
                     namespace: "550e8400-e29b-41d4-a716-446655440000",
-                    subject: "auth0|alice" }} }}"#
+                    subject: "auth0|alice", core_node_name: "cn-old" }} }}"#
             ),
         )
-        .expect("write pre-name-tag file");
+        .expect("write a file carrying the removed tag");
 
-        let err = load(&path).expect_err("missing name tag must be rejected");
+        let loaded = load(&path).expect("the removed tag must not fail the load");
+        assert_eq!(
+            loaded.router.as_ref().expect("router session").subject,
+            "auth0|alice"
+        );
+
+        save(&path, &loaded).expect("save");
         assert!(
-            err.to_string().contains("failed to parse"),
-            "rejection should surface as a parse error: {err}"
+            !std::fs::read_to_string(&path)
+                .expect("read back")
+                .contains("core_node_name"),
+            "the stale key is dropped on the next save rather than carried forever"
         );
     }
 
@@ -410,7 +411,6 @@ mod tests {
             namespace: config::namespace::Namespace::parse("550e8400-e29b-41d4-a716-446655440000")
                 .unwrap(),
             subject: "auth0|alice".into(),
-            core_node_name: "core-node-alice-1".into(),
         };
         assert!(!rs.is_stale(900, 30));
         assert!(rs.is_stale(980, 30)); // 980 + 30 >= 1000

--- a/crates/auth-internal/tests/auth_flow.rs
+++ b/crates/auth-internal/tests/auth_flow.rs
@@ -1,6 +1,6 @@
 //! Engine-level auth tests with every HTTP endpoint mocked (`httpmock`): OIDC
-//! discovery, the Zitadel token endpoint, and the backend `/me` +
-//! `/me/cli/federation`. All auth state is isolated per test via an
+//! discovery, the Zitadel token endpoint, and the backend `/me`,
+//! `/me/cli/router-config`, and `/me/core-nodes`. All auth state is isolated per test via an
 //! explicit credentials path under a tempdir (no `PEPPY_HOME` mutation, so
 //! tests run in parallel). The command-level flows (`peppy platform login` /
 //! `logout` / `whoami`) are covered by the `peppy` crate's own auth tests.
@@ -164,11 +164,11 @@ fn get_me_parses_principal_with_unknown_fields() {
     assert_eq!(principal.display_name(), "alice");
 }
 
-/// The core-node name the federation-pull tests identify the daemon with. The
-/// pull mocks *require* it as the POST body (`json_body`), so a pull that
-/// drops or malforms the body gets no mock response and fails its test.
+/// The core-node name the registration tests claim. The registration mocks
+/// *require* it as the POST body (`json_body`), so a call that drops or
+/// malforms the body gets no mock response and fails its test.
 const CORE_NODE: &str = "core-node-test-1";
-/// The managed router identity every federation pull in these tests reports.
+/// The managed router identity those registrations report.
 const ROUTER_ZID: &str = "7f3a9c1e";
 
 fn router_zid() -> pmi::RouterId {
@@ -180,17 +180,14 @@ fn workspace_namespace() -> config::namespace::Namespace {
 }
 
 #[test]
-fn establish_federation_parses_the_contract() {
+fn fetch_router_config_parses_the_contract() {
     let server = MockServer::start();
-    // The shared router is static, so the POST provisions nothing — but its body
-    // must always identify the daemon by BOTH its core-node name (the
-    // application layer) and its router zid (the transport layer); the backend
-    // registry requires both. The matcher rejects any other body, so this is the
-    // wire-contract check for the pair.
+    // The shared router is static, so this read provisions nothing and carries
+    // no daemon identity: the matcher is a bare GET, and a client that started
+    // sending a body again would still match it. What pins the absence of a
+    // write is the backend's own `router_config_returns_the_shared_router_config`.
     let cfg_mock = server.mock(|when, then| {
-        when.method(POST)
-            .path("/me/cli/federation")
-            .json_body(json!({ "core_node_name": CORE_NODE, "router_zid": ROUTER_ZID }));
+        when.method(GET).path("/me/cli/router-config");
         then.status(200).json_body(json!({
             "endpoint": "tls/localhost:7447",
             "protocol": "tls",
@@ -207,14 +204,8 @@ fn establish_federation_parses_the_contract() {
         token: storage::secret("any-token".to_string()),
         kind: CredentialKind::Pat,
     };
-    let cfg = client::establish_federation(
-        &http,
-        &server.base_url(),
-        &mut cred,
-        CORE_NODE,
-        &router_zid(),
-    )
-    .expect("fetch shared router config");
+    let cfg = client::fetch_router_config(&http, &server.base_url(), &mut cred)
+        .expect("fetch shared router config");
     assert_eq!(cfg.protocol, "tls");
     assert_eq!(cfg.reconnect_after_secs, 3000);
     assert_eq!(cfg.namespace, workspace_namespace());
@@ -250,21 +241,19 @@ fn router_config_pull_refreshes_on_401_then_re_pulls() {
             "scope": "openid",
         }));
     });
-    // First pull (seeded token) is rejected; the retry (rotated token) succeeds.
-    // Both matchers require the full identity body, so the retry provably
-    // re-sends it rather than dropping a field on the way through.
+    // The first read (seeded token) is rejected; the retry (rotated token)
+    // succeeds. The matchers key on the Authorization header, so the retry
+    // provably re-issues the request under the rotated token.
     let pull_rejected = server.mock(|when, then| {
-        when.method(POST)
-            .path("/me/cli/federation")
-            .header("Authorization", "Bearer seeded-access")
-            .json_body(json!({ "core_node_name": CORE_NODE, "router_zid": ROUTER_ZID }));
+        when.method(GET)
+            .path("/me/cli/router-config")
+            .header("Authorization", "Bearer seeded-access");
         then.status(401);
     });
     let pull_ok = server.mock(|when, then| {
-        when.method(POST)
-            .path("/me/cli/federation")
-            .header("Authorization", "Bearer refreshed-access")
-            .json_body(json!({ "core_node_name": CORE_NODE, "router_zid": ROUTER_ZID }));
+        when.method(GET)
+            .path("/me/cli/router-config")
+            .header("Authorization", "Bearer refreshed-access");
         then.status(200).json_body(json!({
             "endpoint": "tls/cap.zenoh.localhost:7443",
             "protocol": "tls",
@@ -294,14 +283,8 @@ fn router_config_pull_refreshes_on_401_then_re_pulls() {
         }),
     };
 
-    let cfg = client::establish_federation(
-        &http,
-        &server.base_url(),
-        &mut cred,
-        CORE_NODE,
-        &router_zid(),
-    )
-    .expect("pull after refresh");
+    let cfg = client::fetch_router_config(&http, &server.base_url(), &mut cred)
+        .expect("pull after refresh");
     assert_eq!(
         cfg.host_port().unwrap(),
         ("cap.zenoh.localhost".to_string(), 7443)
@@ -331,7 +314,7 @@ fn resolve_router_endpoint_reuses_a_fresh_cache_without_pulling() {
     // returned host matching the cached value, not this mock's response; the
     // bogus body only makes an accidental pull obvious.
     let pull = server.mock(|when, then| {
-        when.method(POST).path("/me/cli/federation");
+        when.method(GET).path("/me/cli/router-config");
         then.status(200)
             .json_body(json!({ "endpoint": "tls/should-not-be-used:1" }));
     });
@@ -349,24 +332,14 @@ fn resolve_router_endpoint_reuses_a_fresh_cache_without_pulling() {
             // Matches `seeded_creds`'s subject so the identity tag agrees and the
             // fresh cache is reused (a mismatch would force a re-pull).
             subject: "user-123".into(),
-            // Matches the resolve's core-node name for the same reason.
-            core_node_name: CORE_NODE.into(),
         }),
         ..Default::default()
     };
     storage::save(&path, &creds).expect("seed creds");
 
     let http = HttpClient::new();
-    let endpoint = router::resolve_router_endpoint(
-        &path,
-        &http,
-        &server.base_url(),
-        None,
-        None,
-        CORE_NODE,
-        &router_zid(),
-    )
-    .expect("resolve from cache");
+    let endpoint = router::resolve_router_endpoint(&path, &http, &server.base_url(), None, None)
+        .expect("resolve from cache");
     assert_eq!(endpoint.host, "cached.zenoh.localhost");
     assert_eq!(endpoint.port, 7443);
     assert!(endpoint.tls.verify_name_on_connect);
@@ -383,9 +356,7 @@ fn resolve_federation_target_derives_the_upstream_tls_locator() {
     // The body matcher doubles as the C1 wire-contract check: the daemon's
     // federation pull must always identify itself by core-node name and router zid.
     let pull = server.mock(|when, then| {
-        when.method(POST)
-            .path("/me/cli/federation")
-            .json_body(json!({ "core_node_name": CORE_NODE, "router_zid": ROUTER_ZID }));
+        when.method(GET).path("/me/cli/router-config");
         then.status(200).json_body(json!({
             "endpoint": "tls/cap.zenoh.localhost:7443",
             "protocol": "tls",
@@ -409,8 +380,6 @@ fn resolve_federation_target_derives_the_upstream_tls_locator() {
         None,
         Some(ca.clone()),
         SECS_30,
-        CORE_NODE,
-        &router_zid(),
     )
     .expect("logged in ⇒ a federation target");
     assert_eq!(target.0, "tls/cap.zenoh.localhost:7443");
@@ -433,22 +402,15 @@ fn resolve_federation_target_is_none_when_not_logged_in() {
     // un-provisioned dev box).
     let server = MockServer::start();
     let pull = server.mock(|when, then| {
-        when.method(POST).path("/me/cli/federation");
+        when.method(GET).path("/me/cli/router-config");
         then.status(200)
             .json_body(json!({ "endpoint": "tls/should-not-be-pulled:1" }));
     });
 
     let dir = tempfile::tempdir().expect("temp dir");
     let path = creds_path(&dir); // no creds file written ⇒ no session
-    let target = router::resolve_federation_target_at(
-        &path,
-        &server.base_url(),
-        None,
-        None,
-        SECS_30,
-        CORE_NODE,
-        &router_zid(),
-    );
+    let target =
+        router::resolve_federation_target_at(&path, &server.base_url(), None, None, SECS_30);
     assert!(target.is_none(), "not logged in ⇒ no federation target");
     assert_eq!(pull.calls(), 0, "not logged in ⇒ the backend is never hit");
 }
@@ -462,7 +424,7 @@ fn resolve_federation_target_fails_closed_on_an_invalid_workspace_namespace() {
     // that cannot federate also cannot carry a federating namespace.
     let server = MockServer::start();
     let pull = server.mock(|when, then| {
-        when.method(POST).path("/me/cli/federation");
+        when.method(GET).path("/me/cli/router-config");
         then.status(200).json_body(json!({
             "endpoint": "tls/cap.zenoh.localhost:7443",
             "protocol": "tls",
@@ -479,15 +441,8 @@ fn resolve_federation_target_fails_closed_on_an_invalid_workspace_namespace() {
     };
     storage::save(&path, &creds).expect("seed creds");
 
-    let target = router::resolve_federation_target_at(
-        &path,
-        &server.base_url(),
-        None,
-        None,
-        SECS_30,
-        CORE_NODE,
-        &router_zid(),
-    );
+    let target =
+        router::resolve_federation_target_at(&path, &server.base_url(), None, None, SECS_30);
     assert!(
         target.is_none(),
         "an invalid workspace namespace must fail closed (no federation)"
@@ -509,7 +464,7 @@ fn resolve_federation_target_honors_a_short_connect_timeout() {
     // it's the timeout, not the mock, that fails the short case.
     let server = MockServer::start();
     let pull = server.mock(|when, then| {
-        when.method(POST).path("/me/cli/federation");
+        when.method(GET).path("/me/cli/router-config");
         then.status(200)
             .delay(Duration::from_millis(500))
             .json_body(json!({
@@ -535,8 +490,6 @@ fn resolve_federation_target_honors_a_short_connect_timeout() {
         None,
         None,
         Duration::from_millis(100),
-        CORE_NODE,
-        &router_zid(),
     );
     assert!(
         too_slow.is_none(),
@@ -544,15 +497,8 @@ fn resolve_federation_target_honors_a_short_connect_timeout() {
     );
 
     // A generous bound against the same delay succeeds.
-    let in_time = router::resolve_federation_target_at(
-        &path,
-        &server.base_url(),
-        None,
-        None,
-        SECS_30,
-        CORE_NODE,
-        &router_zid(),
-    );
+    let in_time =
+        router::resolve_federation_target_at(&path, &server.base_url(), None, None, SECS_30);
     assert!(
         in_time.is_some(),
         "a backend within the timeout ⇒ a federation target"
@@ -566,12 +512,8 @@ fn resolve_federation_target_honors_a_short_connect_timeout() {
 #[test]
 fn resolve_router_endpoint_re_pulls_and_caches_when_stale() {
     let server = MockServer::start();
-    // The stale re-pull must also carry both identity fields (the matcher
-    // rejects anything else).
     let pull = server.mock(|when, then| {
-        when.method(POST)
-            .path("/me/cli/federation")
-            .json_body(json!({ "core_node_name": CORE_NODE, "router_zid": ROUTER_ZID }));
+        when.method(GET).path("/me/cli/router-config");
         then.status(200).json_body(json!({
             "endpoint": "tls/fresh.zenoh.localhost:7443",
             "protocol": "tls",
@@ -591,7 +533,6 @@ fn resolve_router_endpoint_re_pulls_and_caches_when_stale() {
             repull_after: 1, // long past ⇒ stale ⇒ re-pull
             namespace: workspace_namespace(),
             subject: "user-123".into(),
-            core_node_name: CORE_NODE.into(),
         }),
         ..Default::default()
     };
@@ -599,16 +540,9 @@ fn resolve_router_endpoint_re_pulls_and_caches_when_stale() {
 
     let http = HttpClient::new();
     let ca = std::path::PathBuf::from("/etc/peppy/ca.pem");
-    let endpoint = router::resolve_router_endpoint(
-        &path,
-        &http,
-        &server.base_url(),
-        None,
-        Some(ca.clone()),
-        CORE_NODE,
-        &router_zid(),
-    )
-    .expect("re-pull");
+    let endpoint =
+        router::resolve_router_endpoint(&path, &http, &server.base_url(), None, Some(ca.clone()))
+            .expect("re-pull");
     assert_eq!(endpoint.host, "fresh.zenoh.localhost");
     assert_eq!(endpoint.port, 7443);
     assert_eq!(
@@ -624,30 +558,22 @@ fn resolve_router_endpoint_re_pulls_and_caches_when_stale() {
     let rs = after.router.as_ref().expect("router cached");
     assert_eq!(rs.endpoint, "tls/fresh.zenoh.localhost:7443");
     assert!(rs.repull_after > storage::now_unix(), "deadline pushed out");
-    assert_eq!(
-        rs.core_node_name, CORE_NODE,
-        "the cache is tagged with the name the config was pulled under"
-    );
 }
 
 #[test]
-fn resolve_router_endpoint_re_pulls_when_the_core_node_name_changed() {
-    // The collision-fix workflow: the daemon registered under one name, the user
-    // renames it (`core_node_name` in peppy_config.json5) and restarts within the
-    // cache-freshness window. The still-fresh cache was pulled under the OLD name,
-    // so it must NOT be reused: the resolve re-pulls, registering the new name in
-    // the backend registry, and re-tags the cache with it.
+fn resolve_router_endpoint_reuses_a_fresh_cache_across_a_core_node_rename() {
+    // The collision-fix workflow: the daemon ran under one name, the user renames
+    // it (`core_node_name` in peppy_config.json5) and restarts within the
+    // cache-freshness window. The cache is no longer tagged with a name, and it
+    // must not be: the backend's router config is identical for every core node
+    // in a workspace, so a rename has nothing to re-pull FOR. Re-registering under
+    // the new name is the federation loop's job now, and it happens on every poll
+    // regardless of cache state.
     let server = MockServer::start();
     let pull = server.mock(|when, then| {
-        when.method(POST)
-            .path("/me/cli/federation")
-            .json_body(json!({ "core_node_name": CORE_NODE, "router_zid": ROUTER_ZID }));
-        then.status(200).json_body(json!({
-            "endpoint": "tls/cap.zenoh.localhost:7443",
-            "protocol": "tls",
-            "reconnect_after_secs": 3000,
-            "workspace_id": "550e8400-e29b-41d4-a716-446655440000",
-        }));
+        when.method(GET).path("/me/cli/router-config");
+        then.status(200)
+            .json_body(json!({ "endpoint": "tls/should-not-be-pulled:1" }));
     });
 
     let dir = tempfile::tempdir().expect("temp dir");
@@ -655,43 +581,160 @@ fn resolve_router_endpoint_re_pulls_when_the_core_node_name_changed() {
     let creds = Credentials {
         session: Some(seeded_creds(&server, 9_999_999_999)),
         router: Some(RouterSession {
-            endpoint: "tls/cap.zenoh.localhost:7443".into(),
+            endpoint: "tls/cached.zenoh.localhost:7443".into(),
             protocol: "tls".into(),
-            // Far in the future ⇒ fresh; only the name tag differs.
             repull_after: storage::now_unix() + 100_000,
             namespace: workspace_namespace(),
             subject: "user-123".into(),
-            core_node_name: "the-old-name".into(),
         }),
         ..Default::default()
     };
     storage::save(&path, &creds).expect("seed creds");
 
     let http = HttpClient::new();
-    let endpoint = router::resolve_router_endpoint(
-        &path,
+    let endpoint = router::resolve_router_endpoint(&path, &http, &server.base_url(), None, None)
+        .expect("resolve from cache");
+
+    assert_eq!(endpoint.host, "cached.zenoh.localhost");
+    assert_eq!(
+        pull.calls(),
+        0,
+        "a rename has no reason to invalidate a config that does not depend on the name"
+    );
+}
+
+#[test]
+fn register_core_node_sends_both_identities_and_accepts_no_content() {
+    // The write half of the split. The matcher requires the full identity body,
+    // so a call that drops or malforms a field gets no mock response and fails.
+    let server = MockServer::start();
+    let register = server.mock(|when, then| {
+        when.method(POST)
+            .path("/me/core-nodes")
+            .json_body(json!({ "core_node_name": CORE_NODE, "router_zid": ROUTER_ZID }));
+        then.status(204);
+    });
+
+    let http = HttpClient::new();
+    let mut cred = auth::Credential {
+        token: storage::secret("any-token".to_string()),
+        kind: CredentialKind::Pat,
+    };
+
+    client::register_core_node(
         &http,
         &server.base_url(),
-        None,
-        None,
+        &mut cred,
         CORE_NODE,
         &router_zid(),
     )
-    .expect("resolve re-pulls under the new name");
-    assert_eq!(endpoint.host, "cap.zenoh.localhost");
-    assert_eq!(
-        pull.calls(),
-        1,
-        "a fresh cache pulled under a different core-node name must re-pull \
-         (registering the new name), not be reused"
-    );
+    .expect("a 204 is success, not an unparseable empty body");
+    assert_eq!(register.calls(), 1);
+}
 
-    // The cache is re-tagged with the new name, so the next resolve reuses it.
-    let cached = storage::load(&path)
-        .expect("reload")
-        .router
-        .expect("router cached");
-    assert_eq!(cached.core_node_name, CORE_NODE);
+#[test]
+fn register_core_node_refreshes_on_401_then_retries() {
+    // The registration honors the same reactive-refresh contract as the sibling
+    // calls: it is issued on every login poke, so a mid-session expiry must not
+    // leave the registry stale.
+    let server = MockServer::start();
+    let base = server.base_url();
+
+    server.mock(|when, then| {
+        when.method(GET).path("/.well-known/openid-configuration");
+        then.status(200).json_body(json!({
+            "device_authorization_endpoint": format!("{base}/oauth/v2/device_authorization"),
+            "token_endpoint": format!("{base}/oauth/v2/token"),
+        }));
+    });
+    let token = server.mock(|when, then| {
+        when.method(POST).path("/oauth/v2/token");
+        then.status(200).json_body(json!({
+            "access_token": "refreshed-access",
+            "refresh_token": "rotated-refresh",
+            "expires_in": 3600,
+            "token_type": "Bearer",
+            "scope": "openid",
+        }));
+    });
+    let rejected = server.mock(|when, then| {
+        when.method(POST)
+            .path("/me/core-nodes")
+            .header("Authorization", "Bearer seeded-access");
+        then.status(401);
+    });
+    let accepted = server.mock(|when, then| {
+        when.method(POST)
+            .path("/me/core-nodes")
+            .header("Authorization", "Bearer refreshed-access")
+            .json_body(json!({ "core_node_name": CORE_NODE, "router_zid": ROUTER_ZID }));
+        then.status(204);
+    });
+
+    let dir = tempfile::tempdir().expect("temp dir");
+    let path = creds_path(&dir);
+    let creds = Credentials {
+        session: Some(seeded_creds(&server, 9_999_999_999)),
+        ..Default::default()
+    };
+    storage::save(&path, &creds).expect("seed creds");
+
+    let http = HttpClient::new();
+    let mut cred = auth::Credential {
+        token: storage::secret("seeded-access".to_string()),
+        kind: CredentialKind::Session(SessionContext {
+            issuer: server.base_url(),
+            client_id: "cli-client-id".to_string(),
+            refresh_token: storage::secret("seeded-refresh".to_string()),
+            creds_path: path.clone(),
+        }),
+    };
+
+    client::register_core_node(
+        &http,
+        &server.base_url(),
+        &mut cred,
+        CORE_NODE,
+        &router_zid(),
+    )
+    .expect("registration succeeds after the refresh");
+
+    assert!(rejected.calls() >= 1, "the seeded token must be tried");
+    assert!(token.calls() >= 1, "a refresh must occur on the 401");
+    assert!(
+        accepted.calls() >= 1,
+        "the retry re-sends the identity under the rotated token"
+    );
+}
+
+#[test]
+fn register_core_node_surfaces_a_backend_outage() {
+    // A registration failure is reported, never swallowed: the daemon turns it
+    // into `NotRegistered` so the user learns the platform's view is stale.
+    let server = MockServer::start();
+    server.mock(|when, then| {
+        when.method(POST).path("/me/core-nodes");
+        then.status(503);
+    });
+
+    let http = HttpClient::new();
+    let mut cred = auth::Credential {
+        token: storage::secret("any-token".to_string()),
+        kind: CredentialKind::Pat,
+    };
+
+    let err = client::register_core_node(
+        &http,
+        &server.base_url(),
+        &mut cred,
+        CORE_NODE,
+        &router_zid(),
+    )
+    .expect_err("a 503 must not read as a successful registration");
+    assert!(
+        err.to_string().contains("temporarily unavailable"),
+        "the shared status contract applies to the bodyless call too: {err}"
+    );
 }
 
 #[test]
@@ -702,7 +745,7 @@ fn router_cache_is_bound_to_the_pull_identity_not_the_on_disk_session() {
     // (cross-tenant) leak.
     let server = MockServer::start();
     let pull = server.mock(|when, then| {
-        when.method(POST).path("/me/cli/federation");
+        when.method(GET).path("/me/cli/router-config");
         then.status(200).json_body(json!({
             "endpoint": "tls/pat-workspace.zenoh.localhost:7443",
             "protocol": "tls",
@@ -735,8 +778,6 @@ fn router_cache_is_bound_to_the_pull_identity_not_the_on_disk_session() {
         &server.base_url(),
         Some("the-pat".to_string()),
         None,
-        CORE_NODE,
-        &router_zid(),
     )
     .expect("PAT pull resolves");
     assert_eq!(ep.host, "pat-workspace.zenoh.localhost");
@@ -759,16 +800,8 @@ fn router_cache_is_bound_to_the_pull_identity_not_the_on_disk_session() {
 
     // With the PAT gone, a session resolve must NOT reuse the PAT's cache: the
     // subjects differ, so it re-pulls rather than leaking the PAT's workspace.
-    let _ = router::resolve_router_endpoint(
-        &path,
-        &http,
-        &server.base_url(),
-        None,
-        None,
-        CORE_NODE,
-        &router_zid(),
-    )
-    .expect("session resolve");
+    let _ = router::resolve_router_endpoint(&path, &http, &server.base_url(), None, None)
+        .expect("session resolve");
     assert_eq!(
         pull.calls(),
         2,

--- a/crates/daemon-internal/src/control.rs
+++ b/crates/daemon-internal/src/control.rs
@@ -38,11 +38,12 @@ pub const REFEDERATE_VERB: &str = "refederate";
 
 /// Extra time the client waits for the daemon's ack on top of the configured
 /// federation connect timeout. Kept strictly larger than the daemon-side ack
-/// budget (`APPLY_ACK_SLACK`, which itself covers the verifying poke's TLS probe)
-/// so the daemon always replies a definite status (even "timed out applying")
-/// before the client gives up, turning a slow apply into a definite status rather
-/// than a client-side timeout. (The `ack_budget_*` test guards this ordering.)
-pub const POKE_READ_SLACK: Duration = Duration::from_secs(11);
+/// budget (`APPLY_ACK_SLACK`, which itself covers the verifying poke's TLS probe
+/// and its core-node registration) so the daemon always replies a definite status
+/// (even "timed out applying") before the client gives up, turning a slow apply
+/// into a definite status rather than a client-side timeout. (The `ack_budget_*`
+/// test guards this ordering.)
+pub const POKE_READ_SLACK: Duration = Duration::from_secs(16);
 
 /// Where the daemon binds (and the client connects to) the federation control
 /// socket for a given [`PeppyDirs`]. Derived, never stored, so both sides agree.
@@ -69,6 +70,11 @@ pub enum ControlResponse {
     /// The daemon attempted the apply and it failed (e.g. backend unreachable
     /// within the federation timeout).
     Error { message: String },
+    /// Federation is in effect, but the daemon could not register this machine
+    /// with the platform, so the platform's roster entry for it is stale (or
+    /// missing). Distinct from `error` on purpose: the transport is working, and
+    /// wording this as a failed apply would send the user to debug it.
+    NotRegistered { message: String },
     /// The credentials changed the daemon's *workspace namespace*, which is
     /// immutable for a live session, so the daemon is restarting its whole
     /// generation to re-open every session under the new namespace. The daemon
@@ -98,6 +104,9 @@ pub enum PokeOutcome {
     /// cloud router does not validate (e.g. UnknownCA); federation with
     /// platform-backend is not in effect.
     Unreachable(String),
+    /// Federation is in effect, but the platform's record of this machine could
+    /// not be updated, so `peppy platform list` shows a stale entry for it.
+    NotRegistered(String),
     /// No running daemon to poke (no socket, or the connection was refused).
     /// Federation will be applied the next time `serve` starts.
     DaemonNotRunning,
@@ -149,6 +158,7 @@ fn poke_inner(socket_path: &Path, read_timeout: Duration) -> std::io::Result<Pok
         ControlResponse::Ok { applied } => PokeOutcome::Applied(applied),
         ControlResponse::Pinned => PokeOutcome::Pinned,
         ControlResponse::Unreachable { message } => PokeOutcome::Unreachable(message),
+        ControlResponse::NotRegistered { message } => PokeOutcome::NotRegistered(message),
         ControlResponse::Error { message } => PokeOutcome::DaemonError(message),
         ControlResponse::Restarting => PokeOutcome::Restarting,
     })
@@ -211,6 +221,10 @@ mod tests {
             (
                 "{\"status\":\"unreachable\",\"message\":\"received fatal alert: UnknownCA\"}\n",
                 PokeOutcome::Unreachable("received fatal alert: UnknownCA".to_string()),
+            ),
+            (
+                "{\"status\":\"not_registered\",\"message\":\"backend temporarily unavailable\"}\n",
+                PokeOutcome::NotRegistered("backend temporarily unavailable".to_string()),
             ),
         ] {
             let dir = tempfile::tempdir().unwrap();

--- a/crates/daemon-internal/src/federation_control.rs
+++ b/crates/daemon-internal/src/federation_control.rs
@@ -33,12 +33,18 @@ const REQUEST_READ_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Extra time the daemon waits for the federation loop to apply, on top of the
 /// configured connect timeout (which bounds the resolve). It must cover the
-/// post-resolve work of a *verifying* login poke: the zenohd bounce plus the TLS
-/// reachability probe ([`super::router_federation::PROBE_TIMEOUT`]). Kept smaller
-/// than the client's read slack ([`crate::control::POKE_READ_SLACK`]) so
-/// the daemon always replies a definite outcome before the client gives up (the
-/// `ack_budget_*` test guards both relationships).
-const APPLY_ACK_SLACK: Duration = Duration::from_secs(8);
+/// post-resolve work of a *verifying* login poke: the zenohd bounce, the TLS
+/// reachability probe ([`super::router_federation::PROBE_TIMEOUT`]), and the
+/// core-node registration ([`super::router_federation::REGISTER_TIMEOUT`]), which
+/// runs after the probe on that same critical path. Kept smaller than the
+/// client's read slack ([`crate::control::POKE_READ_SLACK`]) so the daemon always
+/// replies a definite outcome before the client gives up (the `ack_budget_*` test
+/// guards both relationships).
+///
+/// The cost of covering the registration is that a poke which is going to fail
+/// takes up to `REGISTER_TIMEOUT` longer to say so. The budget exists to
+/// guarantee a definite answer, not a fast one.
+const APPLY_ACK_SLACK: Duration = Duration::from_secs(13);
 
 impl From<FederationOutcome> for ControlResponse {
     fn from(outcome: FederationOutcome) -> Self {
@@ -47,6 +53,7 @@ impl From<FederationOutcome> for ControlResponse {
             FederationOutcome::Pinned => ControlResponse::Pinned,
             FederationOutcome::Failed(message) => ControlResponse::Error { message },
             FederationOutcome::Unreachable(message) => ControlResponse::Unreachable { message },
+            FederationOutcome::NotRegistered(message) => ControlResponse::NotRegistered { message },
             FederationOutcome::Restart => ControlResponse::Restarting,
         }
     }
@@ -284,16 +291,22 @@ mod tests {
     use tokio::sync::mpsc;
 
     /// The daemon ack budget must cover the verifying poke's post-resolve work
-    /// (the TLS probe + bounce), and the client must always outlast the daemon so
-    /// it receives a definite reply rather than a client-side timeout. Guards the
-    /// constants from drifting back into the pre-probe sizing.
+    /// (the TLS probe, the registration, and the zenohd bounce), and the client
+    /// must always outlast the daemon so it receives a definite reply rather than
+    /// a client-side timeout. Guards the constants from drifting back into the
+    /// pre-probe (or pre-registration) sizing, either of which turns a working
+    /// login into a hard `TimedOut` error.
     #[test]
     fn ack_budget_covers_the_verify_probe_and_client_outlasts_daemon() {
         use crate::control::POKE_READ_SLACK;
-        use crate::router_federation::PROBE_TIMEOUT;
+        use crate::router_federation::{PROBE_TIMEOUT, REGISTER_TIMEOUT};
+        /// Headroom for the zenohd bounce that runs alongside the two network
+        /// steps, preserved exactly as it was sized before the registration.
+        const BOUNCE_HEADROOM: Duration = Duration::from_secs(3);
         assert!(
-            PROBE_TIMEOUT < APPLY_ACK_SLACK,
-            "the daemon ack slack must cover the verify probe (plus the bounce)"
+            PROBE_TIMEOUT + REGISTER_TIMEOUT + BOUNCE_HEADROOM <= APPLY_ACK_SLACK,
+            "the daemon ack slack must cover the verify probe AND the registration, \
+             plus the bounce"
         );
         assert!(
             APPLY_ACK_SLACK < POKE_READ_SLACK,
@@ -313,6 +326,22 @@ mod tests {
                 assert_eq!(message, "received fatal alert: UnknownCA")
             }
             other => panic!("expected Unreachable, got {other:?}"),
+        }
+    }
+
+    /// A registration failure crosses the wire as its own status too, never as
+    /// `error`. Collapsing it would report "the daemon could not apply
+    /// federation" for a daemon whose federation is in effect.
+    #[test]
+    fn not_registered_outcome_maps_to_its_own_response() {
+        let resp = ControlResponse::from(FederationOutcome::NotRegistered(
+            "backend temporarily unavailable".to_string(),
+        ));
+        match resp {
+            ControlResponse::NotRegistered { message } => {
+                assert_eq!(message, "backend temporarily unavailable")
+            }
+            other => panic!("expected NotRegistered, got {other:?}"),
         }
     }
 

--- a/crates/daemon-internal/src/router_federation.rs
+++ b/crates/daemon-internal/src/router_federation.rs
@@ -32,17 +32,49 @@
 //!   own (`reconnect: true`), and the backend neither probes this daemon nor
 //!   tears anything down: the router it hands back is a single shared one, not a
 //!   per-user resource with a lifetime.
-//! * **Registration cadence.** Every config pull's POST carries this daemon's
-//!   core-node name *and* its managed router's pinned transport identity
-//!   (`router_zid`), upserting both into the backend's per-principal core-node
-//!   registry. The zid is what lets the platform tell a site whose uplink is
-//!   healthy but whose daemon is dead from one that is simply unreachable: it
-//!   matches the row against the shared router's live session list. The POST fires on cache-stale pulls and on login/logout pokes —
-//!   login clears the router cache, so every login re-registers — never on a
-//!   timer. The backend's `last_seen_at` for a core node therefore means "last
-//!   federation config pull", not liveness. `peppy platform logout` removes the
-//!   row outright (`DELETE /me/core-nodes/{core_node_name}`), since a logged-out
-//!   machine stops federating and stops pulling config.
+//! * **Registration.** A separate `POST /me/core-nodes` tells the backend this
+//!   daemon runs its core node behind the router identity (`router_zid`) it
+//!   pins. The zid is what lets the platform tell a site whose uplink is healthy
+//!   but whose daemon is dead from one that is simply unreachable: it matches
+//!   the row against the shared router's live session list.
+//!
+//!   The rule is a match on the poll's own outcome, deliberately not a
+//!   cache-freshness side effect of the config pull:
+//!
+//!   * `Applied(Some(_))` registers. Every poll does, whatever the config cache
+//!     state, so a boot always re-asserts the identity its live router pins. A
+//!     re-minted identity (a lost or corrupt identity file) therefore corrects
+//!     itself on the next start rather than lingering as a row pointing at a
+//!     session that no longer exists.
+//!   * `Applied(None)` (logged out, or no upstream resolved) does not. `peppy
+//!     platform logout` removes the row outright
+//!     (`DELETE /me/core-nodes/{core_node_name}`), so registering here would
+//!     resurrect a decommissioned machine.
+//!   * `Pinned` does not. Under an operator-pinned `ZENOH_CONFIG` the router
+//!     does not run under the id we would report, so publishing it would be the
+//!     same wrong-zid bug by another route. The row stays absent, which reads as
+//!     `registered: false`.
+//!   * `Unreachable` DOES register. Registration asserts identity, not health:
+//!     the router is pinned to that zid and keeps retrying its connect, and
+//!     whether a session exists is exactly what the platform's NETWORK column
+//!     answers. Suppressing it would hide a site instead of reporting it as
+//!     `unlinked`.
+//!   * `Failed` and `Restart` cannot reach the registration: both return before
+//!     it. In particular a namespace change (every first login on a machine)
+//!     returns `Restart` from the gate, so the outgoing generation never
+//!     publishes the identity it is about to discard; the rebuilt generation
+//!     registers the one it actually mints.
+//!
+//!   The registration runs *after* the verify probe, and regardless of its
+//!   result, but a probe failure still wins the report: `Unreachable` means the
+//!   product is broken, while a failed registration means only that the
+//!   platform's view of this machine is stale ([`FederationOutcome::NotRegistered`]).
+//!
+//!   There is no retry. Polls happen at startup and on login/logout pokes, with
+//!   no timer, and adding one would give a deliberately time-free task
+//!   time-dependent behaviour for a failure mode a single `peppy platform login`
+//!   already fixes. A startup registration failure is therefore logged loudly
+//!   instead, naming the command that corrects it.
 //! * **Live (re)federation.** When the resolved upstream changes (the user logs
 //!   in, logs out, or the endpoint moves) the local router's zenohd config is
 //!   re-rendered and the router restarted, so the change takes effect without a
@@ -70,6 +102,17 @@ use tracing::{info, warn};
 /// firewalled router fails the probe within this bound and surfaces promptly as
 /// [`FederationOutcome::Unreachable`] rather than as a daemon-side ack timeout.
 pub(crate) const PROBE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// How long a poll waits for the core-node registration to reach the backend.
+///
+/// Deliberately its own small bound rather than the resolve's `connect_timeout`
+/// (30s by default), for the same reason [`PROBE_TIMEOUT`] is: this is a second
+/// network step on a verifying poke's critical path, and the daemon's ack budget
+/// ([`super::federation_control`]'s `APPLY_ACK_SLACK`) has to cover resolve +
+/// bounce + probe + this. Inheriting `connect_timeout` would blow that budget, so
+/// a working login would surface as a client-side timeout instead of a definite
+/// answer.
+pub(crate) const REGISTER_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Resolves the desired upstream `(endpoint, tls)` for the local router, or
 /// `None` when there is nothing to federate to (logged out / unreachable). A
@@ -116,6 +159,35 @@ fn real_federator(messenger: Arc<Mutex<Messenger>>) -> Federator {
     })
 }
 
+/// Claims this daemon's identity on the platform: `Ok(())` if the backend
+/// recorded it, `Err(reason)` (human-readable) otherwise. A boxed closure so
+/// tests can inject a deterministic registrar (with a call counter and the
+/// arguments it saw) in place of the real, networked
+/// [`auth::router::register_core_node`].
+type Registrar = Arc<dyn Fn() -> std::result::Result<(), String> + Send + Sync>;
+
+/// The real registrar. It closes over the `router_id` **this generation pinned**
+/// rather than re-reading the identity file, so what reaches the registry is
+/// always the id the live router is actually running under: re-reading would
+/// reintroduce the very skew this call exists to remove.
+fn real_registrar(
+    peppy_dirs: PeppyDirs,
+    api_url: String,
+    core_node_name: String,
+    router_id: pmi::RouterId,
+) -> Registrar {
+    Arc::new(move || {
+        auth::router::register_core_node(
+            &peppy_dirs,
+            &api_url,
+            REGISTER_TIMEOUT,
+            &core_node_name,
+            &router_id,
+        )
+        .map_err(|error| error.to_string())
+    })
+}
+
 /// Outcome of one federation poll, reported back to a control-socket poke so the
 /// CLI can tell the user the post-apply state.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -134,6 +206,16 @@ pub(crate) enum FederationOutcome {
     /// federation with platform-backend is NOT actually in effect (e.g. an
     /// UnknownCA handshake loop). Only a verifying poke produces this.
     Unreachable(String),
+    /// Federation itself is in effect, but the backend did not record this
+    /// machine's identity, so the platform's roster still shows whatever it held
+    /// before (a stale zid, or nothing at all).
+    ///
+    /// Deliberately not folded into [`Self::Failed`]. That reports "the daemon
+    /// could not apply federation", which would be false here and would send the
+    /// user to debug a transport that is working. This is the one fact the whole
+    /// registration split exists to keep separate from the apply, so it stays
+    /// separate all the way out to the CLI.
+    NotRegistered(String),
     /// The credentials changed the daemon's *workspace namespace*. A session's
     /// namespace is immutable after open and the core node holds long-lived
     /// declarations, so the change cannot be applied to the live session by a
@@ -158,6 +240,23 @@ fn real_namespace_resolver(creds_path: PathBuf) -> NamespaceResolver {
     Arc::new(move || auth::router::session_namespace(&creds_path))
 }
 
+/// The injectable collaborators one federation poll needs: apply an upstream,
+/// resolve the desired one, probe the link, claim this machine's identity, and
+/// re-read the namespace.
+///
+/// Bundled rather than passed positionally because five boxed closures in a row
+/// are indistinguishable at a call site: only the field names say which is which.
+/// Grouping them (with [`StartupGates`] doing the same for the two gates) is also
+/// what lets `poll_and_apply` and `manage_federation` drop their
+/// `#[allow(clippy::too_many_arguments)]` rather than grow past it.
+pub(crate) struct FederationDeps {
+    pub(crate) federator: Federator,
+    pub(crate) resolver: Resolver,
+    pub(crate) prober: Prober,
+    pub(crate) registrar: Registrar,
+    pub(crate) namespace_resolver: NamespaceResolver,
+}
+
 /// A "refederate now" request from the control socket: run a poll immediately and
 /// reply with the resulting [`FederationOutcome`] over `ack`.
 pub(crate) struct RefederateRequest {
@@ -172,9 +271,8 @@ pub(crate) type TriggerReceiver = mpsc::Receiver<RefederateRequest>;
 /// Background task (a [`ServeAsyncCommand`]) that federates the local router to
 /// the per-user cloud router and keeps it federated. See the module docs.
 pub(crate) struct RouterFederation {
-    federator: Federator,
-    resolver: Resolver,
-    prober: Prober,
+    /// Everything one poll calls out to (see [`FederationDeps`]).
+    deps: FederationDeps,
     /// Goes `true` once the router process is up (MessagingRouter ran
     /// `start_router` + `start_session`). The task waits on this before touching
     /// the router so its initial federation cannot race the router's own startup.
@@ -188,9 +286,6 @@ pub(crate) struct RouterFederation {
     /// that re-resolves a *different* namespace from fresh creds requests a
     /// restart instead of a live re-federation.
     startup_namespace: config::namespace::Namespace,
-    /// Resolves the current namespace from the credentials (post-pull), compared
-    /// against `startup_namespace` to detect a namespace change.
-    namespace_resolver: NamespaceResolver,
     /// In-process restart signal (the serve coordinator's). The *startup*
     /// federation poll raises it when it discovers the credentials already resolve
     /// to a different namespace than this generation started under, so the live
@@ -226,28 +321,32 @@ impl RouterFederation {
         presence_gate_tx: Option<watch::Sender<bool>>,
         teardown_token: CancellationToken,
     ) -> Self {
-        // Both ambient inputs the loop re-reads on every poll derive from the
-        // generation's data root: the credentials file (namespace re-resolve)
-        // and the federation resolve (credentials + materialized dev TLS).
+        // Every ambient input the loop re-reads on a poll derives from the
+        // generation's data root: the credentials file (namespace re-resolve),
+        // the federation resolve (credentials + materialized dev TLS), and the
+        // registration (credentials again).
         let creds_path = auth::storage::credentials_path(&peppy_dirs);
+        let registrar = real_registrar(
+            peppy_dirs.clone(),
+            api_url.clone(),
+            core_node_name,
+            router_id,
+        );
         let resolver: Resolver = Arc::new(move || {
-            auth::router::resolve_federation_target(
-                &peppy_dirs,
-                &api_url,
-                connect_timeout,
-                &core_node_name,
-                &router_id,
-            )
+            auth::router::resolve_federation_target(&peppy_dirs, &api_url, connect_timeout)
         });
         Self {
-            federator: real_federator(messenger),
-            resolver,
-            prober: real_prober(),
+            deps: FederationDeps {
+                federator: real_federator(messenger),
+                resolver,
+                prober: real_prober(),
+                registrar,
+                namespace_resolver: real_namespace_resolver(creds_path),
+            },
             messaging_ready,
             trigger_rx,
             connect_timeout,
             startup_namespace,
-            namespace_resolver: real_namespace_resolver(creds_path),
             restart_tx,
             presence_gate_tx,
             teardown_token,
@@ -258,14 +357,11 @@ impl RouterFederation {
 impl ServeAsyncCommand for RouterFederation {
     fn run(self: Box<Self>) -> ServeAsyncHandle {
         let RouterFederation {
-            federator,
-            resolver,
-            prober,
+            deps,
             messaging_ready,
             trigger_rx,
             connect_timeout,
             startup_namespace,
-            namespace_resolver,
             restart_tx,
             presence_gate_tx,
             teardown_token,
@@ -282,9 +378,9 @@ impl ServeAsyncCommand for RouterFederation {
             // promptly (the loop is otherwise infinite).
             tokio::select! {
                 _ = manage_federation(
-                    federator, resolver, prober, messaging_ready, trigger_rx, ready_tx,
-                    connect_timeout, startup_namespace, namespace_resolver, restart_tx,
-                    presence_gate_tx,
+                    &deps, messaging_ready, trigger_rx,
+                    StartupGates::new(ready_tx, presence_gate_tx), connect_timeout,
+                    startup_namespace, restart_tx,
                 ) => {}
                 _ = crate::shutdown_signal::shutdown_or_token(&teardown_token) => {}
             }
@@ -294,19 +390,37 @@ impl ServeAsyncCommand for RouterFederation {
     }
 }
 
-/// Fires the startup readiness gate exactly once (idempotent: the `Option` is
-/// `take`n, so later calls or a drop are no-ops) and, in lockstep, the core
-/// node's presence gate (a `watch`, so re-sends are harmless). The two fire at
-/// the same moments so the core node's boot presence check is delayed exactly
-/// as long as `serve`'s own readiness: until the initial federation settled,
-/// bounded by `connect_timeout`, and fail-open (a dropped sender ⇒ the waiter
-/// proceeds).
-fn fire_gate(gate: &mut Option<oneshot::Sender<()>>, presence_gate: &Option<watch::Sender<bool>>) {
-    if let Some(tx) = gate.take() {
-        let _ = tx.send(());
+/// The two gates the initial federation poll opens. They are one type because
+/// they must fire at the same moments and never independently: the core node's
+/// boot presence check has to be delayed exactly as long as `serve`'s own
+/// readiness, or it runs against the always-standalone just-started router and
+/// misses a same-name daemon reachable only through the cloud router.
+pub(crate) struct StartupGates {
+    /// `serve`'s readiness gate. Fired at most once (the `Option` is `take`n),
+    /// so repeat calls and a drop are both no-ops.
+    ready: Option<oneshot::Sender<()>>,
+    /// The core node's presence gate, a `watch`, so re-sends are harmless.
+    /// `None` when no core node was built.
+    presence: Option<watch::Sender<bool>>,
+}
+
+impl StartupGates {
+    pub(crate) fn new(ready: oneshot::Sender<()>, presence: Option<watch::Sender<bool>>) -> Self {
+        Self {
+            ready: Some(ready),
+            presence,
+        }
     }
-    if let Some(tx) = presence_gate {
-        let _ = tx.send(true);
+
+    /// Opens both gates. Idempotent, and fail-open throughout: a dropped
+    /// receiver just means that waiter already proceeded.
+    fn fire(&mut self) {
+        if let Some(tx) = self.ready.take() {
+            let _ = tx.send(());
+        }
+        if let Some(tx) = &self.presence {
+            let _ = tx.send(true);
+        }
     }
 }
 
@@ -334,22 +448,15 @@ struct AppliedState {
 /// against the shutdown signal). There is no periodic keepalive: once federated,
 /// the local router holds its upstream link open on its own and the backend
 /// actively health-checks this daemon.
-#[allow(clippy::too_many_arguments)]
 async fn manage_federation(
-    federator: Federator,
-    resolver: Resolver,
-    prober: Prober,
+    deps: &FederationDeps,
     mut messaging_ready: watch::Receiver<bool>,
     mut trigger_rx: TriggerReceiver,
-    ready_tx: oneshot::Sender<()>,
+    mut gates: StartupGates,
     connect_timeout: Duration,
     startup_namespace: config::namespace::Namespace,
-    namespace_resolver: NamespaceResolver,
     restart_tx: watch::Sender<bool>,
-    presence_gate_tx: Option<watch::Sender<bool>>,
 ) {
-    let mut ready_tx = Some(ready_tx);
-
     // Phase 1: wait for the router, bounded by `connect_timeout`. Don't touch the
     // router until it is up, or the initial federation could race MessagingRouter's
     // `start_router`/`start_session`. `wait_for` checks the current value first,
@@ -364,14 +471,14 @@ async fn manage_federation(
             // `messaging_ready` closed before going true: the router task never
             // started or already exited, so there is nothing to federate. Unblock
             // startup and stop.
-            fire_gate(&mut ready_tx, &presence_gate_tx);
+            gates.fire();
             return;
         }
         Err(_elapsed) => {
             // The router isn't up within the bound: unblock startup now (the
             // daemon proceeds standalone), then keep waiting (unbounded) so the
             // local router still federates once it does come up.
-            fire_gate(&mut ready_tx, &presence_gate_tx);
+            gates.fire();
             if messaging_ready.wait_for(|r| *r).await.is_err() {
                 return;
             }
@@ -392,17 +499,28 @@ async fn manage_federation(
         pinned: false,
     };
     let initial_outcome = poll_and_apply(
-        &federator,
-        &resolver,
-        &prober,
+        deps,
         connect_timeout,
         &mut applied,
         false,
         &startup_namespace,
-        &namespace_resolver,
     )
     .await;
-    fire_gate(&mut ready_tx, &presence_gate_tx);
+    gates.fire();
+
+    // A startup registration failure is discarded like any other non-`Restart`
+    // startup outcome (there is no ack to carry it), so this warning is the only
+    // way it surfaces. There is deliberately no retry, and the daemon federates
+    // happily from cache meanwhile, so the platform's roster can sit stale until
+    // the next login or reboot: say so, and name the one command that fixes it.
+    if let FederationOutcome::NotRegistered(reason) = &initial_outcome {
+        warn!(
+            reason = %reason,
+            "router federation: federated, but this machine could not be registered with the \
+             platform, so `peppy platform list` will show a stale (or missing) entry for it \
+             until the next daemon start; run `peppy platform login` to correct it now"
+        );
+    }
 
     // The initial poll re-pulled the federation config, so the credentials now
     // reflect the current workspace. If that resolves to a *different* namespace than
@@ -435,14 +553,11 @@ async fn manage_federation(
         // A login/logout poke verifies the link (`verify = true`) so the CLI
         // learns whether federation actually validates.
         let outcome = poll_and_apply(
-            &federator,
-            &resolver,
-            &prober,
+            deps,
             connect_timeout,
             &mut applied,
             true,
             &startup_namespace,
-            &namespace_resolver,
         )
         .await;
         // The CLI may have already given up (read timeout); ignore. On a namespace
@@ -462,16 +577,19 @@ async fn manage_federation(
 /// actually validates; a failed handshake is reported as
 /// [`FederationOutcome::Unreachable`] (and logged loudly) instead of a false
 /// `Applied`.
-#[allow(clippy::too_many_arguments)]
+///
+/// Once the upstream is in effect this also claims the daemon's identity on the
+/// platform (see the module docs for which outcomes register and why). That
+/// happens after the probe but independently of it, and the reported outcome
+/// follows a fixed precedence: a failed probe (`Unreachable`, the product is
+/// broken) beats a failed registration ([`FederationOutcome::NotRegistered`],
+/// only the platform's view is stale) beats `Applied`.
 async fn poll_and_apply(
-    federator: &Federator,
-    resolver: &Resolver,
-    prober: &Prober,
+    deps: &FederationDeps,
     connect_timeout: Duration,
     applied: &mut AppliedState,
     verify: bool,
     startup_namespace: &config::namespace::Namespace,
-    namespace_resolver: &NamespaceResolver,
 ) -> FederationOutcome {
     // The resolver is blocking (HTTP + file I/O); keep it off the async worker. It
     // also re-pulls the cloud router's config when the cached copy has gone stale
@@ -479,7 +597,7 @@ async fn poll_and_apply(
     // `connect_timeout` so a hung pull can't
     // stall a poll (or the startup gate) past it; the timed-out blocking thread is
     // harmless (its own HTTP timeout ends it) and its result is simply discarded.
-    let resolver = resolver.clone();
+    let resolver = deps.resolver.clone();
     let resolved = match tokio::time::timeout(
         connect_timeout,
         tokio::task::spawn_blocking(move || resolver()),
@@ -509,7 +627,7 @@ async fn poll_and_apply(
     // Like the resolve above, the namespace re-resolve is blocking (a file-backed
     // credentials read); keep it off the async worker. No timeout bound: it is a
     // local read, not a network pull.
-    let namespace_resolver = namespace_resolver.clone();
+    let namespace_resolver = deps.namespace_resolver.clone();
     let current_namespace = match tokio::task::spawn_blocking(move || namespace_resolver()).await {
         Ok(Ok(namespace)) => namespace,
         Ok(Err(error)) => {
@@ -553,7 +671,7 @@ async fn poll_and_apply(
         // the timeout lands between the router stop and start, the watchdog
         // notices the dead router and respawns it with the already-rewritten
         // config, so the router cannot stay down.
-        match tokio::time::timeout(connect_timeout, federator(resolved.clone())).await {
+        match tokio::time::timeout(connect_timeout, (deps.federator)(resolved.clone())).await {
             Err(_elapsed) => {
                 warn!(
                     "router federation: applying the upstream change timed out, so federation \
@@ -611,7 +729,10 @@ async fn poll_and_apply(
     // actually in effect. The non-verifying initial federation never reaches here.
     // A failed handshake means the local router was federated but the link to
     // platform-backend does not validate (e.g. UnknownCA), so federation is not
-    // really in effect.
+    // really in effect. The verdict is held rather than returned, so the
+    // registration below still runs: a site whose uplink is down is exactly the
+    // one whose row must exist to read `unlinked`.
+    let mut unreachable: Option<String> = None;
     if verify
         && let (FederationOutcome::Applied(Some(ep)), Some((_, tls))) =
             (&outcome, resolved.as_ref())
@@ -623,7 +744,7 @@ async fn poll_and_apply(
                 // daemon's ack budget; otherwise a slow/unreachable router would
                 // blow the budget and surface as a generic ack timeout instead of
                 // the actionable Unreachable.
-                if let Err(reason) = prober(host, port, tls.clone(), PROBE_TIMEOUT).await {
+                if let Err(reason) = (deps.prober)(host, port, tls.clone(), PROBE_TIMEOUT).await {
                     warn!(
                         upstream = %ep, reason = %reason,
                         "router federation: the local router was (re)federated, but the TLS \
@@ -631,7 +752,7 @@ async fn poll_and_apply(
                          established; federation with platform-backend is NOT in effect \
                          (check the router certificate / dev CA); will keep retrying"
                     );
-                    return FederationOutcome::Unreachable(reason);
+                    unreachable = Some(reason);
                 }
             }
             None => {
@@ -640,14 +761,62 @@ async fn poll_and_apply(
                     "router federation: could not parse the upstream endpoint to verify the \
                      federation link to platform-backend"
                 );
-                return FederationOutcome::Unreachable(format!(
-                    "could not parse upstream endpoint `{ep}`"
-                ));
+                unreachable = Some(format!("could not parse upstream endpoint `{ep}`"));
             }
         }
     }
 
-    outcome
+    // Claim this machine's identity, unconditionally per poll rather than as a
+    // side effect of a cache-stale config pull, so the registry always names the
+    // zid the live router pins. Only an upstream that is genuinely in effect
+    // registers: see the module docs for why `Pinned` and `Applied(None)` do not,
+    // and why `Unreachable` does.
+    let registration = match &outcome {
+        FederationOutcome::Applied(Some(_)) => register(&deps.registrar).await,
+        _ => Ok(()),
+    };
+
+    // Precedence: a broken product beats a stale roster beats success. Collapsing
+    // a registration failure into `Failed` would report "the daemon could not
+    // apply federation", which is untrue and would send the user to debug a
+    // transport that is working.
+    match (unreachable, registration) {
+        (Some(reason), _) => FederationOutcome::Unreachable(reason),
+        (None, Err(reason)) => FederationOutcome::NotRegistered(reason),
+        (None, Ok(())) => outcome,
+    }
+}
+
+/// Runs the registration off the async workers and bounds it, the same discipline
+/// every other blocking step in [`poll_and_apply`] follows: it is a blocking HTTP
+/// call, and an unbounded one would hold the poll (and a login poke's ack) open
+/// for as long as the backend cared to stall.
+async fn register(registrar: &Registrar) -> std::result::Result<(), String> {
+    let registrar = registrar.clone();
+    match tokio::time::timeout(
+        REGISTER_TIMEOUT,
+        tokio::task::spawn_blocking(move || registrar()),
+    )
+    .await
+    {
+        Ok(Ok(Ok(()))) => Ok(()),
+        Ok(Ok(Err(reason))) => {
+            warn!(
+                reason = %reason,
+                "router federation: federation is in effect, but registering this machine with \
+                 the platform failed, so its entry there is stale"
+            );
+            Err(reason)
+        }
+        Ok(Err(e)) => {
+            warn!(error = %e, "router federation: registration task panicked");
+            Err(format!("registration task panicked: {e}"))
+        }
+        Err(_elapsed) => {
+            warn!("router federation: registering this machine with the platform timed out");
+            Err("registration timed out".to_string())
+        }
+    }
 }
 
 /// Re-renders the local router's config with the (possibly empty) upstream and,
@@ -758,6 +927,95 @@ mod tests {
         Some((ENDPOINT.to_string(), pmi::TlsConfig::default()))
     }
 
+    /// A registrar returning a fixed result and counting its calls, so a test can
+    /// assert both *whether* this generation claimed its identity and what the
+    /// poll made of the answer.
+    fn counting_registrar(
+        result: std::result::Result<(), String>,
+    ) -> (Registrar, Arc<AtomicUsize>) {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let counter = calls.clone();
+        let registrar: Registrar = Arc::new(move || {
+            counter.fetch_add(1, Ordering::SeqCst);
+            result.clone()
+        });
+        (registrar, calls)
+    }
+
+    /// Assembles the deps for a test, defaulting everything the test does not
+    /// care about. Lives in the test module, not in the business logic: nothing
+    /// in `serve` builds its deps this way.
+    struct TestDeps {
+        federator: Federator,
+        resolver: Resolver,
+        prober: Prober,
+        registrar: Registrar,
+        namespace_resolver: NamespaceResolver,
+    }
+
+    impl TestDeps {
+        /// The uninteresting case: a real rewrite, a resolved upstream, a passing
+        /// probe, a successful registration, and an unchanged namespace.
+        fn new() -> Self {
+            Self {
+                federator: applying_federator(),
+                resolver: counting_resolver(upstream()).0,
+                prober: counting_prober(Ok(())).0,
+                registrar: counting_registrar(Ok(())).0,
+                namespace_resolver: local_ns_resolver(),
+            }
+        }
+
+        fn federator(mut self, federator: Federator) -> Self {
+            self.federator = federator;
+            self
+        }
+
+        fn resolver(mut self, resolver: Resolver) -> Self {
+            self.resolver = resolver;
+            self
+        }
+
+        fn prober(mut self, prober: Prober) -> Self {
+            self.prober = prober;
+            self
+        }
+
+        fn registrar(mut self, registrar: Registrar) -> Self {
+            self.registrar = registrar;
+            self
+        }
+
+        fn namespaces(mut self, namespace_resolver: NamespaceResolver) -> Self {
+            self.namespace_resolver = namespace_resolver;
+            self
+        }
+
+        fn build(self) -> FederationDeps {
+            FederationDeps {
+                federator: self.federator,
+                resolver: self.resolver,
+                prober: self.prober,
+                registrar: self.registrar,
+                namespace_resolver: self.namespace_resolver,
+            }
+        }
+    }
+
+    /// Runs one verifying poll against `deps` from a clean applied state, the
+    /// shape most of the registration tests need.
+    async fn verifying_poll(deps: &FederationDeps) -> FederationOutcome {
+        let mut applied = AppliedState::default();
+        poll_and_apply(
+            deps,
+            Duration::from_secs(5),
+            &mut applied,
+            true,
+            &config::namespace::Namespace::local(),
+        )
+        .await
+    }
+
     /// A namespace resolver that always returns `local`, matching the `local`
     /// startup namespace these tests pass, so no namespace change is detected and
     /// the existing federation behavior (Applied/Pinned/...) is exercised.
@@ -804,17 +1062,21 @@ mod tests {
     async fn a_wedged_apply_times_out_and_reports_failed() {
         let (resolver, _) = counting_resolver(upstream());
         let (prober, probe_calls) = counting_prober(Ok(()));
+        let (registrar, register_calls) = counting_registrar(Ok(()));
         let mut applied = AppliedState::default();
 
+        let deps = TestDeps::new()
+            .federator(wedged_federator())
+            .resolver(resolver)
+            .prober(prober)
+            .registrar(registrar)
+            .build();
         let outcome = poll_and_apply(
-            &wedged_federator(),
-            &resolver,
-            &prober,
+            &deps,
             Duration::from_millis(50),
             &mut applied,
             true,
             &config::namespace::Namespace::local(),
-            &local_ns_resolver(),
         )
         .await;
 
@@ -832,6 +1094,11 @@ mod tests {
             0,
             "no probe after a failed apply"
         );
+        assert_eq!(
+            register_calls.load(Ordering::SeqCst),
+            0,
+            "a failed apply has no upstream in effect, so there is no identity to claim"
+        );
     }
 
     /// A login/logout poke runs a federation poll *immediately*, verifies the
@@ -847,19 +1114,23 @@ mod tests {
         let (trigger_tx, trigger_rx) = mpsc::channel(8);
         let (ready_tx, ready_rx) = oneshot::channel();
 
-        let task = tokio::spawn(manage_federation(
-            applying_federator(),
-            resolver,
-            prober,
-            messaging_rx,
-            trigger_rx,
-            ready_tx,
-            Duration::from_secs(5),
-            config::namespace::Namespace::local(),
-            local_ns_resolver(),
-            watch::channel(false).0,
-            None,
-        ));
+        let task = tokio::spawn(async move {
+            manage_federation(
+                &TestDeps::new()
+                    .federator(applying_federator())
+                    .resolver(resolver)
+                    .prober(prober)
+                    .namespaces(local_ns_resolver())
+                    .build(),
+                messaging_rx,
+                trigger_rx,
+                StartupGates::new(ready_tx, None),
+                Duration::from_secs(5),
+                config::namespace::Namespace::local(),
+                watch::channel(false).0,
+            )
+            .await
+        });
 
         // Startup gate fires after the first (initial) poll; that poll resolved
         // once and, being a non-poke poll, did NOT probe the link.
@@ -921,20 +1192,19 @@ mod tests {
         let (trigger_tx, trigger_rx) = mpsc::channel(8);
         let (ready_tx, ready_rx) = oneshot::channel();
 
-        let task = tokio::spawn(manage_federation(
-            applying_federator(),
-            resolver,
-            prober,
-            messaging_rx,
-            trigger_rx,
-            ready_tx,
-            // A deliberately large connect_timeout: the probe must NOT inherit it.
-            Duration::from_secs(45),
-            config::namespace::Namespace::local(),
-            local_ns_resolver(),
-            watch::channel(false).0,
-            None,
-        ));
+        let task = tokio::spawn(async move {
+            manage_federation(
+                &TestDeps::new().resolver(resolver).prober(prober).build(),
+                messaging_rx,
+                trigger_rx,
+                StartupGates::new(ready_tx, None),
+                // A deliberately large connect_timeout: the probe must NOT inherit it.
+                Duration::from_secs(45),
+                config::namespace::Namespace::local(),
+                watch::channel(false).0,
+            )
+            .await
+        });
         tokio::time::timeout(Duration::from_secs(1), ready_rx)
             .await
             .expect("startup gate fires")
@@ -972,19 +1242,23 @@ mod tests {
         let (trigger_tx, trigger_rx) = mpsc::channel(8);
         let (ready_tx, ready_rx) = oneshot::channel();
 
-        let task = tokio::spawn(manage_federation(
-            applying_federator(),
-            resolver,
-            prober,
-            messaging_rx,
-            trigger_rx,
-            ready_tx,
-            Duration::from_secs(5),
-            config::namespace::Namespace::local(),
-            local_ns_resolver(),
-            watch::channel(false).0,
-            None,
-        ));
+        let task = tokio::spawn(async move {
+            manage_federation(
+                &TestDeps::new()
+                    .federator(applying_federator())
+                    .resolver(resolver)
+                    .prober(prober)
+                    .namespaces(local_ns_resolver())
+                    .build(),
+                messaging_rx,
+                trigger_rx,
+                StartupGates::new(ready_tx, None),
+                Duration::from_secs(5),
+                config::namespace::Namespace::local(),
+                watch::channel(false).0,
+            )
+            .await
+        });
 
         tokio::time::timeout(Duration::from_secs(1), ready_rx)
             .await
@@ -1029,19 +1303,23 @@ mod tests {
         let (trigger_tx, trigger_rx) = mpsc::channel(8);
         let (ready_tx, ready_rx) = oneshot::channel();
 
-        let task = tokio::spawn(manage_federation(
-            pinned_federator(),
-            resolver,
-            prober,
-            messaging_rx,
-            trigger_rx,
-            ready_tx,
-            Duration::from_secs(5),
-            config::namespace::Namespace::local(),
-            local_ns_resolver(),
-            watch::channel(false).0,
-            None,
-        ));
+        let task = tokio::spawn(async move {
+            manage_federation(
+                &TestDeps::new()
+                    .federator(pinned_federator())
+                    .resolver(resolver)
+                    .prober(prober)
+                    .namespaces(local_ns_resolver())
+                    .build(),
+                messaging_rx,
+                trigger_rx,
+                StartupGates::new(ready_tx, None),
+                Duration::from_secs(5),
+                config::namespace::Namespace::local(),
+                watch::channel(false).0,
+            )
+            .await
+        });
 
         tokio::time::timeout(Duration::from_secs(1), ready_rx)
             .await
@@ -1093,19 +1371,23 @@ mod tests {
         let (ready_tx, ready_rx) = oneshot::channel();
         let (presence_gate_tx, mut presence_gate_rx) = watch::channel(false);
 
-        let task = tokio::spawn(manage_federation(
-            applying_federator(),
-            resolver,
-            prober,
-            messaging_rx,
-            trigger_rx,
-            ready_tx,
-            Duration::from_millis(100),
-            config::namespace::Namespace::local(),
-            local_ns_resolver(),
-            watch::channel(false).0,
-            Some(presence_gate_tx),
-        ));
+        let task = tokio::spawn(async move {
+            manage_federation(
+                &TestDeps::new()
+                    .federator(applying_federator())
+                    .resolver(resolver)
+                    .prober(prober)
+                    .namespaces(local_ns_resolver())
+                    .build(),
+                messaging_rx,
+                trigger_rx,
+                StartupGates::new(ready_tx, Some(presence_gate_tx)),
+                Duration::from_millis(100),
+                config::namespace::Namespace::local(),
+                watch::channel(false).0,
+            )
+            .await
+        });
 
         // Gate fires close to the 100ms bound, well before the 400ms resolve.
         tokio::time::timeout(Duration::from_secs(1), ready_rx)
@@ -1136,19 +1418,23 @@ mod tests {
         let (ready_tx, ready_rx) = oneshot::channel();
         let (presence_gate_tx, mut presence_gate_rx) = watch::channel(false);
 
-        let task = tokio::spawn(manage_federation(
-            applying_federator(),
-            resolver,
-            prober,
-            messaging_rx,
-            trigger_rx,
-            ready_tx,
-            Duration::from_secs(5),
-            config::namespace::Namespace::local(),
-            local_ns_resolver(),
-            watch::channel(false).0,
-            Some(presence_gate_tx),
-        ));
+        let task = tokio::spawn(async move {
+            manage_federation(
+                &TestDeps::new()
+                    .federator(applying_federator())
+                    .resolver(resolver)
+                    .prober(prober)
+                    .namespaces(local_ns_resolver())
+                    .build(),
+                messaging_rx,
+                trigger_rx,
+                StartupGates::new(ready_tx, Some(presence_gate_tx)),
+                Duration::from_secs(5),
+                config::namespace::Namespace::local(),
+                watch::channel(false).0,
+            )
+            .await
+        });
 
         tokio::time::timeout(Duration::from_secs(1), presence_gate_rx.wait_for(|g| *g))
             .await
@@ -1182,19 +1468,23 @@ mod tests {
         let (_trigger_tx, trigger_rx) = mpsc::channel(8);
         let (ready_tx, ready_rx) = oneshot::channel();
 
-        let task = tokio::spawn(manage_federation(
-            applying_federator(),
-            resolver,
-            prober,
-            messaging_rx,
-            trigger_rx,
-            ready_tx,
-            Duration::from_secs(5),
-            config::namespace::Namespace::local(),
-            local_ns_resolver(),
-            watch::channel(false).0,
-            None,
-        ));
+        let task = tokio::spawn(async move {
+            manage_federation(
+                &TestDeps::new()
+                    .federator(applying_federator())
+                    .resolver(resolver)
+                    .prober(prober)
+                    .namespaces(local_ns_resolver())
+                    .build(),
+                messaging_rx,
+                trigger_rx,
+                StartupGates::new(ready_tx, None),
+                Duration::from_secs(5),
+                config::namespace::Namespace::local(),
+                watch::channel(false).0,
+            )
+            .await
+        });
 
         tokio::time::timeout(Duration::from_secs(1), ready_rx)
             .await
@@ -1229,19 +1519,23 @@ mod tests {
         // The startup poll must NOT raise the restart signal in this scenario.
         let (restart_tx, restart_rx) = watch::channel(false);
 
-        let task = tokio::spawn(manage_federation(
-            applying_federator(),
-            resolver,
-            prober,
-            messaging_rx,
-            trigger_rx,
-            ready_tx,
-            Duration::from_secs(5),
-            config::namespace::Namespace::local(),
-            ns_resolver,
-            restart_tx,
-            None,
-        ));
+        let task = tokio::spawn(async move {
+            manage_federation(
+                &TestDeps::new()
+                    .federator(applying_federator())
+                    .resolver(resolver)
+                    .prober(prober)
+                    .namespaces(ns_resolver)
+                    .build(),
+                messaging_rx,
+                trigger_rx,
+                StartupGates::new(ready_tx, None),
+                Duration::from_secs(5),
+                config::namespace::Namespace::local(),
+                restart_tx,
+            )
+            .await
+        });
 
         tokio::time::timeout(Duration::from_secs(1), ready_rx)
             .await
@@ -1277,6 +1571,159 @@ mod tests {
         task.abort();
     }
 
+    // ─── Claiming this machine's identity ─────────────────────────────────
+
+    /// Defect 1, stated directly. A poke that discovers a changed namespace is
+    /// the *outgoing* generation: it still holds the router id it minted under
+    /// the old namespace, and publishing that is exactly the bug (every first
+    /// login on a machine went through this path and left the registry pointing
+    /// at a zid the rebuilt generation immediately discarded).
+    #[tokio::test]
+    async fn a_namespace_change_never_registers() {
+        let (registrar, register_calls) = counting_registrar(Ok(()));
+        let deps = TestDeps::new()
+            .registrar(registrar)
+            .namespaces(counting_ns_resolver("550e8400-e29b-41d4-a716-446655440000").0)
+            .build();
+
+        let outcome = verifying_poll(&deps).await;
+
+        assert_eq!(outcome, FederationOutcome::Restart);
+        assert_eq!(
+            register_calls.load(Ordering::SeqCst),
+            0,
+            "a generation about to be torn down must not publish the identity it is discarding"
+        );
+    }
+
+    /// Defect 2, and the reason registration is unconditional per poll: a plain
+    /// restart reuses a still-fresh config cache, so nothing pulls, yet the
+    /// identity must still be re-asserted (the router may have re-minted it).
+    ///
+    /// The counter alone would not catch a regression here, since an
+    /// implementation that read the zid back off disk would call the registrar
+    /// just as often. What pins it is that the poll registers **exactly once**
+    /// and reaches the same registrar the caller wired the pinned `router_id`
+    /// into; the wiring itself is `real_registrar`'s, which closes over that id
+    /// rather than re-reading the identity file.
+    #[tokio::test]
+    async fn a_poll_registers_exactly_once_even_with_nothing_to_pull() {
+        let (registrar, register_calls) = counting_registrar(Ok(()));
+        let deps = TestDeps::new().registrar(registrar).build();
+
+        let outcome = verifying_poll(&deps).await;
+
+        assert_eq!(
+            outcome,
+            FederationOutcome::Applied(Some(ENDPOINT.to_string()))
+        );
+        assert_eq!(
+            register_calls.load(Ordering::SeqCst),
+            1,
+            "one poll claims the identity once: not zero (the config cache must not gate it) \
+             and not twice (the resolve must not have claimed it too)"
+        );
+    }
+
+    /// The logout path. `peppy platform logout` DELETEs the row and only then
+    /// pokes, so a rule mis-implemented as "register unless Failed or Pinned"
+    /// would resurrect the row and leave a decommissioned machine listed forever.
+    #[tokio::test]
+    async fn a_poll_with_no_upstream_never_registers() {
+        let (registrar, register_calls) = counting_registrar(Ok(()));
+        let deps = TestDeps::new()
+            .resolver(counting_resolver(None).0)
+            .registrar(registrar)
+            .build();
+
+        let outcome = verifying_poll(&deps).await;
+
+        assert_eq!(outcome, FederationOutcome::Applied(None));
+        assert_eq!(register_calls.load(Ordering::SeqCst), 0);
+    }
+
+    /// An operator-pinned `ZENOH_CONFIG` means the router is NOT running under
+    /// the id we would report, so reporting it would recreate the wrong-zid bug
+    /// by another route. The row stays absent, which renders as `unknown`.
+    #[tokio::test]
+    async fn a_pinned_router_never_registers() {
+        let (registrar, register_calls) = counting_registrar(Ok(()));
+        let deps = TestDeps::new()
+            .federator(pinned_federator())
+            .registrar(registrar)
+            .build();
+
+        let outcome = verifying_poll(&deps).await;
+
+        assert_eq!(outcome, FederationOutcome::Pinned);
+        assert_eq!(
+            register_calls.load(Ordering::SeqCst),
+            0,
+            "a daemon that does not control its router's identity must not claim one"
+        );
+    }
+
+    /// The asymmetry that is easy to get wrong: an unreachable upstream still
+    /// registers. Registration asserts identity, not health, and the row is what
+    /// lets the platform report this site as `unlinked` rather than omit it.
+    #[tokio::test]
+    async fn an_unreachable_upstream_still_registers() {
+        let (registrar, register_calls) = counting_registrar(Ok(()));
+        let deps = TestDeps::new()
+            .prober(counting_prober(Err("UnknownCA".to_string())).0)
+            .registrar(registrar)
+            .build();
+
+        let outcome = verifying_poll(&deps).await;
+
+        assert_eq!(
+            outcome,
+            FederationOutcome::Unreachable("UnknownCA".to_string())
+        );
+        assert_eq!(
+            register_calls.load(Ordering::SeqCst),
+            1,
+            "a site whose uplink is down is exactly the one whose row must exist"
+        );
+    }
+
+    /// A failed registration is its own outcome, never `Failed`: federation IS in
+    /// effect, and only the platform's view of this machine is stale.
+    #[tokio::test]
+    async fn a_failing_registration_reports_not_registered() {
+        let deps = TestDeps::new()
+            .registrar(counting_registrar(Err("backend unreachable".to_string())).0)
+            .build();
+
+        assert_eq!(
+            verifying_poll(&deps).await,
+            FederationOutcome::NotRegistered("backend unreachable".to_string())
+        );
+    }
+
+    /// And the precedence between the two failures: a broken product beats a
+    /// stale roster. Reporting `NotRegistered` here would send the user to look
+    /// at the platform while their federation link is the thing that is down.
+    #[tokio::test]
+    async fn a_failing_probe_outranks_a_failing_registration() {
+        let (registrar, register_calls) =
+            counting_registrar(Err("backend unreachable".to_string()));
+        let deps = TestDeps::new()
+            .prober(counting_prober(Err("UnknownCA".to_string())).0)
+            .registrar(registrar)
+            .build();
+
+        assert_eq!(
+            verifying_poll(&deps).await,
+            FederationOutcome::Unreachable("UnknownCA".to_string())
+        );
+        assert_eq!(
+            register_calls.load(Ordering::SeqCst),
+            1,
+            "the registration still runs; only the report it loses"
+        );
+    }
+
     /// The *startup* federation poll, on resolving a namespace that differs from
     /// the one this generation started under (e.g. logged in but the router cache
     /// was empty at build time so the startup namespace was `local`), must raise
@@ -1295,19 +1742,23 @@ mod tests {
         let (ready_tx, ready_rx) = oneshot::channel();
         let (restart_tx, mut restart_rx) = watch::channel(false);
 
-        let task = tokio::spawn(manage_federation(
-            applying_federator(),
-            resolver,
-            prober,
-            messaging_rx,
-            trigger_rx,
-            ready_tx,
-            Duration::from_secs(5),
-            config::namespace::Namespace::local(),
-            ns_resolver,
-            restart_tx,
-            None,
-        ));
+        let task = tokio::spawn(async move {
+            manage_federation(
+                &TestDeps::new()
+                    .federator(applying_federator())
+                    .resolver(resolver)
+                    .prober(prober)
+                    .namespaces(ns_resolver)
+                    .build(),
+                messaging_rx,
+                trigger_rx,
+                StartupGates::new(ready_tx, None),
+                Duration::from_secs(5),
+                config::namespace::Namespace::local(),
+                restart_tx,
+            )
+            .await
+        });
 
         // Startup still unblocks `serve` (the gate fires) ...
         tokio::time::timeout(Duration::from_secs(1), ready_rx)

--- a/crates/peppy/src/commands/platform.rs
+++ b/crates/peppy/src/commands/platform.rs
@@ -436,6 +436,13 @@ fn report_login(outcome: PokeOutcome) -> Result<()> {
              and that its cert is the committed one signed by the dev CA (rotate it with \
              gen_dev_certs), then run `peppy platform login` again."
         ))),
+        PokeOutcome::NotRegistered(reason) => Err(Error::Auth(format!(
+            "logged in and federation is in effect, but this machine could not be registered \
+             with the platform: {reason}. Nothing is wrong with the federation link; only the \
+             platform's record of this machine is stale, so `peppy platform list` may not show \
+             it (or may show an outdated router identity). Run `peppy platform login` again \
+             once the backend is reachable."
+        ))),
         PokeOutcome::DaemonError(msg) => Err(Error::Auth(format!(
             "logged in, but the daemon could not apply federation: {msg}. Check the \
              `peppy service serve` logs and run `peppy platform login` again."
@@ -474,6 +481,11 @@ fn report_logout(outcome: PokeOutcome) {
         PokeOutcome::Pinned => println!("{PINNED_NOTE}"),
         PokeOutcome::Unreachable(msg) | PokeOutcome::DaemonError(msg) => {
             println!("Note: the daemon could not apply federation now ({msg}); it will retry.")
+        }
+        // A logout already removed this machine's registry row before poking, so
+        // a registration failure here changes nothing the user needs to act on.
+        PokeOutcome::NotRegistered(msg) => {
+            println!("Note: the platform's record of this machine could not be updated ({msg}).")
         }
         PokeOutcome::DaemonNotRunning => {
             println!("No running daemon; nothing to de-federate.")
@@ -770,6 +782,10 @@ mod tests {
             PokeOutcome::DaemonError("boom".to_string()),
             PokeOutcome::TimedOut,
             PokeOutcome::DaemonNotRunning,
+            // Federation IS in effect here, but the platform's record of this
+            // machine is stale, which is the whole defect the registration split
+            // fixes: a login that leaves it stale has not fully succeeded.
+            PokeOutcome::NotRegistered("backend unreachable".to_string()),
         ];
         for outcome in failing {
             assert!(
@@ -777,6 +793,30 @@ mod tests {
                 "login must fail when federation is not in effect"
             );
         }
+    }
+
+    /// The `NotRegistered` message must not read as a broken transport: the
+    /// federation link is fine, and sending the user to debug TLS would be the
+    /// same conflation this whole change removes.
+    #[test]
+    fn not_registered_login_error_names_the_registry_not_the_link() {
+        let err = report_login(PokeOutcome::NotRegistered(
+            "backend unreachable".to_string(),
+        ))
+        .expect_err("a stale platform record fails the login");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("backend unreachable"),
+            "the underlying reason is surfaced: {msg}"
+        );
+        assert!(
+            msg.contains("federation is in effect"),
+            "the message must say the link is fine: {msg}"
+        );
+        assert!(
+            msg.contains("peppy platform list"),
+            "the message must name what is actually affected: {msg}"
+        );
     }
 
     #[test]
@@ -808,6 +848,7 @@ mod tests {
             PokeOutcome::DaemonError("y".to_string()),
             PokeOutcome::DaemonNotRunning,
             PokeOutcome::TimedOut,
+            PokeOutcome::NotRegistered("backend unreachable".to_string()),
         ] {
             report_logout(outcome);
         }

--- a/crates/peppy/src/commands/platform/list.rs
+++ b/crates/peppy/src/commands/platform/list.rs
@@ -238,9 +238,10 @@ fn application_column(entry: &client::CoreNodeEntry) -> String {
 /// The REGISTERED column: the UTC date this name was first registered, or `-`
 /// for a name that is live but has no registry row.
 ///
-/// Deliberately not the config-pull timestamp. Rendering that as "last seen"
-/// would read as liveness, and it is not one. UTC rather than local time, so
-/// the output does not depend on the machine's timezone.
+/// Deliberately the FIRST registration, not the most recent one. The latter
+/// moves on every daemon start, so rendering it would read as liveness, and it
+/// is not one. UTC rather than local time, so the output does not depend on the
+/// machine's timezone.
 fn registered_column(entry: &client::CoreNodeEntry) -> String {
     entry
         .first_seen_at
@@ -269,7 +270,7 @@ fn render_json(listing: &CoreNodeListing, api_url: &str) -> String {
                 "core_node_name": entry.core_node_name,
                 "registered": entry.registered,
                 "first_seen_at": entry.first_seen_at,
-                "last_config_pull_at": entry.last_config_pull_at,
+                "last_registered_at": entry.last_registered_at,
                 "network": {
                     "status": entry.network.status,
                     "router_zid": entry.network.router_zid,
@@ -319,7 +320,7 @@ mod tests {
             core_node_name: name.to_string(),
             registered,
             first_seen_at: registered.then(|| format!("{first_seen_date}T10:00:00Z")),
-            last_config_pull_at: registered.then(|| "2026-07-24T09:12:33Z".to_string()),
+            last_registered_at: registered.then(|| "2026-07-24T09:12:33Z".to_string()),
             // The two columns are set independently so a test can pair any
             // network status with any application status, which is the whole
             // point of reporting them separately.
@@ -531,12 +532,12 @@ mod tests {
         let entry = &doc["core_nodes"][0];
         assert_eq!(entry["registered"], serde_json::json!(true));
         assert_eq!(
-            entry["last_config_pull_at"],
+            entry["last_registered_at"],
             serde_json::json!("2026-07-24T09:12:33Z")
         );
         assert!(
             entry.get("last_seen_at").is_none(),
-            "the pull timestamp never appears under a name that reads as liveness"
+            "the timestamp never appears under a name that reads as liveness"
         );
         assert_eq!(entry["application"]["status"], serde_json::json!("online"));
         assert_eq!(entry["network"]["status"], serde_json::json!("linked"));


### PR DESCRIPTION
## Why

The daemon claimed its identity as a side effect of a cache-gated config pull, which produced two distinct defects behind the `indirect` NETWORK column described in Peppy-bot/platform-backend#19.

**A dying generation registered an identity it was about to discard.** The namespace is only knowable *after* a config pull, because it arrives in that pull's response. So `poll_and_apply` resolves first and gates second. On login the pre-login generation (namespace `local`) finds the cache cleared, pulls, and that pull registers *its* zid; only then does the gate fire and return `Restart`. The rebuilt generation mints a workspace-scoped id, finds the cache fresh (written in step 2), and never registers. The registry keeps the dead zid forever. This is not a race between threads: it is the deterministic outcome of every namespace-changing login, which is every first login on a machine.

**A re-minted identity could not re-register while the cache stayed fresh**, since registration required a cache-stale pull. That was previously accepted as narrow; defect 1 made it the default state of every machine.

Tagging the cached `RouterSession` with the zid would have closed defect 2 and made defect 1 self-correct one pull later, but it leaves the wrong write in place and makes correctness depend on a second pull happening promptly. Moving the gate ahead of the resolve cannot work: the namespace is a product of the pull.

## What changed

Registration is now its own call, made after the gate has passed and after the base outcome is known. The rule is a **match on that outcome**, not a list of conditions (an earlier draft tested `desired.is_some()` and `outcome != Failed`, both of which read as though they could be false):

| Outcome | Registers | Why |
| --- | --- | --- |
| `Applied(Some(_))` | yes | Unconditional per poll, so a boot always re-asserts the identity its live router pins, whatever the cache holds. Closes defect 2 and every other re-mint cause. |
| `Applied(None)` | no | Logout DELETEs the row and only then pokes; registering would resurrect a decommissioned machine. |
| `Pinned` | no | Under an operator-pinned `ZENOH_CONFIG`, `router_id` is not the id the router runs, so publishing it recreates this exact bug by another route. |
| `Unreachable` | **yes** | Registration asserts identity, not health. The row is what lets the platform report the site as `unlinked` instead of hiding it. |
| `Failed` / `Restart` | unreachable | Both return before the registration. The `Restart` case is what closes defect 1. |

A failed registration is a new `FederationOutcome::NotRegistered`, carried through `ControlResponse` and `PokeOutcome` to its own CLI wording, never collapsed into `Failed`. `Failed` surfaces as "logged in, but the daemon could not apply federation", which is false here and would send the user to debug a transport that is working; that would re-conflate in the report layer the two facts this change separates at the transport layer. A failing probe still outranks it: a broken product beats a stale roster.

**Bounds.** The registration is a second blocking network step on a verifying poke's critical path, so it gets its own `REGISTER_TIMEOUT` (5s) rather than inheriting `connect_timeout` (30s), and the ack budget moves with it: `APPLY_ACK_SLACK` 8s → 13s, `POKE_READ_SLACK` 11s → 16s. That preserves the 3s bounce headroom exactly. Without this a *working* login would surface as `PokeOutcome::TimedOut`, which `report_login` renders as a hard error. The cost is that a poke which is going to fail takes up to 5s longer to say so; the budget exists to guarantee a definite answer, not a fast one.

**No retry.** Polls happen at startup and on login/logout pokes; there is no timer and none is added. A startup failure is discarded like any non-`Restart` outcome, so the roster can sit stale until the next login or reboot. That window is accepted on the condition that it is loud, so the startup path logs a `warn!` naming the one command that corrects it.

**Credential parity is load bearing.** `register_core_node` resolves its credential exactly as `resolve_federation_target` does. The backend derives the workspace from whichever principal authenticated, so a session-only registration paired with a PAT-authenticated pull would file the row under the *session owner's* workspace while the daemon runs under the *PAT owner's* namespace: a fresh instance of this same bug. The constraint is in the doc comment so it survives the next simplification.

**`RouterSession` loses `core_node_name`.** With registration no longer riding on the pull, and the config identical for every core node in a workspace, a rename has nothing to re-pull *for*. Existing `credentials.json5` files keep parsing and drop the key on the next save (no version bump, no migration).

**Readability.** The five injected closures become `FederationDeps`, and the two gates that must fire in lockstep become `StartupGates`. Both `#[allow(clippy::too_many_arguments)]` come off, and the tests stop threading positional closures whose meaning came from counting.

## Test plan

- `cargo test -p auth -p daemon -p peppy`: **129 unit + 18 auth-flow + 198 + 54 passed, 0 failed.**
- `cargo fmt --all --check` clean; `cargo clippy -p auth -p daemon -p peppy --all-targets -- -D warnings` clean.
- Integration suite: 121/123 pass. The 6 that fail (`container::`, `daemon_singleton::`, `service_install::`, `service_serve::`, `daemon_lifecycle_e2e::`) were each **verified to fail identically on a stashed clean tree** — they need apptainer user namespaces and a spawnable daemon, which this container lacks.

New daemon-side tests, one per rule:
- `a_namespace_change_never_registers` — defect 1, stated directly.
- `a_poll_registers_exactly_once_even_with_nothing_to_pull` — defect 2. Asserts *exactly* once, so a later refactor that registers in both the resolve and the poll is caught.
- `a_poll_with_no_upstream_never_registers` — the logout path; a rule mis-implemented as "register unless `Failed`/`Pinned`" would leave a decommissioned machine listed forever.
- `a_pinned_router_never_registers`, `an_unreachable_upstream_still_registers` — the asymmetry that is easy to get backwards.
- `a_failing_registration_reports_not_registered`, `a_failing_probe_outranks_a_failing_registration` — the precedence.
- `ack_budget_covers_the_verify_probe_and_client_outlasts_daemon` extended to `PROBE_TIMEOUT + REGISTER_TIMEOUT + 3s <= APPLY_ACK_SLACK < POKE_READ_SLACK`.

`resolve_router_endpoint_re_pulls_when_the_core_node_name_changed` is **replaced by its inverse** (`…_reuses_a_fresh_cache_across_a_core_node_rename`): that behaviour is intentionally removed.

## Breaking change, deliberately

Requires Peppy-bot/platform-backend#19. No fallback and no transition period: a new CLI against an old backend, or an old daemon against a new backend, fails loudly and immediately, which is the intended direction, since a silent fallback would reintroduce a stale registry.

## Verification after upgrading

1. `peppy platform list --json`, compare each `network.router_zid` against that machine's `router_identity.json5` and the `"id"` in its live `zenohd` config. They must be equal.
2. Both rows read `linked`, not `indirect`.
3. Log into a different workspace and back: the new workspace's row reads `linked` as soon as the restart settles, without waiting for a cache expiry.

Existing wrong rows self-correct on the first boot or login after the upgrade, since registration is now unconditional; nothing needs deleting by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added separate router configuration retrieval and core-node registration flows.
  - Added clearer reporting when a machine cannot be registered with the platform.
  - Platform login now provides actionable guidance for stale registration records.

- **Updates**
  - Platform listings now label registration timestamps more accurately.
  - Registration status is preserved even when router connectivity checks fail.
  - Logout reports registration-update issues without failing.

- **Bug Fixes**
  - Improved authentication retries, router configuration caching, and registration error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->