### PR TITLE
Bundle squashfuse with apptainer so SIFs are FUSE-mounted, not extracted

### DIFF
--- a/crates/containers-internal/Cargo.toml
+++ b/crates/containers-internal/Cargo.toml
@@ -6,6 +6,10 @@ edition.workspace = true
 
 [dependencies]
 config = { workspace = true }
+# `PeppyDirs::tmp_dir` roots the scratch directory handed to apptainer as
+# `APPTAINER_TMPDIR`, so it lands on the same peppy-owned tree as every other
+# peppy temporary instead of the host's `/tmp`.
+daemon-config = { workspace = true }
 serde_yaml = "0.9"
 thiserror = "2.0"
 tracing = "0.1"
@@ -13,8 +17,6 @@ tracing = "0.1"
 [dev-dependencies]
 # Only `test_tmp_root` is needed (no git fixtures), so no `git_fixtures` feature.
 config-test-support = { workspace = true }
-# `DEFAULT_ALPINE_BASE_IMAGE` in tests/facade.rs.
-daemon-config = { workspace = true }
 tempfile = "3"
 
 [build-dependencies]

--- a/crates/containers-internal/build.rs
+++ b/crates/containers-internal/build.rs
@@ -1,7 +1,7 @@
 mod apptainer_build {
     use std::env;
     use std::path::{Path, PathBuf};
-    use std::process::Command;
+    use std::process::{Command, Stdio};
     use std::time::Duration;
 
     const APPTAINER_VERSION: &str = "1.5.2";
@@ -34,6 +34,9 @@ mod apptainer_build {
     /// libraries, a different install layout. It is part of the cache sentinel
     /// filename, so a bump invalidates every previously built cache instead of
     /// silently shipping a tree built by the old recipe.
+    ///
+    /// Bumping [`SQUASHFUSE_VERSION`] is not one of those occasions: it is keyed
+    /// into the sentinel filename in its own right.
     ///
     /// r2 added the bundled `squashfuse_ll` (see [`SQUASHFUSE_VERSION`]). It has
     /// to be a revision bump rather than a retrofit of existing caches: unlike
@@ -106,11 +109,20 @@ mod apptainer_build {
     /// entirely. `mconfig`/`make` do not build it: apptainer's own packaging
     /// compiles it separately and installs it next to `starter`, which is what
     /// [`build_and_install_squashfuse`] mirrors.
+    ///
+    /// Keyed into the cache sentinel filename (see
+    /// [`apptainer_cache_sentinel_path`]), so a bump here invalidates every
+    /// cached tree on its own and needs no [`APPTAINER_RECIPE_REVISION`] bump.
     const SQUASHFUSE_VERSION: &str = "0.6.2";
-    /// SHA-256 of `squashfuse-{SQUASHFUSE_VERSION}.tar.gz` from the GitHub
-    /// source archive. Bump alongside `SQUASHFUSE_VERSION`.
+    /// SHA-256 of `squashfuse-{SQUASHFUSE_VERSION}.tar.gz` as published on the
+    /// GitHub *release*. Bump alongside `SQUASHFUSE_VERSION`.
+    ///
+    /// The release asset, not the `/archive/` snapshot of the same tag: the two
+    /// share a filename but not their contents, and only the release one is an
+    /// autotools `dist` tarball carrying a pre-generated `configure` (see
+    /// [`squashfuse_source_url`]).
     const SQUASHFUSE_SHA256: &str =
-        "ae194df463ac5a9cbb25f94021d44bfb14dc21a0fc577e16348eca2fdc77c83b";
+        "267f2852d6e20147eb1e21931f9d0fe7634a66612f1ede27e15fa60e56ce0eac";
 
     const LIMA_VERSION: &str = "2.1.3";
     const LIMA_DARWIN_ARM64_ARCHIVE_SHA256: &str =
@@ -141,20 +153,73 @@ mod apptainer_build {
     /// `apptainer_compile_steps`) rather than taken from apt, which ships a Go
     /// too old for apptainer's `mconfig`.
     ///
-    /// The second line covers the bundled squashfuse build (see
-    /// [`SQUASHFUSE_VERSION`]): autotools to run its `autogen.sh`, plus headers
-    /// for FUSE and for every compressor a squashfs image may use (zlib, lzo,
-    /// lz4, xz, zstd). They are only ever linked statically into
-    /// `squashfuse_ll`, so nothing here has to exist on the machines peppy
-    /// installs onto.
+    /// The second group covers the bundled squashfuse build (see
+    /// [`SQUASHFUSE_VERSION`]): headers for FUSE and for every compressor a
+    /// squashfs image may use (zlib, lzo, lz4, xz, zstd). They are only ever
+    /// linked statically into `squashfuse_ll`, so nothing here has to exist on
+    /// the machines peppy installs onto. Autotools is deliberately absent:
+    /// squashfuse is built from a `dist` tarball that already carries
+    /// `configure` (see [`squashfuse_source_url`]).
+    ///
+    /// Each entry pairs the package with the probe [`assert_host_build_deps`]
+    /// uses to prove it is present. The probes mirror how the consumer actually
+    /// looks the dependency up — `mconfig` and `configure` find FUSE and
+    /// libseccomp through pkg-config, and the compressors through a plain
+    /// `#include` — so peppy never rejects a host that would have built fine.
     ///
     /// `scripts/functions/lima.py` installs the same set into the release VM,
     /// where cargo (and therefore this build script) runs against a guest this
     /// list never provisions itself. Keep the two in sync.
-    const APPTAINER_BUILD_DEPS: &str = "libseccomp-dev make gcc pkg-config squashfs-tools \
-         cryptsetup curl ca-certificates \
-         autoconf automake libtool libfuse3-dev zlib1g-dev liblzo2-dev liblz4-dev liblzma-dev \
-         libzstd-dev";
+    const APPTAINER_BUILD_DEPS: &[BuildDep] = &[
+        BuildDep::new("make", DepProbe::Binary("make")),
+        BuildDep::new("gcc", DepProbe::Binary(HOST_CC)),
+        BuildDep::new("pkg-config", DepProbe::Binary("pkg-config")),
+        BuildDep::new("squashfs-tools", DepProbe::Binary("unsquashfs")),
+        BuildDep::new("cryptsetup", DepProbe::Binary("cryptsetup")),
+        BuildDep::new("curl", DepProbe::Binary("curl")),
+        // Carries no build input of its own: it is what makes the `curl`
+        // downloads above trust their TLS peers in a bare chroot.
+        BuildDep::new("ca-certificates", DepProbe::Unprobed),
+        BuildDep::new("libseccomp-dev", DepProbe::PkgConfig("libseccomp")),
+        BuildDep::new("libfuse3-dev", DepProbe::PkgConfig("fuse3")),
+        BuildDep::new("zlib1g-dev", DepProbe::Header("zlib.h")),
+        BuildDep::new("liblzo2-dev", DepProbe::Header("lzo/lzo1x.h")),
+        BuildDep::new("liblz4-dev", DepProbe::Header("lz4.h")),
+        BuildDep::new("liblzma-dev", DepProbe::Header("lzma.h")),
+        BuildDep::new("libzstd-dev", DepProbe::Header("zstd.h")),
+    ];
+
+    /// The C compiler both apptainer's `mconfig` and squashfuse's `configure`
+    /// default to, and therefore the one whose include path decides whether a
+    /// [`DepProbe::Header`] is really reachable.
+    const HOST_CC: &str = "cc";
+
+    /// One apt package the apptainer + squashfuse build needs, and the probe
+    /// that proves the host has it.
+    struct BuildDep {
+        /// Debian/Ubuntu package name, as passed to `apt-get install`.
+        package: &'static str,
+        probe: DepProbe,
+    }
+
+    impl BuildDep {
+        const fn new(package: &'static str, probe: DepProbe) -> Self {
+            Self { package, probe }
+        }
+    }
+
+    /// How to tell whether a [`BuildDep`] is installed.
+    enum DepProbe {
+        /// Executable that must be spawnable from `$PATH`.
+        Binary(&'static str),
+        /// pkg-config module that must resolve.
+        PkgConfig(&'static str),
+        /// Header that must be reachable on [`HOST_CC`]'s default search path.
+        Header(&'static str),
+        /// Nothing to probe: the package supplies data, not a build input.
+        Unprobed,
+    }
+
     const LIMA_TEMPLATE: &str = "template:ubuntu-24.04";
     /// Guest-side installation path for apptainer inside the Lima VM.
     /// Must match the `--prefix` used at build time.
@@ -164,10 +229,19 @@ mod apptainer_build {
     // Cache helpers
     // -----------------------------------------------------------------------
 
+    /// Name of the file marking a cache directory as built by *this* recipe.
+    ///
+    /// Every consumer validates the cache by testing this path for existence
+    /// (the contents are for humans), so everything that changes the produced
+    /// tree has to be keyed into the name or a stale cache is silently reused.
+    /// [`SQUASHFUSE_VERSION`] is keyed in alongside the recipe revision because
+    /// squashfuse is compiled into the tree with no version marker of its own —
+    /// unlike gocryptfs, which carries a version-keyed sentinel of its own
+    /// ([`gocryptfs_sentinel_path`]) and so re-installs itself on a bump.
     fn apptainer_cache_sentinel_path(cache_dir: &Path, version: &str) -> PathBuf {
         cache_dir.join(format!(
-            ".peppy-version-{}-r{}",
-            version, APPTAINER_RECIPE_REVISION
+            ".peppy-version-{}-r{}-sq{}",
+            version, APPTAINER_RECIPE_REVISION, SQUASHFUSE_VERSION
         ))
     }
 
@@ -176,8 +250,8 @@ mod apptainer_build {
         std::fs::write(
             &sentinel,
             format!(
-                "version={}\nrecipe={}\n",
-                version, APPTAINER_RECIPE_REVISION
+                "version={}\nrecipe={}\nsquashfuse={}\n",
+                version, APPTAINER_RECIPE_REVISION, SQUASHFUSE_VERSION
             ),
         )
         .unwrap_or_else(|e| panic!("Failed to write cache sentinel {:?}: {}", sentinel, e));
@@ -980,8 +1054,20 @@ mod apptainer_build {
     // finished install tree.
     // -----------------------------------------------------------------------
 
-    fn squashfuse_archive_url(version: &str) -> String {
-        format!("https://github.com/vasi/squashfuse/archive/{version}/squashfuse-{version}.tar.gz")
+    /// URL of the squashfuse release tarball.
+    ///
+    /// Deliberately the release asset rather than the `/archive/` snapshot
+    /// GitHub generates for the same tag. The snapshot is the bare source tree,
+    /// so building it starts with `./autogen.sh` and therefore demands
+    /// autoconf, automake and libtool on every machine that builds peppy; the
+    /// release asset is a `make dist` tarball with `configure` already
+    /// generated, which drops all three from
+    /// [`APPTAINER_BUILD_DEPS`]. Same upstream sources either way — only the
+    /// build-time toolchain requirement differs.
+    fn squashfuse_source_url(version: &str) -> String {
+        format!(
+            "https://github.com/vasi/squashfuse/releases/download/{version}/squashfuse-{version}.tar.gz"
+        )
     }
 
     /// Path apptainer's `FindBin` looks at for the squashfs FUSE mounter.
@@ -1041,13 +1127,13 @@ mod apptainer_build {
         }
         std::fs::remove_file(&tarball_path).ok();
 
-        // `autogen.sh` regenerates configure (the GitHub source archive ships
-        // none), `FLAGS=-std=c99` and `--enable-multithreading` mirror
-        // apptainer's `scripts/compile-dependencies` recipe, and only the
-        // `squashfuse_ll` target is built: apptainer never invokes the
-        // high-level `squashfuse` binary or installs the library.
-        let steps: [(&str, &[&str]); 3] = [
-            ("./autogen.sh", &[]),
+        // No `autogen.sh`: the release tarball ships a generated `configure`
+        // (see [`squashfuse_source_url`]). `FLAGS=-std=c99` and
+        // `--enable-multithreading` mirror apptainer's
+        // `scripts/compile-dependencies` recipe, and only the `squashfuse_ll`
+        // target is built: apptainer never invokes the high-level `squashfuse`
+        // binary or installs the library.
+        let steps: [(&str, &[&str]); 2] = [
             ("./configure", &["--enable-multithreading"]),
             ("make", &["squashfuse_ll", "LDFLAGS=-all-static", "-j"]),
         ];
@@ -1098,7 +1184,7 @@ mod apptainer_build {
             return true;
         }
 
-        let url = squashfuse_archive_url(SQUASHFUSE_VERSION);
+        let url = squashfuse_source_url(SQUASHFUSE_VERSION);
         if !build_helpers::run_command(
             Command::new("curl").args(["-fsSL", &url, "-o"]).arg(dest),
             &format!("download squashfuse {} source archive", SQUASHFUSE_VERSION),
@@ -1158,16 +1244,176 @@ mod apptainer_build {
     // Build apptainer from source
     // -----------------------------------------------------------------------
 
+    /// The package list as an `apt-get install` argument string.
+    fn apptainer_build_deps_apt() -> String {
+        APPTAINER_BUILD_DEPS
+            .iter()
+            .map(|dep| dep.package)
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+
+    /// Fail before the build starts when the host is missing anything in
+    /// [`APPTAINER_BUILD_DEPS`], naming every missing package in one message.
+    ///
+    /// Worth checking up front because both ways this fails without it are bad.
+    /// The loud one is merely slow: apptainer compiles for minutes before
+    /// squashfuse's `configure` dies, and it names only the first thing it
+    /// happened to reach for. The quiet one is worse — a dependency that is
+    /// *optional to the tool being configured* gets skipped rather than
+    /// reported, and the build succeeds with a hole in it. `configure` drops a
+    /// compressor whose headers are absent, leaving a `squashfuse_ll` that
+    /// cannot mount a SIF built with it, so apptainer falls back to extracting
+    /// the whole rootfs — the exact behaviour bundling it was meant to prevent.
+    /// `mconfig` logs `libseccomp+headers... no` and builds an apptainer with
+    /// seccomp filtering compiled out. Both surface much later, on a user's
+    /// machine, looking nothing like a missing apt package.
+    ///
+    /// Only the host build needs this: the Lima guest scripts apt-install the
+    /// same list themselves immediately before building.
+    fn assert_host_build_deps() {
+        let mut missing = Vec::new();
+        let mut unverified = Vec::new();
+        for dep in APPTAINER_BUILD_DEPS {
+            match dep.probe.satisfied() {
+                Some(true) => {}
+                Some(false) => missing.push(dep),
+                None => unverified.push(dep.package),
+            }
+        }
+        if missing.is_empty() {
+            return;
+        }
+
+        let mut report = vec![
+            format!(
+                "Cannot build apptainer {} and its bundled squashfuse {}: {} missing build {} \
+                 on this host.",
+                APPTAINER_VERSION,
+                SQUASHFUSE_VERSION,
+                missing.len(),
+                if missing.len() == 1 {
+                    "dependency"
+                } else {
+                    "dependencies"
+                },
+            ),
+            missing
+                .iter()
+                .map(|dep| format!("  {:<15} {}", dep.package, dep.probe.not_found_hint()))
+                .collect::<Vec<_>>()
+                .join("\n"),
+            format!(
+                "Install them with:\n  sudo apt-get install -y {}",
+                missing
+                    .iter()
+                    .map(|dep| dep.package)
+                    .collect::<Vec<_>>()
+                    .join(" ")
+            ),
+        ];
+        // Only ever non-empty alongside a missing pkg-config or C compiler,
+        // which is itself listed above, so this reads as a follow-up rather
+        // than as an unexplained gap.
+        if !unverified.is_empty() {
+            report.push(format!(
+                "Not checked, because a tool listed above is missing: {}. \
+                 Re-run once the install completes.",
+                unverified.join(", ")
+            ));
+        }
+        report.push(
+            "None of these are optional. `configure` silently *skips* a compressor whose headers \
+             it cannot find and still exits 0, producing a squashfuse that cannot mount images \
+             using that compressor."
+                .to_string(),
+        );
+
+        panic!("{}", report.join("\n\n"));
+    }
+
+    impl DepProbe {
+        /// `Some(false)` means proven absent. `None` means the probe could not
+        /// run because the tool it needs (pkg-config, the C compiler) is itself
+        /// one of the missing packages — an unknown answer, not a negative one,
+        /// and reporting it as missing would blame a dozen `-dev` packages on
+        /// one absent compiler.
+        fn satisfied(&self) -> Option<bool> {
+            match self {
+                DepProbe::Unprobed => Some(true),
+                DepProbe::Binary(program) => Some(binary_runs(program)),
+                DepProbe::PkgConfig(module) => binary_runs("pkg-config").then(|| {
+                    probe_succeeds(Command::new("pkg-config").arg("--exists").arg(module))
+                }),
+                // Preprocess an empty translation unit with the header forced
+                // in, which is how `configure` itself decides: the answer comes
+                // from the compiler's own search path rather than from a guess
+                // at where this distro puts its headers.
+                DepProbe::Header(header) => binary_runs(HOST_CC).then(|| {
+                    probe_succeeds(
+                        Command::new(HOST_CC)
+                            .args(["-x", "c", "-E", "-include"])
+                            .arg(header)
+                            .arg("/dev/null"),
+                    )
+                }),
+            }
+        }
+
+        /// How this probe failed, phrased so the reader can re-run it by hand.
+        fn not_found_hint(&self) -> String {
+            match self {
+                DepProbe::Binary(program) => format!("`{}` not on $PATH", program),
+                DepProbe::PkgConfig(module) => {
+                    format!("pkg-config module `{}` not found", module)
+                }
+                DepProbe::Header(header) => format!("<{}> not found by {}", header, HOST_CC),
+                DepProbe::Unprobed => "no probe".to_string(),
+            }
+        }
+    }
+
+    /// Whether `program` can be spawned from `$PATH`.
+    ///
+    /// Spawnability, not exit status: `unsquashfs` rejects `--version` and
+    /// exits non-zero while being perfectly present.
+    fn binary_runs(program: &str) -> bool {
+        silenced(Command::new(program).arg("--version"))
+            .status()
+            .is_ok()
+    }
+
+    /// Run a probe for its exit status, treating a failure to launch as a
+    /// failed probe.
+    fn probe_succeeds(command: &mut Command) -> bool {
+        silenced(command)
+            .status()
+            .map(|status| status.success())
+            .unwrap_or(false)
+    }
+
+    /// Discard a probe's stdio: these run for their exit status alone, and
+    /// their chatter would otherwise land in the cargo build log.
+    fn silenced(command: &mut Command) -> &mut Command {
+        command
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+    }
+
     /// Build apptainer from source on the local host (native builds only).
     ///
     /// Downloads the source tarball from GitHub, builds with `mconfig` + `make`,
     /// installs to `install_dir`, and adds the bundled squashfuse. Requires the
     /// packages listed in [`APPTAINER_BUILD_DEPS`] (plus Go, which the host
-    /// build takes from `$PATH`) to be available on the host.
+    /// build takes from `$PATH`), which [`assert_host_build_deps`] confirms
+    /// before any of the work below.
     fn build_apptainer_from_source(version: &str, install_dir: &Path, target_arch: &str) -> bool {
+        assert_host_build_deps();
         println!(
             "cargo:warning=Building apptainer {} from source (requires Go and {})...",
-            version, APPTAINER_BUILD_DEPS
+            version,
+            apptainer_build_deps_apt()
         );
 
         let source_cache = build_helpers::cache_dir("apptainer-source");
@@ -1462,7 +1708,7 @@ echo "=== Verifying squashfuse source archive SHA-256 ==="
 echo "{sq_sha}  squashfuse-{sq_version}.tar.gz" | sha256sum -c -
 tar -xzf squashfuse-{sq_version}.tar.gz
 cd squashfuse-{sq_version}
-./autogen.sh
+# No `autogen.sh`: the release tarball ships a generated `configure`.
 FLAGS=-std=c99 ./configure --enable-multithreading
 make squashfuse_ll LDFLAGS=-all-static -j"$(nproc)"
 install -m 755 squashfuse_ll {install_dir}/libexec/apptainer/bin/squashfuse_ll
@@ -1480,7 +1726,7 @@ rm -rf /tmp/apptainer-{version} /tmp/apptainer-{version}.tar.gz"#,
             lib_dir = APPTAINER_BUNDLED_LIB_DIR,
             sq_version = SQUASHFUSE_VERSION,
             sq_sha = SQUASHFUSE_SHA256,
-            sq_url = squashfuse_archive_url(SQUASHFUSE_VERSION),
+            sq_url = squashfuse_source_url(SQUASHFUSE_VERSION),
         )
     }
 
@@ -1497,7 +1743,7 @@ sudo apt-get install -y -qq {deps}
 {compile}
 echo "=== Apptainer build complete ==="
 "#,
-            deps = APPTAINER_BUILD_DEPS,
+            deps = apptainer_build_deps_apt(),
             compile = apptainer_compile_steps(version, install_dir),
         )
     }
@@ -1574,7 +1820,7 @@ echo "=== Apptainer build complete ==="
 "#,
             rootfs_url = ubuntu_base_amd64_url(UBUNTU_BASE_VERSION),
             rootfs_sha = UBUNTU_BASE_AMD64_SHA256,
-            deps = APPTAINER_BUILD_DEPS,
+            deps = apptainer_build_deps_apt(),
             compile = apptainer_compile_steps(version, install_dir),
         )
     }
@@ -1888,7 +2134,9 @@ echo "=== Apptainer build complete ==="
             success,
             "Failed to build apptainer {} from source for {}. \
              Ensure Go is installed, along with: {}.",
-            APPTAINER_VERSION, arch, APPTAINER_BUILD_DEPS
+            APPTAINER_VERSION,
+            arch,
+            apptainer_build_deps_apt()
         );
         assert!(
             cache_dir.join("bin/apptainer").exists(),

--- a/crates/containers-internal/build.rs
+++ b/crates/containers-internal/build.rs
@@ -34,7 +34,13 @@ mod apptainer_build {
     /// libraries, a different install layout. It is part of the cache sentinel
     /// filename, so a bump invalidates every previously built cache instead of
     /// silently shipping a tree built by the old recipe.
-    const APPTAINER_RECIPE_REVISION: u32 = 1;
+    ///
+    /// r2 added the bundled `squashfuse_ll` (see [`SQUASHFUSE_VERSION`]). It has
+    /// to be a revision bump rather than a retrofit of existing caches: unlike
+    /// gocryptfs (a prebuilt download that can be dropped into any cache
+    /// afterwards) squashfuse is compiled for the target ISA, so it can only be
+    /// produced inside the build environment that built apptainer itself.
+    const APPTAINER_RECIPE_REVISION: u32 = 2;
 
     /// Directory, relative to the apptainer install prefix, holding the shared
     /// libraries bundled with the binaries (see [`APPTAINER_CGO_LDFLAGS`]).
@@ -86,6 +92,26 @@ mod apptainer_build {
     const GOCRYPTFS_ARM64_SHA256: &str =
         "64576d550ab8af3f1dc729e93779540c5ecc00967d0185aae51a29a3755d86d0";
 
+    /// Pinned squashfuse version, matching the one apptainer's own RPM spec
+    /// (`dist/rpm/apptainer.spec.in`) bundles for this apptainer release.
+    ///
+    /// Apptainer mounts a SIF's squashfs partition through `squashfuse_ll`,
+    /// which it discovers in `${prefix}/libexec/apptainer/bin/` ahead of
+    /// `$PATH`. Without it the image driver reports no `SquashFeature` and
+    /// `apptainer run` falls back to `unsquashfs`-extracting the ENTIRE rootfs
+    /// into `--tmpdir` ("Converting SIF file to temporary sandbox..."). On a
+    /// distro that puts `/tmp` on tmpfs with a systemd per-user quota that
+    /// fails with "Disk quota exceeded" once a few node instances are up, so
+    /// bundling this binary is what keeps a stack launch off the extract path
+    /// entirely. `mconfig`/`make` do not build it: apptainer's own packaging
+    /// compiles it separately and installs it next to `starter`, which is what
+    /// [`build_and_install_squashfuse`] mirrors.
+    const SQUASHFUSE_VERSION: &str = "0.6.2";
+    /// SHA-256 of `squashfuse-{SQUASHFUSE_VERSION}.tar.gz` from the GitHub
+    /// source archive. Bump alongside `SQUASHFUSE_VERSION`.
+    const SQUASHFUSE_SHA256: &str =
+        "ae194df463ac5a9cbb25f94021d44bfb14dc21a0fc577e16348eca2fdc77c83b";
+
     const LIMA_VERSION: &str = "2.1.3";
     const LIMA_DARWIN_ARM64_ARCHIVE_SHA256: &str =
         "52bcf0780fcb28128ac9f6924d4410a6bc7c92fa80c9a858d89ae34ec3ce4f35";
@@ -114,8 +140,21 @@ mod apptainer_build {
     /// absent: it is pinned and SHA-verified via `GO_VERSION` (see
     /// `apptainer_compile_steps`) rather than taken from apt, which ships a Go
     /// too old for apptainer's `mconfig`.
-    const APPTAINER_BUILD_DEPS: &str =
-        "libseccomp-dev make gcc pkg-config squashfs-tools cryptsetup curl ca-certificates";
+    ///
+    /// The second line covers the bundled squashfuse build (see
+    /// [`SQUASHFUSE_VERSION`]): autotools to run its `autogen.sh`, plus headers
+    /// for FUSE and for every compressor a squashfs image may use (zlib, lzo,
+    /// lz4, xz, zstd). They are only ever linked statically into
+    /// `squashfuse_ll`, so nothing here has to exist on the machines peppy
+    /// installs onto.
+    ///
+    /// `scripts/functions/lima.py` installs the same set into the release VM,
+    /// where cargo (and therefore this build script) runs against a guest this
+    /// list never provisions itself. Keep the two in sync.
+    const APPTAINER_BUILD_DEPS: &str = "libseccomp-dev make gcc pkg-config squashfs-tools \
+         cryptsetup curl ca-certificates \
+         autoconf automake libtool libfuse3-dev zlib1g-dev liblzo2-dev liblz4-dev liblzma-dev \
+         libzstd-dev";
     const LIMA_TEMPLATE: &str = "template:ubuntu-24.04";
     /// Guest-side installation path for apptainer inside the Lima VM.
     /// Must match the `--prefix` used at build time.
@@ -929,18 +968,206 @@ mod apptainer_build {
     }
 
     // -----------------------------------------------------------------------
+    // squashfuse: compiled from source, installed next to `starter`
+    //
+    // Same auto-discovery mechanism as gocryptfs above, but it cannot be a
+    // prebuilt download: upstream publishes no binary releases, so the tool is
+    // compiled here from the pinned source archive with the recipe apptainer's
+    // own packaging uses (`scripts/compile-dependencies`). Because it is
+    // compiled, it can only be produced for the ISA of the machine doing the
+    // build, which is why it is a step of the apptainer build itself (host
+    // build and Lima guest build alike) rather than something bolted onto a
+    // finished install tree.
+    // -----------------------------------------------------------------------
+
+    fn squashfuse_archive_url(version: &str) -> String {
+        format!("https://github.com/vasi/squashfuse/archive/{version}/squashfuse-{version}.tar.gz")
+    }
+
+    /// Path apptainer's `FindBin` looks at for the squashfs FUSE mounter.
+    fn squashfuse_binary_path(install_dir: &Path) -> PathBuf {
+        install_dir.join("libexec/apptainer/bin/squashfuse_ll")
+    }
+
+    /// Compile `squashfuse_ll` for the build machine's own architecture and
+    /// install it into `<install_dir>/libexec/apptainer/bin`.
+    ///
+    /// The binary is linked fully statically (`-all-static`, the libtool
+    /// spelling that survives to the final `gcc` link; a plain `-static` in
+    /// `LDFLAGS` is swallowed by libtool and silently produces a dynamic
+    /// executable). That is not just tidiness: FUSE's SONAME differs across the
+    /// distros peppy builds on and installs onto (`libfuse3.so.3` on Ubuntu
+    /// 24.04, `libfuse3.so.4` on Debian 13), so a dynamically linked
+    /// `squashfuse_ll` would be unloadable on half of them, and the alternative
+    /// (bundling libfuse plus the five compression libraries into
+    /// `<prefix>/lib` behind an rpath, the way [`bundle_libseccomp`] handles
+    /// libseccomp) buys nothing here: none of these libraries talk to the host
+    /// kernel through anything but the stable `/dev/fuse` protocol.
+    fn build_and_install_squashfuse(install_dir: &Path) -> bool {
+        let dest = squashfuse_binary_path(install_dir);
+        println!(
+            "cargo:warning=Building squashfuse {} into {:?}",
+            SQUASHFUSE_VERSION, dest
+        );
+
+        let source_cache = build_helpers::cache_dir("squashfuse-source");
+
+        // Same rationale as the apptainer source build: serialize concurrent
+        // invocations so one run cannot delete the source tree another is
+        // compiling in.
+        let lock_path = source_cache.join(".build.lock");
+        let _build_lock = build_helpers::acquire_file_lock(&lock_path);
+
+        let tarball_path = source_cache.join(format!("squashfuse-{}.tar.gz", SQUASHFUSE_VERSION));
+        let source_dir = source_cache.join(format!("squashfuse-{}", SQUASHFUSE_VERSION));
+
+        if source_dir.exists() {
+            std::fs::remove_dir_all(&source_dir).ok();
+        }
+
+        if !download_squashfuse_archive(&tarball_path) {
+            return false;
+        }
+
+        if !build_helpers::run_command(
+            Command::new("tar")
+                .args(["-xzf"])
+                .arg(&tarball_path)
+                .arg("-C")
+                .arg(&source_cache),
+            "extract squashfuse source archive",
+        ) {
+            return false;
+        }
+        std::fs::remove_file(&tarball_path).ok();
+
+        // `autogen.sh` regenerates configure (the GitHub source archive ships
+        // none), `FLAGS=-std=c99` and `--enable-multithreading` mirror
+        // apptainer's `scripts/compile-dependencies` recipe, and only the
+        // `squashfuse_ll` target is built: apptainer never invokes the
+        // high-level `squashfuse` binary or installs the library.
+        let steps: [(&str, &[&str]); 3] = [
+            ("./autogen.sh", &[]),
+            ("./configure", &["--enable-multithreading"]),
+            ("make", &["squashfuse_ll", "LDFLAGS=-all-static", "-j"]),
+        ];
+        for (program, args) in steps {
+            if !run_squashfuse_step(&source_dir, program, args) {
+                std::fs::remove_dir_all(&source_dir).ok();
+                return false;
+            }
+        }
+
+        let built = source_dir.join("squashfuse_ll");
+        if !built.exists() {
+            println!(
+                "cargo:warning=squashfuse build reported success but {:?} is missing",
+                built
+            );
+            std::fs::remove_dir_all(&source_dir).ok();
+            return false;
+        }
+
+        let installed = install_squashfuse_binary(&built, &dest);
+        std::fs::remove_dir_all(&source_dir).ok();
+        installed
+    }
+
+    /// Run one step of the squashfuse recipe inside the unpacked source tree.
+    ///
+    /// `FLAGS` is what squashfuse's `configure` reads to pick the C dialect;
+    /// the other steps ignore it, so it is set unconditionally rather than
+    /// threaded through per step.
+    fn run_squashfuse_step(source_dir: &Path, program: &str, args: &[&str]) -> bool {
+        build_helpers::run_command_streaming(
+            Command::new(program)
+                .current_dir(source_dir)
+                .env("FLAGS", "-std=c99")
+                .args(args),
+            &format!("squashfuse-{}", program.trim_start_matches("./")),
+        )
+        .success
+    }
+
+    /// Download the pinned squashfuse source archive to `dest`, reusing an
+    /// existing file only when it still matches [`SQUASHFUSE_SHA256`].
+    fn download_squashfuse_archive(dest: &Path) -> bool {
+        if dest.exists()
+            && build_helpers::verify_sha256(dest, SQUASHFUSE_SHA256, "squashfuse source archive")
+        {
+            return true;
+        }
+
+        let url = squashfuse_archive_url(SQUASHFUSE_VERSION);
+        if !build_helpers::run_command(
+            Command::new("curl").args(["-fsSL", &url, "-o"]).arg(dest),
+            &format!("download squashfuse {} source archive", SQUASHFUSE_VERSION),
+        ) {
+            return false;
+        }
+
+        if !build_helpers::verify_sha256(dest, SQUASHFUSE_SHA256, "squashfuse source archive") {
+            std::fs::remove_file(dest).ok();
+            return false;
+        }
+        true
+    }
+
+    /// Copy the freshly built `squashfuse_ll` into apptainer's search directory.
+    fn install_squashfuse_binary(built: &Path, dest: &Path) -> bool {
+        let bin_dir = dest.parent().expect("squashfuse dest always has a parent");
+        if let Err(e) = std::fs::create_dir_all(bin_dir) {
+            println!(
+                "cargo:warning=Failed to create squashfuse install directory {:?}: {}",
+                bin_dir, e
+            );
+            return false;
+        }
+        if let Err(e) = std::fs::copy(built, dest) {
+            println!(
+                "cargo:warning=Failed to copy squashfuse binary to {:?}: {}",
+                dest, e
+            );
+            return false;
+        }
+        build_helpers::set_executable(dest);
+        true
+    }
+
+    /// Fail the build when an apptainer tree that is about to be shipped has no
+    /// bundled `squashfuse_ll`.
+    ///
+    /// Reached only for a tree accepted without rebuilding (a cache hit, or the
+    /// macOS-side cache copied into a Lima guest). Those trees are gated on a
+    /// sentinel carrying [`APPTAINER_RECIPE_REVISION`], so a missing binary
+    /// means the tree was tampered with rather than merely stale, and the only
+    /// honest recovery is to delete it and rebuild: squashfuse cannot be
+    /// retrofitted onto a foreign-architecture tree.
+    fn assert_squashfuse_bundled(install_dir: &Path) {
+        let squashfuse = squashfuse_binary_path(install_dir);
+        assert!(
+            squashfuse.exists(),
+            "Bundled squashfuse missing at {:?}. Without it apptainer extracts every SIF \
+             into --tmpdir instead of FUSE-mounting it. Remove {:?} and rebuild.",
+            squashfuse,
+            install_dir
+        );
+    }
+
+    // -----------------------------------------------------------------------
     // Build apptainer from source
     // -----------------------------------------------------------------------
 
     /// Build apptainer from source on the local host (native builds only).
     ///
     /// Downloads the source tarball from GitHub, builds with `mconfig` + `make`,
-    /// and installs to `install_dir`. Requires Go, make, gcc, libseccomp-dev,
-    /// and pkg-config to be available on the host.
+    /// installs to `install_dir`, and adds the bundled squashfuse. Requires the
+    /// packages listed in [`APPTAINER_BUILD_DEPS`] (plus Go, which the host
+    /// build takes from `$PATH`) to be available on the host.
     fn build_apptainer_from_source(version: &str, install_dir: &Path, target_arch: &str) -> bool {
         println!(
-            "cargo:warning=Building apptainer {} from source (requires Go, make, gcc, libseccomp-dev)...",
-            version
+            "cargo:warning=Building apptainer {} from source (requires Go and {})...",
+            version, APPTAINER_BUILD_DEPS
         );
 
         let source_cache = build_helpers::cache_dir("apptainer-source");
@@ -1054,7 +1281,10 @@ mod apptainer_build {
             return false;
         }
 
-        true
+        // Compiled here, next to the apptainer build, because it has to match
+        // the target ISA and this host build is the only place that ISA is the
+        // one being compiled for.
+        build_and_install_squashfuse(install_dir)
     }
 
     /// Build apptainer from source inside a Lima VM and copy the result back.
@@ -1156,7 +1386,8 @@ mod apptainer_build {
 
     /// The apptainer build commands shared by every strategy: install the pinned
     /// Go toolchain, download + verify the source, configure, compile, install
-    /// to `install_dir`, and bundle libseccomp there. Runs without `sudo`
+    /// to `install_dir`, then bundle libseccomp and a freshly compiled
+    /// `squashfuse_ll` there. Runs without `sudo`
     /// (callers supply root where the environment needs it), and is embedded verbatim into a quoted `bash`
     /// here-doc on the Rosetta path, so its `$(nproc)`, `$go_arch` and other
     /// shell expansions must survive unexpanded until the guest runs them.
@@ -1220,6 +1451,23 @@ if [ -z "$seccomp_so" ] || [ ! -e "$seccomp_so" ]; then
 fi
 mkdir -p {install_dir}/{lib_dir}
 cp -L "$seccomp_so" {install_dir}/{lib_dir}/{libseccomp}
+echo "=== Building squashfuse {sq_version} ==="
+# Built here, in the guest that just built apptainer, because the binary has to
+# match the target ISA. Statically linked for the reasons in
+# `build_and_install_squashfuse`; the recipe is apptainer's own.
+cd /tmp
+rm -rf squashfuse-{sq_version} squashfuse-{sq_version}.tar.gz
+curl -fsSL {sq_url} -o squashfuse-{sq_version}.tar.gz
+echo "=== Verifying squashfuse source archive SHA-256 ==="
+echo "{sq_sha}  squashfuse-{sq_version}.tar.gz" | sha256sum -c -
+tar -xzf squashfuse-{sq_version}.tar.gz
+cd squashfuse-{sq_version}
+./autogen.sh
+FLAGS=-std=c99 ./configure --enable-multithreading
+make squashfuse_ll LDFLAGS=-all-static -j"$(nproc)"
+install -m 755 squashfuse_ll {install_dir}/libexec/apptainer/bin/squashfuse_ll
+cd /tmp
+rm -rf squashfuse-{sq_version} squashfuse-{sq_version}.tar.gz
 rm -rf /tmp/apptainer-{version} /tmp/apptainer-{version}.tar.gz"#,
             version = version,
             install_dir = install_dir,
@@ -1230,6 +1478,9 @@ rm -rf /tmp/apptainer-{version} /tmp/apptainer-{version}.tar.gz"#,
             cgo_ldflags = APPTAINER_CGO_LDFLAGS,
             libseccomp = LIBSECCOMP_SONAME,
             lib_dir = APPTAINER_BUNDLED_LIB_DIR,
+            sq_version = SQUASHFUSE_VERSION,
+            sq_sha = SQUASHFUSE_SHA256,
+            sq_url = squashfuse_archive_url(SQUASHFUSE_VERSION),
         )
     }
 
@@ -1413,6 +1664,7 @@ echo "=== Apptainer build complete ==="
         println!("cargo:rustc-env=APPTAINER_VERSION={}", APPTAINER_VERSION);
         println!("cargo:rustc-env=LIMA_VERSION={}", LIMA_VERSION);
         println!("cargo:rustc-env=GOCRYPTFS_VERSION={}", GOCRYPTFS_VERSION);
+        println!("cargo:rustc-env=SQUASHFUSE_VERSION={}", SQUASHFUSE_VERSION);
         println!(
             "cargo:rustc-env=GUEST_APPTAINER_DIR={}",
             GUEST_APPTAINER_DIR
@@ -1554,6 +1806,10 @@ echo "=== Apptainer build complete ==="
                 GOCRYPTFS_VERSION,
                 target
             );
+            // Built inside the guest by `apptainer_compile_steps`; assert here
+            // so a guest-side failure surfaces as a missing binary rather than
+            // as a silently slow, quota-bound extract at run time.
+            assert_squashfuse_bundled(&target_cache);
             write_cache_sentinel(&target_cache, APPTAINER_VERSION);
         }
     }
@@ -1602,6 +1858,7 @@ echo "=== Apptainer build complete ==="
                 GOCRYPTFS_VERSION,
                 cache_dir
             );
+            assert_squashfuse_bundled(&cache_dir);
             return cache_dir;
         }
 
@@ -1616,6 +1873,7 @@ echo "=== Apptainer build complete ==="
                 GOCRYPTFS_VERSION,
                 arch
             );
+            assert_squashfuse_bundled(&cache_dir);
             write_cache_sentinel(&cache_dir, APPTAINER_VERSION);
             return cache_dir;
         }
@@ -1629,8 +1887,8 @@ echo "=== Apptainer build complete ==="
         assert!(
             success,
             "Failed to build apptainer {} from source for {}. \
-             Ensure Go, make, gcc, libseccomp-dev, and pkg-config are installed.",
-            APPTAINER_VERSION, arch
+             Ensure Go is installed, along with: {}.",
+            APPTAINER_VERSION, arch, APPTAINER_BUILD_DEPS
         );
         assert!(
             cache_dir.join("bin/apptainer").exists(),
@@ -1643,6 +1901,7 @@ echo "=== Apptainer build complete ==="
             GOCRYPTFS_VERSION,
             arch
         );
+        assert_squashfuse_bundled(&cache_dir);
         write_cache_sentinel(&cache_dir, APPTAINER_VERSION);
 
         cache_dir
@@ -1697,7 +1956,12 @@ echo "=== Apptainer build complete ==="
         // avoiding mtime bumps that trigger unnecessary recompilation.
         let out_install_dir = PathBuf::from(&out_dir).join("apptainer-install");
         let sentinel_path = out_install_dir.join(".copy-source");
-        let sentinel_content = format!("{}\ngocryptfs={}", cache_dir.display(), GOCRYPTFS_VERSION);
+        let sentinel_content = format!(
+            "{}\ngocryptfs={}\nsquashfuse={}",
+            cache_dir.display(),
+            GOCRYPTFS_VERSION,
+            SQUASHFUSE_VERSION
+        );
         let needs_copy = !sentinel_path.exists()
             || std::fs::read_to_string(&sentinel_path)
                 .map_or(true, |s| s.trim() != sentinel_content.trim());

--- a/crates/containers-internal/src/apptainer/facade.rs
+++ b/crates/containers-internal/src/apptainer/facade.rs
@@ -15,6 +15,27 @@ static LIMA_INIT: Mutex<()> = Mutex::new(());
 /// Lima hostname that resolves to the macOS host IP from inside the guest VM.
 const LIMA_HOST_GATEWAY: &str = "host.lima.internal";
 
+/// Apptainer's env spelling of its hidden `--tmpdir` flag.
+const APPTAINER_TMPDIR_ENV: &str = "APPTAINER_TMPDIR";
+
+/// Scratch directory handed to apptainer as its `--tmpdir`.
+///
+/// Apptainer only falls back to this when it cannot FUSE-mount an image's
+/// squashfs partition, in which case it `unsquashfs`-extracts the entire rootfs
+/// there ("Converting SIF file to temporary sandbox..."). peppy bundles
+/// `squashfuse_ll` precisely so that path is never taken, but the fallback is
+/// still reachable on a host with no `/dev/fuse`, and apptainer's own default
+/// (`/tmp`) is the worst possible place for it: on a distro that backs `/tmp`
+/// with tmpfs under a systemd per-user quota, extracting several node images
+/// fails with "Disk quota exceeded" partway through a stack launch. Rooting it
+/// in the peppy tree puts it on real storage sized like the rest of peppy's
+/// data.
+fn apptainer_scratch_dir() -> PathBuf {
+    daemon_config::consts::PeppyDirs::default()
+        .tmp_dir()
+        .join("apptainer")
+}
+
 /// Returns `true` if the string looks like a URI reference (e.g. `docker://...`, `library://...`)
 /// rather than a filesystem path.
 pub(crate) fn is_uri(s: &str) -> bool {
@@ -25,7 +46,15 @@ pub(crate) fn is_uri(s: &str) -> bool {
 #[derive(Debug)]
 pub(crate) enum Backend {
     /// Linux: run apptainer directly on the host.
-    Native { apptainer_bin: PathBuf },
+    Native {
+        apptainer_bin: PathBuf,
+        /// Host-side scratch directory exported as `APPTAINER_TMPDIR`; see
+        /// [`apptainer_scratch_dir`]. The Lima backend has no counterpart: its
+        /// commands run over `limactl shell`, which does not carry the host
+        /// environment into the guest, and the guest's own `/tmp` is ordinary
+        /// disk-backed storage inside the VM rather than a quota-limited tmpfs.
+        tmp_dir: PathBuf,
+    },
     /// macOS: route commands through a Lima VM.
     Lima {
         /// Path to `bin/apptainer` used for invocation (guest-side inside the VM).
@@ -403,7 +432,10 @@ impl Apptainer {
                 lima_home,
             }
         } else {
-            Backend::Native { apptainer_bin }
+            Backend::Native {
+                apptainer_bin,
+                tmp_dir: apptainer_scratch_dir(),
+            }
         };
 
         let mut facade = Self {
@@ -418,14 +450,26 @@ impl Apptainer {
     /// Ensures the execution backend is fully ready for running commands.
     /// Called once during construction.
     ///
-    /// On Linux (`Backend::Native`): verifies user namespace prerequisites (AppArmor).
+    /// On Linux (`Backend::Native`): creates the scratch directory apptainer is
+    /// pointed at and verifies user namespace prerequisites (AppArmor).
     ///
     /// On macOS (`Backend::Lima`): boots the Lima VM if it is not already running,
     /// and syncs the apptainer installation into the guest. This may take minutes
     /// on first run.
     fn ensure_ready(&mut self) -> Result<()> {
         match &mut self.backend {
-            Backend::Native { .. } => {
+            Backend::Native { tmp_dir, .. } => {
+                // Created up front rather than on first use: apptainer's
+                // `os.MkdirTemp` into `--tmpdir` fails outright when the
+                // directory is absent, and that only ever happens on the
+                // extract fallback, i.e. the one path that is already
+                // struggling.
+                std::fs::create_dir_all(&*tmp_dir).map_err(|source| {
+                    Error::ScratchDirUnavailable {
+                        path: tmp_dir.display().to_string(),
+                        source,
+                    }
+                })?;
                 #[cfg(target_os = "linux")]
                 check_userns_prerequisites(&self.apptainer_dir)?;
                 Ok(())
@@ -906,7 +950,9 @@ impl Apptainer {
     /// Build a [`Command`] that will invoke apptainer with the given arguments.
     ///
     /// On Linux: runs `{apptainer_bin} <args...>` directly, with `working_dir`
-    /// (when set) applied via [`Command::current_dir`].
+    /// (when set) applied via [`Command::current_dir`] and `APPTAINER_TMPDIR`
+    /// pointed at the backend's scratch directory (see
+    /// [`apptainer_scratch_dir`]).
     /// On macOS: runs `{limactl} shell peppy -- {guest_apptainer_bin} <args...>` to
     /// execute inside the Lima VM using the synced guest-side binary. A
     /// `working_dir` is translated via [`translate_path`](Self::translate_path)
@@ -931,8 +977,12 @@ impl Apptainer {
         working_dir: Option<&Path>,
     ) -> Result<Command> {
         match &self.backend {
-            Backend::Native { apptainer_bin } => {
+            Backend::Native {
+                apptainer_bin,
+                tmp_dir,
+            } => {
                 let mut cmd = Command::new(apptainer_bin);
+                cmd.env(APPTAINER_TMPDIR_ENV, tmp_dir);
                 cmd.args(args);
                 if let Some(dir) = working_dir {
                     cmd.current_dir(dir);

--- a/crates/containers-internal/src/apptainer/facade.rs
+++ b/crates/containers-internal/src/apptainer/facade.rs
@@ -3,6 +3,7 @@ use super::lima;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, ExitStatus, Output, Stdio};
 use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 /// Serializes Lima VM initialization to prevent concurrent boot/sync races.
@@ -47,13 +48,29 @@ fn apptainer_scratch_dir() -> PathBuf {
 /// fallback. Probing here surfaces it at construction, named and pointed at the
 /// offending path. The probe is a file rather than a directory (which would
 /// mirror apptainer's own `os.MkdirTemp` more closely) because it needs the
-/// same `w`+`x` bits on the parent and `File::create` truncates rather than
-/// failing on a stale probe left by a process that died mid-check.
+/// same `w`+`x` bits on the parent.
+///
+/// The probe name is unique per call, not merely per process: several threads
+/// can build an `Apptainer` at once (the unit tests do), and a name keyed only
+/// on the pid has them all probing one shared path, where the first
+/// `remove_file` to land leaves the others failing `ENOENT` on a scratch
+/// directory that is perfectly writable. For the same reason a probe that has
+/// already vanished is not an error — the `create` is what proves writability,
+/// and the `remove` only keeps apptainer's `--tmpdir` free of litter.
 pub(crate) fn prepare_scratch_dir(tmp_dir: &Path) -> Result<()> {
-    let probe = tmp_dir.join(format!(".peppy-scratch-probe-{}", std::process::id()));
+    static PROBE_SEQ: AtomicU64 = AtomicU64::new(0);
+
+    let probe = tmp_dir.join(format!(
+        ".peppy-scratch-probe-{}-{}",
+        std::process::id(),
+        PROBE_SEQ.fetch_add(1, Ordering::Relaxed)
+    ));
     std::fs::create_dir_all(tmp_dir)
         .and_then(|()| std::fs::File::create(&probe))
-        .and_then(|_| std::fs::remove_file(&probe))
+        .and_then(|_| match std::fs::remove_file(&probe) {
+            Err(source) if source.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            other => other,
+        })
         .map_err(|source| Error::ScratchDirUnavailable {
             path: tmp_dir.display().to_string(),
             source,

--- a/crates/containers-internal/src/apptainer/facade.rs
+++ b/crates/containers-internal/src/apptainer/facade.rs
@@ -36,6 +36,30 @@ fn apptainer_scratch_dir() -> PathBuf {
         .join("apptainer")
 }
 
+/// Creates the scratch directory and confirms this process can actually write
+/// into it.
+///
+/// The write probe is not redundant with the creation: `create_dir_all`
+/// succeeds on a directory that already exists whatever its mode, so a scratch
+/// dir left behind non-writable — the classic case being one created while the
+/// daemon ran under `sudo` and now owned by root — passes creation and only
+/// fails later, inside apptainer, as an opaque `MkdirTemp` error on the extract
+/// fallback. Probing here surfaces it at construction, named and pointed at the
+/// offending path. The probe is a file rather than a directory (which would
+/// mirror apptainer's own `os.MkdirTemp` more closely) because it needs the
+/// same `w`+`x` bits on the parent and `File::create` truncates rather than
+/// failing on a stale probe left by a process that died mid-check.
+pub(crate) fn prepare_scratch_dir(tmp_dir: &Path) -> Result<()> {
+    let probe = tmp_dir.join(format!(".peppy-scratch-probe-{}", std::process::id()));
+    std::fs::create_dir_all(tmp_dir)
+        .and_then(|()| std::fs::File::create(&probe))
+        .and_then(|_| std::fs::remove_file(&probe))
+        .map_err(|source| Error::ScratchDirUnavailable {
+            path: tmp_dir.display().to_string(),
+            source,
+        })
+}
+
 /// Returns `true` if the string looks like a URI reference (e.g. `docker://...`, `library://...`)
 /// rather than a filesystem path.
 pub(crate) fn is_uri(s: &str) -> bool {
@@ -450,7 +474,7 @@ impl Apptainer {
     /// Ensures the execution backend is fully ready for running commands.
     /// Called once during construction.
     ///
-    /// On Linux (`Backend::Native`): creates the scratch directory apptainer is
+    /// On Linux (`Backend::Native`): prepares the scratch directory apptainer is
     /// pointed at and verifies user namespace prerequisites (AppArmor).
     ///
     /// On macOS (`Backend::Lima`): boots the Lima VM if it is not already running,
@@ -459,17 +483,12 @@ impl Apptainer {
     fn ensure_ready(&mut self) -> Result<()> {
         match &mut self.backend {
             Backend::Native { tmp_dir, .. } => {
-                // Created up front rather than on first use: apptainer's
+                // Prepared up front rather than on first use: apptainer's
                 // `os.MkdirTemp` into `--tmpdir` fails outright when the
-                // directory is absent, and that only ever happens on the
-                // extract fallback, i.e. the one path that is already
+                // directory is absent or unwritable, and that only ever happens
+                // on the extract fallback, i.e. the one path that is already
                 // struggling.
-                std::fs::create_dir_all(&*tmp_dir).map_err(|source| {
-                    Error::ScratchDirUnavailable {
-                        path: tmp_dir.display().to_string(),
-                        source,
-                    }
-                })?;
+                prepare_scratch_dir(tmp_dir)?;
                 #[cfg(target_os = "linux")]
                 check_userns_prerequisites(&self.apptainer_dir)?;
                 Ok(())

--- a/crates/containers-internal/src/apptainer/tests.rs
+++ b/crates/containers-internal/src/apptainer/tests.rs
@@ -1246,6 +1246,40 @@ fn prepare_scratch_dir_creates_missing_directory() {
     );
 }
 
+/// Regression: concurrent preparation of the same scratch directory must
+/// succeed on every thread. `Apptainer::new()` is called from several test
+/// threads at once (and from more than one daemon thread in production), so a
+/// write probe named only after the process id had them all racing on a single
+/// path: the first `remove_file` to land won and the losers reported
+/// `ScratchDirUnavailable { NotFound }` against a perfectly writable directory.
+#[test]
+fn prepare_scratch_dir_tolerates_concurrent_preparation() {
+    let tmp = TempDir::new().expect("Failed to create temp dir");
+    let scratch = tmp.path().join("apptainer");
+
+    let failures: Vec<Error> = std::thread::scope(|scope| {
+        let handles: Vec<_> = (0..16)
+            .map(|_| scope.spawn(|| prepare_scratch_dir(&scratch)))
+            .collect();
+        handles
+            .into_iter()
+            .filter_map(|handle| handle.join().expect("probe thread should not panic").err())
+            .collect()
+    });
+
+    assert!(
+        failures.is_empty(),
+        "concurrent probes of a writable scratch directory should all succeed, got: {failures:?}"
+    );
+    assert_eq!(
+        fs::read_dir(&scratch)
+            .expect("scratch dir should be readable")
+            .count(),
+        0,
+        "every write probe should clean up after itself"
+    );
+}
+
 /// Regression: an existing but non-writable scratch directory must fail at
 /// construction, not survive `create_dir_all` (which succeeds on any existing
 /// directory, whatever its mode) only to fail later inside apptainer as an

--- a/crates/containers-internal/src/apptainer/tests.rs
+++ b/crates/containers-internal/src/apptainer/tests.rs
@@ -1,4 +1,4 @@
-use super::facade::{Apptainer, Backend, is_uri};
+use super::facade::{Apptainer, Backend, is_uri, prepare_scratch_dir};
 #[cfg(target_os = "linux")]
 use super::facade::{apparmor_profile_ref, check_setup_status, shell_escape_single_quoted};
 use crate::error::Error;
@@ -935,8 +935,9 @@ fn shell_escape_single_quoted_survives_embedded_quotes() {
 /// Verifies that the compile-time `APPTAINER_INSTALL_DIR` injected by build.rs
 /// points to a valid cache directory with the expected sentinel and binary. The
 /// sentinel path comes from build.rs too, via `APPTAINER_CACHE_SENTINEL`: the
-/// name is version and recipe keyed, so re-deriving it here would go stale the
-/// next time the cache key changes.
+/// name is keyed on every input that changes the produced tree (apptainer
+/// version, recipe revision, squashfuse version), so re-deriving it here would
+/// go stale the next time the cache key changes.
 ///
 /// If this test fails after deleting `~/.peppy`, it means the build cache is
 /// stale and `cargo build` needs to re-run build.rs (which the
@@ -1223,6 +1224,67 @@ fn lima_command_does_not_set_apptainer_tmpdir() {
         command_env(&cmd, "APPTAINER_TMPDIR"),
         None,
         "a host-side APPTAINER_TMPDIR would not survive the hop into the guest"
+    );
+}
+
+/// The happy path: a missing scratch directory is created, and the write probe
+/// cleans up after itself rather than littering apptainer's `--tmpdir`.
+#[test]
+fn prepare_scratch_dir_creates_missing_directory() {
+    let tmp = TempDir::new().expect("Failed to create temp dir");
+    let scratch = tmp.path().join("peppy-tmp/apptainer");
+
+    prepare_scratch_dir(&scratch).expect("a fresh scratch directory should be usable");
+
+    assert!(scratch.is_dir(), "the scratch directory should be created");
+    assert_eq!(
+        fs::read_dir(&scratch)
+            .expect("scratch dir should be readable")
+            .count(),
+        0,
+        "the write probe should leave nothing behind"
+    );
+}
+
+/// Regression: an existing but non-writable scratch directory must fail at
+/// construction, not survive `create_dir_all` (which succeeds on any existing
+/// directory, whatever its mode) only to fail later inside apptainer as an
+/// opaque `MkdirTemp` error on the extract fallback.
+#[cfg(unix)]
+#[test]
+fn prepare_scratch_dir_rejects_existing_non_writable_directory() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let tmp = TempDir::new().expect("Failed to create temp dir");
+    let scratch = tmp.path().join("apptainer");
+    fs::create_dir(&scratch).expect("mkdir scratch");
+    fs::set_permissions(&scratch, fs::Permissions::from_mode(0o500)).expect("chmod scratch");
+
+    // Privileged processes ignore the mode bits, so confirm the directory is
+    // genuinely unwritable here before asserting on the failure it should
+    // produce; restore the mode either way so the TempDir can clean itself up.
+    let bypasses_modes = fs::File::create(scratch.join(".privilege-check")).is_ok();
+    let result = if bypasses_modes {
+        Ok(())
+    } else {
+        prepare_scratch_dir(&scratch)
+    };
+    fs::set_permissions(&scratch, fs::Permissions::from_mode(0o700)).expect("restore scratch mode");
+
+    if bypasses_modes {
+        eprintln!(
+            "SKIPPING: this process writes into mode-0o500 directories, so an \
+             unwritable scratch directory cannot be simulated"
+        );
+        return;
+    }
+
+    let err = result.expect_err("a non-writable scratch directory should be rejected");
+    assert!(
+        matches!(&err, Error::ScratchDirUnavailable { path, .. } if path == &scratch.display().to_string()),
+        "expected ScratchDirUnavailable naming {:?}, got: {:?}",
+        scratch,
+        err
     );
 }
 

--- a/crates/containers-internal/src/apptainer/tests.rs
+++ b/crates/containers-internal/src/apptainer/tests.rs
@@ -62,6 +62,11 @@ fn ready_apptainer_dir() -> PathBuf {
         .expect("resolve_apptainer_dir should succeed; apptainer is bundled at compile time")
 }
 
+/// Scratch directory the [`native_facade`] fixture reports as its
+/// `APPTAINER_TMPDIR`. A fixed literal, not the real resolved one: these tests
+/// assert on assembled commands and must not depend on host state.
+const NATIVE_FIXTURE_TMP_DIR: &str = "/opt/peppy-tmp/apptainer";
+
 /// Builds a Native-backend facade for command-assembly and path-translation
 /// tests without touching host state. The apptainer path need not exist: these
 /// tests only inspect assembled argv, translated paths, and the no-op kill path.
@@ -70,6 +75,7 @@ fn native_facade() -> Apptainer {
         apptainer_dir: PathBuf::from("/opt/apptainer"),
         backend: Backend::Native {
             apptainer_bin: PathBuf::from("/opt/apptainer/bin/apptainer"),
+            tmp_dir: PathBuf::from(NATIVE_FIXTURE_TMP_DIR),
         },
         extra_mounts: Vec::new(),
     }
@@ -348,7 +354,9 @@ fn test_from_valid_dir() {
         facade.apptainer_dir.display()
     );
     let apptainer_bin = match &facade.backend {
-        Backend::Native { apptainer_bin } | Backend::Lima { apptainer_bin, .. } => apptainer_bin,
+        Backend::Native { apptainer_bin, .. } | Backend::Lima { apptainer_bin, .. } => {
+            apptainer_bin
+        }
     };
     assert!(
         !apptainer_bin.as_os_str().is_empty(),
@@ -1078,6 +1086,143 @@ fn gocryptfs_path_matches_apptainer_search_dir() {
         expected.exists(),
         "gocryptfs should be bundled at {:?}",
         expected
+    );
+}
+
+// ---------------------------------------------------------------------------
+// squashfuse bundling tests
+//
+// Apptainer mounts a SIF's squashfs partition through `squashfuse_ll`, found in
+// `${prefix}/libexec/apptainer/bin/` ahead of `$PATH`. When it is missing the
+// run still "works", just by extracting the whole rootfs into --tmpdir first,
+// so nothing short of asserting on the binary itself catches its absence.
+// ---------------------------------------------------------------------------
+
+/// Verifies the squashfuse binary is bundled under the name apptainer's
+/// `FindBin` looks for, in the directory it searches first.
+#[test]
+fn squashfuse_bundled_in_apptainer_install_dir() {
+    // The install dir is the *host-side* installation root for both backends:
+    // on macOS the same layout (including libexec/) is synced into the Lima
+    // guest. Resolved directly so this needs no host prerequisites and boots
+    // no VM.
+    let squashfuse_bin = ready_apptainer_dir().join("libexec/apptainer/bin/squashfuse_ll");
+    assert!(
+        squashfuse_bin.exists(),
+        "squashfuse_ll missing at {:?}; apptainer would extract every SIF into --tmpdir \
+         instead of FUSE-mounting it",
+        squashfuse_bin
+    );
+}
+
+/// Runs the bundled `squashfuse_ll` and confirms it reports the pinned release.
+/// This catches a truncated or wrong-architecture binary that the existence
+/// check above would miss.
+#[cfg(target_os = "linux")]
+#[test]
+fn squashfuse_bundled_binary_is_runnable() {
+    let install_dir = env!("APPTAINER_INSTALL_DIR");
+    let squashfuse_bin = Path::new(install_dir).join("libexec/apptainer/bin/squashfuse_ll");
+
+    // Invoked with no arguments: `squashfuse_ll` has no `--version` flag, and
+    // its usage banner carries the version. Apptainer scans the same output for
+    // `-o uid=` to decide whether it can map ownership, so this doubles as a
+    // check that the multithreaded build really does support it.
+    let output = Command::new(&squashfuse_bin).stdin(Stdio::null()).output();
+
+    let output = match output {
+        Ok(o) => o,
+        Err(e) => match e.kind() {
+            std::io::ErrorKind::NotFound | std::io::ErrorKind::PermissionDenied => {
+                eprintln!(
+                    "SKIPPING: cannot invoke bundled squashfuse_ll at {:?}: {} (likely a sandboxed test env)",
+                    squashfuse_bin, e
+                );
+                return;
+            }
+            _ => panic!(
+                "unexpected error invoking bundled squashfuse_ll at {:?}: {} (kind: {:?})",
+                squashfuse_bin,
+                e,
+                e.kind()
+            ),
+        },
+    };
+
+    // The usage banner goes to stderr on some builds and stdout on others;
+    // apptainer merges the two streams for the same reason.
+    let banner = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let expected = format!("squashfuse {}", crate::SQUASHFUSE_VERSION);
+    assert!(
+        banner.contains(&expected),
+        "bundled squashfuse version mismatch: expected to find {:?} in {:?}",
+        expected,
+        banner
+    );
+    assert!(
+        banner.contains("-o uid="),
+        "bundled squashfuse_ll does not advertise `-o uid=`, so apptainer will not map file \
+         ownership into the container; banner was {:?}",
+        banner
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Scratch directory: apptainer is pointed away from the host's /tmp, which on
+// some distros is a tmpfs under a systemd per-user quota.
+// ---------------------------------------------------------------------------
+
+/// Value an assembled command sets for `key`, or `None` when it sets none.
+/// Inherited process environment is invisible here, which is what we want:
+/// these tests assert on what the facade itself puts on the command.
+fn command_env(cmd: &Command, key: &str) -> Option<PathBuf> {
+    cmd.get_envs()
+        .find(|(name, _)| name.to_str() == Some(key))
+        .and_then(|(_, value)| value)
+        .map(PathBuf::from)
+}
+
+/// The native backend exports its scratch directory as `APPTAINER_TMPDIR`, the
+/// env spelling of apptainer's hidden `--tmpdir` flag.
+#[test]
+fn native_command_sets_apptainer_tmpdir() {
+    let facade = native_facade();
+    let cmd = facade
+        .run("image.sif")
+        .into_std_command()
+        .expect("native command assembly should succeed");
+
+    assert_eq!(
+        command_env(&cmd, "APPTAINER_TMPDIR"),
+        Some(PathBuf::from(NATIVE_FIXTURE_TMP_DIR)),
+        "the native backend should point apptainer at its own scratch directory"
+    );
+}
+
+/// The Lima backend leaves it unset: the command is handed to `limactl shell`,
+/// which does not carry the host environment into the guest, so setting it
+/// would only look like it worked.
+#[test]
+fn lima_command_does_not_set_apptainer_tmpdir() {
+    let facade = lima_facade();
+    // Under Lima the image path must be one the guest can see, i.e. under $HOME.
+    let home = std::env::var("HOME").expect("HOME must be set");
+    let sif = PathBuf::from(&home).join("peppy_tmpdir_test/node.sif");
+
+    let cmd = facade
+        .run(sif.to_str().expect("utf-8 sif path"))
+        .into_std_command()
+        .expect("lima command assembly should succeed");
+
+    assert_eq!(
+        command_env(&cmd, "APPTAINER_TMPDIR"),
+        None,
+        "a host-side APPTAINER_TMPDIR would not survive the hop into the guest"
     );
 }
 

--- a/crates/containers-internal/src/error.rs
+++ b/crates/containers-internal/src/error.rs
@@ -60,7 +60,7 @@ pub enum Error {
     #[error("Failed to sync apptainer installation to Lima VM: {0}")]
     LimaSyncFailed(String),
 
-    #[error("Failed to create the apptainer scratch directory {path}: {source}")]
+    #[error("Failed to prepare the apptainer scratch directory {path}: {source}")]
     ScratchDirUnavailable {
         path: String,
         source: std::io::Error,

--- a/crates/containers-internal/src/error.rs
+++ b/crates/containers-internal/src/error.rs
@@ -60,6 +60,12 @@ pub enum Error {
     #[error("Failed to sync apptainer installation to Lima VM: {0}")]
     LimaSyncFailed(String),
 
+    #[error("Failed to create the apptainer scratch directory {path}: {source}")]
+    ScratchDirUnavailable {
+        path: String,
+        source: std::io::Error,
+    },
+
     #[error(transparent)]
     Io(#[from] std::io::Error),
 

--- a/crates/containers-internal/src/lib.rs
+++ b/crates/containers-internal/src/lib.rs
@@ -25,3 +25,12 @@ pub const LIMA_VERSION: &str = env!("LIMA_VERSION");
 /// without requiring users to install gocryptfs via their distro package
 /// manager.
 pub const GOCRYPTFS_VERSION: &str = env!("GOCRYPTFS_VERSION");
+/// Pinned squashfuse version compiled and shipped alongside the apptainer
+/// install.
+///
+/// Apptainer auto-discovers `squashfuse_ll` in `libexec/apptainer/bin/` and
+/// uses it to FUSE-mount a SIF's squashfs partition. Without it every
+/// `apptainer run` first extracts the whole image into a temporary sandbox,
+/// which is both slow and fatal on hosts whose `/tmp` is a quota-limited
+/// tmpfs.
+pub const SQUASHFUSE_VERSION: &str = env!("SQUASHFUSE_VERSION");

--- a/scripts/functions/lima.py
+++ b/scripts/functions/lima.py
@@ -313,7 +313,7 @@ rustup target add x86_64-unknown-linux-gnu
 sudo apt-get update -qq
 sudo apt-get install -y -qq build-essential unzip gcc-x86-64-linux-gnu \
     libseccomp-dev make pkg-config squashfs-tools cryptsetup \
-    autoconf automake libtool libfuse3-dev zlib1g-dev liblzo2-dev liblz4-dev \
+    libfuse3-dev zlib1g-dev liblzo2-dev liblz4-dev \
     liblzma-dev libzstd-dev > /dev/null 2>&1
 """
     result = _lima_shell(limactl, install_script)

--- a/scripts/functions/lima.py
+++ b/scripts/functions/lima.py
@@ -276,7 +276,13 @@ rm -f /tmp/go-{GO_VERSION}.tar.gz
 
 
 def ensure_rust_in_vm(limactl: Path) -> None:
-    """Install Rust and cross-compilation tools inside the Lima VM if missing."""
+    """Install Rust and cross-compilation tools inside the Lima VM if missing.
+
+    The apt list also carries the apptainer build dependencies: the release
+    build runs cargo in this VM, and containers-internal's build script compiles
+    apptainer (and the squashfuse it bundles) from source there. Keep it in sync
+    with `APPTAINER_BUILD_DEPS` in that build script.
+    """
     _ensure_pinned_go_in_vm(limactl)
     check = _run_limactl(
         limactl,
@@ -306,7 +312,9 @@ export PATH="{GUEST_CARGO_HOME}/bin:$PATH"
 rustup target add x86_64-unknown-linux-gnu
 sudo apt-get update -qq
 sudo apt-get install -y -qq build-essential unzip gcc-x86-64-linux-gnu \
-    libseccomp-dev make pkg-config squashfs-tools cryptsetup > /dev/null 2>&1
+    libseccomp-dev make pkg-config squashfs-tools cryptsetup \
+    autoconf automake libtool libfuse3-dev zlib1g-dev liblzo2-dev liblz4-dev \
+    liblzma-dev libzstd-dev > /dev/null 2>&1
 """
     result = _lima_shell(limactl, install_script)
     if result.returncode != 0:


### PR DESCRIPTION
## Problem

`peppy stack launch openarm_v2_teleop_mujoco` died on an Ubuntu 26.04 host at the 8th node instance with `Write on output file failed because Disk quota exceeded`, during `Converting SIF file to temporary sandbox`.

peppy's bundled apptainer ships no squashfuse in `libexec/apptainer/bin/` (only `gocryptfs`, `gocryptfs-xray`, `starter`). Apptainer's image driver therefore reports no `SquashFeature`, and `launcher_linux.go` falls back to `unsquashfs`-extracting the entire rootfs into `--tmpdir` for every run. Ubuntu 26.04 puts `/tmp` on a tmpfs with a systemd 258 per-user quota of 80%, so eight concurrent sandboxes blew the quota (EDQUOT, not ENOSPC). The dev host only survives because its `/tmp` is ~62 GiB; it takes the same extraction path.

## Change

**Bundle `squashfuse_ll`.** Compiled from the pinned `vasi/squashfuse` 0.6.2 source archive (SHA-verified) and installed next to `starter`, which is the directory apptainer's `FindBin` searches ahead of `$PATH`. With it present the image driver advertises `SquashFeature` and `convert` is never set, so the extract path is not reached at all.

- The recipe is apptainer's own (`scripts/compile-dependencies` in its release tarball, pinning the same version its RPM spec bundles): `autogen.sh`, `FLAGS=-std=c99 ./configure --enable-multithreading`, `make squashfuse_ll`.
- The link is forced fully static with `LDFLAGS=-all-static`. libfuse's SONAME differs across the distros peppy builds on and installs onto (`libfuse3.so.3` on Ubuntu 24.04, `libfuse3.so.4` on Debian 13), so a dynamic binary would be unloadable on half of them. `-all-static` is the libtool spelling; a plain `-static` in `LDFLAGS` is swallowed by libtool and silently yields a dynamic executable.
- Unlike gocryptfs (a prebuilt download that can be dropped into a finished tree), squashfuse has to be compiled for the target ISA, so it is a step of the apptainer build itself on both paths: `build_apptainer_from_source` for host builds, `apptainer_compile_steps` for the Lima guest and Rosetta chroot builds. `APPTAINER_RECIPE_REVISION` goes 1 to 2 so every existing cache is rebuilt rather than shipped without it, and `assert_squashfuse_bundled` fails loudly on any tree accepted without a rebuild.
- `APPTAINER_BUILD_DEPS` and the matching apt list in `scripts/functions/lima.py` gain autotools plus FUSE and compressor headers. They are only linked statically into `squashfuse_ll`; nothing new is required on machines peppy installs onto.

**Defense in depth: `APPTAINER_TMPDIR`.** The native backend now exports `<peppy_root>/tmp/apptainer` as apptainer's `--tmpdir` (verified against apptainer 1.5.2: the hidden `--tmpdir` flag carries `EnvKeys: ["TMPDIR"]` under the `APPTAINER_` prefix, and its value is what `convertImage` extracts into). If the extract fallback is ever reached anyway on a host with no `/dev/fuse`, it lands on real storage instead of a quota-limited tmpfs. The Lima backend deliberately does not set it: `limactl shell` does not carry the host environment into the guest, and the guest's `/tmp` is ordinary disk-backed storage.

## Test plan

Run on a Debian 13 container against a real build of the crate.

- `cargo check -p containers` builds apptainer 1.5.2 and squashfuse 0.6.2 from source; `libexec/apptainer/bin/squashfuse_ll` lands at mode 0755, `file` reports `statically linked`, and the cache sentinel is `.peppy-version-1.5.2-r2`.
- `cargo test -p containers`: 89 passed, 0 failed. Four new tests cover the bundled binary's presence, that it runs and reports `squashfuse 0.6.2` and advertises `-o uid=` (which is what apptainer scans its banner for), and that `APPTAINER_TMPDIR` is set on the native backend and absent on the Lima one.
- `apptainer -d exec` confirms the binary search path starts with the bundled `libexec/apptainer/bin`, which is the mechanism `FindBin("squashfuse_ll")` uses.
- `cargo clippy -p containers --all-targets` clean, `cargo fmt --check` clean, `cargo check --workspace --all-targets` passes with `containers` gaining `daemon-config` as a production dependency.
- Verified `libfuse3-dev`, `zlib1g-dev`, `liblzo2-dev`, `liblz4-dev`, `liblzma-dev` and `libzstd-dev` all ship the static archives on Ubuntu 24.04, which is what the Lima guest and Rosetta chroot builds link against.

Not verified here: an actual SIF FUSE-mount. The build container has neither `/dev/fuse` nor unprivileged user namespaces. The success check on a real host is that a launch log no longer contains `Converting SIF file to temporary sandbox`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Native Apptainer execution now uses a dedicated temporary workspace for improved isolation and reliability.
  * Added bundled SquashFUSE support for running compressed container images.
  * Added version and compatibility checks for the bundled image-mounting support.

* **Bug Fixes**
  * Clearer error reporting is provided when the required temporary workspace cannot be created.

* **Chores**
  * Updated Lima environment setup with the tools required for Apptainer and SquashFUSE support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->