### PR TITLE
Report repository resolution failures instead of guessing, and contain them

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3328,6 +3328,7 @@ dependencies = [
  "auth",
  "build-helpers",
  "bytes",
+ "chrono",
  "clap",
  "containers",
  "core-node",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,7 +573,7 @@ dependencies = [
 [[package]]
 name = "build-helpers"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#83ecd03e248149faa08ec30960c5c2933be8cb24"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#679cdf8ba810940e104d69992029887287153c8c"
 dependencies = [
  "sha2",
 ]
@@ -765,7 +765,7 @@ dependencies = [
 [[package]]
 name = "config-test-support"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#83ecd03e248149faa08ec30960c5c2933be8cb24"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#679cdf8ba810940e104d69992029887287153c8c"
 dependencies = [
  "askama",
  "git2",
@@ -909,7 +909,7 @@ dependencies = [
 [[package]]
 name = "core-node-api"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#83ecd03e248149faa08ec30960c5c2933be8cb24"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#679cdf8ba810940e104d69992029887287153c8c"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -1263,13 +1263,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2005,9 +2005,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -2114,9 +2114,9 @@ checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "typenum",
 ]
@@ -2581,7 +2581,7 @@ dependencies = [
 [[package]]
 name = "json5-pretty"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#83ecd03e248149faa08ec30960c5c2933be8cb24"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#679cdf8ba810940e104d69992029887287153c8c"
 dependencies = [
  "serde",
  "serde_json",
@@ -3371,7 +3371,7 @@ dependencies = [
 [[package]]
 name = "peppy-config-model"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#83ecd03e248149faa08ec30960c5c2933be8cb24"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#679cdf8ba810940e104d69992029887287153c8c"
 dependencies = [
  "capnp",
  "clap",
@@ -3394,7 +3394,7 @@ version = "0.0.1"
 [[package]]
 name = "peppylib-rs"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#83ecd03e248149faa08ec30960c5c2933be8cb24"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#679cdf8ba810940e104d69992029887287153c8c"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -3589,7 +3589,7 @@ dependencies = [
 [[package]]
 name = "pmi"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#83ecd03e248149faa08ec30960c5c2933be8cb24"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#679cdf8ba810940e104d69992029887287153c8c"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -4248,9 +4248,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.42"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -5225,13 +5225,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -5284,9 +5284,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.3+spec-1.1.0"
+version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "indexmap 2.14.0",
  "serde_core",

--- a/crates/core-node-internal/src/services/node/add_batch.rs
+++ b/crates/core-node-internal/src/services/node/add_batch.rs
@@ -288,6 +288,7 @@ async fn resolve_transitive_closure<'a>(
     let mut to_add: Vec<ResolvedBatchNode> = Vec::new();
     let mut seen: HashSet<(String, String)> = HashSet::new();
     let mut missing: Vec<(String, String)> = Vec::new();
+    let mut ambiguous: Vec<String> = Vec::new();
     let mut pending: Vec<(String, String, bool)> =
         vec![(root_name.to_owned(), root_tag.to_owned(), true)];
     let mut in_flight: FuturesUnordered<BoxFuture<'a, MaterializeOutput>> = FuturesUnordered::new();
@@ -303,7 +304,17 @@ async fn resolve_transitive_closure<'a>(
             // pushed. `push_config_impl` handles in-place replacement for
             // keys already in the stack, including the live-instance and
             // dependents safety gates.
-            let Some(entry) = cache::lookup(entries, &name, &tag) else {
+            // An identity claimed twice is present, not absent, so it is
+            // kept out of `missing`: telling the user it is missing sends
+            // them to add a node that is already there twice.
+            let resolved = match cache::lookup(entries, &name, &tag) {
+                Ok(resolved) => resolved,
+                Err(ambiguity) => {
+                    ambiguous.push(ambiguity.to_string());
+                    continue;
+                }
+            };
+            let Some(entry) = resolved else {
                 missing.push(key);
                 continue;
             };
@@ -368,16 +379,25 @@ async fn resolve_transitive_closure<'a>(
         });
     }
 
+    // Everything wrong with the closure is reported in one pass, sorted,
+    // so a user with several problems fixes them all after one run.
+    let mut problems: Vec<String> = Vec::new();
+    ambiguous.sort();
+    problems.append(&mut ambiguous);
     if !missing.is_empty() {
+        missing.sort();
         let list = missing
             .iter()
             .map(|(n, t)| format!("{}:{}", n, t))
             .collect::<Vec<_>>()
             .join(", ");
-        return Err(format!(
+        problems.push(format!(
             "Dependencies missing from nodes cache ({}): {list}. Run `peppy repo refresh` or add the missing nodes to a configured repository.",
             cache::nodes_repo_cache_path(peppy_dirs).display()
         ));
+    }
+    if !problems.is_empty() {
+        return Err(daemon_config::format_bulleted(&problems));
     }
 
     Ok(Resolution { to_add })

--- a/crates/core-node-internal/src/services/node/sync/deps.rs
+++ b/crates/core-node-internal/src/services/node/sync/deps.rs
@@ -79,7 +79,12 @@ pub(super) async fn materialize_repo_deps(
             );
         }
         let (entries, cache_generation) = cache.as_ref().expect("cache loaded above");
-        let Some(entry) = repo_cache::lookup(entries, &name, &tag) else {
+        // An ambiguity two levels down the closure is exactly as fatal as
+        // one at the top, and must not read as "not found": the dep is
+        // present, twice.
+        let cache_hit =
+            repo_cache::lookup(entries, &name, &tag).map_err(|ambiguity| ambiguity.to_string())?;
+        let Some(entry) = cache_hit else {
             return Err(format!(
                 "dep `{name}:{tag}` not found in node stack or repository cache; \
                  run `peppy repo refresh`"

--- a/crates/core-node-internal/src/services/node/sync/interfaces.rs
+++ b/crates/core-node-internal/src/services/node/sync/interfaces.rs
@@ -390,9 +390,11 @@ pub(crate) fn resolve_contract_doc(
     let cache = repo_cache::load_contract_cache(peppy_dirs)
         .map_err(|e| format!("failed to load contract cache: {e}"))?;
 
+    // A sha pin names one exact manifest, so it is never ambiguous.
     let entry = match sha256_pin {
         Some(sha) => repo_cache::lookup_contract_by_sha256(&cache, name, tag, sha),
-        None => repo_cache::lookup_contract(&cache, name, tag),
+        None => repo_cache::lookup_contract(&cache, name, tag)
+            .map_err(|ambiguity| ambiguity.to_string())?,
     };
 
     repo_cache::resolve_cached_doc(

--- a/crates/core-node-internal/src/services/node/sync/pairings.rs
+++ b/crates/core-node-internal/src/services/node/sync/pairings.rs
@@ -36,9 +36,11 @@ fn resolve_pairing_doc_cached(
     sha256_pin: Option<&str>,
     on_feedback: &dyn Fn(&str),
 ) -> std::result::Result<PeppyPairing, String> {
+    // A sha pin names one exact manifest, so it is never ambiguous.
     let entry = match sha256_pin {
         Some(sha) => repo_cache::lookup_pairing_by_sha256(cache, name, tag, sha),
-        None => repo_cache::lookup_pairing(cache, name, tag),
+        None => repo_cache::lookup_pairing(cache, name, tag)
+            .map_err(|ambiguity| ambiguity.to_string())?,
     };
 
     repo_cache::resolve_cached_doc(

--- a/crates/core-node-internal/src/services/repo.rs
+++ b/crates/core-node-internal/src/services/repo.rs
@@ -5,6 +5,7 @@ mod init;
 mod list;
 mod refresh;
 mod remove;
+pub(crate) mod status;
 
 pub use add::listen_for_repo_add;
 pub use exclude::listen_for_repo_exclude;
@@ -13,7 +14,7 @@ pub use list::listen_for_repo_list;
 pub use refresh::listen_for_repo_refresh;
 pub use remove::listen_for_repo_remove;
 
-use core_node_api::encoding::RepoSource;
+use core_node_api::encoding::{RepoSource, RepoSourceKind};
 use serde_json::Value;
 use std::collections::HashSet;
 use std::path::Path;
@@ -116,6 +117,70 @@ pub(crate) fn json_entry_identity(entry: &Value) -> Option<String> {
     }
 }
 
+/// Whether a cache entry was discovered under the repository described by
+/// the `repositories.json5` entry `repo`.
+///
+/// The one definition of "this entry belongs to that repository", so
+/// `repo_id` tagging at load time, retention of a failed repository's
+/// previous entries, and `repo list` grouping cannot drift apart.
+///
+/// - `fs`: the entry's path lies inside the repository's directory.
+/// - `git`: the url matches, and a non-empty pinned `ref` must equal the
+///   entry's `resolved_ref`. An unpinned repository matches any ref,
+///   since whatever branch was checked out did come from it. The ref
+///   check matters: without it, two entries for one url on different
+///   refs both attribute to the lower id and read as one repository
+///   claiming an identity twice.
+/// - `url`: the url matches.
+pub(crate) fn entry_belongs_to_repo(
+    repo: &Value,
+    source_type: RepoSourceKind,
+    source_uri: Option<&str>,
+    resolved_ref: Option<&str>,
+    path: &str,
+) -> bool {
+    let Some(typ) = repo.get("type").and_then(|v| v.as_str()) else {
+        return false;
+    };
+    let repo_url = repo.get("url").and_then(|v| v.as_str());
+    match source_type {
+        RepoSourceKind::Fs if typ == "fs" => repo
+            .get("path")
+            .and_then(|v| v.as_str())
+            .is_some_and(|p| Path::new(path).starts_with(Path::new(p))),
+        RepoSourceKind::Git if typ == "git" => {
+            repo_url == source_uri
+                && match repo.get("ref").and_then(|v| v.as_str()) {
+                    Some(pinned) if !pinned.is_empty() => Some(pinned) == resolved_ref,
+                    _ => true,
+                }
+        }
+        RepoSourceKind::Url if typ == "url" => repo_url == source_uri,
+        _ => false,
+    }
+}
+
+/// Id of the repository that owns this cache entry: the first match in
+/// id order, which (since `repos` arrives sorted by id) is the
+/// highest-priority repository that could have produced it. `None` when
+/// no configured repository matches.
+///
+/// Nested fs repositories can both contain an entry; first-match makes
+/// exactly one of them its owner, so retention and `repo_id` tagging
+/// never double-count.
+pub(crate) fn owning_repo_id(
+    repos: &[Value],
+    source_type: RepoSourceKind,
+    source_uri: Option<&str>,
+    resolved_ref: Option<&str>,
+    path: &str,
+) -> Option<u64> {
+    repos
+        .iter()
+        .find(|repo| entry_belongs_to_repo(repo, source_type, source_uri, resolved_ref, path))
+        .and_then(|repo| repo.get("id").and_then(|v| v.as_u64()))
+}
+
 /// Normalize a list of repo JSON entries: auto-assign missing `id` fields,
 /// detect duplicate ids, sort by id, and write back if any ids were assigned.
 pub(crate) fn normalize_repo_entries(
@@ -182,8 +247,9 @@ mod tests {
     // Coverage for `source_identity` (relocated here from `core-node-api`
     // alongside the function, which moved out of the pure wire-codec crate
     // because its `Fs` arm canonicalizes against the real filesystem).
-    use super::source_identity;
-    use core_node_api::encoding::RepoSource;
+    use super::{entry_belongs_to_repo, source_identity};
+    use core_node_api::encoding::{RepoSource, RepoSourceKind};
+    use serde_json::Value;
 
     #[test]
     fn identity_git_distinguishes_refs() {
@@ -260,5 +326,110 @@ mod tests {
     fn identity_url_is_unchanged() {
         let src = RepoSource::Url("https://example.com/packages".to_string());
         assert_eq!(source_identity(&src), "https://example.com/packages");
+    }
+
+    fn git_repo(url: &str, git_ref: Option<&str>) -> Value {
+        let mut map = serde_json::Map::new();
+        map.insert("type".into(), Value::String("git".into()));
+        map.insert("url".into(), Value::String(url.into()));
+        if let Some(r) = git_ref {
+            map.insert("ref".into(), Value::String(r.into()));
+        }
+        Value::Object(map)
+    }
+
+    /// Two repositories on one url pinned to different refs are different
+    /// repositories. Attributing by url alone would give both the lower
+    /// id, which makes their entries look like one repository claiming an
+    /// identity twice.
+    #[test]
+    fn git_attribution_distinguishes_pinned_refs() {
+        let main = git_repo("https://example.com/hub.git", Some("main"));
+        let dev = git_repo("https://example.com/hub.git", Some("dev"));
+        let url = Some("https://example.com/hub.git");
+
+        assert!(entry_belongs_to_repo(
+            &main,
+            RepoSourceKind::Git,
+            url,
+            Some("main"),
+            "node/peppy.json5"
+        ));
+        assert!(!entry_belongs_to_repo(
+            &main,
+            RepoSourceKind::Git,
+            url,
+            Some("dev"),
+            "node/peppy.json5"
+        ));
+        assert!(entry_belongs_to_repo(
+            &dev,
+            RepoSourceKind::Git,
+            url,
+            Some("dev"),
+            "node/peppy.json5"
+        ));
+    }
+
+    /// An unpinned repository takes whatever branch was checked out, so
+    /// it matches any resolved ref on its url.
+    #[test]
+    fn git_attribution_unpinned_repo_matches_any_ref() {
+        let unpinned = git_repo("https://example.com/hub.git", None);
+        let url = Some("https://example.com/hub.git");
+
+        assert!(entry_belongs_to_repo(
+            &unpinned,
+            RepoSourceKind::Git,
+            url,
+            Some("some-branch"),
+            "node/peppy.json5"
+        ));
+        assert!(
+            !entry_belongs_to_repo(
+                &unpinned,
+                RepoSourceKind::Git,
+                Some("https://example.com/other.git"),
+                Some("main"),
+                "node/peppy.json5"
+            ),
+            "a different url is a different repository"
+        );
+    }
+
+    /// An fs entry belongs to the repository whose directory contains it,
+    /// and to no other.
+    #[test]
+    fn fs_attribution_matches_by_containment() {
+        let repo = serde_json::json!({ "type": "fs", "path": "/home/user/workspace" });
+
+        assert!(entry_belongs_to_repo(
+            &repo,
+            RepoSourceKind::Fs,
+            None,
+            None,
+            "/home/user/workspace/arm/peppy.json5"
+        ));
+        assert!(!entry_belongs_to_repo(
+            &repo,
+            RepoSourceKind::Fs,
+            None,
+            None,
+            "/home/user/elsewhere/arm/peppy.json5"
+        ));
+    }
+
+    /// Source kinds never cross-attribute, even when the other fields
+    /// would otherwise line up.
+    #[test]
+    fn attribution_requires_matching_source_kind() {
+        let git = git_repo("https://example.com/hub.git", None);
+        assert!(!entry_belongs_to_repo(
+            &git,
+            RepoSourceKind::Url,
+            Some("https://example.com/hub.git"),
+            None,
+            "node/peppy.json5"
+        ));
     }
 }

--- a/crates/core-node-internal/src/services/repo/cache.rs
+++ b/crates/core-node-internal/src/services/repo/cache.rs
@@ -449,9 +449,10 @@ pub(crate) fn write_repo_cache<E: RepoCacheEntry>(
 /// Reads `E`'s cache file, tags each entry with the `repo_id` of its
 /// originating repository entry (derived from `repositories.json5` at
 /// read time; never serialized back), and drops malformed entries with
-/// a warning. Missing repository matches default to id 0 (highest
-/// priority) to preserve behavior for hand-written caches. Returns an
-/// empty vec when the file is missing.
+/// a warning. Entries no repository claims fall back to
+/// [`UNOWNED_REPO_ID`], so a hand-written cache still resolves without
+/// outranking a configured repository. Returns an empty vec when the
+/// file is missing.
 pub(crate) fn load_repo_cache<E: RepoCacheEntry>(peppy_dirs: &PeppyDirs) -> Result<Vec<E>> {
     let path = repo_cache_path::<E>(peppy_dirs);
     if !path.exists() {
@@ -627,9 +628,21 @@ fn repositories_mtime(peppy_dirs: &PeppyDirs) -> SystemTime {
         .unwrap_or(SystemTime::UNIX_EPOCH)
 }
 
-/// Owning repository id narrowed to the wire's `u32`, defaulting to 0
-/// (highest priority) when no repository matches, which preserves
-/// resolution for hand-written caches.
+/// Priority given to a cached entry that no configured repository
+/// claims: the lowest there is. Such an entry still resolves when
+/// nothing else claims its identity, which is what keeps a hand-written
+/// cache working, but it never outranks a configured repository.
+///
+/// Configuration and the caches are published as separate files, so an
+/// entry outlives its repository for as long as the re-index that
+/// follows a `repo remove` or `repo exclude` takes to land, and longer
+/// still when that re-index fails. Treating those entries as the highest
+/// priority would let the repository a user just removed shadow the ones
+/// they kept.
+pub(crate) const UNOWNED_REPO_ID: u32 = u32::MAX;
+
+/// Owning repository id narrowed to the wire's `u32`, falling back to
+/// [`UNOWNED_REPO_ID`] when no repository matches.
 fn lookup_repo_id(
     repos: &[serde_json::Value],
     source_type: RepoSourceKind,
@@ -639,7 +652,7 @@ fn lookup_repo_id(
 ) -> u32 {
     crate::services::repo::owning_repo_id(repos, source_type, uri, resolved_ref, path)
         .and_then(|id| u32::try_from(id).ok())
-        .unwrap_or(0)
+        .unwrap_or(UNOWNED_REPO_ID)
 }
 
 /// Returns the highest-priority (lowest `repo_id`) node entry for
@@ -1314,6 +1327,55 @@ mod tests {
         assert_eq!(loaded[0].sha256, "aaaa");
         assert_eq!(loaded[1].node_name, "b");
         assert_eq!(loaded[1].sha256, "bbbb");
+    }
+
+    /// An entry no configured repository claims must not outrank one that
+    /// a repository does claim. `repo remove` and `repo exclude` publish
+    /// the new configuration before the re-index rewrites the caches, and
+    /// a lookup landing in that window (or after a re-index that failed)
+    /// would otherwise resolve to the repository the user just dropped.
+    #[test]
+    fn unowned_entries_rank_below_configured_repositories() {
+        let tmp = tempfile::tempdir().unwrap();
+        let peppy_dirs = PeppyDirs::new(tmp.path());
+
+        let live = tmp.path().join("live_repo");
+        let dropped = tmp.path().join("dropped_repo");
+        std::fs::create_dir_all(peppy_dirs.conf_dir()).unwrap();
+        std::fs::write(
+            repositories_list_path(&peppy_dirs),
+            serde_json::to_string(&serde_json::json!([
+                { "id": 7, "type": "fs", "path": live.to_string_lossy() }
+            ]))
+            .unwrap(),
+        )
+        .unwrap();
+
+        write_repo_cache(
+            &peppy_dirs,
+            &[
+                mk_fs_entry("a", "v1", &dropped.join("a/peppy.json5").to_string_lossy()),
+                mk_fs_entry("a", "v1", &live.join("a/peppy.json5").to_string_lossy()),
+                mk_fs_entry("b", "v1", &dropped.join("b/peppy.json5").to_string_lossy()),
+            ],
+        )
+        .unwrap();
+
+        let entries = load_repo_cache::<NodeCacheEntry>(&peppy_dirs).unwrap();
+        assert_eq!(entries[0].repo_id, UNOWNED_REPO_ID);
+        assert_eq!(entries[1].repo_id, 7);
+
+        let hit = lookup(&entries, "a", "v1")
+            .expect("one entry per repository is not ambiguous")
+            .expect("should resolve");
+        assert_eq!(hit.repo_id, 7, "the configured repository wins");
+
+        // Still resolvable on its own: a hand-written cache with no
+        // matching repository entry keeps working.
+        let hit = lookup(&entries, "b", "v1")
+            .expect("a single claimant is not ambiguous")
+            .expect("should resolve");
+        assert_eq!(hit.repo_id, UNOWNED_REPO_ID);
     }
 
     // -- resolve_repo_node_source tests --

--- a/crates/core-node-internal/src/services/repo/cache.rs
+++ b/crates/core-node-internal/src/services/repo/cache.rs
@@ -471,7 +471,13 @@ pub(crate) fn load_repo_cache<E: RepoCacheEntry>(peppy_dirs: &PeppyDirs) -> Resu
     let entries = raw
         .into_iter()
         .map(|mut e| {
-            let id = lookup_repo_id(&repos, e.source_type(), e.source_uri(), e.path());
+            let id = lookup_repo_id(
+                &repos,
+                e.source_type(),
+                e.source_uri(),
+                e.resolved_ref(),
+                e.path(),
+            );
             e.set_repo_id(id);
             e
         })
@@ -490,19 +496,83 @@ pub(crate) fn load_repo_cache<E: RepoCacheEntry>(peppy_dirs: &PeppyDirs) -> Resu
     Ok(entries)
 }
 
+/// One identity answered more than once by a single repository. Unlike
+/// two repositories claiming an identity, which the `repo_id` order
+/// settles deterministically, this has no defensible winner: picking one
+/// would be an arbitrary choice presented as an answer.
+///
+/// `repo refresh` refuses a repository that contains such a conflict, so
+/// reaching this at lookup means the cache predates that check or was
+/// hand-edited.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RepoAmbiguity {
+    /// Singular kind label ("node", "launcher", ...).
+    pub kind: &'static str,
+    /// `name:tag` label, or the bare name for untagged kinds.
+    pub id: String,
+    pub repo_id: u32,
+    /// Every claimant's path, sorted.
+    pub paths: Vec<String>,
+}
+
+impl std::fmt::Display for RepoAmbiguity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{} {} entries in repository {} claim `{}`: {}; \
+             fix the repository so one manifest claims it, then run \
+             `peppy repo refresh`",
+            self.paths.len(),
+            self.kind,
+            self.repo_id,
+            self.id,
+            self.paths.join(", ")
+        )
+    }
+}
+
 /// Returns the highest-priority (lowest `repo_id`) entry matching
-/// `(name, tag)`, or `None`. The repo-priority tiebreak lives here so
-/// all four caches resolve cross-repo name collisions identically.
-/// Untagged kinds (launchers) match with `tag = ""`.
+/// `(name, tag)`, `None` when nothing matches, or an error when the
+/// winning repository claims the identity more than once.
+///
+/// The repo-priority tiebreak lives here so all four caches resolve
+/// cross-repo name collisions identically. Untagged kinds (launchers)
+/// match with `tag = ""`.
+///
+/// Only entries tied at the winning `repo_id` are ambiguous. A
+/// lower-id repository shadowing a higher-id one stays a supported
+/// feature with a documented order, and still resolves.
 pub(crate) fn lookup_repo_entry<'a, E: RepoCacheEntry>(
     entries: &'a [E],
     name: &str,
     tag: &str,
-) -> Option<&'a E> {
-    entries
+) -> std::result::Result<Option<&'a E>, RepoAmbiguity> {
+    let matches: Vec<&E> = entries
         .iter()
         .filter(|e| e.name() == name && e.tag() == tag)
-        .min_by_key(|e| e.repo_id())
+        .collect();
+    let Some(winning_id) = matches.iter().map(|e| e.repo_id()).min() else {
+        return Ok(None);
+    };
+
+    let mut winners = matches.into_iter().filter(|e| e.repo_id() == winning_id);
+    let first = winners.next().expect("min came from a non-empty set");
+    let contested: Vec<&E> = winners.collect();
+    if contested.is_empty() {
+        return Ok(Some(first));
+    }
+
+    let mut paths: Vec<String> = std::iter::once(first)
+        .chain(contested)
+        .map(|e| e.path().to_owned())
+        .collect();
+    paths.sort();
+    Err(RepoAmbiguity {
+        kind: E::KIND,
+        id: first.display_id(),
+        repo_id: winning_id,
+        paths,
+    })
 }
 
 /// Returns the entry whose `(name, tag, sha256)` triple matches
@@ -557,59 +627,50 @@ fn repositories_mtime(peppy_dirs: &PeppyDirs) -> SystemTime {
         .unwrap_or(SystemTime::UNIX_EPOCH)
 }
 
+/// Owning repository id narrowed to the wire's `u32`, defaulting to 0
+/// (highest priority) when no repository matches, which preserves
+/// resolution for hand-written caches.
 fn lookup_repo_id(
     repos: &[serde_json::Value],
     source_type: RepoSourceKind,
     uri: Option<&str>,
+    resolved_ref: Option<&str>,
     path: &str,
 ) -> u32 {
-    for entry in repos {
-        let Some(typ) = entry.get("type").and_then(|v| v.as_str()) else {
-            continue;
-        };
-        let matches = match source_type {
-            RepoSourceKind::Fs if typ == "fs" => entry
-                .get("path")
-                .and_then(|v| v.as_str())
-                .is_some_and(|p| Path::new(path).starts_with(Path::new(p))),
-            RepoSourceKind::Git if typ == "git" => entry.get("url").and_then(|v| v.as_str()) == uri,
-            RepoSourceKind::Url if typ == "url" => entry.get("url").and_then(|v| v.as_str()) == uri,
-            _ => false,
-        };
-        if matches {
-            let id = entry.get("id").and_then(|v| v.as_u64()).unwrap_or(0);
-            return u32::try_from(id).unwrap_or(0);
-        }
-    }
-    0
+    crate::services::repo::owning_repo_id(repos, source_type, uri, resolved_ref, path)
+        .and_then(|id| u32::try_from(id).ok())
+        .unwrap_or(0)
 }
 
 /// Returns the highest-priority (lowest `repo_id`) node entry for
-/// `(name, tag)`. Returns `None` when no entry matches.
+/// `(name, tag)`, `None` when no entry matches, or [`RepoAmbiguity`]
+/// when the winning repository claims it more than once.
 pub fn lookup<'a>(
     entries: &'a [NodeCacheEntry],
     name: &str,
     tag: &str,
-) -> Option<&'a NodeCacheEntry> {
+) -> std::result::Result<Option<&'a NodeCacheEntry>, RepoAmbiguity> {
     lookup_repo_entry(entries, name, tag)
 }
 
 /// Returns the highest-priority (lowest `repo_id`) launcher entry
-/// matching `name`. Returns `None` when no entry matches.
+/// matching `name`, `None` when no entry matches, or [`RepoAmbiguity`]
+/// when the winning repository claims it more than once.
 pub fn lookup_launcher<'a>(
     entries: &'a [LauncherCacheEntry],
     name: &str,
-) -> Option<&'a LauncherCacheEntry> {
+) -> std::result::Result<Option<&'a LauncherCacheEntry>, RepoAmbiguity> {
     lookup_repo_entry(entries, name, "")
 }
 
 /// Returns the highest-priority (lowest `repo_id`) contract entry
-/// matching `(name, tag)`. Returns `None` when no entry matches.
+/// matching `(name, tag)`, `None` when no entry matches, or
+/// [`RepoAmbiguity`] when the winning repository claims it more than once.
 pub fn lookup_contract<'a>(
     entries: &'a [ContractCacheEntry],
     name: &str,
     tag: &str,
-) -> Option<&'a ContractCacheEntry> {
+) -> std::result::Result<Option<&'a ContractCacheEntry>, RepoAmbiguity> {
     lookup_repo_entry(entries, name, tag)
 }
 
@@ -625,12 +686,13 @@ pub fn lookup_contract_by_sha256<'a>(
 }
 
 /// Returns the highest-priority (lowest `repo_id`) pairing entry
-/// matching `(name, tag)`. Returns `None` when no entry matches.
+/// matching `(name, tag)`, `None` when no entry matches, or
+/// [`RepoAmbiguity`] when the winning repository claims it more than once.
 pub fn lookup_pairing<'a>(
     entries: &'a [PairingCacheEntry],
     name: &str,
     tag: &str,
-) -> Option<&'a PairingCacheEntry> {
+) -> std::result::Result<Option<&'a PairingCacheEntry>, RepoAmbiguity> {
     lookup_repo_entry(entries, name, tag)
 }
 
