### PR TITLE
Name a node that exists in the benchmark render fixture

### DIFF
--- a/crates/peppy/src/commands/stack/benchmark.rs
+++ b/crates/peppy/src/commands/stack/benchmark.rs
@@ -494,7 +494,7 @@ mod tests {
                 None,
             ),
             row(
-                "uvc_camera_video_reconstruction",
+                "uvc_camera_video_reconstruction_rust",
                 "uvc_camera_python_mock",
                 "video_stream",
                 "camera",
@@ -516,7 +516,7 @@ mod tests {
                 Some("payload 64B → 4.0KB (rebuild producer for sized replies)"),
             ),
             row(
-                "uvc_camera_video_reconstruction",
+                "uvc_camera_video_reconstruction_rust",
                 "uvc_camera_python_mock",
                 "video_stream",
                 "camera",
@@ -549,7 +549,7 @@ mod tests {
         let contract_edge = edge_cell(&rows[1], false);
         assert_eq!(
             contract_edge,
-            "uvc_camera_video_reconstruction:v1\n➔ uvc_camera_python_mock:v1\n  /video_stream"
+            "uvc_camera_video_reconstruction_rust:v1\n➔ uvc_camera_python_mock:v1\n  /video_stream"
         );
     }
 


### PR DESCRIPTION
## Summary

Follow-up to Peppy-bot/nodes-hub#41, which splits the single `uvc_camera_video_reconstruction:v1` identity into `uvc_camera_video_reconstruction_rust:v1` and `uvc_camera_video_reconstruction_python:v1`.

`sample_rows()` in the `stack benchmark` render tests referenced the old shared name, which no longer exists in `nodes-hub`. The fixture now names the Rust variant, so it keeps describing a real node.

This is fixture text only. `edge_cell` formats a fixed three-line cell (`from`, arrow + `to`, indented interface) and does not wrap on width, so the longer name only changes the expected string in `edge_cell_wraps_onto_three_lines_with_kind_arrow`. No production code path reads this name.

## Test plan

`cargo test -p peppy --lib benchmark`, all 6 tests pass:

```
test commands::stack::benchmark::tests::edge_cell_wraps_onto_three_lines_with_kind_arrow ... ok
test commands::stack::benchmark::tests::legend_color_key_stays_aligned_and_plain_when_uncolored ... ok
test commands::stack::benchmark::tests::rows_partition_into_synthetic_and_real_tables ... ok
test commands::stack::benchmark::tests::note_names_interface_and_wraps_long_payload_note ... ok
test commands::stack::benchmark::tests::synthetic_table_shows_measure_and_real_table_shows_clock ... ok
test commands::stack::benchmark::tests::both_tables_render_boxes_and_stay_narrow ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 192 filtered out
```

The two box-rendering tests (`both_tables_render_boxes_and_stay_narrow`, `synthetic_table_shows_measure_and_real_table_shows_clock`) consume the same fixture and confirm the wider name still lays out.