@@ -643,6 +705,33 @@ pub fn lookup_pairing_by_sha256<'a>(
     sha256: &str,
 ) -> Option<&'a PairingCacheEntry> {
     lookup_repo_entry_by_sha256(entries, name, tag, sha256)
+}
+
+/// Suffix appended to a cache-miss message when the machine excludes
+/// repositories, so an identity that is absent because its repository was
+/// excluded is attributable rather than looking like missing content.
+///
+/// An excluded repository is never scanned, so peppy cannot know whether
+/// it would have provided the identity; the wording says so instead of
+/// implying it did.
+fn excluded_repositories_hint(peppy_dirs: &PeppyDirs) -> String {
+    let excluded = crate::services::repo::exclude::ExclusionSet::load(peppy_dirs);
+    if excluded.entries.is_empty() {
+        return String::new();
+    }
+    let mut identities: Vec<&str> = excluded
+        .entries
+        .iter()
+        .map(|e| e.identity.as_str())
+        .collect();
+    identities.sort();
+    let plural = if identities.len() == 1 { "y" } else { "ies" };
+    format!(
+        ". {} excluded repositor{plural} ({}) {} not indexed at all and may have provided it",
+        identities.len(),
+        identities.join(", "),
+        if identities.len() == 1 { "is" } else { "are" },
+    )
 }
 
 pub fn nodes_repo_cache_path(peppy_dirs: &PeppyDirs) -> PathBuf {
@@ -688,12 +777,15 @@ pub(crate) fn resolve_repo_node_source(
     let (entries, _) =
         load_with_generation(peppy_dirs).map_err(|e| format!("failed to load nodes cache: {e}"))?;
     let id = format!("{name}:{tag}");
-    let entry = lookup(&entries, name, tag).ok_or_else(|| {
-        format!(
-            "repo-node `{id}` not found in {}",
-            nodes_repo_cache_path(peppy_dirs).display()
-        )
-    })?;
+    let entry = lookup(&entries, name, tag)
+        .map_err(|ambiguity| ambiguity.to_string())?
+        .ok_or_else(|| {
+            format!(
+                "repo-node `{id}` not found in {}{}",
+                nodes_repo_cache_path(peppy_dirs).display(),
+                excluded_repositories_hint(peppy_dirs)
+            )
+        })?;
 
     match entry.source_type {
         RepoSourceKind::Fs => {
@@ -765,12 +857,15 @@ pub(crate) fn resolve_repo_launcher_path(
     let entries: Vec<LauncherCacheEntry> =
         load_repo_cache(peppy_dirs).map_err(|e| format!("failed to load launcher cache: {e}"))?;
 
-    let entry = lookup_launcher(&entries, name).ok_or_else(|| {
-        format!(
-            "launcher `{name}` not found in {}",
-            launchers_repo_cache_path(peppy_dirs).display()
-        )
-    })?;
+    let entry = lookup_launcher(&entries, name)
+        .map_err(|ambiguity| ambiguity.to_string())?
+        .ok_or_else(|| {
+            format!(
+                "launcher `{name}` not found in {}{}",
+                launchers_repo_cache_path(peppy_dirs).display(),
+                excluded_repositories_hint(peppy_dirs)
+            )
+        })?;
 
     resolve_cached_artifact_path(
         peppy_dirs,
@@ -860,12 +955,15 @@ pub(crate) fn resolve_cached_doc<T>(
     parse: impl FnOnce(&str) -> std::result::Result<T, String>,
     on_feedback: &dyn Fn(&str),
 ) -> std::result::Result<T, String> {
-    let entry = entry.ok_or_else(|| match sha256_pin {
-        Some(sha) => format!(
-            "{kind} `{id}` (sha256 `{sha}`) not in {kind} cache; \
-             run `peppy repo refresh`"
-        ),
-        None => format!("{kind} `{id}` not in {kind} cache; run `peppy repo refresh`"),
+    let entry = entry.ok_or_else(|| {
+        let hint = excluded_repositories_hint(peppy_dirs);
+        match sha256_pin {
+            Some(sha) => format!(
+                "{kind} `{id}` (sha256 `{sha}`) not in {kind} cache; \
+                 run `peppy repo refresh`{hint}"
+            ),
+            None => format!("{kind} `{id}` not in {kind} cache; run `peppy repo refresh`{hint}"),
+        }
     })?;
 
     let resolved_path = resolve_cached_artifact_path(
@@ -1050,7 +1148,9 @@ mod tests {
             mk_entry("a", "v1", 2),
             mk_entry("a", "v1", 9),
         ];
-        let hit = lookup(&entries, "a", "v1").unwrap();
+        let hit = lookup(&entries, "a", "v1")
+            .expect("distinct repo ids are not ambiguous")
+            .expect("should resolve");
         assert_eq!(hit.repo_id, 2);
     }
 
@@ -1059,8 +1159,98 @@ mod tests {
     #[test]
     fn lookup_returns_highest_priority_when_multiple_match() {
         let entries = vec![mk_entry("a", "v1", 7), mk_entry("a", "v1", 3)];
-        let hit = lookup(&entries, "a", "v1").unwrap();
+        let hit = lookup(&entries, "a", "v1")
+            .expect("distinct repo ids are not ambiguous")
+            .expect("should resolve");
         assert_eq!(hit.repo_id, 3);
+    }
+
+    /// Two entries tied at the winning repo id have no defensible
+    /// winner, so lookup reports the ambiguity instead of picking one.
+    #[test]
+    fn lookup_reports_ambiguity_within_one_repo() {
+        let mut first = mk_entry("a", "v1", 2);
+        first.path = "/repo/rust/peppy.json5".to_owned();
+        let mut second = mk_entry("a", "v1", 2);
+        second.path = "/repo/python/peppy.json5".to_owned();
+
+        let err = lookup(&[first, second], "a", "v1").expect_err("should be ambiguous");
+
+        assert_eq!(err.kind, "node");
+        assert_eq!(err.id, "a:v1");
+        assert_eq!(err.repo_id, 2);
+        assert_eq!(
+            err.paths,
+            vec!["/repo/python/peppy.json5", "/repo/rust/peppy.json5"],
+            "both claimants named, sorted"
+        );
+    }
+
+    /// The message names both files and says what to do. It must not
+    /// read as "not found": the identity is present, twice.
+    #[test]
+    fn ambiguity_message_names_both_claimants() {
+        let mut first = mk_entry("uvc_recon", "v1", 1000);
+        first.path = "uvc_recon/rust/peppy.json5".to_owned();
+        let mut second = mk_entry("uvc_recon", "v1", 1000);
+        second.path = "uvc_recon/python/peppy.json5".to_owned();
+
+        let msg = lookup(&[first, second], "uvc_recon", "v1")
+            .expect_err("should be ambiguous")
+            .to_string();
+
+        assert!(msg.contains("uvc_recon:v1"), "got: {msg}");
+        assert!(msg.contains("uvc_recon/rust/peppy.json5"), "got: {msg}");
+        assert!(msg.contains("uvc_recon/python/peppy.json5"), "got: {msg}");
+        assert!(msg.contains("repository 1000"), "got: {msg}");
+        assert!(!msg.contains("not found"), "got: {msg}");
+    }
+
+    /// A lower-id repository shadowing a higher-id one is a supported
+    /// feature, so a tie at the *losing* id must not make the winner
+    /// ambiguous.
+    #[test]
+    fn lookup_ignores_ties_below_the_winning_repo_id() {
+        let entries = vec![
+            mk_entry("a", "v1", 1),
+            mk_entry("a", "v1", 7),
+            mk_entry("a", "v1", 7),
+        ];
+
+        let hit = lookup(&entries, "a", "v1")
+            .expect("only the winning id is checked")
+            .expect("should resolve");
+
+        assert_eq!(hit.repo_id, 1);
+    }
+
+    /// Launchers are untagged, so the ambiguity label is the bare name
+    /// rather than a `name:` with an empty tag.
+    #[test]
+    fn launcher_ambiguity_uses_the_bare_name() {
+        let entries = vec![
+            mk_launcher_entry(
+                "bringup",
+                RepoSourceKind::Fs,
+                None,
+                None,
+                "/repo/sim/bringup.json5",
+                3,
+            ),
+            mk_launcher_entry(
+                "bringup",
+                RepoSourceKind::Fs,
+                None,
+                None,
+                "/repo/real/bringup.json5",
+                3,
+            ),
+        ];
+
+        let err = lookup_launcher(&entries, "bringup").expect_err("should be ambiguous");
+
+        assert_eq!(err.kind, "launcher");
+        assert_eq!(err.id, "bringup");
     }
 
     /// `lookup_repo_entry_by_sha256` returns the entry whose content fingerprint
@@ -1388,7 +1578,9 @@ mod tests {
                 1,
             ),
         ];
-        let hit = lookup_launcher(&entries, "demo").expect("should resolve");
+        let hit = lookup_launcher(&entries, "demo")
+            .expect("distinct repo ids are not ambiguous")
+            .expect("should resolve");
         assert_eq!(hit.repo_id, 1);
         assert!(hit.path.ends_with("demo_high_priority.json5"));
     }
@@ -1663,7 +1855,9 @@ mod tests {
                 1,
             ),
         ];
-        let hit = lookup_contract(&entries, "uvc_camera", "v1").unwrap();
+        let hit = lookup_contract(&entries, "uvc_camera", "v1")
+            .expect("distinct repo ids are not ambiguous")
+            .expect("should resolve");
         assert_eq!(hit.repo_id, 1);
         assert_eq!(hit.sha256, "aaaa");
     }

--- a/crates/core-node-internal/src/services/repo/exclude.rs
+++ b/crates/core-node-internal/src/services/repo/exclude.rs
@@ -57,9 +57,7 @@ async fn handle_repo_exclude_request(
 
     // The exclusion itself already landed, so `success` stays true; the
     // report says whether the re-read that makes it take effect worked.
-    if needs_refresh
-        && let Some(report) = reindex_after_change(&peppy_dirs).await
-    {
+    if needs_refresh && let Some(report) = reindex_after_change(&peppy_dirs).await {
         warn!("Re-indexing after the exclusion reported problems: {report}");
         response = RepoExcludeResponse::success_with_refresh_report(report);
     }

--- a/crates/core-node-internal/src/services/repo/exclude.rs
+++ b/crates/core-node-internal/src/services/repo/exclude.rs
@@ -1,5 +1,5 @@
 use crate::Result;
-use crate::services::repo::refresh::{process_refresh, write_all_caches};
+use crate::services::repo::refresh::reindex_after_change;
 use crate::services::repo::{
     json_entry_identity, normalize_repo_entries, repo_source_to_json, source_identity,
 };
@@ -50,33 +50,21 @@ async fn handle_repo_exclude_request(
     context: ServiceRequestContext,
     peppy_dirs: PeppyDirs,
 ) -> PeppyResult<Payload> {
-    let (payload, needs_refresh) = into_service_response(
+    let (mut response, needs_refresh) = into_service_response(
         &context,
         handle_repo_exclude_request_inner(&context, &peppy_dirs),
     )?;
 
-    if needs_refresh {
-        let dirs = peppy_dirs.clone();
-        match tokio::task::spawn_blocking(move || {
-            let _guard = crate::services::repo::refresh_lock().lock();
-            match process_refresh(&dirs, &mut |_| {}) {
-                Ok(refreshed) => write_all_caches(&dirs, &refreshed),
-                Err(e) => Err(e),
-            }
-        })
-        .await
-        {
-            Ok(Ok(())) => {}
-            Ok(Err(e)) => {
-                warn!("Failed to refresh after repo exclusion: {}", e);
-            }
-            Err(e) => {
-                warn!("Refresh task panicked after repo exclusion: {}", e);
-            }
-        }
+    // The exclusion itself already landed, so `success` stays true; the
+    // report says whether the re-read that makes it take effect worked.
+    if needs_refresh
+        && let Some(report) = reindex_after_change(&peppy_dirs).await
+    {
+        warn!("Re-indexing after the exclusion reported problems: {report}");
+        response = RepoExcludeResponse::success_with_refresh_report(report);
     }
 
-    Ok(payload)
+    into_service_response(&context, response.encode().map_err(Into::into))
 }
 
 /// Reads excluded repositories from `conf/excluded_repositories.json5`.
@@ -164,11 +152,13 @@ impl ExclusionSet {
     }
 }
 
-/// Returns `(payload, needs_refresh)`.
+/// Returns `(response, needs_refresh)`. The response is returned
+/// unencoded so the caller can fold the post-change re-index report into
+/// it before putting it on the wire.
 fn handle_repo_exclude_request_inner(
     context: &ServiceRequestContext,
     peppy_dirs: &PeppyDirs,
-) -> Result<(Payload, bool)> {
+) -> Result<(RepoExcludeResponse, bool)> {
     let sender_instance_id = context.message().instance_id();
     let payload = context.message().payload();
 
@@ -182,7 +172,7 @@ fn handle_repo_exclude_request_inner(
     let identity = source_identity(&request.source);
     if identity.trim().is_empty() {
         return Ok((
-            RepoExcludeResponse::failure("repository path/URL must not be empty").encode()?,
+            RepoExcludeResponse::failure("repository path/URL must not be empty"),
             false,
         ));
     }
@@ -194,7 +184,7 @@ fn handle_repo_exclude_request_inner(
     let mut repos = match read_excluded_repos(peppy_dirs) {
         Ok(repos) => repos,
         Err(e) => {
-            return Ok((RepoExcludeResponse::failure(e.to_string()).encode()?, false));
+            return Ok((RepoExcludeResponse::failure(e.to_string()), false));
         }
     };
 
@@ -205,8 +195,7 @@ fn handle_repo_exclude_request_inner(
 
     if is_duplicate {
         return Ok((
-            RepoExcludeResponse::failure(format!("repository '{}' already exists", new_identity))
-                .encode()?,
+            RepoExcludeResponse::failure(format!("repository '{}' already exists", new_identity)),
             false,
         ));
     }
@@ -227,5 +216,5 @@ fn handle_repo_exclude_request_inner(
 
     drop(_guard);
 
-    Ok((RepoExcludeResponse::success().encode()?, true))
+    Ok((RepoExcludeResponse::success(), true))
 }

--- a/crates/core-node-internal/src/services/repo/list.rs
+++ b/crates/core-node-internal/src/services/repo/list.rs
@@ -93,7 +93,11 @@ fn handle_repo_list_request_inner(
     let mut claims: HashSet<(u32, &str, &str)> = HashSet::new();
     let mut conflicted: HashSet<(u32, &str, &str)> = HashSet::new();
     for node in &cached {
-        let key = (node.repo_id, node.node_name.as_str(), node.node_tag.as_str());
+        let key = (
+            node.repo_id,
+            node.node_name.as_str(),
+            node.node_tag.as_str(),
+        );
         if !claims.insert(key) {
             conflicted.insert(key);
         }
@@ -174,11 +178,11 @@ fn repo_entry(
         source_type: source.kind(),
         last_read_unix_secs: status.and_then(|s| s.last_read_unix_secs),
         retained: status.is_some_and(|s| s.is_retained()),
-        failure: status.and_then(|s| s.last_failure.as_ref()).map(|f| {
-            RepoListRepoFailure {
+        failure: status
+            .and_then(|s| s.last_failure.as_ref())
+            .map(|f| RepoListRepoFailure {
                 kind: f.kind.clone(),
                 detail: f.message.clone(),
-            }
-        }),
+            }),
     }
 }

--- a/crates/core-node-internal/src/services/repo/list.rs
+++ b/crates/core-node-internal/src/services/repo/list.rs
@@ -1,12 +1,13 @@
 use crate::Result;
-use crate::services::repo::cache::nodes_repo_cache_path;
+use crate::services::repo::cache::{NodeCacheEntry, load_repo_cache};
 use crate::services::repo::exclude::ExclusionSet;
-use crate::services::repo::refresh::{parse_repo_entry, read_or_create_repos, walk_directory};
-use crate::services::repo::source_identity;
+use crate::services::repo::refresh::{parse_repo_entry, read_or_create_repos};
+use crate::services::repo::status::{self, RepoStatus};
+use crate::services::repo::{owning_repo_id, source_identity};
 use crate::services::response::into_service_response;
 use core_node_api::ServiceId;
 use core_node_api::encoding::{
-    RepoListNodeEntry, RepoListRequest, RepoListResponse, RepoSource, RepoSourceKind,
+    RepoListNodeEntry, RepoListRepoEntry, RepoListRepoFailure, RepoListRequest, RepoListResponse,
 };
 use core_node_api::names;
 use daemon_config::consts::PeppyDirs;
@@ -14,7 +15,6 @@ use peppylib::messaging::SenderTarget;
 use peppylib::messaging::ServiceRequestContext;
 use peppylib::types::Payload;
 use peppylib::{MessengerHandle, PeppyResult, ServiceMessenger};
-use serde_json::Value;
 use std::collections::HashSet;
 use tokio::task::JoinHandle;
 use tracing::{debug, warn};
@@ -55,6 +55,14 @@ async fn handle_repo_list_request(
     )
 }
 
+/// Lists what will actually resolve.
+///
+/// Every source kind is read from `nodes.json5` rather than re-walked
+/// live. Walking fs repositories on the fly would show whatever is on
+/// disk right now, which is a different question: after a failed refresh
+/// it would display the entries peppy refused, and at any time it would
+/// display nodes added since the last refresh that cannot yet resolve.
+/// Reading the cache is what makes a partial update legible.
 fn handle_repo_list_request_inner(
     context: &ServiceRequestContext,
     peppy_dirs: &PeppyDirs,
@@ -72,12 +80,28 @@ fn handle_repo_list_request_inner(
     };
 
     let exclusions = ExclusionSet::load(peppy_dirs);
+    let statuses = status::read(peppy_dirs);
+    let cached: Vec<NodeCacheEntry> = load_repo_cache(peppy_dirs).unwrap_or_else(|e| {
+        warn!("Failed to read the nodes cache: {e}");
+        Vec::new()
+    });
 
-    // Read cached nodes for git/url repos
-    let cached_nodes = read_cached_nodes(peppy_dirs);
+    // Identities claimed more than once by a single repository. Refresh
+    // refuses such a repository, so this only fires for a cache written
+    // by an older peppy or hand-edited, which is exactly when a user
+    // needs to be told which entry is poisoned.
+    let mut claims: HashSet<(u32, &str, &str)> = HashSet::new();
+    let mut conflicted: HashSet<(u32, &str, &str)> = HashSet::new();
+    for node in &cached {
+        let key = (node.repo_id, node.node_name.as_str(), node.node_tag.as_str());
+        if !claims.insert(key) {
+            conflicted.insert(key);
+        }
+    }
 
-    let mut global_seen: HashSet<(String, String)> = HashSet::new();
+    let mut global_seen: HashSet<(&str, &str)> = HashSet::new();
     let mut all_entries: Vec<RepoListNodeEntry> = Vec::new();
+    let mut all_repos: Vec<RepoListRepoEntry> = Vec::new();
 
     for entry in &repos {
         let Some(source) = parse_repo_entry(entry) else {
@@ -86,118 +110,75 @@ fn handle_repo_list_request_inner(
         };
 
         let identity = source_identity(&source);
-
         if exclusions.is_excluded(&identity) {
             debug!("Excluding repository from list: {}", identity);
             continue;
         }
 
         let repo_id_u64 = entry.get("id").and_then(|v| v.as_u64()).unwrap_or(0);
-        let repo_id = match u32::try_from(repo_id_u64) {
-            Ok(id) => id,
-            Err(_) => {
-                warn!(
-                    "Skipping repository entry with id {} (exceeds u32 wire-format limit)",
-                    repo_id_u64
-                );
-                continue;
-            }
+        let Ok(repo_id) = u32::try_from(repo_id_u64) else {
+            warn!(
+                "Skipping repository entry with id {} (exceeds u32 wire-format limit)",
+                repo_id_u64
+            );
+            continue;
         };
 
-        match source {
-            RepoSource::Fs(path) => {
-                if !path.exists() {
-                    debug!("Skipping non-existent FS repository: {}", path.display());
-                    continue;
-                }
-                let repo_label = path.to_string_lossy().into_owned();
-                let walked =
-                    walk_directory(&path, RepoSourceKind::Fs, None, None, &exclusions.fs_paths);
-                for node in walked.nodes {
-                    let key = (node.node_name.clone(), node.node_tag.clone());
-                    let duplicate = !global_seen.insert(key);
-                    all_entries.push(RepoListNodeEntry {
-                        node_name: node.node_name,
-                        node_tag: node.node_tag,
-                        source_type: node.source_type,
-                        path: node.path,
-                        duplicate,
-                        repo_id,
-                        repo_label: repo_label.clone(),
-                    });
-                }
+        let repo_label = source.display_label();
+        let status = statuses.iter().find(|s| s.id == repo_id_u64);
+        all_repos.push(repo_entry(repo_id, &repo_label, &source, status));
+
+        for node in &cached {
+            if owning_repo_id(
+                &repos,
+                node.source_type,
+                node.source_uri.as_deref(),
+                node.resolved_ref.as_deref(),
+                &node.path,
+            ) != Some(repo_id_u64)
+            {
+                continue;
             }
-            RepoSource::Git { repo_url, repo_ref } => {
-                for cached in &cached_nodes {
-                    if cached.get("source_type").and_then(|v| v.as_str()) != Some("git") {
-                        continue;
-                    }
-                    if cached.get("source_uri").and_then(|v| v.as_str()) != Some(&repo_url) {
-                        continue;
-                    }
-                    let resolved_ref = cached
-                        .get("resolved_ref")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("HEAD");
-                    // When the repo entry pins a specific ref, only match cached
-                    // nodes whose resolved_ref equals it. Otherwise match any ref.
-                    if let Some(pinned) = repo_ref.as_deref()
-                        && !pinned.is_empty()
-                        && pinned != resolved_ref
-                    {
-                        continue;
-                    }
-                    let name = cached
-                        .get("node_name")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("");
-                    let tag = cached
-                        .get("node_tag")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("");
-                    let key = (name.to_string(), tag.to_string());
-                    let duplicate = !global_seen.insert(key);
-                    let repo_label = format!("{repo_url} (ref: {resolved_ref})");
-                    all_entries.push(RepoListNodeEntry {
-                        node_name: name.to_string(),
-                        node_tag: tag.to_string(),
-                        source_type: RepoSourceKind::Git,
-                        path: cached
-                            .get("path")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or("")
-                            .to_string(),
-                        duplicate,
-                        repo_id,
-                        repo_label,
-                    });
-                }
-            }
-            RepoSource::Url(url) => {
-                warn!("Skipping URL repository (not yet supported): {}", url);
-            }
+            let key = (node.node_name.as_str(), node.node_tag.as_str());
+            let duplicate = !global_seen.insert(key);
+            all_entries.push(RepoListNodeEntry {
+                node_name: node.node_name.clone(),
+                node_tag: node.node_tag.clone(),
+                source_type: node.source_type,
+                path: node.path.clone(),
+                duplicate,
+                repo_id,
+                repo_label: repo_label.clone(),
+                conflict: conflicted.contains(&(repo_id, key.0, key.1)),
+            });
         }
     }
 
-    RepoListResponse::success(all_entries)
+    RepoListResponse::success(all_entries, all_repos)
         .encode()
         .map_err(Into::into)
 }
 
-/// Read cached node entries from nodes.json5 in the cache directory.
-fn read_cached_nodes(peppy_dirs: &PeppyDirs) -> Vec<Value> {
-    let cache_path = nodes_repo_cache_path(peppy_dirs);
-    if !cache_path.exists() {
-        return Vec::new();
-    }
-    match std::fs::read_to_string(&cache_path) {
-        Ok(content) => serde_json5::from_str(&content).unwrap_or_else(|e| {
-            warn!(
-                "Failed to parse nodes cache (nodes.json5) at {}: {e}",
-                cache_path.display()
-            );
-            Vec::new()
+/// Projects one repository's recorded status onto the wire. A repository
+/// with no status line has never been through a refresh that recorded
+/// one, so it reads as never-read rather than as failed.
+fn repo_entry(
+    repo_id: u32,
+    label: &str,
+    source: &core_node_api::encoding::RepoSource,
+    status: Option<&RepoStatus>,
+) -> RepoListRepoEntry {
+    RepoListRepoEntry {
+        id: repo_id,
+        label: label.to_owned(),
+        source_type: source.kind(),
+        last_read_unix_secs: status.and_then(|s| s.last_read_unix_secs),
+        retained: status.is_some_and(|s| s.is_retained()),
+        failure: status.and_then(|s| s.last_failure.as_ref()).map(|f| {
+            RepoListRepoFailure {
+                kind: f.kind.clone(),
+                detail: f.message.clone(),
+            }
         }),
-        Err(_) => Vec::new(),
     }
 }

--- a/crates/core-node-internal/src/services/repo/list.rs
+++ b/crates/core-node-internal/src/services/repo/list.rs
@@ -7,7 +7,8 @@ use crate::services::repo::{owning_repo_id, source_identity};
 use crate::services::response::into_service_response;
 use core_node_api::ServiceId;
 use core_node_api::encoding::{
-    RepoListNodeEntry, RepoListRepoEntry, RepoListRepoFailure, RepoListRequest, RepoListResponse,
+    RepoListNodeEntry, RepoListRepoEntry, RepoListRepoFailure, RepoListRepoFailureKind,
+    RepoListRequest, RepoListResponse,
 };
 use core_node_api::names;
 use daemon_config::consts::PeppyDirs;
@@ -103,6 +104,22 @@ fn handle_repo_list_request_inner(
         }
     }
 
+    // Each cached node's owning repository, resolved once. The loop below
+    // considers every node for every repository, and resolving inside it
+    // re-scans the repository list on each of those visits.
+    let owners: Vec<Option<u64>> = cached
+        .iter()
+        .map(|node| {
+            owning_repo_id(
+                &repos,
+                node.source_type,
+                node.source_uri.as_deref(),
+                node.resolved_ref.as_deref(),
+                &node.path,
+            )
+        })
+        .collect();
+
     let mut global_seen: HashSet<(&str, &str)> = HashSet::new();
     let mut all_entries: Vec<RepoListNodeEntry> = Vec::new();
     let mut all_repos: Vec<RepoListRepoEntry> = Vec::new();
@@ -132,15 +149,8 @@ fn handle_repo_list_request_inner(
         let status = statuses.iter().find(|s| s.id == repo_id_u64);
         all_repos.push(repo_entry(repo_id, &repo_label, &source, status));
 
-        for node in &cached {
-            if owning_repo_id(
-                &repos,
-                node.source_type,
-                node.source_uri.as_deref(),
-                node.resolved_ref.as_deref(),
-                &node.path,
-            ) != Some(repo_id_u64)
-            {
+        for (node, owner) in cached.iter().zip(&owners) {
+            if *owner != Some(repo_id_u64) {
                 continue;
             }
             let key = (node.node_name.as_str(), node.node_tag.as_str());
@@ -180,9 +190,25 @@ fn repo_entry(
         retained: status.is_some_and(|s| s.is_retained()),
         failure: status
             .and_then(|s| s.last_failure.as_ref())
-            .map(|f| RepoListRepoFailure {
-                kind: f.kind.clone(),
-                detail: f.message.clone(),
-            }),
+            .map(|f| wire_failure(&f.kind, &f.message)),
+    }
+}
+
+/// Projects a recorded failure onto the wire's closed kind. The status
+/// file keeps the kind as text so a value written by a future peppy is a
+/// label rather than a parse error; the wire has two kinds only, so an
+/// unrecognized one reads as unreachable with its raw label kept in the
+/// detail. Dropping the failure instead would show a retained repository
+/// with no reason at all.
+fn wire_failure(kind: &str, message: &str) -> RepoListRepoFailure {
+    match RepoListRepoFailureKind::parse(kind) {
+        Some(kind) => RepoListRepoFailure {
+            kind,
+            detail: message.to_owned(),
+        },
+        None => RepoListRepoFailure {
+            kind: RepoListRepoFailureKind::Unreachable,
+            detail: format!("{kind}: {message}"),
+        },
     }
 }

--- a/crates/core-node-internal/src/services/repo/refresh.rs
+++ b/crates/core-node-internal/src/services/repo/refresh.rs
@@ -272,10 +272,21 @@ pub(crate) enum RepoFailureKind {
 }
 
 impl RepoFailureKind {
+    /// Stable machine-readable value, recorded in `repo_status.json5` and
+    /// put on the wire. Kept separate from [`Self::describe`] so the
+    /// prose can be reworded without changing what tools match on.
     pub(crate) fn as_str(self) -> &'static str {
         match self {
             RepoFailureKind::Unreachable => "unreachable",
             RepoFailureKind::Conflict => "conflict",
+        }
+    }
+
+    /// Predicate that reads as a sentence about the repository.
+    fn describe(self) -> &'static str {
+        match self {
+            RepoFailureKind::Unreachable => "could not be read",
+            RepoFailureKind::Conflict => "contradicts itself",
         }
     }
 }
@@ -298,22 +309,20 @@ impl std::fmt::Display for RepoFailure {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "repository {} ({}) is {}: {}",
+            "repository {} ({}) {} [{}]: {}",
             self.id,
             self.label,
+            self.kind.describe(),
             self.kind.as_str(),
             self.detail
         )?;
-        if self.retained > 0 {
-            write!(
-                f,
-                " (kept {} entry/entries from its last successful read)",
-                self.retained
-            )?;
-        } else {
-            f.write_str(" (nothing previously read from it, so it contributes nothing)")?;
+        match self.retained {
+            0 => f.write_str(
+                ". Nothing had been read from it before, so it contributes nothing this time",
+            ),
+            1 => f.write_str(". Kept 1 entry from its last successful read"),
+            n => write!(f, ". Kept {n} entries from its last successful read"),
         }
-        Ok(())
     }
 }
 
@@ -1432,9 +1441,53 @@ mod tests {
         assert_eq!(failure.id, 2);
         assert_eq!(failure.kind, RepoFailureKind::Conflict);
         assert_eq!(failure.retained, 1, "one node kept from the last read");
-        assert!(failure.detail.contains("contested:v1"), "{}", failure.detail);
+        assert!(
+            failure.detail.contains("contested:v1"),
+            "{}",
+            failure.detail
+        );
         assert!(failure.detail.contains("dup_a"), "{}", failure.detail);
         assert!(failure.detail.contains("dup_b"), "{}", failure.detail);
+    }
+
+    /// The report reads as prose while still carrying the machine value,
+    /// so an operator can act on it and a tool can match on it.
+    #[test]
+    fn failure_report_reads_as_a_sentence_and_names_the_kind() {
+        let unreachable = RepoFailure {
+            id: 1002,
+            label: "https://example.com/hub.git (ref: main)".to_owned(),
+            kind: RepoFailureKind::Unreachable,
+            detail: "failed to connect".to_owned(),
+            retained: 8,
+        };
+        let conflict = RepoFailure {
+            id: 1000,
+            label: "/home/user/workspace".to_owned(),
+            kind: RepoFailureKind::Conflict,
+            detail: "2 node manifests claim `a:v1`".to_owned(),
+            retained: 0,
+        };
+
+        let report = failure_report(&[conflict, unreachable]);
+
+        assert!(
+            report.contains("could not be read [unreachable]"),
+            "{report}"
+        );
+        assert!(report.contains("contradicts itself [conflict]"), "{report}");
+        assert!(
+            report.contains("Kept 8 entries from its last successful read"),
+            "{report}"
+        );
+        assert!(
+            report.contains("contributes nothing this time"),
+            "a machine with nothing to fall back to says so: {report}"
+        );
+        assert!(
+            report.contains("Every other repository was updated normally"),
+            "{report}"
+        );
     }
 
     /// A failing repository keeps the timestamp of its last successful
@@ -1449,7 +1502,10 @@ mod tests {
         write_peppy_json5(&repo.join("node_a"), "node_a", "v1");
         write_repos(
             &peppy_dirs,
-            &format!(r#"[{{ "id": 1, "type": "fs", "path": "{}" }}]"#, repo.display()),
+            &format!(
+                r#"[{{ "id": 1, "type": "fs", "path": "{}" }}]"#,
+                repo.display()
+            ),
         );
 
         let first_read = SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1_000);
@@ -1488,7 +1544,10 @@ mod tests {
         write_peppy_json5(&repo.join("dup_b"), "contested", "v1");
         write_repos(
             &peppy_dirs,
-            &format!(r#"[{{ "id": 1, "type": "fs", "path": "{}" }}]"#, repo.display()),
+            &format!(
+                r#"[{{ "id": 1, "type": "fs", "path": "{}" }}]"#,
+                repo.display()
+            ),
         );
 
         let broken = process_refresh(&peppy_dirs, TEST_NOW, &mut |_| {}).unwrap();
@@ -1573,11 +1632,8 @@ mod tests {
 
         let refreshed = process_refresh(&peppy_dirs, TEST_NOW, &mut |_| {}).unwrap();
 
-        let seen: Vec<(u64, RepoFailureKind)> = refreshed
-            .failures
-            .iter()
-            .map(|f| (f.id, f.kind))
-            .collect();
+        let seen: Vec<(u64, RepoFailureKind)> =
+            refreshed.failures.iter().map(|f| (f.id, f.kind)).collect();
         assert_eq!(
             seen,
             vec![
@@ -1876,7 +1932,8 @@ mod tests {
             ),
         );
 
-        let RefreshedRepos { contracts, .. } = process_refresh(&peppy_dirs, TEST_NOW, &mut |_| {}).unwrap();
+        let RefreshedRepos { contracts, .. } =
+            process_refresh(&peppy_dirs, TEST_NOW, &mut |_| {}).unwrap();
         assert_eq!(contracts.len(), 1, "exactly one contract expected");
         let iface = &contracts[0];
         assert_eq!(iface.contract_name, "uvc_camera");
@@ -1936,7 +1993,8 @@ mod tests {
             &format!(r#"[{{ "id": 1, "type": "git", "url": "{repo_url}", "ref": "{branch}" }}]"#,),
         );
 
-        let RefreshedRepos { contracts, .. } = process_refresh(&peppy_dirs, TEST_NOW, &mut |_| {}).unwrap();
+        let RefreshedRepos { contracts, .. } =
+            process_refresh(&peppy_dirs, TEST_NOW, &mut |_| {}).unwrap();
         assert_eq!(contracts.len(), 1, "exactly one contract expected");
         let iface = &contracts[0];
         assert_eq!(iface.contract_name, "uvc_camera");
@@ -2131,10 +2189,7 @@ mod tests {
         assert_eq!(walked.conflicts.len(), 1);
         assert_eq!(walked.conflicts[0].kind, RepoItemKind::Launcher);
         assert_eq!(walked.conflicts[0].name, "bringup");
-        assert_eq!(
-            walked.conflicts[0].tag, "",
-            "launchers carry no tag"
-        );
+        assert_eq!(walked.conflicts[0].tag, "", "launchers carry no tag");
         assert_eq!(walked.conflicts[0].paths.len(), 2);
     }
 
@@ -2316,7 +2371,8 @@ mod tests {
             ),
         );
 
-        let RefreshedRepos { launchers, .. } = process_refresh(&peppy_dirs, TEST_NOW, &mut |_| {}).unwrap();
+        let RefreshedRepos { launchers, .. } =
+            process_refresh(&peppy_dirs, TEST_NOW, &mut |_| {}).unwrap();
         assert_eq!(
             launchers.len(),
             1,
@@ -2345,7 +2401,8 @@ mod tests {
             ),
         );
 
-        let RefreshedRepos { launchers, .. } = process_refresh(&peppy_dirs, TEST_NOW, &mut |_| {}).unwrap();
+        let RefreshedRepos { launchers, .. } =
+            process_refresh(&peppy_dirs, TEST_NOW, &mut |_| {}).unwrap();
         write_repo_cache(&peppy_dirs, &launchers).unwrap();
 
         let cache_path = launchers_repo_cache_path(&peppy_dirs);
@@ -2424,7 +2481,8 @@ mod tests {
             &format!(r#"[{{ "id": 1, "type": "git", "url": "{repo_url}", "ref": "{branch}" }}]"#,),
         );
 
-        let RefreshedRepos { launchers, .. } = process_refresh(&peppy_dirs, TEST_NOW, &mut |_| {}).unwrap();
+        let RefreshedRepos { launchers, .. } =
+            process_refresh(&peppy_dirs, TEST_NOW, &mut |_| {}).unwrap();
         assert_eq!(launchers.len(), 1, "exactly one launcher expected");
         let launcher = &launchers[0];
         assert_eq!(launcher.launcher_name, "openarm01_teleop");

--- a/crates/core-node-internal/src/services/repo/refresh.rs
+++ b/crates/core-node-internal/src/services/repo/refresh.rs
@@ -161,30 +161,24 @@ impl GoalHandler for RepoRefreshGoalHandler {
                 // store every entry so that `repo list` can display every
                 // source and users can pick a specific `sha256`.
                 write_all_caches(&dirs, &refreshed)?;
-                Ok((
-                    count_unique(&refreshed.nodes),
-                    count_unique(&refreshed.launchers),
-                    count_unique(&refreshed.contracts),
-                    count_unique(&refreshed.pairings),
-                    refreshed.failures,
-                ))
+                Ok(RefreshCounts {
+                    nodes: count_unique(&refreshed.nodes),
+                    launchers: count_unique(&refreshed.launchers),
+                    contracts: count_unique(&refreshed.contracts),
+                    pairings: count_unique(&refreshed.pairings),
+                    failures: refreshed.failures,
+                })
             })
             .await;
 
             let result = match scan {
-                Ok(Ok((
-                    unique_nodes,
-                    unique_launchers,
-                    unique_contracts,
-                    unique_pairings,
-                    failures,
-                ))) if failures.is_empty() => RepoRefreshResult::success(
-                    unique_nodes,
-                    unique_launchers,
-                    unique_contracts,
-                    unique_pairings,
+                Ok(Ok(counts)) if counts.failures.is_empty() => RepoRefreshResult::success(
+                    counts.nodes,
+                    counts.launchers,
+                    counts.contracts,
+                    counts.pairings,
                 ),
-                Ok(Ok((.., failures))) => RepoRefreshResult::failure(failure_report(&failures)),
+                Ok(Ok(counts)) => RepoRefreshResult::failure(failure_report(&counts.failures)),
                 Ok(Err(e)) => {
                     warn!("Repo refresh failed: {}", e);
                     RepoRefreshResult::failure(e.to_string())
@@ -205,8 +199,16 @@ impl GoalHandler for RepoRefreshGoalHandler {
 }
 
 /// Unique-identity counts for the four caches, plus the repositories
-/// that failed. What one refresh has to report back.
-type RefreshCounts = (u32, u32, u32, u32, Vec<RepoFailure>);
+/// that failed. What one refresh has to report back. Named fields rather
+/// than a tuple: four `u32`s in a row are indistinguishable at the call
+/// site, and swapping two of them would go unnoticed.
+struct RefreshCounts {
+    nodes: u32,
+    launchers: u32,
+    contracts: u32,
+    pairings: u32,
+    failures: Vec<RepoFailure>,
+}
 
 /// One message naming every repository that failed and why, so a user
 /// with four problems fixes four things after one run rather than
@@ -616,9 +618,13 @@ pub(crate) fn process_refresh(
             Ok(_) => None,
         };
 
+        // Matched on identity as well as id: an id repointed at another
+        // path or url is a different repository, and carrying the old
+        // read timestamp forward would date entries this source never
+        // published.
         let previous_read = previous_statuses
             .iter()
-            .find(|s| s.id == id)
+            .find(|s| s.id == id && s.identity == identity)
             .and_then(|s| s.last_read_unix_secs);
 
         let walked = match failure {
@@ -1448,6 +1454,57 @@ mod tests {
         );
         assert!(failure.detail.contains("dup_a"), "{}", failure.detail);
         assert!(failure.detail.contains("dup_b"), "{}", failure.detail);
+    }
+
+    /// A re-index that reads every repository cleanly has nothing to add
+    /// to the caller's response, and publishes the caches that make the
+    /// caller's edit take effect.
+    #[tokio::test]
+    async fn reindex_after_change_reports_nothing_when_the_re_read_is_clean() {
+        let tmp = tempfile::tempdir().unwrap();
+        let peppy_dirs = PeppyDirs::new(tmp.path());
+
+        let repo = tmp.path().join("repo");
+        write_peppy_json5(&repo.join("first"), "first", "v1");
+        write_repos(
+            &peppy_dirs,
+            &format!(
+                r#"[{{ "id": 1, "type": "fs", "path": "{}" }}]"#,
+                repo.display()
+            ),
+        );
+
+        assert_eq!(reindex_after_change(&peppy_dirs).await, None);
+
+        let cached = crate::services::repo::cache::load_repo_cache::<NodeCacheEntry>(&peppy_dirs)
+            .expect("the re-index published the node cache");
+        assert_eq!(cached.len(), 1);
+        assert_eq!(cached[0].node_name, "first");
+    }
+
+    /// A re-index that cannot read the configuration at all reports it:
+    /// the caller just changed that configuration, so this belongs in
+    /// their response rather than in a log nobody reads.
+    #[tokio::test]
+    async fn reindex_after_change_reports_a_re_read_that_failed_outright() {
+        let tmp = tempfile::tempdir().unwrap();
+        let peppy_dirs = PeppyDirs::new(tmp.path());
+        write_repos(
+            &peppy_dirs,
+            r#"[
+                { "id": 1, "type": "fs", "path": "/a" },
+                { "id": 1, "type": "fs", "path": "/b" }
+            ]"#,
+        );
+
+        let report = reindex_after_change(&peppy_dirs)
+            .await
+            .expect("a re-read that failed outright is reported");
+        assert!(report.starts_with("re-indexing failed:"), "got: {report}");
+        assert!(
+            report.contains("duplicate repository id 1"),
+            "the report names what to fix, got: {report}"
+        );
     }
 
     /// The report reads as prose while still carrying the machine value,

--- a/crates/core-node-internal/src/services/repo/refresh.rs
+++ b/crates/core-node-internal/src/services/repo/refresh.rs
@@ -7,6 +7,7 @@ use crate::services::repo::cache::{
     RepoCacheEntry, write_repo_cache,
 };
 use crate::services::repo::exclude::ExclusionSet;
+use crate::services::repo::status::{self, RepoStatus, RepoStatusFailure};
 use crate::services::repo::{normalize_repo_entries, source_identity};
 use config::consts::NODE_CONFIG_FILE;
 use config::fingerprint::fingerprint_for_bytes;
@@ -14,8 +15,8 @@ use config::node::NodeConfigParser;
 use config::schema::PeppySchema;
 use core_node_api::ActionId;
 use core_node_api::encoding::{
-    RepoRefreshFeedback, RepoRefreshGoal, RepoRefreshGoalResponse, RepoRefreshResult, RepoSource,
-    RepoSourceKind,
+    RepoItemKind, RepoRefreshFeedback, RepoRefreshGoal, RepoRefreshGoalResponse, RepoRefreshResult,
+    RepoSource, RepoSourceKind,
 };
 use core_node_api::names;
 use daemon_config::consts::PeppyDirs;
@@ -28,8 +29,9 @@ use peppylib::types::Payload;
 use peppylib::{MessengerHandle, PeppyError, PeppyResult};
 use serde::Deserialize;
 use serde_json::Value;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
+use std::time::SystemTime;
 use tokio::task::JoinHandle;
 use tracing::{debug, warn};
 
@@ -146,27 +148,26 @@ impl GoalHandler for RepoRefreshGoalHandler {
             });
 
             let dirs = peppy_dirs;
-            let scan = tokio::task::spawn_blocking(move || {
+            let scan = tokio::task::spawn_blocking(move || -> Result<RefreshCounts> {
                 let _guard = crate::services::repo::refresh_lock().lock();
                 let mut emit = |fb: RepoRefreshFeedback| {
                     let _ = tx.send(fb);
                 };
-                match process_refresh(&dirs, &mut emit) {
-                    Ok(refreshed) => {
-                        // Caches store every discovered entry so that
-                        // `repo list` can display every source and users
-                        // can pick a specific `sha256` when they need to.
-                        write_all_caches(&dirs, &refreshed)?;
-                        Ok((
-                            count_unique(&refreshed.nodes),
-                            count_unique(&refreshed.launchers),
-                            count_unique(&refreshed.contracts),
-                            count_unique(&refreshed.pairings),
-                            refreshed.excluded,
-                        ))
-                    }
-                    Err(e) => Err(e),
-                }
+                let refreshed = process_refresh(&dirs, SystemTime::now(), &mut emit)?;
+                // Written whether or not a repository failed: the whole
+                // point of containing a failure is that the repositories
+                // that did update take effect, and that the ones that
+                // did not keep the entries they last published. Caches
+                // store every entry so that `repo list` can display every
+                // source and users can pick a specific `sha256`.
+                write_all_caches(&dirs, &refreshed)?;
+                Ok((
+                    count_unique(&refreshed.nodes),
+                    count_unique(&refreshed.launchers),
+                    count_unique(&refreshed.contracts),
+                    count_unique(&refreshed.pairings),
+                    refreshed.failures,
+                ))
             })
             .await;
 
@@ -176,13 +177,14 @@ impl GoalHandler for RepoRefreshGoalHandler {
                     unique_launchers,
                     unique_contracts,
                     unique_pairings,
-                    _excluded,
-                ))) => RepoRefreshResult::success(
+                    failures,
+                ))) if failures.is_empty() => RepoRefreshResult::success(
                     unique_nodes,
                     unique_launchers,
                     unique_contracts,
                     unique_pairings,
                 ),
+                Ok(Ok((.., failures))) => RepoRefreshResult::failure(failure_report(&failures)),
                 Ok(Err(e)) => {
                     warn!("Repo refresh failed: {}", e);
                     RepoRefreshResult::failure(e.to_string())
@@ -202,6 +204,50 @@ impl GoalHandler for RepoRefreshGoalHandler {
     }
 }
 
+/// Unique-identity counts for the four caches, plus the repositories
+/// that failed. What one refresh has to report back.
+type RefreshCounts = (u32, u32, u32, u32, Vec<RepoFailure>);
+
+/// One message naming every repository that failed and why, so a user
+/// with four problems fixes four things after one run rather than
+/// running four times. `failures` arrives in repository id order, which
+/// is what makes the report reproducible between machines.
+pub(crate) fn failure_report(failures: &[RepoFailure]) -> String {
+    let lines: Vec<String> = failures.iter().map(|f| f.to_string()).collect();
+    format!(
+        "{} of the configured repositories could not be updated. \
+         Every other repository was updated normally.{}",
+        failures.len(),
+        daemon_config::format_bulleted(&lines)
+    )
+}
+
+/// Re-indexes after a change to the repository list, returning a report
+/// of everything that went wrong, or `None` when it all worked.
+///
+/// The caller's own edit has already been applied; this is the re-read
+/// that makes it take effect. Its problems belong in the caller's
+/// response rather than in a log nobody reads: this is the recovery
+/// path, where a user who just added, removed or excluded a repository
+/// to unblock themselves needs to know whether it worked.
+pub(crate) async fn reindex_after_change(peppy_dirs: &PeppyDirs) -> Option<String> {
+    let dirs = peppy_dirs.clone();
+    let outcome = tokio::task::spawn_blocking(move || -> Result<Vec<RepoFailure>> {
+        let _guard = crate::services::repo::refresh_lock().lock();
+        let refreshed = process_refresh(&dirs, SystemTime::now(), &mut |_| {})?;
+        write_all_caches(&dirs, &refreshed)?;
+        Ok(refreshed.failures)
+    })
+    .await;
+
+    match outcome {
+        Ok(Ok(failures)) if failures.is_empty() => None,
+        Ok(Ok(failures)) => Some(failure_report(&failures)),
+        Ok(Err(e)) => Some(format!("re-indexing failed: {e}")),
+        Err(e) => Some(format!("re-indexing task panicked: {e}")),
+    }
+}
+
 /// A repository that was skipped during refresh because it appears in the
 /// `excluded_repositories.json5` configuration.
 #[derive(Debug, Clone)]
@@ -210,26 +256,148 @@ pub(crate) struct ExcludedRepo {
     pub(crate) identity: String,
 }
 
-/// Aggregated output of [`process_refresh`]: all discovered entries
-/// (nodes, launchers, contracts) plus the repositories that were
-/// skipped because they appear in the exclusion list.
+/// Why one repository contributed nothing new to a refresh.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RepoFailureKind {
+    /// Could not be read at all: the clone failed, the configured path is
+    /// gone, the configuration entry is unrecognized. Kept distinct from
+    /// [`RepoFailureKind::Conflict`] because an outage is not a content
+    /// bug, and reporting one as the other sends the user to the wrong
+    /// place entirely.
+    Unreachable,
+    /// Read fine; the contents are wrong. An identity is claimed by
+    /// several manifests, so the repository states two different answers
+    /// to the same question and there is no defensible winner.
+    Conflict,
+}
+
+impl RepoFailureKind {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            RepoFailureKind::Unreachable => "unreachable",
+            RepoFailureKind::Conflict => "conflict",
+        }
+    }
+}
+
+/// One repository whose read failed, and what the machine fell back to.
+/// A failure is scoped to its own repository: the others still update.
+#[derive(Debug, Clone)]
+pub(crate) struct RepoFailure {
+    pub(crate) id: u64,
+    /// Human-facing label (path for fs, `url (ref: r)` for git).
+    pub(crate) label: String,
+    pub(crate) kind: RepoFailureKind,
+    pub(crate) detail: String,
+    /// Previous entries kept in place for this repository, across all
+    /// four kinds. Zero on a machine that has never read it successfully.
+    pub(crate) retained: usize,
+}
+
+impl std::fmt::Display for RepoFailure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "repository {} ({}) is {}: {}",
+            self.id,
+            self.label,
+            self.kind.as_str(),
+            self.detail
+        )?;
+        if self.retained > 0 {
+            write!(
+                f,
+                " (kept {} entry/entries from its last successful read)",
+                self.retained
+            )?;
+        } else {
+            f.write_str(" (nothing previously read from it, so it contributes nothing)")?;
+        }
+        Ok(())
+    }
+}
+
+/// Aggregated output of [`process_refresh`]: all entries that belong in
+/// the caches (freshly read, plus previous entries retained for
+/// repositories that failed), the repositories skipped by the exclusion
+/// list, and the repositories that failed.
 pub(crate) struct RefreshedRepos {
     pub(crate) nodes: Vec<NodeCacheEntry>,
     pub(crate) launchers: Vec<LauncherCacheEntry>,
     pub(crate) contracts: Vec<ContractCacheEntry>,
     pub(crate) pairings: Vec<PairingCacheEntry>,
+    /// Reported to the client through [`RepoRefreshFeedback::Excluded`]
+    /// as the scan runs, so the handler has nothing left to do with it;
+    /// kept on the result because the tests assert against it.
+    #[allow(dead_code)]
     pub(crate) excluded: Vec<ExcludedRepo>,
+    pub(crate) failures: Vec<RepoFailure>,
+    /// One entry per repository that was actually read (excluded ones are
+    /// absent), carrying when it last read cleanly and how it last failed.
+    pub(crate) statuses: Vec<RepoStatus>,
 }
 
-/// Publishes every cache file from one refresh result. The four caches
-/// must always move together: rewriting only a subset leaves the
+/// The four caches as they stood before this refresh. A repository that
+/// fails its read keeps serving what it last published, so its
+/// identities do not vanish out from under launchers that reference
+/// them.
+struct PreviousCaches {
+    nodes: Vec<NodeCacheEntry>,
+    launchers: Vec<LauncherCacheEntry>,
+    contracts: Vec<ContractCacheEntry>,
+    pairings: Vec<PairingCacheEntry>,
+}
+
+impl PreviousCaches {
+    /// A cache that cannot be read is treated as empty rather than fatal:
+    /// this runs on the recovery path, where refusing to start because
+    /// the fallback is also broken helps nobody.
+    fn load(peppy_dirs: &PeppyDirs) -> Self {
+        fn read<E: RepoCacheEntry>(peppy_dirs: &PeppyDirs) -> Vec<E> {
+            crate::services::repo::cache::load_repo_cache::<E>(peppy_dirs).unwrap_or_else(|e| {
+                warn!("Could not read the previous {} cache: {e}", E::KIND);
+                Vec::new()
+            })
+        }
+        Self {
+            nodes: read(peppy_dirs),
+            launchers: read(peppy_dirs),
+            contracts: read(peppy_dirs),
+            pairings: read(peppy_dirs),
+        }
+    }
+}
+
+/// The previous entries of one kind that `repo_id` owns, using the same
+/// attribution rule that tags entries at lookup time so a retained entry
+/// keeps exactly the priority it had.
+fn retained_entries<E: RepoCacheEntry>(previous: &[E], repos: &[Value], repo_id: u64) -> Vec<E> {
+    previous
+        .iter()
+        .filter(|e| {
+            crate::services::repo::owning_repo_id(
+                repos,
+                e.source_type(),
+                e.source_uri(),
+                e.resolved_ref(),
+                e.path(),
+            ) == Some(repo_id)
+        })
+        .cloned()
+        .collect()
+}
+
+/// Publishes every cache file from one refresh result. The four entry
+/// caches must always move together: rewriting only a subset leaves the
 /// untouched files still listing items from repositories that are no
-/// longer configured.
+/// longer configured. The status file moves with them so it always
+/// describes the entries that are actually on disk.
 pub(crate) fn write_all_caches(peppy_dirs: &PeppyDirs, refreshed: &RefreshedRepos) -> Result<()> {
     write_repo_cache(peppy_dirs, &refreshed.nodes)?;
     write_repo_cache(peppy_dirs, &refreshed.launchers)?;
     write_repo_cache(peppy_dirs, &refreshed.contracts)?;
-    write_repo_cache(peppy_dirs, &refreshed.pairings)
+    write_repo_cache(peppy_dirs, &refreshed.pairings)?;
+    status::write(peppy_dirs, &refreshed.statuses)
 }
 
 /// Source-and-file context shared by every `.json5` collector. The
@@ -300,8 +468,8 @@ pub(crate) fn read_or_create_repos(peppy_dirs: &PeppyDirs) -> Result<Vec<Value>>
 }
 
 /// Main synchronous processing: reads repos, walks each source, returns
-/// discovered nodes, launchers, contracts, and the list of
-/// repositories that were excluded.
+/// the entries that belong in the caches plus the repositories that were
+/// excluded or failed.
 ///
 /// Every discovered entry is kept in the result so the cache (and
 /// `repo list`) can display every source. When several repositories
@@ -310,8 +478,21 @@ pub(crate) fn read_or_create_repos(peppy_dirs: &PeppyDirs) -> Result<Vec<Value>>
 /// distinguish entries with the same identity but different content.
 /// Discovery feedback is emitted once per unique identity from the
 /// highest-priority repository; extra entries are silently cached.
+///
+/// A failure is contained to the repository that caused it: that
+/// repository keeps its previous entries and is recorded in `failures`,
+/// while every other repository updates normally. The caller decides
+/// what a non-empty `failures` means for the run as a whole. One
+/// consequence is deliberate and worth knowing: a cache can then hold
+/// entries read at two different times. The caches never had a notion of
+/// a synchronised snapshot across repositories, so this is not a new
+/// class of skew, but anything that later needs one coherent set of
+/// bytes must establish that itself.
+/// `now` is passed in rather than read from the clock so that tests are
+/// deterministic.
 pub(crate) fn process_refresh(
     peppy_dirs: &PeppyDirs,
+    now: SystemTime,
     on_feedback: &mut dyn FnMut(RepoRefreshFeedback),
 ) -> Result<RefreshedRepos> {
     let (repos, exclusions) = {
@@ -320,6 +501,11 @@ pub(crate) fn process_refresh(
         let exclusions = ExclusionSet::load(peppy_dirs);
         (repos, exclusions)
     };
+    let previous = PreviousCaches::load(peppy_dirs);
+    let previous_statuses = status::read(peppy_dirs);
+    let stamp = status::unix_secs(now);
+    let mut failures: Vec<RepoFailure> = Vec::new();
+    let mut statuses: Vec<RepoStatus> = Vec::new();
 
     let mut global_seen_nodes: HashSet<(String, String)> = HashSet::new();
     let mut global_seen_launchers: HashSet<(String, String)> = HashSet::new();
@@ -346,8 +532,18 @@ pub(crate) fn process_refresh(
     }
 
     for entry in &repos {
+        let id = entry.get("id").and_then(|v| v.as_u64()).unwrap_or(0);
+
+        // An entry peppy cannot parse has no source kind or identity to
+        // record, so it is reported but gets no status line.
         let Some(source) = parse_repo_entry(entry) else {
-            warn!("Skipping unrecognized repository entry: {:?}", entry);
+            failures.push(RepoFailure {
+                id,
+                label: entry.to_string(),
+                kind: RepoFailureKind::Unreachable,
+                detail: "unrecognized repository entry".to_owned(),
+                retained: 0,
+            });
             continue;
         };
 
@@ -358,20 +554,28 @@ pub(crate) fn process_refresh(
             continue;
         }
 
-        let walked = match source {
+        let read = match &source {
             RepoSource::Url(url) => {
+                // Not a failure: URL repositories are unimplemented, not
+                // broken, so they must not fail a run that is otherwise fine.
                 debug!("Skipping URL repository (not yet implemented): {}", url);
                 continue;
             }
             RepoSource::Fs(path) => {
-                if !path.exists() {
-                    debug!("Skipping non-existent FS repository: {}", path.display());
-                    continue;
+                if path.exists() {
+                    on_feedback(RepoRefreshFeedback::Progress {
+                        message: format!("Scanning {}", path.display()),
+                    });
+                    Ok(walk_directory(
+                        path,
+                        RepoSourceKind::Fs,
+                        None,
+                        None,
+                        &exclusions.fs_paths,
+                    ))
+                } else {
+                    Err(format!("path does not exist: {}", path.display()))
                 }
-                on_feedback(RepoRefreshFeedback::Progress {
-                    message: format!("Scanning {}", path.display()),
-                });
-                walk_directory(&path, RepoSourceKind::Fs, None, None, &exclusions.fs_paths)
             }
             RepoSource::Git { repo_url, repo_ref } => {
                 let ref_suffix = repo_ref
@@ -381,21 +585,91 @@ pub(crate) fn process_refresh(
                 on_feedback(RepoRefreshFeedback::Progress {
                     message: format!("Cloning {}{}", repo_url, ref_suffix),
                 });
-                match clone_and_walk_git_repo(
-                    &repo_url,
-                    repo_ref.as_deref(),
-                    peppy_dirs,
-                    on_feedback,
-                ) {
-                    Ok(walked) => walked,
-                    Err(e) => {
-                        warn!("Failed to refresh git repository {}: {}", repo_url, e);
-                        continue;
-                    }
-                }
+                clone_and_walk_git_repo(repo_url, repo_ref.as_deref(), peppy_dirs, on_feedback)
             }
         };
 
+        // A repository that could not be read and one whose contents
+        // contradict themselves both fall back to their previous entries;
+        // only the wording differs, so an outage never reads as a content
+        // bug.
+        let failure = match &read {
+            Err(detail) => Some((RepoFailureKind::Unreachable, detail.clone())),
+            Ok(walked) if !walked.conflicts.is_empty() => Some((
+                RepoFailureKind::Conflict,
+                walked
+                    .conflicts
+                    .iter()
+                    .map(|c| c.to_string())
+                    .collect::<Vec<_>>()
+                    .join("; "),
+            )),
+            Ok(_) => None,
+        };
+
+        let previous_read = previous_statuses
+            .iter()
+            .find(|s| s.id == id)
+            .and_then(|s| s.last_read_unix_secs);
+
+        let walked = match failure {
+            None => {
+                statuses.push(RepoStatus {
+                    id,
+                    identity: identity.clone(),
+                    source_type: source.kind(),
+                    last_read_unix_secs: Some(stamp),
+                    // Cleared on success, so a repository that recovered
+                    // stops reporting an old failure.
+                    last_failure: None,
+                });
+                read.expect("checked to be Ok above")
+            }
+            Some((kind, detail)) => {
+                let retained = WalkResult {
+                    nodes: retained_entries(&previous.nodes, &repos, id),
+                    launchers: retained_entries(&previous.launchers, &repos, id),
+                    contracts: retained_entries(&previous.contracts, &repos, id),
+                    pairings: retained_entries(&previous.pairings, &repos, id),
+                    conflicts: Vec::new(),
+                };
+                let count = retained.nodes.len()
+                    + retained.launchers.len()
+                    + retained.contracts.len()
+                    + retained.pairings.len();
+                let failure = RepoFailure {
+                    id,
+                    label: source.display_label(),
+                    kind,
+                    detail,
+                    retained: count,
+                };
+                statuses.push(RepoStatus {
+                    id,
+                    identity: identity.clone(),
+                    source_type: source.kind(),
+                    // Carried forward untouched: the retained entries are
+                    // still the ones read at that time, and overwriting it
+                    // with now would claim they are current.
+                    last_read_unix_secs: previous_read,
+                    last_failure: Some(RepoStatusFailure {
+                        kind: failure.kind.as_str().to_owned(),
+                        message: failure.detail.clone(),
+                        unix_secs: stamp,
+                    }),
+                });
+                warn!("{failure}");
+                on_feedback(RepoRefreshFeedback::Progress {
+                    message: failure.to_string(),
+                });
+                failures.push(failure);
+                retained
+            }
+        };
+
+        // Merged in this repository's own slot in the id-ordered loop,
+        // retained or not, so priority order and the first-seen discovery
+        // feedback stay exactly as they would have been.
         merge_walked(
             walked.nodes,
             &mut global_seen_nodes,
@@ -428,6 +702,8 @@ pub(crate) fn process_refresh(
         contracts: all_contracts,
         pairings: all_pairings,
         excluded: excluded_repos,
+        failures,
+        statuses,
     })
 }
 
@@ -437,6 +713,75 @@ pub(crate) struct WalkResult {
     pub launchers: Vec<LauncherCacheEntry>,
     pub contracts: Vec<ContractCacheEntry>,
     pub pairings: Vec<PairingCacheEntry>,
+    /// Identities claimed by more than one manifest in this repository.
+    /// Non-empty means the repository has no defensible answer for those
+    /// identities, so the caller refuses it rather than picking one.
+    pub conflicts: Vec<RepoConflict>,
+}
+
+/// An identity claimed by several manifests inside one repository. There
+/// is no priority rule that can settle this: the repository states two
+/// different answers to the same question.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RepoConflict {
+    pub kind: RepoItemKind,
+    pub name: String,
+    /// Empty for untagged kinds (launchers).
+    pub tag: String,
+    /// Every claimant's path, sorted.
+    pub paths: Vec<String>,
+}
+
+impl RepoConflict {
+    /// `name:tag` label, or the bare name for untagged kinds.
+    fn display_id(&self) -> String {
+        if self.tag.is_empty() {
+            self.name.clone()
+        } else {
+            format!("{}:{}", self.name, self.tag)
+        }
+    }
+}
+
+impl std::fmt::Display for RepoConflict {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{} {} manifests claim `{}`: {}",
+            self.paths.len(),
+            self.kind,
+            self.display_id(),
+            self.paths.join(", ")
+        )
+    }
+}
+
+/// Every path that claimed a given `(name, tag)` during one repository
+/// walk, in the order the walker met them. Recording all of them (rather
+/// than remembering only that the identity was seen) is what lets a
+/// conflict name both files instead of silently keeping one.
+type ClaimMap = HashMap<(String, String), Vec<String>>;
+
+/// Turns one kind's claim map into the conflicts it holds: every identity
+/// with more than one claimant. Sorted by identity, with sorted paths, so
+/// the report never inherits the filesystem's walk order and stays
+/// comparable between machines.
+fn conflicts_from_claims(kind: RepoItemKind, claims: ClaimMap) -> Vec<RepoConflict> {
+    let mut conflicts: Vec<RepoConflict> = claims
+        .into_iter()
+        .filter(|(_, paths)| paths.len() > 1)
+        .map(|((name, tag), mut paths)| {
+            paths.sort();
+            RepoConflict {
+                kind,
+                name,
+                tag,
+                paths,
+            }
+        })
+        .collect();
+    conflicts.sort_by(|a, b| (&a.name, &a.tag).cmp(&(&b.name, &b.tag)));
+    conflicts
 }
 
 /// Appends one repository's walked entries to the running cross-repo
@@ -483,9 +828,14 @@ fn count_unique<E: RepoCacheEntry>(entries: &[E]) -> u32 {
 /// Each `.json5` file is read once. Files named `peppy.json5` are tried
 /// as nodes first (preserves filename-driven node ergonomics); any
 /// `.json5` whose body declares a `peppy_schema` value is dispatched to
-/// the matching collector. Within a single repository walk, a given
-/// `(name, tag)` (or launcher name) is collected only once; the
-/// global cross-repo dedup happens in `process_refresh`.
+/// the matching collector.
+///
+/// A given `(name, tag)` (or launcher name) reaches the entry vectors at
+/// most once per walk, but every claimant is recorded: an identity with
+/// several claimants comes back in `conflicts` for the caller to refuse
+/// the repository over. The cross-repo merge, where several repositories
+/// claiming one identity is a supported feature rather than a conflict,
+/// happens in `process_refresh`.
 pub(crate) fn walk_directory(
     root: &Path,
     source_type: RepoSourceKind,
@@ -518,10 +868,10 @@ pub(crate) fn walk_directory(
         })
         .build();
 
-    let mut nodes_seen: HashSet<(String, String)> = HashSet::new();
-    let mut launchers_seen: HashSet<(String, String)> = HashSet::new();
-    let mut contracts_seen: HashSet<(String, String)> = HashSet::new();
-    let mut pairings_seen: HashSet<(String, String)> = HashSet::new();
+    let mut nodes_seen = ClaimMap::new();
+    let mut launchers_seen = ClaimMap::new();
+    let mut contracts_seen = ClaimMap::new();
+    let mut pairings_seen = ClaimMap::new();
     let mut nodes: Vec<NodeCacheEntry> = Vec::new();
     let mut launchers: Vec<LauncherCacheEntry> = Vec::new();
     let mut contracts: Vec<ContractCacheEntry> = Vec::new();
@@ -584,11 +934,23 @@ pub(crate) fn walk_directory(
         }
     }
 
+    let mut conflicts = conflicts_from_claims(RepoItemKind::Node, nodes_seen);
+    conflicts.extend(conflicts_from_claims(
+        RepoItemKind::Launcher,
+        launchers_seen,
+    ));
+    conflicts.extend(conflicts_from_claims(
+        RepoItemKind::Contract,
+        contracts_seen,
+    ));
+    conflicts.extend(conflicts_from_claims(RepoItemKind::Pairing, pairings_seen));
+
     WalkResult {
         nodes,
         launchers,
         contracts,
         pairings,
+        conflicts,
     }
 }
 
@@ -611,7 +973,7 @@ fn peek_peppy_schema(bytes: &[u8]) -> Option<PeppySchema> {
 }
 
 /// Shared body of the four collectors: UTF-8 check, strict parse via
-/// `identity`, intra-repo dedup, then entry construction through
+/// `identity`, claim recording, then entry construction through
 /// [`RepoCacheEntry::from_discovered`]. The strict parse catches
 /// structural problems (unknown fields, malformed sections) that the
 /// cheap schema peek can't.
@@ -623,13 +985,19 @@ fn peek_peppy_schema(bytes: &[u8]) -> Option<PeppySchema> {
 /// the node parse is usually a different document kind rather than a
 /// malformed node, so the node collector logs "non-node".
 ///
+/// Every claimant is recorded in `claims`, including the second and
+/// later ones that are not pushed to `out`; the caller turns identities
+/// with several claimants into [`RepoConflict`]s and refuses the whole
+/// repository. Which claimant reaches `out` is walk-order dependent and
+/// deliberately not relied upon.
+///
 /// Returns `false` only on parse failure, so the node collector can
-/// fall back to schema dispatch; intra-repo duplicates return `true`
-/// because the file is a valid document of the kind.
+/// fall back to schema dispatch; repeat claimants return `true` because
+/// the file is a valid document of the kind.
 fn collect_repo_entry<E: RepoCacheEntry>(
     ctx: &EntryContext<'_>,
     parse_failure_label: &str,
-    seen: &mut HashSet<(String, String)>,
+    claims: &mut ClaimMap,
     out: &mut Vec<E>,
     identity: impl FnOnce(&str) -> std::result::Result<Option<(String, String)>, String>,
 ) -> bool {
@@ -659,7 +1027,10 @@ fn collect_repo_entry<E: RepoCacheEntry>(
         }
     };
 
-    if !seen.insert((name.clone(), tag.clone())) {
+    let path = relative_or_absolute_file_path(ctx.root, ctx.config_path, ctx.source_type);
+    let claimants = claims.entry((name.clone(), tag.clone())).or_default();
+    claimants.push(path.clone());
+    if claimants.len() > 1 {
         return true;
     }
 
@@ -667,7 +1038,7 @@ fn collect_repo_entry<E: RepoCacheEntry>(
         name,
         tag,
         sha256: fingerprint_for_bytes(ctx.bytes),
-        path: relative_or_absolute_file_path(ctx.root, ctx.config_path, ctx.source_type),
+        path,
         source_type: ctx.source_type,
         source_uri: ctx.source_uri.map(str::to_owned),
         resolved_ref: ctx.resolved_ref.map(str::to_owned),
@@ -675,16 +1046,15 @@ fn collect_repo_entry<E: RepoCacheEntry>(
     true
 }
 
-/// Returns `true` when the file parsed cleanly as a node and was
-/// collected (or skipped because of an intra-repo duplicate). `false`
-/// means parsing failed; the caller can fall back to a different
-/// schema dispatch.
+/// Returns `true` when the file parsed cleanly as a node and its claim
+/// was recorded. `false` means parsing failed; the caller can fall back
+/// to a different schema dispatch.
 fn try_collect_node_entry(
     ctx: &EntryContext<'_>,
-    seen: &mut HashSet<(String, String)>,
+    claims: &mut ClaimMap,
     nodes: &mut Vec<NodeCacheEntry>,
 ) -> bool {
-    collect_repo_entry(ctx, "non-node", seen, nodes, |content| {
+    collect_repo_entry(ctx, "non-node", claims, nodes, |content| {
         let parsed = NodeConfigParser::from_content(content).map_err(|e| e.to_string())?;
         Ok(Some((
             parsed.manifest.name.as_str().to_string(),
@@ -695,10 +1065,10 @@ fn try_collect_node_entry(
 
 fn collect_launcher_entry(
     ctx: &EntryContext<'_>,
-    seen: &mut HashSet<(String, String)>,
+    claims: &mut ClaimMap,
     launchers: &mut Vec<LauncherCacheEntry>,
 ) {
-    collect_repo_entry(ctx, "malformed launcher", seen, launchers, |content| {
+    collect_repo_entry(ctx, "malformed launcher", claims, launchers, |content| {
         let parsed = PeppyLauncherParser::from_content(content).map_err(|e| e.to_string())?;
         if parsed.peppy_schema != PeppySchema::LauncherV1 {
             return Ok(None);
@@ -718,10 +1088,10 @@ fn collect_launcher_entry(
 
 fn collect_contract_entry(
     ctx: &EntryContext<'_>,
-    seen: &mut HashSet<(String, String)>,
+    claims: &mut ClaimMap,
     contracts: &mut Vec<ContractCacheEntry>,
 ) {
-    collect_repo_entry(ctx, "malformed contract", seen, contracts, |content| {
+    collect_repo_entry(ctx, "malformed contract", claims, contracts, |content| {
         let parsed = PeppyContractParser::from_content(content).map_err(|e| e.to_string())?;
         Ok(Some((
             parsed.manifest.name.as_str().to_string(),
@@ -732,10 +1102,10 @@ fn collect_contract_entry(
 
 fn collect_pairing_entry(
     ctx: &EntryContext<'_>,
-    seen: &mut HashSet<(String, String)>,
+    claims: &mut ClaimMap,
     pairings: &mut Vec<PairingCacheEntry>,
 ) {
-    collect_repo_entry(ctx, "malformed pairing", seen, pairings, |content| {
+    collect_repo_entry(ctx, "malformed pairing", claims, pairings, |content| {
         let parsed = PeppyPairingParser::from_content(content).map_err(|e| e.to_string())?;
         Ok(Some((
             parsed.manifest.name.as_str().to_string(),
@@ -834,6 +1204,10 @@ fn clone_and_walk_git_repo(
 mod tests {
     use super::*;
     use crate::services::repo::cache::repositories_list_path;
+
+    /// A fixed instant for every refresh under test, so nothing depends
+    /// on the host clock or on how fast the test runs.
+    const TEST_NOW: SystemTime = SystemTime::UNIX_EPOCH;
 
     #[test]
     fn read_or_create_repos_creates_file_when_missing() {
@@ -1000,6 +1374,265 @@ mod tests {
         std::fs::write(conf_dir.join("excluded_repositories.json5"), content).unwrap();
     }
 
+    /// The load-bearing case: a failure is scoped to the repository that
+    /// caused it. The healthy repository picks up its change, the broken
+    /// one keeps the entries it last published, and only the broken one
+    /// is named.
+    #[test]
+    fn process_refresh_contains_a_failure_to_its_own_repository() {
+        let tmp = tempfile::tempdir().unwrap();
+        let peppy_dirs = PeppyDirs::new(tmp.path());
+
+        let healthy = tmp.path().join("healthy");
+        let broken = tmp.path().join("broken");
+        write_peppy_json5(&healthy.join("first"), "first", "v1");
+        write_peppy_json5(&broken.join("kept"), "kept", "v1");
+        write_repos(
+            &peppy_dirs,
+            &format!(
+                r#"[{{ "id": 1, "type": "fs", "path": "{}" }}, {{ "id": 2, "type": "fs", "path": "{}" }}]"#,
+                healthy.display(),
+                broken.display()
+            ),
+        );
+
+        // A clean run first, so the broken repository has something to
+        // fall back to.
+        let clean = process_refresh(&peppy_dirs, TEST_NOW, &mut |_| {}).unwrap();
+        assert!(clean.failures.is_empty());
+        write_all_caches(&peppy_dirs, &clean).unwrap();
+
+        // Now break the second repository and add a node to the first.
+        write_peppy_json5(&healthy.join("second"), "second", "v1");
+        write_peppy_json5(&broken.join("dup_a"), "contested", "v1");
+        write_peppy_json5(&broken.join("dup_b"), "contested", "v1");
+
+        let refreshed = process_refresh(&peppy_dirs, TEST_NOW, &mut |_| {}).unwrap();
+
+        let names: HashSet<&str> = refreshed
+            .nodes
+            .iter()
+            .map(|n| n.node_name.as_str())
+            .collect();
+        assert!(
+            names.contains("first") && names.contains("second"),
+            "the healthy repository still picked up its change: {names:?}"
+        );
+        assert!(
+            names.contains("kept"),
+            "the broken repository kept its previous entries: {names:?}"
+        );
+        assert!(
+            !names.contains("contested"),
+            "the contested identity is not resolved to an arbitrary winner: {names:?}"
+        );
+
+        assert_eq!(refreshed.failures.len(), 1, "only the broken repo failed");
+        let failure = &refreshed.failures[0];
+        assert_eq!(failure.id, 2);
+        assert_eq!(failure.kind, RepoFailureKind::Conflict);
+        assert_eq!(failure.retained, 1, "one node kept from the last read");
+        assert!(failure.detail.contains("contested:v1"), "{}", failure.detail);
+        assert!(failure.detail.contains("dup_a"), "{}", failure.detail);
+        assert!(failure.detail.contains("dup_b"), "{}", failure.detail);
+    }
+
+    /// A failing repository keeps the timestamp of its last successful
+    /// read rather than being stamped with now: the retained entries are
+    /// still the ones read at that time, and restamping them would claim
+    /// they are current.
+    #[test]
+    fn process_refresh_carries_forward_the_last_successful_read_time() {
+        let tmp = tempfile::tempdir().unwrap();
+        let peppy_dirs = PeppyDirs::new(tmp.path());
+        let repo = tmp.path().join("repo");
+        write_peppy_json5(&repo.join("node_a"), "node_a", "v1");
+        write_repos(
+            &peppy_dirs,
+            &format!(r#"[{{ "id": 1, "type": "fs", "path": "{}" }}]"#, repo.display()),
+        );
+
+        let first_read = SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1_000);
+        let clean = process_refresh(&peppy_dirs, first_read, &mut |_| {}).unwrap();
+        write_all_caches(&peppy_dirs, &clean).unwrap();
+        assert_eq!(clean.statuses.len(), 1);
+        assert_eq!(clean.statuses[0].last_read_unix_secs, Some(1_000));
+        assert!(!clean.statuses[0].is_retained());
+
+        // Break it, and refresh much later.
+        write_peppy_json5(&repo.join("dup_a"), "contested", "v1");
+        write_peppy_json5(&repo.join("dup_b"), "contested", "v1");
+        let later = SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(99_000);
+        let failed = process_refresh(&peppy_dirs, later, &mut |_| {}).unwrap();
+
+        let status = &failed.statuses[0];
+        assert_eq!(
+            status.last_read_unix_secs,
+            Some(1_000),
+            "the entries still date from the last clean read"
+        );
+        assert!(status.is_retained());
+        let failure = status.last_failure.as_ref().expect("failure recorded");
+        assert_eq!(failure.kind, "conflict");
+        assert_eq!(failure.unix_secs, 99_000, "the failure itself is recent");
+    }
+
+    /// A repository that recovers stops reporting its old failure, so a
+    /// fixed problem does not linger in the diagnostics.
+    #[test]
+    fn process_refresh_clears_the_failure_once_a_repository_recovers() {
+        let tmp = tempfile::tempdir().unwrap();
+        let peppy_dirs = PeppyDirs::new(tmp.path());
+        let repo = tmp.path().join("repo");
+        write_peppy_json5(&repo.join("dup_a"), "contested", "v1");
+        write_peppy_json5(&repo.join("dup_b"), "contested", "v1");
+        write_repos(
+            &peppy_dirs,
+            &format!(r#"[{{ "id": 1, "type": "fs", "path": "{}" }}]"#, repo.display()),
+        );
+
+        let broken = process_refresh(&peppy_dirs, TEST_NOW, &mut |_| {}).unwrap();
+        write_all_caches(&peppy_dirs, &broken).unwrap();
+        assert!(broken.statuses[0].is_retained());
+
+        std::fs::remove_dir_all(repo.join("dup_b")).unwrap();
+        let fixed = process_refresh(&peppy_dirs, TEST_NOW, &mut |_| {}).unwrap();
+
+        assert!(fixed.failures.is_empty());
+        assert!(!fixed.statuses[0].is_retained());
+        assert!(fixed.statuses[0].last_failure.is_none());
+    }
+
+    /// A repository that cannot be reached at all is reported as
+    /// unreachable, not as broken content: an outage and a content bug
+    /// send the user to completely different places.
+    #[test]
+    fn process_refresh_reports_a_missing_fs_repo_as_unreachable() {
+        let tmp = tempfile::tempdir().unwrap();
+        let peppy_dirs = PeppyDirs::new(tmp.path());
+
+        let healthy = tmp.path().join("healthy");
+        write_peppy_json5(&healthy.join("node_a"), "node_a", "v1");
+        let gone = tmp.path().join("not-mounted");
+        write_repos(
+            &peppy_dirs,
+            &format!(
+                r#"[{{ "id": 1, "type": "fs", "path": "{}" }}, {{ "id": 2, "type": "fs", "path": "{}" }}]"#,
+                healthy.display(),
+                gone.display()
+            ),
+        );
+
+        let refreshed = process_refresh(&peppy_dirs, TEST_NOW, &mut |_| {}).unwrap();
+
+        assert_eq!(refreshed.nodes.len(), 1, "the healthy repository updated");
+        assert_eq!(refreshed.failures.len(), 1);
+        assert_eq!(refreshed.failures[0].kind, RepoFailureKind::Unreachable);
+        assert_eq!(
+            refreshed.failures[0].retained, 0,
+            "nothing was ever read from it"
+        );
+    }
+
+    /// An unrecognized `repositories.json5` entry is a failure rather
+    /// than a silent skip: a typo in the configuration should not look
+    /// like a repository that simply has no content.
+    #[test]
+    fn process_refresh_reports_an_unrecognized_entry() {
+        let tmp = tempfile::tempdir().unwrap();
+        let peppy_dirs = PeppyDirs::new(tmp.path());
+
+        write_repos(&peppy_dirs, r#"[{ "id": 1, "type": "nonsense" }]"#);
+
+        let refreshed = process_refresh(&peppy_dirs, TEST_NOW, &mut |_| {}).unwrap();
+
+        assert_eq!(refreshed.failures.len(), 1);
+        assert_eq!(refreshed.failures[0].kind, RepoFailureKind::Unreachable);
+    }
+
+    /// Several failures across several repositories come back in one
+    /// pass, ordered by repository id, so one run tells the user
+    /// everything they have to fix.
+    #[test]
+    fn process_refresh_reports_every_failure_in_repository_id_order() {
+        let tmp = tempfile::tempdir().unwrap();
+        let peppy_dirs = PeppyDirs::new(tmp.path());
+
+        let conflicted = tmp.path().join("conflicted");
+        write_peppy_json5(&conflicted.join("a"), "contested", "v1");
+        write_peppy_json5(&conflicted.join("b"), "contested", "v1");
+        let gone = tmp.path().join("not-mounted");
+        write_repos(
+            &peppy_dirs,
+            &format!(
+                r#"[{{ "id": 5, "type": "fs", "path": "{}" }}, {{ "id": 9, "type": "fs", "path": "{}" }}]"#,
+                gone.display(),
+                conflicted.display()
+            ),
+        );
+
+        let refreshed = process_refresh(&peppy_dirs, TEST_NOW, &mut |_| {}).unwrap();
+
+        let seen: Vec<(u64, RepoFailureKind)> = refreshed
+            .failures
+            .iter()
+            .map(|f| (f.id, f.kind))
+            .collect();
+        assert_eq!(
+            seen,
+            vec![
+                (5, RepoFailureKind::Unreachable),
+                (9, RepoFailureKind::Conflict)
+            ]
+        );
+
+        let report = failure_report(&refreshed.failures);
+        assert!(report.contains("unreachable"), "{report}");
+        assert!(report.contains("conflict"), "{report}");
+    }
+
+    /// Retention follows the same attribution rule as lookup, so a
+    /// retained entry keeps exactly the priority it had and a failing
+    /// repository never inherits another repository's entries.
+    #[test]
+    fn process_refresh_retains_only_the_failed_repositorys_own_entries() {
+        let tmp = tempfile::tempdir().unwrap();
+        let peppy_dirs = PeppyDirs::new(tmp.path());
+
+        let one = tmp.path().join("one");
+        let two = tmp.path().join("two");
+        write_peppy_json5(&one.join("from_one"), "from_one", "v1");
+        write_peppy_json5(&two.join("from_two"), "from_two", "v1");
+        write_repos(
+            &peppy_dirs,
+            &format!(
+                r#"[{{ "id": 1, "type": "fs", "path": "{}" }}, {{ "id": 2, "type": "fs", "path": "{}" }}]"#,
+                one.display(),
+                two.display()
+            ),
+        );
+        let clean = process_refresh(&peppy_dirs, TEST_NOW, &mut |_| {}).unwrap();
+        write_all_caches(&peppy_dirs, &clean).unwrap();
+
+        // Break repository 2 only.
+        write_peppy_json5(&two.join("dup_a"), "contested", "v1");
+        write_peppy_json5(&two.join("dup_b"), "contested", "v1");
+        let refreshed = process_refresh(&peppy_dirs, TEST_NOW, &mut |_| {}).unwrap();
+
+        assert_eq!(refreshed.failures.len(), 1);
+        assert_eq!(
+            refreshed.failures[0].retained, 1,
+            "only `from_two` is retained, not `from_one`"
+        );
+        let retained: Vec<&str> = refreshed
+            .nodes
+            .iter()
+            .filter(|n| n.path.starts_with(two.to_string_lossy().as_ref()))
+            .map(|n| n.node_name.as_str())
+            .collect();
+        assert_eq!(retained, vec!["from_two"]);
+    }
+
     #[test]
     fn process_refresh_skips_excluded_fs_repo() {
         let tmp = tempfile::tempdir().unwrap();
@@ -1030,7 +1663,7 @@ mod tests {
             nodes: discovered,
             excluded,
             ..
-        } = process_refresh(&peppy_dirs, &mut |_| {}).unwrap();
+        } = process_refresh(&peppy_dirs, TEST_NOW, &mut |_| {}).unwrap();
         assert_eq!(discovered.len(), 1, "only non-excluded repo nodes returned");
         assert_eq!(discovered[0].node_name, "node_a");
         assert_eq!(excluded.len(), 1, "one repo should be excluded");
@@ -1077,7 +1710,7 @@ mod tests {
             nodes: discovered,
             excluded,
             ..
-        } = process_refresh(&peppy_dirs, &mut |_| {}).unwrap();
+        } = process_refresh(&peppy_dirs, TEST_NOW, &mut |_| {}).unwrap();
         assert_eq!(
             discovered.len(),
             1,
@@ -1125,7 +1758,7 @@ mod tests {
             nodes: discovered,
             excluded,
             ..
-        } = process_refresh(&peppy_dirs, &mut |_| {}).unwrap();
+        } = process_refresh(&peppy_dirs, TEST_NOW, &mut |_| {}).unwrap();
         assert_eq!(discovered.len(), 1, "FS node should still be found");
         assert_eq!(discovered[0].node_name, "node_a");
         assert_eq!(excluded.len(), 1, "git repo should be excluded");
@@ -1154,7 +1787,7 @@ mod tests {
             nodes: discovered,
             excluded,
             ..
-        } = process_refresh(&peppy_dirs, &mut |_| {}).unwrap();
+        } = process_refresh(&peppy_dirs, TEST_NOW, &mut |_| {}).unwrap();
         assert_eq!(discovered.len(), 1, "node should be found normally");
         assert!(excluded.is_empty(), "no repos should be excluded");
     }
@@ -1186,7 +1819,7 @@ mod tests {
             nodes: discovered,
             excluded,
             ..
-        } = process_refresh(&peppy_dirs, &mut |_| {}).unwrap();
+        } = process_refresh(&peppy_dirs, TEST_NOW, &mut |_| {}).unwrap();
         assert_eq!(discovered.len(), 1, "FS node should still be found");
         assert_eq!(excluded.len(), 1, "url repo should be excluded");
         assert_eq!(excluded[0].source_type, RepoSourceKind::Url);
@@ -1243,7 +1876,7 @@ mod tests {
             ),
         );
 
-        let RefreshedRepos { contracts, .. } = process_refresh(&peppy_dirs, &mut |_| {}).unwrap();
+        let RefreshedRepos { contracts, .. } = process_refresh(&peppy_dirs, TEST_NOW, &mut |_| {}).unwrap();
         assert_eq!(contracts.len(), 1, "exactly one contract expected");
         let iface = &contracts[0];
         assert_eq!(iface.contract_name, "uvc_camera");
@@ -1303,7 +1936,7 @@ mod tests {
             &format!(r#"[{{ "id": 1, "type": "git", "url": "{repo_url}", "ref": "{branch}" }}]"#,),
         );
 
-        let RefreshedRepos { contracts, .. } = process_refresh(&peppy_dirs, &mut |_| {}).unwrap();
+        let RefreshedRepos { contracts, .. } = process_refresh(&peppy_dirs, TEST_NOW, &mut |_| {}).unwrap();
         assert_eq!(contracts.len(), 1, "exactly one contract expected");
         let iface = &contracts[0];
         assert_eq!(iface.contract_name, "uvc_camera");
@@ -1365,7 +1998,7 @@ mod tests {
 
         let mut feedbacks = Vec::new();
         let RefreshedRepos { contracts, .. } =
-            process_refresh(&peppy_dirs, &mut |fb| feedbacks.push(fb)).unwrap();
+            process_refresh(&peppy_dirs, TEST_NOW, &mut |fb| feedbacks.push(fb)).unwrap();
 
         assert_eq!(
             contracts.len(),
@@ -1424,6 +2057,148 @@ mod tests {
         assert_eq!(walked.launchers[0].launcher_name, "teleop");
         assert_eq!(walked.contracts.len(), 1, "one contract");
         assert_eq!(walked.contracts[0].contract_name, "uvc_camera");
+        assert!(walked.conflicts.is_empty(), "nothing claimed twice");
+    }
+
+    /// Helper: write a minimal valid pairing manifest at `path`.
+    fn write_pairing_json5(path: &Path, name: &str, tag: &str) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(
+            path,
+            format!(
+                r#"{{
+  peppy_schema: "pairing/v1",
+  manifest: {{ name: "{name}", tag: "{tag}" }},
+  roles: ["leader", "follower"],
+  topics: [
+    {{ emitted_by: "leader", name: "setpoints" }},
+    {{ emitted_by: "follower", name: "states" }}
+  ]
+}}"#
+            ),
+        )
+        .unwrap();
+    }
+
+    /// The motivating case: one repository declaring one node identity
+    /// twice. Both claimants are named, so the report points at the two
+    /// files to look at rather than silently keeping whichever the
+    /// filesystem happened to yield first.
+    #[test]
+    fn walk_directory_reports_node_claimed_twice() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("nodes-hub");
+        write_peppy_json5(&repo.join("uvc_recon/rust"), "uvc_recon", "v1");
+        write_peppy_json5(&repo.join("uvc_recon/python"), "uvc_recon", "v1");
+
+        let walked = walk_directory(&repo, RepoSourceKind::Fs, None, None, &[]);
+
+        assert_eq!(walked.conflicts.len(), 1, "one contested identity");
+        let conflict = &walked.conflicts[0];
+        assert_eq!(conflict.kind, RepoItemKind::Node);
+        assert_eq!(conflict.name, "uvc_recon");
+        assert_eq!(conflict.tag, "v1");
+        assert_eq!(conflict.paths.len(), 2, "both claimants named");
+        assert!(
+            conflict.paths.iter().any(|p| p.contains("rust")),
+            "got: {:?}",
+            conflict.paths
+        );
+        assert!(
+            conflict.paths.iter().any(|p| p.contains("python")),
+            "got: {:?}",
+            conflict.paths
+        );
+        // Only one claimant reaches the entry vector; which one is walk
+        // order and deliberately not asserted.
+        assert_eq!(walked.nodes.len(), 1);
+    }
+
+    /// Launchers are keyed by file stem, so two identically named
+    /// launcher files in one repository contest the same identity even
+    /// though they live in different directories.
+    #[test]
+    fn walk_directory_reports_launcher_stem_claimed_twice() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("launchers-hub");
+        write_launcher_json5(&repo.join("sim/bringup.json5"));
+        write_launcher_json5(&repo.join("real/bringup.json5"));
+
+        let walked = walk_directory(&repo, RepoSourceKind::Fs, None, None, &[]);
+
+        assert_eq!(walked.conflicts.len(), 1);
+        assert_eq!(walked.conflicts[0].kind, RepoItemKind::Launcher);
+        assert_eq!(walked.conflicts[0].name, "bringup");
+        assert_eq!(
+            walked.conflicts[0].tag, "",
+            "launchers carry no tag"
+        );
+        assert_eq!(walked.conflicts[0].paths.len(), 2);
+    }
+
+    /// Contracts and pairings are contested the same way as nodes, so a
+    /// duplicate in either is caught rather than silently resolved.
+    #[test]
+    fn walk_directory_reports_contract_and_pairing_claimed_twice() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("contracts-hub");
+        write_contract_json5(&repo.join("a/rgb.json5"), "rgb_camera", "v1");
+        write_contract_json5(&repo.join("b/rgb.json5"), "rgb_camera", "v1");
+        write_pairing_json5(&repo.join("a/joint.json5"), "joint_link", "v1");
+        write_pairing_json5(&repo.join("b/joint.json5"), "joint_link", "v1");
+
+        let walked = walk_directory(&repo, RepoSourceKind::Fs, None, None, &[]);
+
+        let kinds: Vec<RepoItemKind> = walked.conflicts.iter().map(|c| c.kind).collect();
+        assert_eq!(
+            kinds,
+            vec![RepoItemKind::Contract, RepoItemKind::Pairing],
+            "one conflict per kind, grouped by kind"
+        );
+        assert_eq!(walked.conflicts[0].name, "rgb_camera");
+        assert_eq!(walked.conflicts[1].name, "joint_link");
+    }
+
+    /// The report is ordered by identity with sorted paths, so it is
+    /// reproducible in a test and comparable between two machines whose
+    /// filesystems hand back directories in different orders.
+    #[test]
+    fn walk_directory_conflicts_are_ordered_independently_of_walk_order() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("repo");
+        for dir in ["zzz", "aaa", "mmm"] {
+            write_peppy_json5(&repo.join(dir), "beta", "v1");
+        }
+        write_peppy_json5(&repo.join("one"), "alpha", "v1");
+        write_peppy_json5(&repo.join("two"), "alpha", "v1");
+
+        let walked = walk_directory(&repo, RepoSourceKind::Fs, None, None, &[]);
+
+        let names: Vec<&str> = walked.conflicts.iter().map(|c| c.name.as_str()).collect();
+        assert_eq!(names, vec!["alpha", "beta"], "sorted by identity");
+
+        let beta_paths = &walked.conflicts[1].paths;
+        assert_eq!(beta_paths.len(), 3, "every claimant is named, not just two");
+        let mut sorted = beta_paths.clone();
+        sorted.sort();
+        assert_eq!(beta_paths, &sorted, "paths sorted");
+    }
+
+    /// Same name under different tags is two identities, not a conflict.
+    /// This is the guard against the check firing on ordinary versioning.
+    #[test]
+    fn walk_directory_same_name_different_tags_is_not_a_conflict() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("repo");
+        write_peppy_json5(&repo.join("v1"), "my_sensor", "v1");
+        write_peppy_json5(&repo.join("v2"), "my_sensor", "v2");
+
+        let walked = walk_directory(&repo, RepoSourceKind::Fs, None, None, &[]);
+
+        assert!(walked.conflicts.is_empty(), "{:?}", walked.conflicts);
+        assert_eq!(walked.nodes.len(), 2);
     }
 
     /// Process_refresh discovers launcher files (any `.json5` filename
@@ -1459,7 +2234,7 @@ mod tests {
             nodes: discovered,
             launchers,
             ..
-        } = process_refresh(&peppy_dirs, &mut |_| {}).unwrap();
+        } = process_refresh(&peppy_dirs, TEST_NOW, &mut |_| {}).unwrap();
         assert_eq!(discovered.len(), 1, "node_a should be the only node");
         assert_eq!(
             launchers.len(),
@@ -1541,7 +2316,7 @@ mod tests {
             ),
         );
 
-        let RefreshedRepos { launchers, .. } = process_refresh(&peppy_dirs, &mut |_| {}).unwrap();
+        let RefreshedRepos { launchers, .. } = process_refresh(&peppy_dirs, TEST_NOW, &mut |_| {}).unwrap();
         assert_eq!(
             launchers.len(),
             1,
@@ -1570,7 +2345,7 @@ mod tests {
             ),
         );
 
-        let RefreshedRepos { launchers, .. } = process_refresh(&peppy_dirs, &mut |_| {}).unwrap();
+        let RefreshedRepos { launchers, .. } = process_refresh(&peppy_dirs, TEST_NOW, &mut |_| {}).unwrap();
         write_repo_cache(&peppy_dirs, &launchers).unwrap();
 
         let cache_path = launchers_repo_cache_path(&peppy_dirs);
@@ -1649,7 +2424,7 @@ mod tests {
             &format!(r#"[{{ "id": 1, "type": "git", "url": "{repo_url}", "ref": "{branch}" }}]"#,),
         );
 
-        let RefreshedRepos { launchers, .. } = process_refresh(&peppy_dirs, &mut |_| {}).unwrap();
+        let RefreshedRepos { launchers, .. } = process_refresh(&peppy_dirs, TEST_NOW, &mut |_| {}).unwrap();
         assert_eq!(launchers.len(), 1, "exactly one launcher expected");
         let launcher = &launchers[0];
         assert_eq!(launcher.launcher_name, "openarm01_teleop");
@@ -1707,7 +2482,7 @@ mod tests {
         );
 
         let mut feedbacks: Vec<RepoRefreshFeedback> = Vec::new();
-        let _ = process_refresh(&peppy_dirs, &mut |fb| feedbacks.push(fb)).unwrap();
+        let _ = process_refresh(&peppy_dirs, TEST_NOW, &mut |fb| feedbacks.push(fb)).unwrap();
 
         let progress_messages: Vec<&str> = feedbacks
             .iter()

--- a/crates/core-node-internal/src/services/repo/remove.rs
+++ b/crates/core-node-internal/src/services/repo/remove.rs
@@ -1,6 +1,6 @@
 use crate::Result;
 use crate::services::repo::cache::repositories_list_path;
-use crate::services::repo::refresh::{process_refresh, read_or_create_repos, write_all_caches};
+use crate::services::repo::refresh::{read_or_create_repos, reindex_after_change};
 use crate::services::response::into_service_response;
 use core_node_api::ServiceId;
 use core_node_api::encoding::{RepoRemoveRequest, RepoRemoveResponse};
@@ -43,40 +43,30 @@ async fn handle_repo_remove_request(
     context: ServiceRequestContext,
     peppy_dirs: PeppyDirs,
 ) -> PeppyResult<Payload> {
-    let (payload, needs_refresh) = into_service_response(
+    let (mut response, needs_refresh) = into_service_response(
         &context,
         handle_repo_remove_request_inner(&context, &peppy_dirs),
     )?;
 
-    if needs_refresh {
-        let dirs = peppy_dirs.clone();
-        match tokio::task::spawn_blocking(move || {
-            let _guard = crate::services::repo::refresh_lock().lock();
-            match process_refresh(&dirs, &mut |_| {}) {
-                Ok(refreshed) => write_all_caches(&dirs, &refreshed),
-                Err(e) => Err(e),
-            }
-        })
-        .await
-        {
-            Ok(Ok(())) => {}
-            Ok(Err(e)) => {
-                warn!("Failed to refresh after repo removal: {}", e);
-            }
-            Err(e) => {
-                warn!("Refresh task panicked after repo removal: {}", e);
-            }
-        }
+    // The removal itself already landed, so `success` stays true; the
+    // report says whether the re-read that makes it take effect worked.
+    if needs_refresh
+        && let Some(report) = reindex_after_change(&peppy_dirs).await
+    {
+        warn!("Re-indexing after the removal reported problems: {report}");
+        response = RepoRemoveResponse::success_with_refresh_report(report);
     }
 
-    Ok(payload)
+    into_service_response(&context, response.encode().map_err(Into::into))
 }
 
-/// Returns `(payload, needs_refresh)`.
+/// Returns `(response, needs_refresh)`. The response is returned
+/// unencoded so the caller can fold the post-change re-index report into
+/// it before putting it on the wire.
 fn handle_repo_remove_request_inner(
     context: &ServiceRequestContext,
     peppy_dirs: &PeppyDirs,
-) -> Result<(Payload, bool)> {
+) -> Result<(RepoRemoveResponse, bool)> {
     let sender_instance_id = context.message().instance_id();
     let payload = context.message().payload();
 
@@ -94,7 +84,7 @@ fn handle_repo_remove_request_inner(
     let mut repos = match read_or_create_repos(peppy_dirs) {
         Ok(repos) => repos,
         Err(e) => {
-            return Ok((RepoRemoveResponse::failure(e.to_string()).encode()?, false));
+            return Ok((RepoRemoveResponse::failure(e.to_string()), false));
         }
     };
 
@@ -105,8 +95,7 @@ fn handle_repo_remove_request_inner(
 
     let Some(pos) = position else {
         return Ok((
-            RepoRemoveResponse::failure(format!("repository with id {} not found", request.id))
-                .encode()?,
+            RepoRemoveResponse::failure(format!("repository with id {} not found", request.id)),
             false,
         ));
     };
@@ -120,6 +109,5 @@ fn handle_repo_remove_request_inner(
 
     drop(_guard);
 
-    let payload = RepoRemoveResponse::success().encode()?;
-    Ok((payload, true))
+    Ok((RepoRemoveResponse::success(), true))
 }

--- a/crates/core-node-internal/src/services/repo/remove.rs
+++ b/crates/core-node-internal/src/services/repo/remove.rs
@@ -50,9 +50,7 @@ async fn handle_repo_remove_request(
 
     // The removal itself already landed, so `success` stays true; the
     // report says whether the re-read that makes it take effect worked.
-    if needs_refresh
-        && let Some(report) = reindex_after_change(&peppy_dirs).await
-    {
+    if needs_refresh && let Some(report) = reindex_after_change(&peppy_dirs).await {
         warn!("Re-indexing after the removal reported problems: {report}");
         response = RepoRemoveResponse::success_with_refresh_report(report);
     }

--- a/crates/core-node-internal/src/services/repo/status.rs
+++ b/crates/core-node-internal/src/services/repo/status.rs
@@ -1,0 +1,191 @@
+//! Per-repository read status, written to `~/.peppy/cache/repo_status.json5`
+//! by every refresh.
+//!
+//! Containment lets a repository keep serving the entries it last
+//! published while later refreshes fail. That is the right default, since
+//! the alternative is losing identities that launchers reference, but it
+//! means a repository failing for a month is still serving month-old
+//! entries. Recording when each repository was last read successfully is
+//! what keeps that visible instead of a machine sitting on stale bytes
+//! believing it is current.
+//!
+//! This lives beside the four entry caches rather than as fields on the
+//! entries themselves: it is per repository, not per entry, and keeping
+//! it separate leaves the entry caches' on-disk shape untouched.
+//!
+//! Deliberately records a timestamp and not a revision. Knowing *when*
+//! entries were last read is enough for everything here; recording which
+//! commit they came from is a larger change to what a cache holds.
+
+use crate::Result;
+use core_node_api::encoding::RepoSourceKind;
+use daemon_config::consts::PeppyDirs;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+use tracing::warn;
+
+pub(crate) const FILE_NAME: &str = "repo_status.json5";
+
+/// How the most recent read of a repository went wrong.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub(crate) struct RepoStatusFailure {
+    /// `"unreachable"` or `"conflict"`. Text on disk so the file stays
+    /// readable and an unknown value from a future peppy degrades to a
+    /// label rather than a parse error.
+    pub kind: String,
+    pub message: String,
+    pub unix_secs: u64,
+}
+
+/// One repository's read history, as of the last refresh.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub(crate) struct RepoStatus {
+    pub id: u64,
+    pub identity: String,
+    pub source_type: RepoSourceKind,
+    /// Unix seconds of the last read that produced entries. `None` on a
+    /// machine that has never read this repository successfully, which is
+    /// exactly the fresh-machine case where there is nothing to fall back
+    /// to.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_read_unix_secs: Option<u64>,
+    /// Absent once a read succeeds, so a repository that recovered does
+    /// not keep reporting an old failure.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_failure: Option<RepoStatusFailure>,
+}
+
+impl RepoStatus {
+    /// Whether the entries currently in the caches for this repository
+    /// came from an earlier run than this one.
+    pub(crate) fn is_retained(&self) -> bool {
+        self.last_failure.is_some()
+    }
+}
+
+pub(crate) fn repo_status_path(peppy_dirs: &PeppyDirs) -> PathBuf {
+    peppy_dirs.cache_dir().join(FILE_NAME)
+}
+
+/// Unix seconds for `now`, saturating at the epoch for clocks set before
+/// it. A status file is a diagnostic, so a nonsense clock degrades the
+/// reporting rather than failing the refresh that produced it.
+pub(crate) fn unix_secs(now: SystemTime) -> u64 {
+    now.duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// Reads the status file, or an empty list when it is missing or
+/// unreadable. Never an error: this is diagnostic data, and refusing to
+/// refresh because the diagnostics are corrupt helps nobody.
+pub(crate) fn read(peppy_dirs: &PeppyDirs) -> Vec<RepoStatus> {
+    let path = repo_status_path(peppy_dirs);
+    if !path.exists() {
+        return Vec::new();
+    }
+    let parsed = std::fs::read_to_string(&path)
+        .map_err(|e| e.to_string())
+        .and_then(|content| serde_json5::from_str::<Vec<RepoStatus>>(&content).map_err(|e| e.to_string()));
+    match parsed {
+        Ok(statuses) => statuses,
+        Err(e) => {
+            warn!("Could not read {} at {}: {e}", FILE_NAME, path.display());
+            Vec::new()
+        }
+    }
+}
+
+/// Publishes the status file atomically, like the entry caches, so a
+/// concurrent `repo list` never observes a partial file.
+pub(crate) fn write(peppy_dirs: &PeppyDirs, statuses: &[RepoStatus]) -> Result<()> {
+    let content = json5_pretty::to_string_pretty(statuses).map_err(|e| {
+        core_node_api::Error::Encoding(format!("failed to serialize {FILE_NAME}: {e}"))
+    })?;
+    daemon_config::atomic_write::publish_atomic(&repo_status_path(peppy_dirs), |tmp| {
+        std::fs::write(tmp, &content)
+    })?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn status(id: u64) -> RepoStatus {
+        RepoStatus {
+            id,
+            identity: format!("https://example.com/{id}.git"),
+            source_type: RepoSourceKind::Git,
+            last_read_unix_secs: Some(1_753_900_000),
+            last_failure: None,
+        }
+    }
+
+    #[test]
+    fn write_then_read_roundtrips() {
+        let tmp = tempfile::tempdir().unwrap();
+        let peppy_dirs = PeppyDirs::new(tmp.path());
+        std::fs::create_dir_all(peppy_dirs.cache_dir()).unwrap();
+
+        let mut failed = status(1001);
+        failed.last_failure = Some(RepoStatusFailure {
+            kind: "conflict".to_owned(),
+            message: "two node manifests claim `a:v1`".to_owned(),
+            unix_secs: 1_753_986_400,
+        });
+        let written = vec![status(1000), failed];
+
+        write(&peppy_dirs, &written).unwrap();
+
+        assert_eq!(read(&peppy_dirs), written);
+    }
+
+    #[test]
+    fn read_returns_empty_when_file_is_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(read(&PeppyDirs::new(tmp.path())).is_empty());
+    }
+
+    /// A corrupt status file must not stop a refresh: it holds
+    /// diagnostics, not the entries themselves.
+    #[test]
+    fn read_returns_empty_when_file_is_corrupt() {
+        let tmp = tempfile::tempdir().unwrap();
+        let peppy_dirs = PeppyDirs::new(tmp.path());
+        std::fs::create_dir_all(peppy_dirs.cache_dir()).unwrap();
+        std::fs::write(repo_status_path(&peppy_dirs), "not json5 at all {{{").unwrap();
+
+        assert!(read(&peppy_dirs).is_empty());
+    }
+
+    /// A repository is "retained" exactly while its last read failed;
+    /// once it reads cleanly the failure is cleared and it is current.
+    #[test]
+    fn is_retained_tracks_the_last_failure() {
+        let mut s = status(1000);
+        assert!(!s.is_retained());
+        s.last_failure = Some(RepoStatusFailure {
+            kind: "unreachable".to_owned(),
+            message: "network is unreachable".to_owned(),
+            unix_secs: 1_753_986_400,
+        });
+        assert!(s.is_retained());
+    }
+
+    /// Timestamps come from a caller-supplied `SystemTime` so tests stay
+    /// deterministic, and a clock set before the epoch degrades to 0
+    /// rather than failing.
+    #[test]
+    fn unix_secs_converts_and_saturates() {
+        assert_eq!(
+            unix_secs(UNIX_EPOCH + std::time::Duration::from_secs(1_753_900_000)),
+            1_753_900_000
+        );
+        assert_eq!(
+            unix_secs(UNIX_EPOCH - std::time::Duration::from_secs(60)),
+            0,
+            "a clock set before the epoch degrades rather than panicking"
+        );
+    }
+}

--- a/crates/core-node-internal/src/services/repo/status.rs
+++ b/crates/core-node-internal/src/services/repo/status.rs
@@ -86,7 +86,9 @@ pub(crate) fn read(peppy_dirs: &PeppyDirs) -> Vec<RepoStatus> {
     }
     let parsed = std::fs::read_to_string(&path)
         .map_err(|e| e.to_string())
-        .and_then(|content| serde_json5::from_str::<Vec<RepoStatus>>(&content).map_err(|e| e.to_string()));
+        .and_then(|content| {
+            serde_json5::from_str::<Vec<RepoStatus>>(&content).map_err(|e| e.to_string())
+        });
     match parsed {
         Ok(statuses) => statuses,
         Err(e) => {

--- a/crates/core-node-internal/tests/listen_for_repo_list.rs
+++ b/crates/core-node-internal/tests/listen_for_repo_list.rs
@@ -451,7 +451,11 @@ async fn list_omits_nodes_that_are_on_disk_but_not_indexed() {
 
     let resp = send_repo_list(&started).await;
     assert!(resp.success);
-    assert_eq!(resp.nodes.len(), 1, "only the indexed node should be listed");
+    assert_eq!(
+        resp.nodes.len(),
+        1,
+        "only the indexed node should be listed"
+    );
     assert_eq!(resp.nodes[0].node_name, "keep_node");
 }
 

--- a/crates/core-node-internal/tests/listen_for_repo_list.rs
+++ b/crates/core-node-internal/tests/listen_for_repo_list.rs
@@ -3,7 +3,9 @@ mod common;
 use common::{CALLER_INSTANCE_ID, StartedCoreNode, start_core_node_with_mock_messenger};
 use config::consts::NODE_CONFIG_FILE;
 use core_node::{nodes_repo_cache_path, repositories_list_path};
-use core_node_api::encoding::{RepoListRequest, RepoListResponse, RepoSourceKind};
+use core_node_api::encoding::{
+    RepoListRepoFailureKind, RepoListRequest, RepoListResponse, RepoSourceKind,
+};
 use peppylib::core_node::transport::poll;
 use std::time::Duration;
 
@@ -620,7 +622,8 @@ async fn list_reports_retained_entries_and_the_failure_reason() {
     );
     let failure = repo_status.failure.as_ref().expect("reason reported");
     assert_eq!(
-        failure.kind, "unreachable",
+        failure.kind,
+        RepoListRepoFailureKind::Unreachable,
         "an outage must not read as a content bug"
     );
 
@@ -663,6 +666,7 @@ async fn list_reports_a_healthy_repository_as_current() {
     assert_eq!(resp.repos.len(), 1);
     assert!(!resp.repos[0].retained);
     assert!(resp.repos[0].failure.is_none());
+    assert_eq!(resp.nodes.len(), 1);
     assert!(!resp.nodes[0].conflict);
     assert!(!resp.nodes[0].duplicate);
 }

--- a/crates/core-node-internal/tests/listen_for_repo_list.rs
+++ b/crates/core-node-internal/tests/listen_for_repo_list.rs
@@ -40,6 +40,29 @@ fn write_packages_cache(started: &StartedCoreNode, content: &str) {
     std::fs::write(nodes_repo_cache_path(&started.peppy_dirs), content).expect("write cache file");
 }
 
+/// One `nodes.json5` entry for an fs-discovered node, shaped exactly as
+/// `repo refresh` records it: the path points at the manifest file.
+///
+/// `repo list` reads the caches for every source kind rather than
+/// re-walking fs repositories, so an fs node has to be indexed to be
+/// listed, just like a git one.
+fn fs_cache_entry(node_dir: &std::path::Path, name: &str, tag: &str) -> serde_json::Value {
+    serde_json::json!({
+        "node_name": name,
+        "node_tag": tag,
+        "source_type": "fs",
+        "path": node_dir.join(NODE_CONFIG_FILE).to_string_lossy(),
+    })
+}
+
+/// Write `entries` as the nodes cache.
+fn index_nodes(started: &StartedCoreNode, entries: Vec<serde_json::Value>) {
+    write_packages_cache(
+        started,
+        &serde_json::to_string(&serde_json::Value::Array(entries)).unwrap(),
+    );
+}
+
 /// Create a directory with a valid peppy.json5 inside it.
 fn create_node_dir(base: &std::path::Path, name: &str, tag: &str) -> std::path::PathBuf {
     let dir = base.join(format!("{name}_{tag}"));
@@ -97,8 +120,8 @@ async fn list_finds_nodes_in_fs_repo() {
     let started = start_core_node_with_mock_messenger().await;
 
     let repo_dir = started.peppy_dirs.root().join("test_repo");
-    create_node_dir(&repo_dir, "my_sensor", "v1");
-    create_node_dir(&repo_dir, "my_actuator", "v2");
+    let sensor_dir = create_node_dir(&repo_dir, "my_sensor", "v1");
+    let actuator_dir = create_node_dir(&repo_dir, "my_actuator", "v2");
 
     write_repositories_json5(
         &started,
@@ -106,6 +129,13 @@ async fn list_finds_nodes_in_fs_repo() {
             { "id": 1, "type": "fs", "path": repo_dir.to_string_lossy() }
         ]))
         .unwrap(),
+    );
+    index_nodes(
+        &started,
+        vec![
+            fs_cache_entry(&sensor_dir, "my_sensor", "v1"),
+            fs_cache_entry(&actuator_dir, "my_actuator", "v2"),
+        ],
     );
 
     let resp = send_repo_list(&started).await;
@@ -200,9 +230,9 @@ async fn list_marks_cross_repo_duplicates_fs() {
 
     let repo_a = started.peppy_dirs.root().join("list_dup_a");
     let repo_b = started.peppy_dirs.root().join("list_dup_b");
-    create_node_dir(&repo_a, "shared", "v1");
-    create_node_dir(&repo_b, "shared", "v1");
-    create_node_dir(&repo_b, "unique_b", "v1");
+    let shared_a = create_node_dir(&repo_a, "shared", "v1");
+    let shared_b = create_node_dir(&repo_b, "shared", "v1");
+    let unique_b = create_node_dir(&repo_b, "unique_b", "v1");
 
     write_repositories_json5(
         &started,
@@ -211,6 +241,14 @@ async fn list_marks_cross_repo_duplicates_fs() {
             { "id": 2, "type": "fs", "path": repo_b.to_string_lossy() }
         ]))
         .unwrap(),
+    );
+    index_nodes(
+        &started,
+        vec![
+            fs_cache_entry(&shared_a, "shared", "v1"),
+            fs_cache_entry(&shared_b, "shared", "v1"),
+            fs_cache_entry(&unique_b, "unique_b", "v1"),
+        ],
     );
 
     let resp = send_repo_list(&started).await;
@@ -266,7 +304,7 @@ async fn list_marks_git_duplicate_of_fs() {
     let started = start_core_node_with_mock_messenger().await;
 
     let repo_dir = started.peppy_dirs.root().join("fs_repo");
-    create_node_dir(&repo_dir, "overlapping", "v1");
+    let overlapping = create_node_dir(&repo_dir, "overlapping", "v1");
 
     let git_url = "https://github.com/example/nodes.git";
 
@@ -279,18 +317,20 @@ async fn list_marks_git_duplicate_of_fs() {
         .unwrap(),
     );
 
-    // Cache has the same node from git
-    write_packages_cache(
+    // Both repositories provide the same identity; the lower id wins.
+    index_nodes(
         &started,
-        &serde_json::to_string(&serde_json::json!([{
-            "node_name": "overlapping",
-            "node_tag": "v1",
-            "source_type": "git",
-            "source_uri": git_url,
-            "resolved_ref": "main",
-            "path": "nodes/overlapping"
-        }]))
-        .unwrap(),
+        vec![
+            fs_cache_entry(&overlapping, "overlapping", "v1"),
+            serde_json::json!({
+                "node_name": "overlapping",
+                "node_tag": "v1",
+                "source_type": "git",
+                "source_uri": git_url,
+                "resolved_ref": "main",
+                "path": "nodes/overlapping"
+            }),
+        ],
     );
 
     let resp = send_repo_list(&started).await;
@@ -320,7 +360,11 @@ async fn list_marks_git_duplicate_of_fs() {
         "git entry should be marked as duplicate"
     );
     assert_eq!(git_entry.repo_id, 2);
-    assert_eq!(git_entry.repo_label, format!("{git_url} (ref: main)"));
+    // The label describes the repository as configured, which is what
+    // `repo add` and `repo exclude` print, so a user can match them up.
+    // This repository pins no ref, so the label is the bare url even
+    // though the cached entry resolved to `main`.
+    assert_eq!(git_entry.repo_label, git_url);
 }
 
 /// Write an excluded_repositories.json5 file in the conf_dir.
@@ -349,8 +393,8 @@ async fn list_excludes_fs_repo() {
 
     let repo_a = started.peppy_dirs.root().join("repo_a");
     let repo_b = started.peppy_dirs.root().join("repo_b");
-    create_node_dir(&repo_a, "node_a", "v1");
-    create_node_dir(&repo_b, "node_b", "v1");
+    let node_a = create_node_dir(&repo_a, "node_a", "v1");
+    let node_b = create_node_dir(&repo_b, "node_b", "v1");
 
     write_repositories_json5(
         &started,
@@ -359,6 +403,14 @@ async fn list_excludes_fs_repo() {
             { "id": 2, "type": "fs", "path": repo_b.to_string_lossy() }
         ]))
         .unwrap(),
+    );
+    // Both are indexed; the exclusion is what keeps repo_b out of the list.
+    index_nodes(
+        &started,
+        vec![
+            fs_cache_entry(&node_a, "node_a", "v1"),
+            fs_cache_entry(&node_b, "node_b", "v1"),
+        ],
     );
     write_excluded_repositories_json5(
         &started,
@@ -374,14 +426,19 @@ async fn list_excludes_fs_repo() {
     assert_eq!(resp.nodes[0].node_name, "node_a");
 }
 
-/// An excluded subdirectory within an FS repo should be pruned from the list.
+/// `repo list` reports what will actually resolve, so a node sitting on
+/// disk but absent from the index is not listed: it cannot be launched
+/// until the next refresh, and showing it would promise otherwise.
+///
+/// Subdirectory exclusion is applied while walking, so it is covered by
+/// the refresh tests rather than here.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn list_excludes_fs_subdirectory() {
+async fn list_omits_nodes_that_are_on_disk_but_not_indexed() {
     let started = start_core_node_with_mock_messenger().await;
 
     let repo = started.peppy_dirs.root().join("mixed_repo");
-    create_node_dir(&repo, "keep_node", "v1");
-    create_node_dir(&repo, "secret_node", "v1");
+    let indexed = create_node_dir(&repo, "keep_node", "v1");
+    create_node_dir(&repo, "added_since_the_last_refresh", "v1");
 
     write_repositories_json5(
         &started,
@@ -390,17 +447,11 @@ async fn list_excludes_fs_subdirectory() {
         ]))
         .unwrap(),
     );
-    write_excluded_repositories_json5(
-        &started,
-        &serde_json::to_string(&serde_json::json!([
-            { "id": 1, "type": "fs", "path": repo.join("secret_node_v1").to_string_lossy() }
-        ]))
-        .unwrap(),
-    );
+    index_nodes(&started, vec![fs_cache_entry(&indexed, "keep_node", "v1")]);
 
     let resp = send_repo_list(&started).await;
     assert!(resp.success);
-    assert_eq!(resp.nodes.len(), 1, "only keep_node should be listed");
+    assert_eq!(resp.nodes.len(), 1, "only the indexed node should be listed");
     assert_eq!(resp.nodes[0].node_name, "keep_node");
 }
 
@@ -410,7 +461,7 @@ async fn list_excludes_git_repo() {
     let started = start_core_node_with_mock_messenger().await;
 
     let repo_dir = started.peppy_dirs.root().join("fs_repo");
-    create_node_dir(&repo_dir, "fs_node", "v1");
+    let fs_node = create_node_dir(&repo_dir, "fs_node", "v1");
 
     let git_url = "https://github.com/example/excluded.git";
 
@@ -422,16 +473,18 @@ async fn list_excludes_git_repo() {
         ]))
         .unwrap(),
     );
-    write_packages_cache(
+    index_nodes(
         &started,
-        &serde_json::to_string(&serde_json::json!([{
-            "node_name": "git_node",
-            "node_tag": "v1",
-            "source_type": "git",
-            "source_uri": git_url,
-            "path": "nodes/git_node"
-        }]))
-        .unwrap(),
+        vec![
+            fs_cache_entry(&fs_node, "fs_node", "v1"),
+            serde_json::json!({
+                "node_name": "git_node",
+                "node_tag": "v1",
+                "source_type": "git",
+                "source_uri": git_url,
+                "path": "nodes/git_node"
+            }),
+        ],
     );
     write_excluded_repositories_json5(
         &started,
@@ -446,4 +499,166 @@ async fn list_excludes_git_repo() {
     assert_eq!(resp.nodes.len(), 1, "only fs_node should be listed");
     assert_eq!(resp.nodes[0].node_name, "fs_node");
     assert_eq!(resp.nodes[0].source_type, RepoSourceKind::Fs);
+}
+
+/// Two repositories claiming one identity and one repository claiming it
+/// twice are different situations and must be labelled differently.
+/// Reporting a conflict as harmless shadowing is what let the original
+/// defect hide.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn list_distinguishes_conflict_from_cross_repo_shadowing() {
+    let started = start_core_node_with_mock_messenger().await;
+
+    let repo_a = started.peppy_dirs.root().join("repo_a");
+    let repo_b = started.peppy_dirs.root().join("repo_b");
+    let shadowed_a = create_node_dir(&repo_a, "shadowed", "v1");
+    let shadowed_b = create_node_dir(&repo_b, "shadowed", "v1");
+    let contested_one = create_node_dir(&repo_b, "contested_one", "v1");
+    let contested_two = create_node_dir(&repo_b, "contested_two", "v1");
+
+    write_repositories_json5(
+        &started,
+        &serde_json::to_string(&serde_json::json!([
+            { "id": 1, "type": "fs", "path": repo_a.to_string_lossy() },
+            { "id": 2, "type": "fs", "path": repo_b.to_string_lossy() }
+        ]))
+        .unwrap(),
+    );
+    // `contested` claimed twice inside repo_b: a cache an older peppy
+    // could have written, since refresh now refuses to produce one.
+    index_nodes(
+        &started,
+        vec![
+            fs_cache_entry(&shadowed_a, "shadowed", "v1"),
+            fs_cache_entry(&shadowed_b, "shadowed", "v1"),
+            fs_cache_entry(&contested_one, "contested", "v1"),
+            fs_cache_entry(&contested_two, "contested", "v1"),
+        ],
+    );
+
+    let resp = send_repo_list(&started).await;
+    assert!(resp.success);
+
+    let shadowed: Vec<_> = resp
+        .nodes
+        .iter()
+        .filter(|n| n.node_name == "shadowed")
+        .collect();
+    assert_eq!(shadowed.len(), 2);
+    assert!(
+        shadowed.iter().all(|n| !n.conflict),
+        "shadowing across repositories is not a conflict"
+    );
+    assert_eq!(
+        shadowed.iter().filter(|n| n.duplicate).count(),
+        1,
+        "exactly the losing entry is marked as shadowed"
+    );
+
+    let contested: Vec<_> = resp
+        .nodes
+        .iter()
+        .filter(|n| n.node_name == "contested")
+        .collect();
+    assert_eq!(contested.len(), 2);
+    assert!(
+        contested.iter().all(|n| n.conflict),
+        "both claimants inside one repository are marked as conflicting"
+    );
+}
+
+/// A repository whose last refresh failed is reported as retained, with
+/// the timestamp of the read its entries actually came from and a reason
+/// that says whether it was an outage or a content bug.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn list_reports_retained_entries_and_the_failure_reason() {
+    let started = start_core_node_with_mock_messenger().await;
+
+    let repo = started.peppy_dirs.root().join("stale_repo");
+    let node = create_node_dir(&repo, "kept", "v1");
+
+    write_repositories_json5(
+        &started,
+        &serde_json::to_string(&serde_json::json!([
+            { "id": 1, "type": "fs", "path": repo.to_string_lossy() }
+        ]))
+        .unwrap(),
+    );
+    index_nodes(&started, vec![fs_cache_entry(&node, "kept", "v1")]);
+    std::fs::write(
+        started.peppy_dirs.cache_dir().join("repo_status.json5"),
+        serde_json::to_string(&serde_json::json!([{
+            "id": 1,
+            "identity": repo.to_string_lossy(),
+            "source_type": "fs",
+            "last_read_unix_secs": 1_753_900_000u64,
+            "last_failure": {
+                "kind": "unreachable",
+                "message": "path does not exist",
+                "unix_secs": 1_753_986_400u64
+            }
+        }]))
+        .unwrap(),
+    )
+    .expect("write repo status");
+
+    let resp = send_repo_list(&started).await;
+    assert!(resp.success);
+
+    assert_eq!(resp.repos.len(), 1);
+    let repo_status = &resp.repos[0];
+    assert_eq!(repo_status.id, 1);
+    assert!(repo_status.retained, "its last read failed");
+    assert_eq!(
+        repo_status.last_read_unix_secs,
+        Some(1_753_900_000),
+        "the entries date from the last clean read, not from now"
+    );
+    let failure = repo_status.failure.as_ref().expect("reason reported");
+    assert_eq!(
+        failure.kind, "unreachable",
+        "an outage must not read as a content bug"
+    );
+
+    // The retained entry is still listed: launchers referencing it keep working.
+    assert_eq!(resp.nodes.len(), 1);
+    assert_eq!(resp.nodes[0].node_name, "kept");
+}
+
+/// A repository that read cleanly is current, with no failure and no
+/// retained marker.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn list_reports_a_healthy_repository_as_current() {
+    let started = start_core_node_with_mock_messenger().await;
+
+    let repo = started.peppy_dirs.root().join("healthy_repo");
+    let node = create_node_dir(&repo, "fresh", "v1");
+
+    write_repositories_json5(
+        &started,
+        &serde_json::to_string(&serde_json::json!([
+            { "id": 1, "type": "fs", "path": repo.to_string_lossy() }
+        ]))
+        .unwrap(),
+    );
+    index_nodes(&started, vec![fs_cache_entry(&node, "fresh", "v1")]);
+    std::fs::write(
+        started.peppy_dirs.cache_dir().join("repo_status.json5"),
+        serde_json::to_string(&serde_json::json!([{
+            "id": 1,
+            "identity": repo.to_string_lossy(),
+            "source_type": "fs",
+            "last_read_unix_secs": 1_753_900_000u64
+        }]))
+        .unwrap(),
+    )
+    .expect("write repo status");
+
+    let resp = send_repo_list(&started).await;
+    assert!(resp.success);
+    assert_eq!(resp.repos.len(), 1);
+    assert!(!resp.repos[0].retained);
+    assert!(resp.repos[0].failure.is_none());
+    assert!(!resp.nodes[0].conflict);
+    assert!(!resp.nodes[0].duplicate);
 }

--- a/crates/peppy/Cargo.toml
+++ b/crates/peppy/Cargo.toml
@@ -18,7 +18,8 @@ node-stack = { workspace = true }
 latency-report = { workspace = true }
 json5-pretty = { workspace = true }
 bytes = "1"
-chrono = "0.4"
+# 0.4.31 for `DateTime::from_timestamp`, used to render repo read times.
+chrono = "0.4.31"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 gix-url = "0.37"

--- a/crates/peppy/Cargo.toml
+++ b/crates/peppy/Cargo.toml
@@ -18,6 +18,7 @@ node-stack = { workspace = true }
 latency-report = { workspace = true }
 json5-pretty = { workspace = true }
 bytes = "1"
+chrono = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 gix-url = "0.37"

--- a/crates/peppy/src/commands/repo/exclude.rs
+++ b/crates/peppy/src/commands/repo/exclude.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use core_node_api::encoding::{RepoExcludeRequest, RepoSource};
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::commands::CALLER_INSTANCE_ID;
 use crate::commands::repo::add::parse_repo_source;
@@ -48,6 +48,13 @@ async fn exclude_repo_async(
 
     if response.success {
         info!("Repository '{label}' excluded successfully");
+        // The exclusion landed, but the re-index that makes it take
+        // effect may not have. Saying so matters most here: excluding is
+        // what a blocked user reaches for, and they need to know whether
+        // it unblocked them.
+        if !response.refresh_report.is_empty() {
+            warn!("Re-indexing after the exclusion: {}", response.refresh_report);
+        }
         Ok(())
     } else {
         Err(Error::ExecutionFailed(format!(

--- a/crates/peppy/src/commands/repo/exclude.rs
+++ b/crates/peppy/src/commands/repo/exclude.rs
@@ -53,7 +53,10 @@ async fn exclude_repo_async(
         // what a blocked user reaches for, and they need to know whether
         // it unblocked them.
         if !response.refresh_report.is_empty() {
-            warn!("Re-indexing after the exclusion: {}", response.refresh_report);
+            warn!(
+                "Re-indexing after the exclusion: {}",
+                response.refresh_report
+            );
         }
         Ok(())
     } else {

--- a/crates/peppy/src/commands/repo/list.rs
+++ b/crates/peppy/src/commands/repo/list.rs
@@ -11,6 +11,13 @@ use peppylib::core_node::transport::poll;
 
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Orange, for the two states that are not errors but are not the plain
+/// answer either: entries kept from an earlier read, and an identity a
+/// higher-priority repository already answers.
+const ORANGE: &str = "\x1b[38;5;208m";
+/// Red, for what does not resolve at all.
+const RED: &str = "\x1b[31m";
+
 pub(super) fn list_repos(ctx: &Arc<AppContext>) -> Result<()> {
     crate::commands::block_on(list_repos_async(ctx))
 }
@@ -75,10 +82,11 @@ async fn list_repos_async(ctx: &Arc<AppContext>) -> Result<()> {
 
 fn print_repo_header(repo: &RepoListRepoEntry, node_count: usize, colorize: bool) {
     let mut header = format!(
-        "{} ({} {} nodes):",
+        "{} ({} {} node{}):",
         repo.label,
         node_count,
-        repo.source_type.as_str()
+        repo.source_type.as_str(),
+        if node_count == 1 { "" } else { "s" }
     );
     if repo.retained {
         // Retention is the whole point of containment, but entries kept
@@ -90,7 +98,7 @@ fn print_repo_header(repo: &RepoListRepoEntry, node_count: usize, colorize: bool
             .unwrap_or_else(|| "never".to_owned());
         header.push_str(&paint(
             &format!("  [retained, last read {when}]"),
-            "\x1b[38;5;208m",
+            ORANGE,
             colorize,
         ));
     }
@@ -104,7 +112,7 @@ fn print_repo_header(repo: &RepoListRepoEntry, node_count: usize, colorize: bool
                     "  last refresh failed ({}): {}",
                     failure.kind, failure.detail
                 ),
-                "\x1b[31m",
+                RED,
                 colorize,
             )
         );
@@ -121,13 +129,13 @@ fn print_nodes(nodes: &[&RepoListNodeEntry], winner: &HashMap<(&str, &str), &str
         // conflict has no winner and does not resolve at all. Reading the
         // second as the first is what let the original defect hide.
         let suffix = if node.conflict {
-            paint("  (conflict: claimed twice here)", "\x1b[31m", colorize)
+            paint("  (conflict: claimed twice here)", RED, colorize)
         } else if node.duplicate {
             let by = winner
                 .get(&(node.node_name.as_str(), node.node_tag.as_str()))
                 .copied()
                 .unwrap_or("a higher-priority repository");
-            paint(&format!("  (shadowed by {by})"), "\x1b[38;5;208m", colorize)
+            paint(&format!("  (shadowed by {by})"), ORANGE, colorize)
         } else {
             String::new()
         };

--- a/crates/peppy/src/commands/repo/list.rs
+++ b/crates/peppy/src/commands/repo/list.rs
@@ -1,7 +1,8 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
-use core_node_api::encoding::{RepoListNodeEntry, RepoListRequest};
+use core_node_api::encoding::{RepoListNodeEntry, RepoListRepoEntry, RepoListRequest};
 
 use crate::commands::CALLER_INSTANCE_ID;
 use crate::context::AppContext;
@@ -35,52 +36,106 @@ async fn list_repos_async(ctx: &Arc<AppContext>) -> Result<()> {
         )));
     }
 
-    if response.nodes.is_empty() {
-        println!("No nodes found. Run `peppy repo refresh` to discover nodes.");
+    if response.repos.is_empty() {
+        println!("No repositories configured. Run `peppy repo init` to add the defaults.");
         return Ok(());
     }
 
-    let mut first_section = true;
-    let mut start = 0;
-    while start < response.nodes.len() {
-        let repo_id = response.nodes[start].repo_id;
-        let mut end = start + 1;
-        while end < response.nodes.len() && response.nodes[end].repo_id == repo_id {
-            end += 1;
-        }
-        let group: Vec<&RepoListNodeEntry> = response.nodes[start..end].iter().collect();
-        if !first_section {
+    // The repository that wins each identity is the first one listed for
+    // it: the daemon emits nodes in repository id order, and the lower id
+    // wins resolution.
+    let mut winner: HashMap<(&str, &str), &str> = HashMap::new();
+    for node in &response.nodes {
+        winner
+            .entry((node.node_name.as_str(), node.node_tag.as_str()))
+            .or_insert(node.repo_label.as_str());
+    }
+
+    let colorize = crate::terminal::colors_enabled();
+    for (index, repo) in response.repos.iter().enumerate() {
+        let nodes: Vec<&RepoListNodeEntry> = response
+            .nodes
+            .iter()
+            .filter(|n| n.repo_id == repo.id)
+            .collect();
+        if index > 0 {
             println!();
         }
-        first_section = false;
-        let head = group[0];
-        println!(
-            "{} ({} {} nodes):",
-            head.repo_label,
-            group.len(),
-            head.source_type.as_str()
-        );
-        print_nodes(&group);
-        start = end;
+        print_repo_header(repo, nodes.len(), colorize);
+        print_nodes(&nodes, &winner, colorize);
+    }
+
+    if response.nodes.is_empty() {
+        println!();
+        println!("No nodes found. Run `peppy repo refresh` to discover nodes.");
     }
 
     Ok(())
 }
 
-fn print_nodes(nodes: &[&RepoListNodeEntry]) {
+fn print_repo_header(repo: &RepoListRepoEntry, node_count: usize, colorize: bool) {
+    let mut header = format!(
+        "{} ({} {} nodes):",
+        repo.label,
+        node_count,
+        repo.source_type.as_str()
+    );
+    if repo.retained {
+        // Retention is the whole point of containment, but entries kept
+        // from an earlier read are not current and saying so is what
+        // stops a machine sitting on stale bytes believing otherwise.
+        let when = repo
+            .last_read_unix_secs
+            .map(format_timestamp)
+            .unwrap_or_else(|| "never".to_owned());
+        header.push_str(&paint(
+            &format!("  [retained, last read {when}]"),
+            "\x1b[38;5;208m",
+            colorize,
+        ));
+    }
+    println!("{header}");
+
+    if let Some(failure) = &repo.failure {
+        println!(
+            "{}",
+            paint(
+                &format!("  last refresh failed ({}): {}", failure.kind, failure.detail),
+                "\x1b[31m",
+                colorize,
+            )
+        );
+    }
+}
+
+fn print_nodes(
+    nodes: &[&RepoListNodeEntry],
+    winner: &HashMap<(&str, &str), &str>,
+    colorize: bool,
+) {
     let max_name_len = nodes.iter().map(|n| n.node_name.len()).max().unwrap_or(0);
     let max_tag_len = nodes.iter().map(|n| n.node_tag.len()).max().unwrap_or(0);
-    let colorize = crate::terminal::colors_enabled();
 
     for node in nodes {
-        let mut suffix = String::new();
-        if node.duplicate {
-            if colorize {
-                suffix.push_str("  \x1b[38;5;208m(duplicate)\x1b[0m");
-            } else {
-                suffix.push_str("  (duplicate)");
-            }
-        }
+        // Two situations that used to share one "(duplicate)" label.
+        // Shadowing resolves deterministically and is a feature; a
+        // conflict has no winner and does not resolve at all. Reading the
+        // second as the first is what let the original defect hide.
+        let suffix = if node.conflict {
+            paint("  (conflict: claimed twice here)", "\x1b[31m", colorize)
+        } else if node.duplicate {
+            let by = winner
+                .get(&(node.node_name.as_str(), node.node_tag.as_str()))
+                .copied()
+                .unwrap_or("a higher-priority repository");
+            paint(
+                &format!("  (shadowed by {by})"),
+                "\x1b[38;5;208m",
+                colorize,
+            )
+        } else {
+            String::new()
+        };
         println!(
             "  {:<name_w$}  {:<tag_w$}  {}{}",
             node.node_name,
@@ -89,6 +144,60 @@ fn print_nodes(nodes: &[&RepoListNodeEntry]) {
             suffix,
             name_w = max_name_len,
             tag_w = max_tag_len,
+        );
+    }
+}
+
+fn paint(text: &str, colour: &str, colorize: bool) -> String {
+    if colorize {
+        format!("{colour}{text}\x1b[0m")
+    } else {
+        text.to_owned()
+    }
+}
+
+/// Renders a unix timestamp in local time, to the minute. Out-of-range
+/// values render as the raw number rather than being dropped: a status
+/// file is a diagnostic, so showing something odd beats showing nothing.
+fn format_timestamp(unix_secs: u64) -> String {
+    i64::try_from(unix_secs)
+        .ok()
+        .and_then(|secs| chrono::DateTime::from_timestamp(secs, 0))
+        .map(|dt| {
+            dt.with_timezone(&chrono::Local)
+                .format("%Y-%m-%d %H:%M")
+                .to_string()
+        })
+        .unwrap_or_else(|| format!("unix {unix_secs}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn timestamp_renders_to_the_minute() {
+        // Compare against the same conversion rather than a fixed string,
+        // so the test does not depend on the host's timezone.
+        let expected = chrono::DateTime::from_timestamp(1_753_900_000, 0)
+            .unwrap()
+            .with_timezone(&chrono::Local)
+            .format("%Y-%m-%d %H:%M")
+            .to_string();
+        assert_eq!(format_timestamp(1_753_900_000), expected);
+    }
+
+    #[test]
+    fn out_of_range_timestamp_degrades_to_the_raw_value() {
+        assert_eq!(format_timestamp(u64::MAX), format!("unix {}", u64::MAX));
+    }
+
+    #[test]
+    fn paint_is_a_no_op_without_colour() {
+        assert_eq!(paint("  (conflict)", "\x1b[31m", false), "  (conflict)");
+        assert_eq!(
+            paint("  (conflict)", "\x1b[31m", true),
+            "\x1b[31m  (conflict)\x1b[0m"
         );
     }
 }

--- a/crates/peppy/src/commands/repo/list.rs
+++ b/crates/peppy/src/commands/repo/list.rs
@@ -100,7 +100,10 @@ fn print_repo_header(repo: &RepoListRepoEntry, node_count: usize, colorize: bool
         println!(
             "{}",
             paint(
-                &format!("  last refresh failed ({}): {}", failure.kind, failure.detail),
+                &format!(
+                    "  last refresh failed ({}): {}",
+                    failure.kind, failure.detail
+                ),
                 "\x1b[31m",
                 colorize,
             )
@@ -108,11 +111,7 @@ fn print_repo_header(repo: &RepoListRepoEntry, node_count: usize, colorize: bool
     }
 }
 
-fn print_nodes(
-    nodes: &[&RepoListNodeEntry],
-    winner: &HashMap<(&str, &str), &str>,
-    colorize: bool,
-) {
+fn print_nodes(nodes: &[&RepoListNodeEntry], winner: &HashMap<(&str, &str), &str>, colorize: bool) {
     let max_name_len = nodes.iter().map(|n| n.node_name.len()).max().unwrap_or(0);
     let max_tag_len = nodes.iter().map(|n| n.node_tag.len()).max().unwrap_or(0);
 
@@ -128,11 +127,7 @@ fn print_nodes(
                 .get(&(node.node_name.as_str(), node.node_tag.as_str()))
                 .copied()
                 .unwrap_or("a higher-priority repository");
-            paint(
-                &format!("  (shadowed by {by})"),
-                "\x1b[38;5;208m",
-                colorize,
-            )
+            paint(&format!("  (shadowed by {by})"), "\x1b[38;5;208m", colorize)
         } else {
             String::new()
         };

--- a/crates/peppy/src/commands/repo/remove.rs
+++ b/crates/peppy/src/commands/repo/remove.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use core_node_api::encoding::RepoRemoveRequest;
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::commands::CALLER_INSTANCE_ID;
 use crate::context::AppContext;
@@ -34,6 +34,11 @@ async fn remove_repo_async(ctx: &Arc<AppContext>, id: u64) -> Result<()> {
 
     if response.success {
         info!("Repository with id {id} removed successfully");
+        // The removal landed, but the re-index that makes it take effect
+        // may not have.
+        if !response.refresh_report.is_empty() {
+            warn!("Re-indexing after the removal: {}", response.refresh_report);
+        }
         Ok(())
     } else {
         Err(Error::ExecutionFailed(format!(

--- a/docs/src/content/docs/advanced_guides/repositories.mdx
+++ b/docs/src/content/docs/advanced_guides/repositories.mdx
@@ -33,6 +33,7 @@ Repository configuration lives in `~/.peppy/conf/`, and the indexes built by `pe
 | `cache/launchers.json5` | Index of launch files discovered across repositories |
 | `cache/contracts.json5` | Index of contract definitions discovered across repositories |
 | `cache/pairings.json5` | Index of pairing definitions discovered across repositories |
+| `cache/repo_status.json5` | Per-repository read status: when each one was last read successfully, and how its most recent read failed |
 
 The two `conf/` files are JSON5 arrays. Each entry has an `id` (auto-assigned if missing), a `type`, and source-specific fields:
 
@@ -69,7 +70,16 @@ Syncs `repositories.json5` with the bundled default template. If the file does n
 peppy repo list
 ```
 
-Shows all discovered nodes grouped by the repository that provides them. Each group is headed by the repository's display label (path for `fs`, `url (ref: r)` for `git`) followed by the node count and source kind, then lists each node's name, tag, and path. Duplicate nodes (same `name:tag` provided by multiple repositories) are flagged so you can see which repository currently wins resolution.
+Shows the indexed nodes grouped by the repository that provides them. Each group is headed by the repository's display label (path for `fs`, `url (ref: r)` for `git`) followed by the node count and source kind, then lists each node's name, tag, and path.
+
+The list reflects the index, not the filesystem, so it shows what will actually resolve at launch. A node added to a local repository since the last refresh does not appear until you run `peppy repo refresh` — which is also when it becomes launchable.
+
+Two different situations are flagged, and they mean opposite things:
+
+- `(shadowed by <repository>)` — another repository with a lower `id` provides the same `name:tag`. This resolves deterministically to the named repository; the shadowed entry is recorded and inspectable but not used. A supported arrangement, not a problem.
+- `(conflict: claimed twice here)` — **one** repository claims this `name:tag` more than once. There is no priority rule that can settle this, so the identity does not resolve at all. `peppy repo refresh` refuses a repository in this state, so seeing it here means the index predates that check; re-running `peppy repo refresh` will report the offending files.
+
+A repository whose last refresh failed is marked `[retained, last read <date>]`, with the reason on the following line. Its entries are the ones it last published successfully, so anything referencing them keeps working; the date tells you how old they are.
 
 ### Refresh the index
 
@@ -84,11 +94,42 @@ Re-scans all configured repositories and rebuilds the node, launcher, contract, 
 - Walks local directories and shallow-clones git repositories.
 - Records every `peppy.json5` as a node, every `.json5` file whose body declares `peppy_schema: "launcher/v1"` as a launcher (file stem becomes the launcher name), every `.json5` file whose body declares `peppy_schema: "contract/v1"` as a contract (keyed by the `name:tag` in its manifest), and every `.json5` file whose body declares `peppy_schema: "pairing/v1"` as a pairing (also keyed by its manifest `name:tag`).
 - Reports each discovered node, launcher, contract, pairing, and excluded repository in real time.
-- Caches results in `~/.peppy/cache/nodes.json5`, `~/.peppy/cache/launchers.json5`, `~/.peppy/cache/contracts.json5`, and `~/.peppy/cache/pairings.json5`.
+- Caches results in `~/.peppy/cache/nodes.json5`, `~/.peppy/cache/launchers.json5`, `~/.peppy/cache/contracts.json5`, and `~/.peppy/cache/pairings.json5`, and records per-repository read status in `~/.peppy/cache/repo_status.json5`.
 
 On completion it prints a summary, for example `Repository refresh complete. 12 node(s), 3 launcher(s), 5 contract(s), 2 pairing(s) found.`
 
-When multiple repositories provide the same `name:tag` pair, the repository with the lower `id` takes priority. The duplicate is still recorded and shown in `repo list` but does not override the primary source.
+When **multiple repositories** provide the same `name:tag` pair, the repository with the lower `id` takes priority. The shadowed entry is still recorded and shown in `repo list` but does not override the primary source.
+
+When **one repository** provides the same `name:tag` twice, there is no winner to pick. That repository fails its refresh; see [When a repository fails](#when-a-repository-fails) below.
+
+### When a repository fails
+
+A failure is scoped to the repository that caused it. The repositories that read cleanly are indexed as usual, so a problem in one hub never blocks picking up changes from the others.
+
+A repository that fails **keeps the entries it last published**. Nothing disappears out from under a launcher that references it, and the machine keeps launching everything it could launch before. `peppy repo list` marks those entries as retained, with the date they were read.
+
+The run itself still fails, and names every repository that failed in one message, so you fix everything after one run rather than running repeatedly:
+
+```text
+2 of the configured repositories could not be updated. Every other repository was updated normally.
+  - repository 1000 (https://github.com/Peppy-bot/nodes-hub.git (ref: main)) contradicts itself [conflict]: 2 node manifests claim `uvc_camera_video_reconstruction:v1`: uvc_camera_video_reconstruction/python/peppy.json5, uvc_camera_video_reconstruction/rust/peppy.json5. Kept 18 entries from its last successful read
+  - repository 1002 (https://github.com/Peppy-bot/contracts-hub.git (ref: main)) could not be read [unreachable]: failed to connect to github.com. Kept 8 entries from its last successful read
+```
+
+Two kinds of failure are reported, and the distinction matters because they send you to different places:
+
+| Kind | Meaning | Typical cause |
+| --- | --- | --- |
+| `unreachable` | The repository could not be read at all. | Network outage, a bad git ref, a local path that is not mounted, an unrecognized entry in `repositories.json5`. |
+| `conflict` | The repository was read fine, but its contents contradict themselves: one identity is claimed by more than one manifest. | Two `peppy.json5` files declaring the same `name:tag`, or two launcher files with the same filename. |
+
+An `unreachable` repository is an outage, so the fix is usually to wait or fix connectivity. A `conflict` is a content bug in the repository, and the message names the exact files, so the fix is a change to that repository.
+
+The report is ordered by repository `id` and never inherits the filesystem's directory order, so two machines seeing the same problem report it identically.
+
+:::caution
+A machine that has **never** read a repository successfully has nothing to fall back to. Containment gets it every other repository, but a broken repository gives it nothing, and excluding a repository is the only local lever — it removes every identity that repository provides, not just the offending one. The real fix for a broken shared repository is to stop it being published broken.
+:::
 
 ### Add a repository
 
@@ -150,6 +191,19 @@ peppy node add uvc_camera:v1
 ```
 
 This is the shortest form of `peppy node add`. It works for any node provided by any repository listed in `repositories.json5`, including the default [nodes-hub](https://github.com/Peppy-bot/nodes-hub.git) community repository. When several repositories provide the same `name:tag`, the [resolution rule from `repo refresh`](#refresh-the-index) applies: the repository with the lower `id` wins.
+
+Resolving a `name:tag` has three outcomes, not two:
+
+- **Resolved.** Exactly one repository wins, either because it is the only one providing the identity or because it has the lowest `id`.
+- **Not found.** No repository provides it. The error names the cache file it looked in, and if you have excluded any repositories it says so, since an excluded repository is never indexed and may well have been the one that provided it.
+- **Ambiguous.** The winning repository claims the identity more than once. This is a distinct error naming both files, never a "not found" — reporting it as missing would send you to add a node that is already there twice:
+
+  ```text
+  2 node entries in repository 1000 claim `uvc_camera_video_reconstruction:v1`:
+  uvc_camera_video_reconstruction/python/peppy.json5,
+  uvc_camera_video_reconstruction/rust/peppy.json5;
+  fix the repository so one manifest claims it, then run `peppy repo refresh`
+  ```
 
 One constraint applies to this source shape:
 

--- a/docs/src/content/docs/guides/launch_files.mdx
+++ b/docs/src/content/docs/guides/launch_files.mdx
@@ -47,7 +47,9 @@ The `source` attribute supports four formats:
  - **Repository**: Reference a node that is already registered in your user repositories. Specify `name` and `tag`, or use the combined `name: "<name>:<tag>"` shorthand. The node is resolved against your local nodes cache at `~/.peppy/cache/nodes.json5`.
 
 :::note
-The repository source resolves nodes from a locally cached index. Run `peppy repo refresh` before launching to ensure the cache is up to date. If a node or tag is missing from the cache, the launch will fail with a "not found" error.
+The repository source resolves nodes from a locally cached index. Run `peppy repo refresh` before launching to ensure the cache is up to date.
+
+If a node or tag is missing from the cache, the launch fails with a "not found" error. If the cache instead contains the same `name:tag` **twice from one repository**, the launch fails with a distinct ambiguity error naming both manifests — never "not found", since the node is present rather than absent. The refusal happens while sources are being resolved, before anything is added, built, or run, and it covers transitive dependencies too: an ambiguity two levels down is exactly as fatal as one at the top. See [Using a repository-indexed node](/advanced_guides/repositories/#using-a-repository-indexed-node).
 :::
 
 ```json5
@@ -103,7 +105,9 @@ Launchers discovered by `peppy repo refresh` (see [Repositories](/advanced_guide
 peppy stack launch openarm01_sim_teleop
 ```
 
-An argument that contains a path separator or ends in `.json5` is always resolved as a filesystem path. A bare name (no separator, no extension) is first tried on disk as `<name>.json5` next to your current directory, and only falls back to the repository cache at `~/.peppy/cache/launchers.json5` when no such file exists. Run `peppy repo refresh` first to ensure the launcher cache is populated. If the name resolves neither to a file nor to a cached launcher, the launch fails with an explicit "not found" error.
+An argument that contains a path separator or ends in `.json5` is always resolved as a filesystem path. A bare name (no separator, no extension) is first tried on disk as `<name>.json5` next to your current directory, and only falls back to the repository cache at `~/.peppy/cache/launchers.json5` when no such file exists. Run `peppy repo refresh` first to ensure the launcher cache is populated.
+
+If the name resolves neither to a file nor to a cached launcher, the launch fails with an explicit "not found" error. If one repository provides two launcher files with that name, the launch fails with a distinct ambiguity error naming both — launchers are keyed by filename, so two identically named `.json5` files anywhere in one repository contest the same name even in different directories.
 
 :::caution
 Running the `peppy stack launch` command clears the existing node stack and stops all running instances

--- a/docs/src/content/docs/reference/faq.mdx
+++ b/docs/src/content/docs/reference/faq.mdx
@@ -48,6 +48,30 @@ This dashboard will also allow you to "vibecode" robot environements.
 </details>
 
 <details>
+<summary>My launch failed with an error that looks unrelated to what I changed. Where do I start?</summary>
+
+Check `peppy repo list` first, before reading the error too literally.
+
+Peppy's default repositories track a moving branch, so a change merged upstream reaches your machine on the next `peppy repo refresh` without a Peppy release. If a repository ends up declaring the same `name:tag` twice, that identity has no defensible answer, and the symptom can surface far from the cause: two machines in one federated launch may each have resolved a different node, and the launch then fails much later with something like a pairing-slot mismatch between two nodes that were never meant to be in the same graph.
+
+Peppy refuses such an identity up front rather than picking one, naming both manifests. `peppy repo list` marks the offending entries `(conflict: claimed twice here)`, and `peppy repo refresh` reports the exact files. See [When a repository fails](/advanced_guides/repositories/#when-a-repository-fails).
+
+</details>
+
+<details>
+<summary>Why did <code>peppy repo refresh</code> start failing, and can I still work?</summary>
+
+Yes, you can almost certainly still work. A refresh failure is scoped to the repository that caused it: every other repository is indexed as usual, and the failing one **keeps the entries it last published**, so everything that launched before still launches. The run reports failure so you know the state is not current, and names every repository that failed in one message.
+
+Read the failure kind. `unreachable` means the repository could not be read at all (network, a bad ref, an unmounted path) and is usually an outage to wait out. `conflict` means it was read fine but its contents contradict themselves, and the message names the files to fix.
+
+`peppy repo list` marks a failing repository's entries `[retained, last read <date>]`. Watch that date: retention is deliberate so that identities do not vanish out from under your launchers, but a repository failing for weeks is still serving weeks-old entries.
+
+The one case with no local workaround is a machine that has never read that repository successfully — it has nothing to fall back to. Excluding the repository is the only lever, and it removes every identity that repository provides, not just the broken one.
+
+</details>
+
+<details>
 <summary>Is there an LLM-friendly version of the documentation?</summary>
 
 Yes! LLM-optimized versions of the documentation are available at [`/llms.txt`](/llms.txt) (index with links) and [`/llms-full.txt`](/llms-full.txt) (full content). Those are always in sync with the latest version of the documentation.


### PR DESCRIPTION
> **Merge order:** depends on Peppy-bot/public-peppy-libs#74. This branch follows `public-peppy-libs` at `main` and will not compile until that lands and `cargo update -p core-node-api` bumps the lock here.

Every repository peppy ships by default tracks a moving branch, so any defect in a shared repository is a fleet-wide defect. Failure handling amplified that.

## Guessing instead of reporting

When a repository's scan met an identity it had already seen **in that same repository**, it discarded the later one silently — no warning, no error, and nothing left in the cache to notice afterwards. Which claimant survived was filesystem walk order, so it could differ between a laptop and a robot.

That is live today: `uvc_camera_video_reconstruction:v1` is declared under both `rust/` and `python/` in nodes-hub. The resulting wrong answer does not fail where it is made; it fails much later as a pairing-slot mismatch describing two nodes that were never meant to be in one graph.

Now:

```
2 node manifests in repository 1000 claim `uvc_camera_video_reconstruction:v1`:
uvc_camera_video_reconstruction/python/peppy.json5,
uvc_camera_video_reconstruction/rust/peppy.json5
```

Ambiguity is a **distinct refusal from "not found"** — reporting an identity as missing when it is present twice sends the user to add a node that is already there twice. `lookup_repo_entry` returning a `Result` is what forces every call site to handle it, so the whole dependency closure is covered rather than just the identity named. Cross-repository shadowing is untouched and still resolves by the documented lower-id-wins rule.

## Containing the blast radius

A git clone failure used to be a `warn!` with the run still reporting success, while anything that did fail failed everything — so one bad hub blocked picking up changes from three healthy ones.

A repository that fails now keeps the entries it last published and is named in the report; every other repository updates normally. The caches are written even when the run fails, since that is the point. Unreachable and malformed both retain and both fail the run, but stay separately worded so an outage never reads as a content bug. Every problem is reported in one pass, ordered by repository id.

## Also in here

- **`lookup_repo_id` ignoring the git ref was a latent bug this surfaced.** Matching on url alone gave two entries for one url on different refs the same id, which the new ambiguity check would have refused as an in-repository conflict. One shared predicate now backs `repo_id` tagging, retention, and `repo list`.
- **New `cache/repo_status.json5`** records when each repository last read cleanly, so retained entries read as retained rather than a machine sitting on month-old bytes believing it is current. Timestamps are passed in, never read from the clock, so tests stay deterministic.
- **`repo list` reads the caches for every source kind.** It re-walked fs repositories live, which would have shown a failed repository's on-disk entries as though nothing were wrong. Behaviour change: a node added on disk since the last refresh no longer appears until you refresh — which is correct, since it cannot resolve either.
- A cache miss now names the excluded repositories, so an identity absent because its repository was excluded is attributable.
- `repo remove` / `repo exclude` return the re-index report instead of `warn!`-ing it into a log nobody reads.

## Test plan

`cargo test --locked` — full workspace green, 333 core-node unit tests plus the repo integration suites.

New coverage:
- Conflict detection per kind (node, launcher by file stem, contract, pairing), with report ordering asserted to be independent of walk order, and same-name-different-tag pinned as *not* a conflict.
- Ambiguity at the winning repo id only, so a tie at a *losing* id still resolves — the regression guard for shadowing.
- **The load-bearing containment test:** healthy repository picks up its change while the broken one keeps its previous entries and is the only one named.
- Unreachable vs conflict stay separate; a failing repository keeps its last clean read timestamp; a recovered repository clears its failure.
- `repo list` distinguishes conflict from shadowing, and reports retained entries with the reason.

## Not in this PR

- **Docs.** `repositories.mdx`, `launch_files.mdx` and `faq.mdx` still describe only the success path.
- **The nodes-hub content fix.** Until `uvc_camera_video_reconstruction:v1` stops being declared twice, a fresh machine gets nothing from nodes-hub — established machines keep their previous entries, but there is no per-identity escape hatch by design. I audited all four hubs; this is the only collision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Repository listings now show status, metadata, retention details, refresh failures, and empty repositories.
  - Added clear indicators for duplicate shadowing and conflicting nodes.
  - Repository refreshes retain healthy cached data when another repository fails.
  - Exclusion and removal operations report re-indexing issues without hiding successful changes.

- **Bug Fixes**
  - Ambiguous duplicate identities are now reported instead of selected arbitrarily.
  - Missing and ambiguous dependencies are distinguished with sorted, actionable error details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->