### PR TITLE
Add the repository index and `peppy repo index`, the tooling half

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,7 +573,7 @@ dependencies = [
 [[package]]
 name = "build-helpers"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#679cdf8ba810940e104d69992029887287153c8c"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#d2afb2af63ef7e9c845498b801744be3d70c9099"
 dependencies = [
  "sha2",
 ]
@@ -765,7 +765,7 @@ dependencies = [
 [[package]]
 name = "config-test-support"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#679cdf8ba810940e104d69992029887287153c8c"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#d2afb2af63ef7e9c845498b801744be3d70c9099"
 dependencies = [
  "askama",
  "git2",
@@ -909,7 +909,7 @@ dependencies = [
 [[package]]
 name = "core-node-api"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#679cdf8ba810940e104d69992029887287153c8c"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#d2afb2af63ef7e9c845498b801744be3d70c9099"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -1248,7 +1248,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1396,7 +1396,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2581,7 +2581,7 @@ dependencies = [
 [[package]]
 name = "json5-pretty"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#679cdf8ba810940e104d69992029887287153c8c"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#d2afb2af63ef7e9c845498b801744be3d70c9099"
 dependencies = [
  "serde",
  "serde_json",
@@ -2985,7 +2985,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3371,7 +3371,7 @@ dependencies = [
 [[package]]
 name = "peppy-config-model"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#679cdf8ba810940e104d69992029887287153c8c"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#d2afb2af63ef7e9c845498b801744be3d70c9099"
 dependencies = [
  "capnp",
  "clap",
@@ -3394,7 +3394,7 @@ version = "0.0.1"
 [[package]]
 name = "peppylib-rs"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#679cdf8ba810940e104d69992029887287153c8c"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#d2afb2af63ef7e9c845498b801744be3d70c9099"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -3589,7 +3589,7 @@ dependencies = [
 [[package]]
 name = "pmi"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#679cdf8ba810940e104d69992029887287153c8c"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#d2afb2af63ef7e9c845498b801744be3d70c9099"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -3807,7 +3807,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.5",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4057,7 +4057,7 @@ dependencies = [
  "pin-project-lite",
  "rustls",
  "rustls-pki-types",
- "rustls-platform-verifier 0.7.0",
+ "rustls-platform-verifier 0.6.2",
  "serde",
  "serde_json",
  "sync_wrapper",
@@ -4243,7 +4243,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4311,7 +4311,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4332,7 +4332,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4708,7 +4708,7 @@ version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
 dependencies = [
- "dirs 6.0.0",
+ "dirs 4.0.0",
 ]
 
 [[package]]
@@ -5044,7 +5044,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5947,7 +5947,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Claude.md
+++ b/Claude.md
@@ -10,10 +10,12 @@
 - I err on the side of handling more edge cases, not fewer; thoughtfulness > speed.
 - Bias toward explicit over clever (the code must stay human readable with meaningful function names).
 - Do not leave legacy code behind or code that is meant to support previous version of the code.
+- Documentation and code comments describe the code exactly as it is today, nothing else. Never refer to a previous state of the code (what it used to do, what changed, migration notes) and never announce a future one ("a future release will", "breaking change ahead", "not yet implemented"). If a behaviour does not exist in the code you are documenting, it does not appear in the docs; when it lands, the docs are rewritten in the present tense as if it had always been that way.
 - When you write comments or documentation, stop using em-dash `—`, this is a recurring pattern that you make and immediately jumps at users as being your coding style.
 - Push back hard against design implementation that you think are fundamentally wrong and explain your reasoning
 - Never merge PRs in the remote repository without my consent
 - When tests are written, never make them time-based, they should be deterministic and should not depend on the speed of the host
+
 ---
 
 ## Workflow and interaction style

--- a/crates/core-node-internal/src/lib.rs
+++ b/crates/core-node-internal/src/lib.rs
@@ -11,6 +11,10 @@ pub use services::repo::cache::{
     contracts_repo_cache_path, launchers_repo_cache_path, nodes_repo_cache_path,
     pairings_repo_cache_path, repositories_list_path,
 };
+pub use services::repo::index::{
+    IndexDrift, IndexError, RepoConflict, check_repository_index, generate_repository_index,
+    read_repository_index, write_repository_index,
+};
 pub use services::repo::{InitOutcome, ensure_default_repos};
 pub use services::{
     CoreNode, CoreNodeArguments, CoreNodeConfig, NAME_CLAIM_LINKED_SETTLE, TEARDOWN_REAP_BUDGET,

--- a/crates/core-node-internal/src/services/repo.rs
+++ b/crates/core-node-internal/src/services/repo.rs
@@ -18,7 +18,7 @@ pub use remove::listen_for_repo_remove;
 use core_node_api::encoding::{RepoSource, RepoSourceKind};
 use serde_json::Value;
 use std::collections::HashSet;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 /// Guards read-modify-write cycles on repositories.json5 and
 /// excluded_repositories.json5 to prevent concurrent corruption.
@@ -125,7 +125,8 @@ pub(crate) fn json_entry_identity(entry: &Value) -> Option<String> {
 /// `repo_id` tagging at load time, retention of a failed repository's
 /// previous entries, and `repo list` grouping cannot drift apart.
 ///
-/// - `fs`: the entry's path lies inside the repository's directory.
+/// - `fs`: the entry's path lies inside the repository's directory, tested in
+///   canonical form so a root spelled through a symlink still matches.
 /// - `git`: the url matches, and a non-empty pinned `ref` must equal the
 ///   entry's `resolved_ref`. An unpinned repository matches any ref,
 ///   since whatever branch was checked out did come from it. The ref
@@ -148,7 +149,7 @@ pub(crate) fn entry_belongs_to_repo(
         RepoSourceKind::Fs if typ == "fs" => repo
             .get("path")
             .and_then(|v| v.as_str())
-            .is_some_and(|p| Path::new(path).starts_with(Path::new(p))),
+            .is_some_and(|root| entry_is_within_fs_root(path, root)),
         RepoSourceKind::Git if typ == "git" => {
             repo_url == source_uri
                 && match repo.get("ref").and_then(|v| v.as_str()) {
@@ -159,6 +160,24 @@ pub(crate) fn entry_belongs_to_repo(
         RepoSourceKind::Url if typ == "url" => repo_url == source_uri,
         _ => false,
     }
+}
+
+/// Whether a cache entry stored at `entry_path` sits inside the fs repository
+/// rooted at `configured_root`.
+///
+/// The walk stores entry paths canonicalized: it resolves the root with
+/// `std::fs::canonicalize` before emitting them, so on macOS an entry under a
+/// `/var/...` temp or symlinked directory is spelled `/private/var/...`. The
+/// configured root arrives from `repositories.json5` exactly as the user wrote
+/// it, so it is canonicalized here too before the containment test; without
+/// this the two never share a prefix on such a directory and every entry looks
+/// unowned. A root that cannot be resolved (removed, or momentarily
+/// unreachable) falls back to its written spelling, which still matches on
+/// platforms that do not put the tree behind a symlink.
+fn entry_is_within_fs_root(entry_path: &str, configured_root: &str) -> bool {
+    let root =
+        std::fs::canonicalize(configured_root).unwrap_or_else(|_| PathBuf::from(configured_root));
+    Path::new(entry_path).starts_with(root)
 }
 
 /// Id of the repository that owns this cache entry: the first match in
@@ -418,6 +437,41 @@ mod tests {
             None,
             "/home/user/elsewhere/arm/peppy.json5"
         ));
+    }
+
+    /// A repository configured through a symlinked root still owns the entries
+    /// discovered under it. The walk stores canonicalized entry paths, so the
+    /// configured root has to be canonicalized before the containment test or
+    /// the two never share a prefix. macOS hits this because a `/var` temp dir
+    /// is really `/private/var`; the test creates its own symlink so the case
+    /// is exercised deterministically on every platform, not just where the
+    /// host's tmpdir happens to be symlinked.
+    #[cfg(unix)]
+    #[test]
+    fn fs_attribution_matches_through_a_symlinked_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        let base = std::fs::canonicalize(tmp.path()).unwrap();
+        let real_root = base.join("real");
+        std::fs::create_dir_all(real_root.join("arm")).unwrap();
+
+        let link_root = base.join("link");
+        std::os::unix::fs::symlink(&real_root, &link_root).unwrap();
+
+        // The entry path is canonical (what the walk emits); the configured
+        // root is the symlink spelling (what the user wrote).
+        let entry = real_root.join("arm/peppy.json5");
+        let repo = serde_json::json!({ "type": "fs", "path": link_root.to_str().unwrap() });
+
+        assert!(
+            entry_belongs_to_repo(
+                &repo,
+                RepoSourceKind::Fs,
+                None,
+                None,
+                entry.to_str().unwrap()
+            ),
+            "an entry under the symlink target belongs to the repo configured by the symlink path"
+        );
     }
 
     /// Source kinds never cross-attribute, even when the other fields

--- a/crates/core-node-internal/src/services/repo.rs
+++ b/crates/core-node-internal/src/services/repo.rs
@@ -1,6 +1,7 @@
 mod add;
 pub(crate) mod cache;
 mod exclude;
+pub(crate) mod index;
 mod init;
 mod list;
 mod refresh;

--- a/crates/core-node-internal/src/services/repo/cache.rs
+++ b/crates/core-node-internal/src/services/repo/cache.rs
@@ -159,8 +159,20 @@ pub struct PairingCacheEntry {
     pub repo_id: u32,
 }
 
+/// One repository's items, split by kind. Whatever learned what the
+/// repository holds (walking its tree, or reading its index) hands back
+/// this shape, so the merge, retention and cache-writing below it are
+/// written once.
+#[derive(Debug, Default)]
+pub(crate) struct RepoItems {
+    pub nodes: Vec<NodeCacheEntry>,
+    pub launchers: Vec<LauncherCacheEntry>,
+    pub contracts: Vec<ContractCacheEntry>,
+    pub pairings: Vec<PairingCacheEntry>,
+}
+
 /// Kind-independent fields of a just-discovered cache entry, produced
-/// by the shared collector in `refresh.rs` and turned into a concrete
+/// by the shared collector in `index.rs` and turned into a concrete
 /// entry by [`RepoCacheEntry::from_discovered`]. `tag` is empty for
 /// untagged kinds (launchers).
 pub(crate) struct DiscoveredEntry {

--- a/crates/core-node-internal/src/services/repo/index.rs
+++ b/crates/core-node-internal/src/services/repo/index.rs
@@ -1,10 +1,12 @@
 //! Discovering what a repository publishes, and recording it in the
 //! repository's own index.
 //!
-//! The walk here is the authoring tool: `peppy repo index` runs it to
-//! produce a repository's `peppy_repository.json5`, which is what states the
-//! identities the repository publishes and where each is declared. Reading
-//! that file is what resolution uses; walking is what writes it.
+//! The walk here serves both readers of a repository. `peppy repo index`
+//! runs it to produce the repository's `peppy_repository.json5`, which
+//! states the identities the repository publishes and where each is
+//! declared, and `refresh.rs` runs it to build a machine's caches, so what
+//! a repository commits and what a machine caches come from one description
+//! of the tree.
 //!
 //! A given identity reaches [`WalkResult::items`] at most once per walk, but
 //! every claimant is recorded: an identity with several claimants comes back

--- a/crates/core-node-internal/src/services/repo/index.rs
+++ b/crates/core-node-internal/src/services/repo/index.rs
@@ -17,7 +17,6 @@ use crate::services::repo::cache::{
     ContractCacheEntry, DiscoveredEntry, LauncherCacheEntry, NodeCacheEntry, PairingCacheEntry,
     RepoCacheEntry, RepoItems,
 };
-use config::consts::NODE_CONFIG_FILE;
 use config::fingerprint::fingerprint_for_bytes;
 use config::node::NodeConfigParser;
 use config::schema::PeppySchema;
@@ -360,7 +359,8 @@ pub(crate) fn resolve_declared_item(
     let bytes = std::fs::read(&canonical).map_err(|e| format!("cannot be read: {e}"))?;
     let content = std::str::from_utf8(&bytes).map_err(|e| format!("is not valid UTF-8: {e}"))?;
 
-    let (name, tag) = declared_identity(item.kind, content, item.path.as_path())?;
+    let (name, tag) = identity_of(item.kind, content, item.path.as_path())
+        .map_err(|detail| format!("is not a {}: {detail}", item.kind))?;
     let expected_tag = item.tag.map(ItemTag::as_str).unwrap_or_default();
     if name != item.name.as_str() || tag != expected_tag {
         let found = format_identity(&name, &tag);
@@ -370,30 +370,38 @@ pub(crate) fn resolve_declared_item(
     Ok(bytes)
 }
 
-/// The identity a file declares, read with the parser for `kind`. A file
-/// that is not that kind at all is reported as such, which is what catches
-/// an item filed under the wrong section.
-fn declared_identity(
+/// The identity a document declares when read as `kind`: its `(name, tag)`,
+/// with an empty tag for a launcher.
+///
+/// The single place that maps a kind to its parser and pulls the identity out.
+/// Both the walk (discovering items) and [`resolve_declared_item`] (verifying
+/// a listed path still declares what it was filed under) go through it, so the
+/// two ways of learning what a file declares cannot disagree. `Err` carries why
+/// the file is not a usable `kind`: it does not parse as one, carries a
+/// `peppy_schema` that is not this kind's, or (for a launcher) has no usable
+/// file stem to take a name from.
+fn identity_of(
     kind: RepoItemKind,
     content: &str,
     path: &Path,
 ) -> std::result::Result<(String, String), String> {
-    let not_this_kind = |e: String| format!("is not a {kind}: {e}");
     match kind {
         RepoItemKind::Node => {
-            let parsed = NodeConfigParser::from_content(content)
-                .map_err(|e| not_this_kind(e.to_string()))?;
+            let parsed = NodeConfigParser::from_content(content).map_err(|e| e.to_string())?;
             Ok((
                 parsed.manifest.name.as_str().to_owned(),
                 parsed.manifest.tag.clone(),
             ))
         }
         RepoItemKind::Launcher => {
-            let parsed = PeppyLauncherParser::from_content(content)
-                .map_err(|e| not_this_kind(e.to_string()))?;
+            let parsed = PeppyLauncherParser::from_content(content).map_err(|e| e.to_string())?;
             if parsed.peppy_schema != PeppySchema::LauncherV1 {
-                return Err(not_this_kind("wrong schema tag".to_owned()));
+                return Err("wrong schema tag".to_owned());
             }
+            // Launcher name = basename without `.json5` (launcher documents
+            // carry no manifest name). This matches `resolve_launcher_path`,
+            // which appends `.json5` to a bare name when looking up a launcher
+            // file.
             let stem = path
                 .file_stem()
                 .and_then(|s| s.to_str())
@@ -402,16 +410,14 @@ fn declared_identity(
             Ok((stem.to_owned(), String::new()))
         }
         RepoItemKind::Contract => {
-            let parsed = PeppyContractParser::from_content(content)
-                .map_err(|e| not_this_kind(e.to_string()))?;
+            let parsed = PeppyContractParser::from_content(content).map_err(|e| e.to_string())?;
             Ok((
                 parsed.manifest.name.as_str().to_owned(),
                 parsed.manifest.tag.clone(),
             ))
         }
         RepoItemKind::Pairing => {
-            let parsed = PeppyPairingParser::from_content(content)
-                .map_err(|e| not_this_kind(e.to_string()))?;
+            let parsed = PeppyPairingParser::from_content(content).map_err(|e| e.to_string())?;
             Ok((
                 parsed.manifest.name.as_str().to_owned(),
                 parsed.manifest.tag.clone(),
@@ -509,10 +515,10 @@ fn identity_label(item: &DeclaredItem<'_>) -> String {
 /// Any directory whose path matches one of the `excluded_paths` entries is
 /// pruned from the walk (neither descended into nor scanned).
 ///
-/// Each `.json5` file is read once. Files named `peppy.json5` are tried as
-/// nodes first (preserving the filename-driven node convention); any
-/// `.json5` whose body declares a `peppy_schema` value is dispatched to the
-/// matching collector.
+/// Each `.json5` file is read once and dispatched by the `peppy_schema` value
+/// its body declares. A node manifest is required to declare `node/v1`, so the
+/// filename carries no special meaning here: a node in `peppy.json5` and a node
+/// in any other `.json5` are both found by the same schema dispatch.
 pub(crate) fn walk_directory(root: &Path, excluded_paths: &[PathBuf]) -> WalkResult {
     // Canonicalize the root so that paths emitted by the walker share a
     // common prefix representation with the excluded paths (which come from
@@ -554,7 +560,6 @@ pub(crate) fn walk_directory(root: &Path, excluded_paths: &[PathBuf]) -> WalkRes
     let mut items: Vec<WalkedItem> = Vec::new();
 
     for entry in walker.flatten() {
-        let file_name = entry.file_name().to_string_lossy();
         let config_path = entry.path();
         if !has_json5_extension(config_path) {
             continue;
@@ -576,33 +581,27 @@ pub(crate) fn walk_directory(root: &Path, excluded_paths: &[PathBuf]) -> WalkRes
             config_path,
             bytes: &bytes,
         };
-        if file_name == NODE_CONFIG_FILE {
-            // Try node parse first to preserve the documented filename
-            // convention for nodes. If the file's schema doesn't match,
-            // fall through to the launcher/contract dispatch; that
-            // way a non-node `peppy.json5` is still discoverable.
-            if collect_node_item(&ctx, &mut nodes_seen, &mut items) {
-                continue;
-            }
-        }
         let Some(schema) = peek_peppy_schema(&bytes) else {
             continue;
         };
         match schema {
             PeppySchema::NodeV1 => {
-                // A non-`peppy.json5` file declaring `node/v1` is unusual
-                // but we still parse it strictly: matches the documented
-                // "schema dispatch" rule for any `.json5`.
-                collect_node_item(&ctx, &mut nodes_seen, &mut items);
+                collect_item(&ctx, RepoItemKind::Node, &mut nodes_seen, &mut items)
             }
-            PeppySchema::LauncherV1 => {
-                collect_launcher_item(&ctx, &mut launchers_seen, &mut items);
-            }
-            PeppySchema::ContractV1 => {
-                collect_contract_item(&ctx, &mut contracts_seen, &mut items);
-            }
+            PeppySchema::LauncherV1 => collect_item(
+                &ctx,
+                RepoItemKind::Launcher,
+                &mut launchers_seen,
+                &mut items,
+            ),
+            PeppySchema::ContractV1 => collect_item(
+                &ctx,
+                RepoItemKind::Contract,
+                &mut contracts_seen,
+                &mut items,
+            ),
             PeppySchema::PairingV1 => {
-                collect_pairing_item(&ctx, &mut pairings_seen, &mut items);
+                collect_item(&ctx, RepoItemKind::Pairing, &mut pairings_seen, &mut items)
             }
             // The repository's own index declares no item. It is the
             // output of this walk, not an input to it.
@@ -651,35 +650,26 @@ struct EntryContext<'a> {
     bytes: &'a [u8],
 }
 
-/// Shared body of the four collectors: UTF-8 check, strict parse via
-/// `identity`, claim recording, then item construction. The strict parse
-/// catches structural problems (unknown fields, malformed sections) that
-/// the cheap schema peek can't.
+/// Reads one discovered `.json5` and, when it declares a usable identity of
+/// `kind`, records the claim and pushes the item.
 ///
-/// `identity` returns the document's `(name, tag)`, `Ok(None)` to skip the
-/// file silently (wrong schema variant, unusable file stem), or `Err` when
-/// the content does not parse as that document kind at all.
-/// `parse_failure_label` words that last case: a `peppy.json5` failing the
-/// node parse is usually a different document kind rather than a malformed
-/// node, so the node collector logs "non-node".
+/// Every claimant is recorded in `claims`, including the second and later ones
+/// that are not pushed to `out`; the caller turns identities with several
+/// claimants into [`RepoConflict`]s and refuses the whole repository. Which
+/// claimant reaches `out` is walk-order dependent and deliberately not relied
+/// upon.
 ///
-/// Every claimant is recorded in `claims`, including the second and later
-/// ones that are not pushed to `out`; the caller turns identities with
-/// several claimants into [`RepoConflict`]s and refuses the whole
-/// repository. Which claimant reaches `out` is walk-order dependent and
-/// deliberately not relied upon.
-///
-/// Returns `false` only on parse failure, so the node collector can fall
-/// back to schema dispatch; repeat claimants return `true` because the file
-/// is a valid document of the kind.
-fn collect_walked_item(
+/// A file that does not name a usable identity (non-UTF-8 bytes, a parse
+/// failure, a launcher with no usable stem) is skipped with a debug line
+/// rather than failing the walk: the strict parse in [`identity_of`] catches
+/// structural problems the cheap schema peek can't, and a repository is free
+/// to hold `.json5` files that declare nothing.
+fn collect_item(
     ctx: &EntryContext<'_>,
     kind: RepoItemKind,
-    parse_failure_label: &str,
     claims: &mut ClaimMap,
     out: &mut Vec<WalkedItem>,
-    identity: impl FnOnce(&str) -> std::result::Result<Option<(String, String)>, String>,
-) -> bool {
+) {
     let content = match std::str::from_utf8(ctx.bytes) {
         Ok(s) => s,
         Err(e) => {
@@ -689,20 +679,19 @@ fn collect_walked_item(
                 ctx.config_path.display(),
                 e
             );
-            return false;
+            return;
         }
     };
-    let (name, tag) = match identity(content) {
-        Ok(Some(identity)) => identity,
-        Ok(None) => return true,
+    let (name, tag) = match identity_of(kind, content, ctx.config_path) {
+        Ok(identity) => identity,
         Err(e) => {
             debug!(
                 "Skipping {} .json5 at {}: {}",
-                parse_failure_label,
+                kind,
                 ctx.config_path.display(),
                 e
             );
-            return false;
+            return;
         }
     };
 
@@ -714,7 +703,7 @@ fn collect_walked_item(
     let claimants = claims.entry((name.clone(), tag.clone())).or_default();
     claimants.push(relative_path.clone());
     if claimants.len() > 1 {
-        return true;
+        return;
     }
 
     out.push(WalkedItem {
@@ -725,96 +714,12 @@ fn collect_walked_item(
         absolute_path: ctx.config_path.to_path_buf(),
         sha256: fingerprint_for_bytes(ctx.bytes),
     });
-    true
-}
-
-/// Returns `true` when the file parsed cleanly as a node and its claim
-/// was recorded. `false` means parsing failed; the caller can fall back
-/// to a different schema dispatch.
-fn collect_node_item(
-    ctx: &EntryContext<'_>,
-    claims: &mut ClaimMap,
-    out: &mut Vec<WalkedItem>,
-) -> bool {
-    collect_walked_item(
-        ctx,
-        RepoItemKind::Node,
-        "non-node",
-        claims,
-        out,
-        |content| {
-            let parsed = NodeConfigParser::from_content(content).map_err(|e| e.to_string())?;
-            Ok(Some((
-                parsed.manifest.name.as_str().to_string(),
-                parsed.manifest.tag.clone(),
-            )))
-        },
-    )
-}
-
-fn collect_launcher_item(ctx: &EntryContext<'_>, claims: &mut ClaimMap, out: &mut Vec<WalkedItem>) {
-    collect_walked_item(
-        ctx,
-        RepoItemKind::Launcher,
-        "malformed launcher",
-        claims,
-        out,
-        |content| {
-            let parsed = PeppyLauncherParser::from_content(content).map_err(|e| e.to_string())?;
-            if parsed.peppy_schema != PeppySchema::LauncherV1 {
-                return Ok(None);
-            }
-            // Launcher name = basename without `.json5` (launcher documents
-            // carry no manifest name). This matches `resolve_launcher_path`,
-            // which appends `.json5` to a bare name when looking up a
-            // launcher file.
-            Ok(ctx
-                .config_path
-                .file_stem()
-                .and_then(|s| s.to_str())
-                .filter(|stem| !stem.is_empty())
-                .map(|stem| (stem.to_string(), String::new())))
-        },
-    );
-}
-
-fn collect_contract_item(ctx: &EntryContext<'_>, claims: &mut ClaimMap, out: &mut Vec<WalkedItem>) {
-    collect_walked_item(
-        ctx,
-        RepoItemKind::Contract,
-        "malformed contract",
-        claims,
-        out,
-        |content| {
-            let parsed = PeppyContractParser::from_content(content).map_err(|e| e.to_string())?;
-            Ok(Some((
-                parsed.manifest.name.as_str().to_string(),
-                parsed.manifest.tag.clone(),
-            )))
-        },
-    );
-}
-
-fn collect_pairing_item(ctx: &EntryContext<'_>, claims: &mut ClaimMap, out: &mut Vec<WalkedItem>) {
-    collect_walked_item(
-        ctx,
-        RepoItemKind::Pairing,
-        "malformed pairing",
-        claims,
-        out,
-        |content| {
-            let parsed = PeppyPairingParser::from_content(content).map_err(|e| e.to_string())?;
-            Ok(Some((
-                parsed.manifest.name.as_str().to_string(),
-                parsed.manifest.tag.clone(),
-            )))
-        },
-    );
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use config::consts::NODE_CONFIG_FILE;
 
     /// Helper: write a minimal valid node manifest under `dir`.
     fn write_node_json5(dir: &Path, name: &str, tag: &str) {

--- a/crates/core-node-internal/src/services/repo/index.rs
+++ b/crates/core-node-internal/src/services/repo/index.rs
@@ -1,0 +1,1502 @@
+//! Discovering what a repository publishes, and recording it in the
+//! repository's own index.
+//!
+//! The walk here is the authoring tool: `peppy repo index` runs it to
+//! produce a repository's `peppy_repository.json5`, which is what states the
+//! identities the repository publishes and where each is declared. Reading
+//! that file is what resolution uses; walking is what writes it.
+//!
+//! A given identity reaches [`WalkResult::items`] at most once per walk, but
+//! every claimant is recorded: an identity with several claimants comes back
+//! in [`WalkResult::conflicts`] so the caller refuses rather than silently
+//! promoting one of two answers. The cross-repository merge, where several
+//! repositories claiming one identity is a supported feature rather than a
+//! conflict, happens in `refresh.rs`.
+
+use crate::services::repo::cache::{
+    ContractCacheEntry, DiscoveredEntry, LauncherCacheEntry, NodeCacheEntry, PairingCacheEntry,
+    RepoCacheEntry, RepoItems,
+};
+use config::consts::NODE_CONFIG_FILE;
+use config::fingerprint::fingerprint_for_bytes;
+use config::node::NodeConfigParser;
+use config::schema::PeppySchema;
+use core_node_api::encoding::{RepoItemKind, RepoSourceKind};
+use daemon_config::contract::PeppyContractParser;
+use daemon_config::launcher::PeppyLauncherParser;
+use daemon_config::pairing::PeppyPairingParser;
+use daemon_config::repository::{
+    DeclaredItem, ItemName, ItemTag, PeppyRepositoryIndexParser, RepoRelativePath, RepositoryIndex,
+};
+use serde::Deserialize;
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use tracing::debug;
+
+/// Directory names that are never descended into while looking for the
+/// files that declare items.
+pub(crate) const PRUNED_DIR_NAMES: &[&str] = &[
+    ".git",
+    ".peppy",
+    "target",
+    "node_modules",
+    ".venv",
+    "__pycache__",
+];
+
+/// One item found in a repository: the identity it declares and where it is
+/// declared, plus the fingerprint of the bytes that declared it.
+///
+/// This is the seam between finding items and caching them. Both the walk
+/// and the index reader produce these, and [`build_cache_entries`] is the
+/// single place that turns them into cache entries, so the two ways of
+/// learning what a repository holds cannot drift in what they record.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct WalkedItem {
+    pub kind: RepoItemKind,
+    pub name: String,
+    /// Empty for launchers, matching the identity key the caches use.
+    pub tag: String,
+    /// Relative to the root of the scanned tree.
+    pub relative_path: String,
+    /// The same file, absolute on this machine.
+    pub absolute_path: PathBuf,
+    pub sha256: String,
+}
+
+/// Items found by walking one repository's working tree.
+pub(crate) struct WalkResult {
+    pub items: Vec<WalkedItem>,
+    /// Identities claimed by more than one manifest in this repository.
+    /// Non-empty means the repository has no defensible answer for those
+    /// identities, so the caller refuses it rather than picking one.
+    pub conflicts: Vec<RepoConflict>,
+}
+
+/// An identity claimed by several manifests inside one repository. There
+/// is no priority rule that can settle this: the repository states two
+/// different answers to the same question.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RepoConflict {
+    pub kind: RepoItemKind,
+    pub name: String,
+    /// Empty for untagged kinds (launchers).
+    pub tag: String,
+    /// Every claimant's path, sorted.
+    pub paths: Vec<String>,
+}
+
+impl RepoConflict {
+    /// `name:tag` label, or the bare name for untagged kinds.
+    fn display_id(&self) -> String {
+        if self.tag.is_empty() {
+            self.name.clone()
+        } else {
+            format!("{}:{}", self.name, self.tag)
+        }
+    }
+}
+
+impl std::fmt::Display for RepoConflict {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{} {} manifests claim `{}`: {}",
+            self.paths.len(),
+            self.kind,
+            self.display_id(),
+            self.paths.join(", ")
+        )
+    }
+}
+
+/// Every path that claimed a given `(name, tag)` during one repository
+/// walk, in the order the walker met them. Recording all of them (rather
+/// than remembering only that the identity was seen) is what lets a
+/// conflict name both files instead of silently keeping one.
+type ClaimMap = HashMap<(String, String), Vec<String>>;
+
+/// Turns one kind's claim map into the conflicts it holds: every identity
+/// with more than one claimant. Sorted by identity, with sorted paths, so
+/// the report never inherits the filesystem's walk order and stays
+/// comparable between machines.
+fn conflicts_from_claims(kind: RepoItemKind, claims: ClaimMap) -> Vec<RepoConflict> {
+    let mut conflicts: Vec<RepoConflict> = claims
+        .into_iter()
+        .filter(|(_, paths)| paths.len() > 1)
+        .map(|((name, tag), mut paths)| {
+            paths.sort();
+            RepoConflict {
+                kind,
+                name,
+                tag,
+                paths,
+            }
+        })
+        .collect();
+    conflicts.sort_by(|a, b| (&a.name, &a.tag).cmp(&(&b.name, &b.tag)));
+    conflicts
+}
+
+/// Turns found items into the four cache-entry vectors, attributing each to
+/// the source it came from.
+///
+/// Git entries record a repository-relative path because the checkout they
+/// resolve against is materialized per machine; fs entries record the
+/// absolute path, which is also what `entry_belongs_to_repo` matches a
+/// configured repository path against.
+pub(crate) fn build_cache_entries(
+    items: Vec<WalkedItem>,
+    source_type: RepoSourceKind,
+    source_uri: Option<&str>,
+    resolved_ref: Option<&str>,
+) -> RepoItems {
+    let mut built = RepoItems::default();
+    for item in items {
+        let path = if source_type == RepoSourceKind::Git {
+            item.relative_path
+        } else {
+            item.absolute_path.to_string_lossy().into_owned()
+        };
+        let discovered = DiscoveredEntry {
+            name: item.name,
+            tag: item.tag,
+            sha256: item.sha256,
+            path,
+            source_type,
+            source_uri: source_uri.map(str::to_owned),
+            resolved_ref: resolved_ref.map(str::to_owned),
+        };
+        match item.kind {
+            RepoItemKind::Node => built
+                .nodes
+                .push(NodeCacheEntry::from_discovered(discovered)),
+            RepoItemKind::Launcher => built
+                .launchers
+                .push(LauncherCacheEntry::from_discovered(discovered)),
+            RepoItemKind::Contract => built
+                .contracts
+                .push(ContractCacheEntry::from_discovered(discovered)),
+            RepoItemKind::Pairing => built
+                .pairings
+                .push(PairingCacheEntry::from_discovered(discovered)),
+        }
+    }
+    built
+}
+
+/// Why a repository's index could not be produced, read, or trusted.
+#[derive(Debug, thiserror::Error)]
+pub enum IndexError {
+    #[error("{path}: {source}")]
+    Io {
+        path: String,
+        source: std::io::Error,
+    },
+    #[error("{0}")]
+    Unreadable(String),
+    /// One identity claimed by several manifests. There is no index that
+    /// can state this repository's contents, so generation refuses rather
+    /// than writing one of the two answers.
+    #[error("{}", format_conflicts(.0))]
+    ContestedIdentity(Vec<RepoConflict>),
+    /// An item the index has no way to state, such as a tag the caches
+    /// could never key on. Refused at generation rather than skipped: a
+    /// silent skip would produce an index that `--check` calls correct
+    /// while the item is invisible to peppy.
+    #[error("{0}")]
+    Unrepresentable(String),
+}
+
+fn format_conflicts(conflicts: &[RepoConflict]) -> String {
+    conflicts
+        .iter()
+        .map(|conflict| conflict.to_string())
+        .collect::<Vec<_>>()
+        .join("; ")
+}
+
+/// How a committed index differs from the repository it describes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IndexDrift {
+    /// An item in the tree that the index does not publish. Left alone it
+    /// would simply be invisible, which is why the check exists.
+    Unlisted {
+        kind: RepoItemKind,
+        id: String,
+        path: String,
+    },
+    /// An entry naming something that is not the item it was filed under:
+    /// a missing file, a file of another kind, or one whose manifest
+    /// declares a different identity.
+    Unmatched {
+        kind: RepoItemKind,
+        id: String,
+        path: String,
+        detail: String,
+    },
+    /// The right identity, declared somewhere else than the index says.
+    Moved {
+        kind: RepoItemKind,
+        id: String,
+        listed: String,
+        found: String,
+    },
+}
+
+impl std::fmt::Display for IndexDrift {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            IndexDrift::Unlisted { kind, id, path } => write!(
+                f,
+                "{path} declares {kind} `{id}`, which is not listed in {}",
+                daemon_config::consts::REPOSITORY_INDEX_FILE
+            ),
+            IndexDrift::Unmatched {
+                kind,
+                id,
+                path,
+                detail,
+            } => write!(f, "{kind} `{id}` points at {path}, which {detail}"),
+            IndexDrift::Moved {
+                kind,
+                id,
+                listed,
+                found,
+            } => write!(
+                f,
+                "{kind} `{id}` is listed at {listed} but is declared at {found}"
+            ),
+        }
+    }
+}
+
+/// Walks `root` and produces the index it should contain.
+pub fn generate_repository_index(root: &Path) -> Result<RepositoryIndex, IndexError> {
+    let walked = walk_directory(root, &[]);
+    if !walked.conflicts.is_empty() {
+        return Err(IndexError::ContestedIdentity(walked.conflicts));
+    }
+
+    let mut index = RepositoryIndex::default();
+    for item in walked.items {
+        let declared = declare_walked_item(&mut index, &item);
+        declared.map_err(|detail| {
+            IndexError::Unrepresentable(format!("{}: {detail}", item.relative_path))
+        })?;
+    }
+    Ok(index)
+}
+
+/// Records one walked item in `index`, converting the strings the walk
+/// produced into the validated identity the index is keyed on.
+fn declare_walked_item(
+    index: &mut RepositoryIndex,
+    item: &WalkedItem,
+) -> std::result::Result<(), String> {
+    let name = ItemName::parse(&item.name)?;
+    let tag = if item.kind == RepoItemKind::Launcher {
+        None
+    } else {
+        Some(ItemTag::parse(&item.tag)?)
+    };
+    let path = RepoRelativePath::parse(&item.relative_path).map_err(|e| e.to_string())?;
+    index.declare(item.kind, name, tag, path)
+}
+
+/// Writes `index` to `root`, replacing any existing one.
+pub fn write_repository_index(root: &Path, index: &RepositoryIndex) -> Result<(), IndexError> {
+    let path = root.join(daemon_config::consts::REPOSITORY_INDEX_FILE);
+    let content = json5_pretty::to_string_pretty(index)
+        .map_err(|e| IndexError::Unreadable(format!("failed to serialize the index: {e}")))?;
+    daemon_config::atomic_write::publish_atomic(&path, |tmp| {
+        std::fs::write(tmp, format!("{content}\n"))
+    })
+    .map_err(|source| IndexError::Io {
+        path: path.display().to_string(),
+        source,
+    })?;
+    Ok(())
+}
+
+/// Reads the index committed at `root`.
+pub fn read_repository_index(root: &Path) -> Result<RepositoryIndex, IndexError> {
+    let path = root.join(daemon_config::consts::REPOSITORY_INDEX_FILE);
+    PeppyRepositoryIndexParser::from_path(&path).map_err(|e| IndexError::Unreadable(e.to_string()))
+}
+
+/// Resolves one declared item against the tree at `root`, returning the
+/// bytes of the file that declares it.
+///
+/// `root` must already be canonical. The parse is not redundant with the
+/// index: the index states where an item is, the manifest states what it
+/// is. Without checking the two agree, a stale index would silently serve
+/// the wrong identity and a repository could file a README under `nodes`.
+pub(crate) fn resolve_declared_item(
+    root: &Path,
+    item: &DeclaredItem<'_>,
+) -> std::result::Result<Vec<u8>, String> {
+    let joined = root.join(item.path.as_path());
+    // Canonicalizing is the only way to catch a target reached through a
+    // symlink that leaves the tree: the walk never follows a symlinked
+    // directory, but reading a symlinked file does follow it.
+    let canonical = std::fs::canonicalize(&joined).map_err(|e| format!("cannot be read: {e}"))?;
+    if !canonical.starts_with(root) {
+        return Err(format!(
+            "resolves to {}, which is outside the repository",
+            canonical.display()
+        ));
+    }
+    if !canonical.is_file() {
+        return Err("is not a file".to_owned());
+    }
+    let bytes = std::fs::read(&canonical).map_err(|e| format!("cannot be read: {e}"))?;
+    let content = std::str::from_utf8(&bytes).map_err(|e| format!("is not valid UTF-8: {e}"))?;
+
+    let (name, tag) = declared_identity(item.kind, content, item.path.as_path())?;
+    let expected_tag = item.tag.map(ItemTag::as_str).unwrap_or_default();
+    if name != item.name.as_str() || tag != expected_tag {
+        let found = if tag.is_empty() {
+            name
+        } else {
+            format!("{name}:{tag}")
+        };
+        return Err(format!("declares `{found}`"));
+    }
+
+    Ok(bytes)
+}
+
+/// The identity a file declares, read with the parser for `kind`. A file
+/// that is not that kind at all is reported as such, which is what catches
+/// an item filed under the wrong section.
+fn declared_identity(
+    kind: RepoItemKind,
+    content: &str,
+    path: &Path,
+) -> std::result::Result<(String, String), String> {
+    let not_this_kind = |e: String| format!("is not a {kind}: {e}");
+    match kind {
+        RepoItemKind::Node => {
+            let parsed = NodeConfigParser::from_content(content)
+                .map_err(|e| not_this_kind(e.to_string()))?;
+            Ok((
+                parsed.manifest.name.as_str().to_owned(),
+                parsed.manifest.tag.clone(),
+            ))
+        }
+        RepoItemKind::Launcher => {
+            let parsed = PeppyLauncherParser::from_content(content)
+                .map_err(|e| not_this_kind(e.to_string()))?;
+            if parsed.peppy_schema != PeppySchema::LauncherV1 {
+                return Err(not_this_kind("wrong schema tag".to_owned()));
+            }
+            let stem = path
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .filter(|stem| !stem.is_empty())
+                .ok_or_else(|| "has no usable file stem".to_owned())?;
+            Ok((stem.to_owned(), String::new()))
+        }
+        RepoItemKind::Contract => {
+            let parsed = PeppyContractParser::from_content(content)
+                .map_err(|e| not_this_kind(e.to_string()))?;
+            Ok((
+                parsed.manifest.name.as_str().to_owned(),
+                parsed.manifest.tag.clone(),
+            ))
+        }
+        RepoItemKind::Pairing => {
+            let parsed = PeppyPairingParser::from_content(content)
+                .map_err(|e| not_this_kind(e.to_string()))?;
+            Ok((
+                parsed.manifest.name.as_str().to_owned(),
+                parsed.manifest.tag.clone(),
+            ))
+        }
+    }
+}
+
+/// Verifies the index committed at `root` against the repository itself.
+///
+/// Three steps, and all three are load-bearing. Parsing refuses a
+/// duplicated identity and a path that leaves the tree. Resolving proves
+/// every listed path is a real file inside the tree declaring what it was
+/// filed under, which is what catches a symlinked file pointing outside:
+/// the walk collects it and regeneration reproduces it, so comparing alone
+/// would pass while `repo refresh` refused the repository. Comparing
+/// against a fresh walk is what catches an item nobody listed.
+///
+/// An empty result means the index matches the repository.
+pub fn check_repository_index(root: &Path) -> Result<Vec<IndexDrift>, IndexError> {
+    let root = std::fs::canonicalize(root).map_err(|source| IndexError::Io {
+        path: root.display().to_string(),
+        source,
+    })?;
+    let committed = read_repository_index(&root)?;
+    let generated = generate_repository_index(&root)?;
+
+    let listed_paths: HashMap<(&str, String), &str> = committed
+        .declared_items()
+        .map(|item| {
+            (
+                (item.kind.as_str(), identity_label(&item)),
+                item.path.as_str(),
+            )
+        })
+        .collect();
+
+    let mut drifts = Vec::new();
+    let mut moved_identities = HashSet::new();
+    for item in generated.declared_items() {
+        let id = identity_label(&item);
+        let found = item.path.as_str().to_owned();
+        match listed_paths.get(&(item.kind.as_str(), id.clone())) {
+            None => drifts.push(IndexDrift::Unlisted {
+                kind: item.kind,
+                id,
+                path: found,
+            }),
+            Some(listed) if **listed != found => {
+                moved_identities.insert((item.kind.as_str(), id.clone()));
+                drifts.push(IndexDrift::Moved {
+                    kind: item.kind,
+                    id,
+                    listed: (*listed).to_owned(),
+                    found,
+                });
+            }
+            Some(_) => {}
+        }
+    }
+
+    for item in committed.declared_items() {
+        let id = identity_label(&item);
+        // An identity found somewhere else is already reported as moved,
+        // and the stale path failing to resolve is the same fact told
+        // twice.
+        if moved_identities.contains(&(item.kind.as_str(), id.clone())) {
+            continue;
+        }
+        if let Err(detail) = resolve_declared_item(&root, &item) {
+            drifts.push(IndexDrift::Unmatched {
+                kind: item.kind,
+                id,
+                path: item.path.as_str().to_owned(),
+                detail,
+            });
+        }
+    }
+
+    // Sorted by rendered text so the report is reproducible in a test and
+    // comparable between two machines.
+    drifts.sort_by_key(|drift| drift.to_string());
+    Ok(drifts)
+}
+
+fn identity_label(item: &DeclaredItem<'_>) -> String {
+    match item.tag {
+        Some(tag) => format!("{}:{tag}", item.name),
+        None => item.name.to_string(),
+    }
+}
+
+/// Walk a repository's working tree for the files that declare items.
+///
+/// Any directory whose path matches one of the `excluded_paths` entries is
+/// pruned from the walk (neither descended into nor scanned).
+///
+/// Each `.json5` file is read once. Files named `peppy.json5` are tried as
+/// nodes first (preserving the filename-driven node convention); any
+/// `.json5` whose body declares a `peppy_schema` value is dispatched to the
+/// matching collector.
+pub(crate) fn walk_directory(root: &Path, excluded_paths: &[PathBuf]) -> WalkResult {
+    // Canonicalize the root so that paths emitted by the walker share a
+    // common prefix representation with the excluded paths (which come from
+    // `ExclusionSet::load` already canonicalized). Without this, macOS
+    // `/var/...` symlinks break subdirectory exclusion: the walker emits
+    // `/var/...` while excluded paths resolve to `/private/var/...`.
+    let root = std::fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
+    let excluded = excluded_paths.to_vec();
+    let walker = ignore::WalkBuilder::new(&root)
+        .hidden(true)
+        // What a repository publishes must not depend on the machine doing
+        // the reading. A developer's global gitignore or a clone's
+        // `.git/info/exclude` are machine-local, so they are ignored here
+        // while the repository's own `.gitignore` and `.ignore` still
+        // apply. Without this, one contributor's git config could change
+        // the index they generate and commit.
+        .git_global(false)
+        .git_exclude(false)
+        .filter_entry(move |entry| {
+            if !entry.file_type().is_some_and(|ft| ft.is_dir()) {
+                return true;
+            }
+            if entry.depth() == 0 {
+                return true;
+            }
+            let name = entry.file_name().to_string_lossy();
+            if PRUNED_DIR_NAMES.iter().any(|pruned| name == *pruned) {
+                return false;
+            }
+            let entry_path = entry.path();
+            !excluded.iter().any(|exc| entry_path.starts_with(exc))
+        })
+        .build();
+
+    let mut nodes_seen = ClaimMap::new();
+    let mut launchers_seen = ClaimMap::new();
+    let mut contracts_seen = ClaimMap::new();
+    let mut pairings_seen = ClaimMap::new();
+    let mut items: Vec<WalkedItem> = Vec::new();
+
+    for entry in walker.flatten() {
+        let file_name = entry.file_name().to_string_lossy();
+        let config_path = entry.path();
+        if !has_json5_extension(config_path) {
+            continue;
+        }
+        let bytes = match std::fs::read(config_path) {
+            Ok(bytes) if !bytes.is_empty() => bytes,
+            Ok(_) => continue,
+            Err(e) => {
+                debug!(
+                    "Skipping unreadable .json5 at {}: {}",
+                    config_path.display(),
+                    e
+                );
+                continue;
+            }
+        };
+        let ctx = EntryContext {
+            root: &root,
+            config_path,
+            bytes: &bytes,
+        };
+        if file_name == NODE_CONFIG_FILE {
+            // Try node parse first to preserve the documented filename
+            // convention for nodes. If the file's schema doesn't match,
+            // fall through to the launcher/contract dispatch; that
+            // way a non-node `peppy.json5` is still discoverable.
+            if collect_node_item(&ctx, &mut nodes_seen, &mut items) {
+                continue;
+            }
+        }
+        let Some(schema) = peek_peppy_schema(&bytes) else {
+            continue;
+        };
+        match schema {
+            PeppySchema::NodeV1 => {
+                // A non-`peppy.json5` file declaring `node/v1` is unusual
+                // but we still parse it strictly: matches the documented
+                // "schema dispatch" rule for any `.json5`.
+                collect_node_item(&ctx, &mut nodes_seen, &mut items);
+            }
+            PeppySchema::LauncherV1 => {
+                collect_launcher_item(&ctx, &mut launchers_seen, &mut items);
+            }
+            PeppySchema::ContractV1 => {
+                collect_contract_item(&ctx, &mut contracts_seen, &mut items);
+            }
+            PeppySchema::PairingV1 => {
+                collect_pairing_item(&ctx, &mut pairings_seen, &mut items);
+            }
+            // The repository's own index declares no item. It is the
+            // output of this walk, not an input to it.
+            PeppySchema::RepositoryV1 => {}
+        }
+    }
+
+    let mut conflicts = conflicts_from_claims(RepoItemKind::Node, nodes_seen);
+    conflicts.extend(conflicts_from_claims(
+        RepoItemKind::Launcher,
+        launchers_seen,
+    ));
+    conflicts.extend(conflicts_from_claims(
+        RepoItemKind::Contract,
+        contracts_seen,
+    ));
+    conflicts.extend(conflicts_from_claims(RepoItemKind::Pairing, pairings_seen));
+
+    WalkResult { items, conflicts }
+}
+
+fn has_json5_extension(path: &Path) -> bool {
+    path.extension().is_some_and(|ext| ext == "json5")
+}
+
+/// Cheap schema sniff over the raw bytes. Returns `None` when the file
+/// either doesn't declare a `peppy_schema` field or declares one we
+/// don't know about; the caller treats both as "skip silently".
+fn peek_peppy_schema(bytes: &[u8]) -> Option<PeppySchema> {
+    #[derive(Deserialize)]
+    struct SchemaPeek {
+        peppy_schema: PeppySchema,
+    }
+    let content = std::str::from_utf8(bytes).ok()?;
+    serde_json5::from_str::<SchemaPeek>(content)
+        .ok()
+        .map(|p| p.peppy_schema)
+}
+
+/// File context shared by every collector. The collectors only need read
+/// access; bundling these arguments keeps their signatures focused on the
+/// entry-specific state (claim map + output vector).
+struct EntryContext<'a> {
+    root: &'a Path,
+    config_path: &'a Path,
+    bytes: &'a [u8],
+}
+
+/// Shared body of the four collectors: UTF-8 check, strict parse via
+/// `identity`, claim recording, then item construction. The strict parse
+/// catches structural problems (unknown fields, malformed sections) that
+/// the cheap schema peek can't.
+///
+/// `identity` returns the document's `(name, tag)`, `Ok(None)` to skip the
+/// file silently (wrong schema variant, unusable file stem), or `Err` when
+/// the content does not parse as that document kind at all.
+/// `parse_failure_label` words that last case: a `peppy.json5` failing the
+/// node parse is usually a different document kind rather than a malformed
+/// node, so the node collector logs "non-node".
+///
+/// Every claimant is recorded in `claims`, including the second and later
+/// ones that are not pushed to `out`; the caller turns identities with
+/// several claimants into [`RepoConflict`]s and refuses the whole
+/// repository. Which claimant reaches `out` is walk-order dependent and
+/// deliberately not relied upon.
+///
+/// Returns `false` only on parse failure, so the node collector can fall
+/// back to schema dispatch; repeat claimants return `true` because the file
+/// is a valid document of the kind.
+fn collect_walked_item(
+    ctx: &EntryContext<'_>,
+    kind: RepoItemKind,
+    parse_failure_label: &str,
+    claims: &mut ClaimMap,
+    out: &mut Vec<WalkedItem>,
+    identity: impl FnOnce(&str) -> std::result::Result<Option<(String, String)>, String>,
+) -> bool {
+    let content = match std::str::from_utf8(ctx.bytes) {
+        Ok(s) => s,
+        Err(e) => {
+            debug!(
+                "Skipping non-utf8 {} .json5 at {}: {}",
+                kind,
+                ctx.config_path.display(),
+                e
+            );
+            return false;
+        }
+    };
+    let (name, tag) = match identity(content) {
+        Ok(Some(identity)) => identity,
+        Ok(None) => return true,
+        Err(e) => {
+            debug!(
+                "Skipping {} .json5 at {}: {}",
+                parse_failure_label,
+                ctx.config_path.display(),
+                e
+            );
+            return false;
+        }
+    };
+
+    let relative_path = ctx
+        .config_path
+        .strip_prefix(ctx.root)
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    let claimants = claims.entry((name.clone(), tag.clone())).or_default();
+    claimants.push(relative_path.clone());
+    if claimants.len() > 1 {
+        return true;
+    }
+
+    out.push(WalkedItem {
+        kind,
+        name,
+        tag,
+        relative_path,
+        absolute_path: ctx.config_path.to_path_buf(),
+        sha256: fingerprint_for_bytes(ctx.bytes),
+    });
+    true
+}
+
+/// Returns `true` when the file parsed cleanly as a node and its claim
+/// was recorded. `false` means parsing failed; the caller can fall back
+/// to a different schema dispatch.
+fn collect_node_item(
+    ctx: &EntryContext<'_>,
+    claims: &mut ClaimMap,
+    out: &mut Vec<WalkedItem>,
+) -> bool {
+    collect_walked_item(
+        ctx,
+        RepoItemKind::Node,
+        "non-node",
+        claims,
+        out,
+        |content| {
+            let parsed = NodeConfigParser::from_content(content).map_err(|e| e.to_string())?;
+            Ok(Some((
+                parsed.manifest.name.as_str().to_string(),
+                parsed.manifest.tag.clone(),
+            )))
+        },
+    )
+}
+
+fn collect_launcher_item(ctx: &EntryContext<'_>, claims: &mut ClaimMap, out: &mut Vec<WalkedItem>) {
+    collect_walked_item(
+        ctx,
+        RepoItemKind::Launcher,
+        "malformed launcher",
+        claims,
+        out,
+        |content| {
+            let parsed = PeppyLauncherParser::from_content(content).map_err(|e| e.to_string())?;
+            if parsed.peppy_schema != PeppySchema::LauncherV1 {
+                return Ok(None);
+            }
+            // Launcher name = basename without `.json5` (launcher documents
+            // carry no manifest name). This matches `resolve_launcher_path`,
+            // which appends `.json5` to a bare name when looking up a
+            // launcher file.
+            Ok(ctx
+                .config_path
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .filter(|stem| !stem.is_empty())
+                .map(|stem| (stem.to_string(), String::new())))
+        },
+    );
+}
+
+fn collect_contract_item(ctx: &EntryContext<'_>, claims: &mut ClaimMap, out: &mut Vec<WalkedItem>) {
+    collect_walked_item(
+        ctx,
+        RepoItemKind::Contract,
+        "malformed contract",
+        claims,
+        out,
+        |content| {
+            let parsed = PeppyContractParser::from_content(content).map_err(|e| e.to_string())?;
+            Ok(Some((
+                parsed.manifest.name.as_str().to_string(),
+                parsed.manifest.tag.clone(),
+            )))
+        },
+    );
+}
+
+fn collect_pairing_item(ctx: &EntryContext<'_>, claims: &mut ClaimMap, out: &mut Vec<WalkedItem>) {
+    collect_walked_item(
+        ctx,
+        RepoItemKind::Pairing,
+        "malformed pairing",
+        claims,
+        out,
+        |content| {
+            let parsed = PeppyPairingParser::from_content(content).map_err(|e| e.to_string())?;
+            Ok(Some((
+                parsed.manifest.name.as_str().to_string(),
+                parsed.manifest.tag.clone(),
+            )))
+        },
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Helper: write a minimal valid node manifest under `dir`.
+    fn write_node_json5(dir: &Path, name: &str, tag: &str) {
+        std::fs::create_dir_all(dir).unwrap();
+        std::fs::write(
+            dir.join(NODE_CONFIG_FILE),
+            format!(
+                r#"{{
+  peppy_schema: "node/v1",
+  manifest: {{ name: "{name}", tag: "{tag}" }},
+  interfaces: {{}},
+  execution: {{ language: "rust", build_cmd: ["true"], run_cmd: ["true"] }},
+}}"#
+            ),
+        )
+        .unwrap();
+    }
+
+    /// Helper: write a `.json5` launcher file at `path` (any name accepted).
+    fn write_launcher_json5(path: &Path) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(
+            path,
+            r#"{
+  peppy_schema: "launcher/v1",
+  deployments: []
+}"#,
+        )
+        .unwrap();
+    }
+
+    /// Helper: write a minimal valid contract manifest at `path`.
+    fn write_contract_json5(path: &Path, name: &str, tag: &str) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(
+            path,
+            format!(
+                r#"{{
+  peppy_schema: "contract/v1",
+  manifest: {{ name: "{name}", tag: "{tag}" }},
+  interfaces: {{}}
+}}"#
+            ),
+        )
+        .unwrap();
+    }
+
+    /// Helper: write a minimal valid pairing manifest at `path`.
+    fn write_pairing_json5(path: &Path, name: &str, tag: &str) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(
+            path,
+            format!(
+                r#"{{
+  peppy_schema: "pairing/v1",
+  manifest: {{ name: "{name}", tag: "{tag}" }},
+  roles: ["leader", "follower"],
+  topics: [
+    {{ emitted_by: "leader", name: "setpoints" }},
+    {{ emitted_by: "follower", name: "states" }}
+  ]
+}}"#
+            ),
+        )
+        .unwrap();
+    }
+
+    /// The identities the walk found, of one kind, as `name:tag` labels.
+    fn found(walked: &WalkResult, kind: RepoItemKind) -> Vec<String> {
+        walked
+            .items
+            .iter()
+            .filter(|item| item.kind == kind)
+            .map(|item| {
+                if item.tag.is_empty() {
+                    item.name.clone()
+                } else {
+                    format!("{}:{}", item.name, item.tag)
+                }
+            })
+            .collect()
+    }
+
+    /// The walk dispatches `.json5` files by `peppy_schema`: a node
+    /// manifest, a launcher, a contract and a pairing coexisting in the
+    /// same repository each land under the matching kind.
+    #[test]
+    fn walk_directory_dispatches_by_schema() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("mixed");
+        write_node_json5(&repo.join("nodes/my_sensor"), "my_sensor", "v1");
+        write_launcher_json5(&repo.join("teleop.json5"));
+        write_contract_json5(
+            &repo.join("interfaces/uvc_camera.json5"),
+            "uvc_camera",
+            "v1",
+        );
+        write_pairing_json5(&repo.join("robot/joint.json5"), "joint_link", "v1");
+
+        let walked = walk_directory(&repo, &[]);
+
+        assert_eq!(found(&walked, RepoItemKind::Node), vec!["my_sensor:v1"]);
+        assert_eq!(found(&walked, RepoItemKind::Launcher), vec!["teleop"]);
+        assert_eq!(
+            found(&walked, RepoItemKind::Contract),
+            vec!["uvc_camera:v1"]
+        );
+        assert_eq!(found(&walked, RepoItemKind::Pairing), vec!["joint_link:v1"]);
+        assert!(walked.conflicts.is_empty(), "nothing claimed twice");
+    }
+
+    /// Every item records where it was found, relative to the scanned
+    /// root, which is what an index entry states.
+    #[test]
+    fn walk_directory_records_repository_relative_paths() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("repo");
+        write_node_json5(&repo.join("nodes/my_sensor"), "my_sensor", "v1");
+
+        let walked = walk_directory(&repo, &[]);
+
+        let item = &walked.items[0];
+        assert_eq!(item.relative_path, "nodes/my_sensor/peppy.json5");
+        assert!(item.absolute_path.ends_with("nodes/my_sensor/peppy.json5"));
+        assert!(
+            !item.sha256.is_empty(),
+            "the manifest bytes are fingerprinted"
+        );
+    }
+
+    /// The repository's own index declares no item. It is the output of
+    /// this walk, not an input to it.
+    #[test]
+    fn walk_directory_skips_the_repository_index_itself() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("repo");
+        write_node_json5(&repo.join("a"), "a", "v1");
+        std::fs::write(
+            repo.join(daemon_config::consts::REPOSITORY_INDEX_FILE),
+            r#"{ peppy_schema: "repository/v1", nodes: { "a": { "v1": { path: "a/peppy.json5" } } } }"#,
+        )
+        .unwrap();
+
+        let walked = walk_directory(&repo, &[]);
+
+        assert_eq!(found(&walked, RepoItemKind::Node), vec!["a:v1"]);
+        assert_eq!(walked.items.len(), 1, "the index is not an item");
+    }
+
+    /// Build artifacts and vendored trees are never descended into, so a
+    /// manifest under one of them is not published.
+    #[test]
+    fn walk_directory_skips_pruned_directories() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("repo");
+        write_node_json5(&repo.join("real"), "real", "v1");
+        for pruned in PRUNED_DIR_NAMES {
+            write_node_json5(&repo.join(pruned).join("buried"), "buried", "v1");
+        }
+
+        let walked = walk_directory(&repo, &[]);
+
+        assert_eq!(found(&walked, RepoItemKind::Node), vec!["real:v1"]);
+    }
+
+    /// The motivating case: one repository declaring one node identity
+    /// twice. Both claimants are named, so the report points at the two
+    /// files to look at rather than silently keeping whichever the
+    /// filesystem happened to yield first.
+    #[test]
+    fn walk_directory_reports_node_claimed_twice() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("nodes-hub");
+        write_node_json5(&repo.join("uvc_recon/rust"), "uvc_recon", "v1");
+        write_node_json5(&repo.join("uvc_recon/python"), "uvc_recon", "v1");
+
+        let walked = walk_directory(&repo, &[]);
+
+        assert_eq!(walked.conflicts.len(), 1, "one contested identity");
+        let conflict = &walked.conflicts[0];
+        assert_eq!(conflict.kind, RepoItemKind::Node);
+        assert_eq!(conflict.name, "uvc_recon");
+        assert_eq!(conflict.tag, "v1");
+        assert_eq!(
+            conflict.paths,
+            vec![
+                "uvc_recon/python/peppy.json5".to_owned(),
+                "uvc_recon/rust/peppy.json5".to_owned()
+            ],
+            "both claimants named, by repository-relative path"
+        );
+        // Only one claimant reaches the item vector; which one is walk
+        // order and deliberately not asserted.
+        assert_eq!(walked.items.len(), 1);
+    }
+
+    /// Launchers are keyed by file stem, so two identically named
+    /// launcher files in one repository contest the same identity even
+    /// though they live in different directories.
+    #[test]
+    fn walk_directory_reports_launcher_stem_claimed_twice() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("launchers-hub");
+        write_launcher_json5(&repo.join("sim/bringup.json5"));
+        write_launcher_json5(&repo.join("real/bringup.json5"));
+
+        let walked = walk_directory(&repo, &[]);
+
+        assert_eq!(walked.conflicts.len(), 1);
+        assert_eq!(walked.conflicts[0].kind, RepoItemKind::Launcher);
+        assert_eq!(walked.conflicts[0].name, "bringup");
+        assert_eq!(walked.conflicts[0].tag, "", "launchers carry no tag");
+        assert_eq!(walked.conflicts[0].paths.len(), 2);
+    }
+
+    /// Contracts and pairings are contested the same way as nodes, so a
+    /// duplicate in either is caught rather than silently resolved.
+    #[test]
+    fn walk_directory_reports_contract_and_pairing_claimed_twice() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("contracts-hub");
+        write_contract_json5(&repo.join("a/rgb.json5"), "rgb_camera", "v1");
+        write_contract_json5(&repo.join("b/rgb.json5"), "rgb_camera", "v1");
+        write_pairing_json5(&repo.join("a/joint.json5"), "joint_link", "v1");
+        write_pairing_json5(&repo.join("b/joint.json5"), "joint_link", "v1");
+
+        let walked = walk_directory(&repo, &[]);
+
+        let kinds: Vec<RepoItemKind> = walked.conflicts.iter().map(|c| c.kind).collect();
+        assert_eq!(
+            kinds,
+            vec![RepoItemKind::Contract, RepoItemKind::Pairing],
+            "one conflict per kind, grouped by kind"
+        );
+        assert_eq!(walked.conflicts[0].name, "rgb_camera");
+        assert_eq!(walked.conflicts[1].name, "joint_link");
+    }
+
+    /// The report is ordered by identity with sorted paths, so it is
+    /// reproducible in a test and comparable between two machines whose
+    /// filesystems hand back directories in different orders.
+    #[test]
+    fn walk_directory_conflicts_are_ordered_independently_of_walk_order() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("repo");
+        for dir in ["zzz", "aaa", "mmm"] {
+            write_node_json5(&repo.join(dir), "beta", "v1");
+        }
+        write_node_json5(&repo.join("one"), "alpha", "v1");
+        write_node_json5(&repo.join("two"), "alpha", "v1");
+
+        let walked = walk_directory(&repo, &[]);
+
+        let names: Vec<&str> = walked.conflicts.iter().map(|c| c.name.as_str()).collect();
+        assert_eq!(names, vec!["alpha", "beta"], "sorted by identity");
+
+        let beta_paths = &walked.conflicts[1].paths;
+        assert_eq!(beta_paths.len(), 3, "every claimant is named, not just two");
+        let mut sorted = beta_paths.clone();
+        sorted.sort();
+        assert_eq!(beta_paths, &sorted, "paths sorted");
+    }
+
+    /// Same name under different tags is two identities, not a conflict.
+    /// This is the guard against the check firing on ordinary versioning.
+    #[test]
+    fn walk_directory_same_name_different_tags_is_not_a_conflict() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("repo");
+        write_node_json5(&repo.join("v1"), "my_sensor", "v1");
+        write_node_json5(&repo.join("v2"), "my_sensor", "v2");
+
+        let walked = walk_directory(&repo, &[]);
+
+        assert!(walked.conflicts.is_empty(), "{:?}", walked.conflicts);
+        assert_eq!(
+            found(&walked, RepoItemKind::Node),
+            vec!["my_sensor:v1", "my_sensor:v2"]
+        );
+    }
+
+    /// A git repository's entries carry the repository-relative path,
+    /// because the checkout they resolve against is materialized per
+    /// machine; an fs repository's entries carry the absolute path,
+    /// which is what repository attribution matches against.
+    #[test]
+    fn build_cache_entries_picks_the_path_form_the_source_needs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("repo");
+        write_node_json5(&repo.join("nodes/a"), "a", "v1");
+        let items = walk_directory(&repo, &[]).items;
+
+        let git = build_cache_entries(
+            items.clone(),
+            RepoSourceKind::Git,
+            Some("https://example.invalid/hub"),
+            Some("main"),
+        );
+        assert_eq!(git.nodes[0].path, "nodes/a/peppy.json5");
+        assert_eq!(git.nodes[0].resolved_ref.as_deref(), Some("main"));
+
+        let fs = build_cache_entries(items, RepoSourceKind::Fs, None, None);
+        assert!(Path::new(&fs.nodes[0].path).is_absolute());
+        assert_eq!(fs.nodes[0].source_uri, None);
+    }
+
+    /// The rollout depends on this: a peppy that predates `repository/v1`
+    /// meets the schema tag, fails to recognize it, and skips the file. So
+    /// a repository can commit its index before the peppy that requires
+    /// one exists, and nothing in the fleet notices.
+    #[test]
+    fn an_unrecognized_schema_tag_is_skipped_rather_than_refused() {
+        assert_eq!(
+            peek_peppy_schema(br#"{ peppy_schema: "repository/v99" }"#),
+            None
+        );
+        assert_eq!(peek_peppy_schema(br#"{ unrelated: true }"#), None);
+        assert_eq!(
+            peek_peppy_schema(br#"{ peppy_schema: "repository/v1" }"#),
+            Some(PeppySchema::RepositoryV1)
+        );
+    }
+
+    /// A repository with every kind is indexed exactly once per identity,
+    /// in a deterministic order.
+    #[test]
+    fn generate_finds_every_kind() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("hub");
+        write_node_json5(&repo.join("nodes/my_sensor"), "my_sensor", "v1");
+        write_node_json5(&repo.join("nodes/my_sensor_v2"), "my_sensor", "v2");
+        write_launcher_json5(&repo.join("teleop.json5"));
+        write_contract_json5(&repo.join("interfaces/rgb.json5"), "rgb_camera", "v1");
+        write_pairing_json5(&repo.join("robot/joint.json5"), "joint_link", "v1");
+
+        let index = generate_repository_index(&repo).expect("generates");
+
+        let declared: Vec<String> = index
+            .declared_items()
+            .map(|item| format!("{item} -> {}", item.path))
+            .collect();
+        assert_eq!(
+            declared,
+            vec![
+                "node `my_sensor:v1` -> nodes/my_sensor/peppy.json5",
+                "node `my_sensor:v2` -> nodes/my_sensor_v2/peppy.json5",
+                "launcher `teleop` -> teleop.json5",
+                "contract `rgb_camera:v1` -> interfaces/rgb.json5",
+                "pairing `joint_link:v1` -> robot/joint.json5",
+            ]
+        );
+    }
+
+    /// The same tree yields the same index regardless of the order its
+    /// files were created in, so a generated index is comparable between
+    /// machines rather than a record of one filesystem's walk order.
+    #[test]
+    fn generate_is_deterministic_across_creation_order() {
+        let render = |order: [&str; 4]| {
+            let tmp = tempfile::tempdir().unwrap();
+            let repo = tmp.path().join("hub");
+            for name in order {
+                write_node_json5(&repo.join(name), name, "v1");
+            }
+            let index = generate_repository_index(&repo).expect("generates");
+            json5_pretty::to_string_pretty(&index).expect("serializes")
+        };
+        assert_eq!(
+            render(["zulu", "alpha", "mike", "bravo"]),
+            render(["bravo", "mike", "alpha", "zulu"])
+        );
+    }
+
+    /// Generation refuses a repository that claims one identity twice and
+    /// names both files, so the author sees which two claims collide.
+    #[test]
+    fn generate_fails_naming_both_paths_on_a_duplicate() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("hub");
+        write_node_json5(&repo.join("uvc/rust"), "uvc", "v1");
+        write_node_json5(&repo.join("uvc/python"), "uvc", "v1");
+
+        let err = generate_repository_index(&repo).expect_err("a contested identity is refused");
+
+        assert!(matches!(err, IndexError::ContestedIdentity(_)));
+        let message = err.to_string();
+        assert!(message.contains("uvc:v1"), "{message}");
+        assert!(message.contains("uvc/rust/peppy.json5"), "{message}");
+        assert!(message.contains("uvc/python/peppy.json5"), "{message}");
+    }
+
+    #[test]
+    fn generate_fails_on_a_duplicate_launcher_stem() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("hub");
+        write_launcher_json5(&repo.join("sim/bringup.json5"));
+        write_launcher_json5(&repo.join("real/bringup.json5"));
+
+        let err = generate_repository_index(&repo).expect_err("a contested stem is refused");
+        assert!(err.to_string().contains("bringup"), "{err}");
+    }
+
+    /// An identity the index has no way to state is refused rather than
+    /// skipped. Skipping would write an index that `--check` calls correct
+    /// while the item is invisible to peppy.
+    #[test]
+    fn generate_fails_on_an_identity_the_index_cannot_state() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("hub");
+        write_node_json5(&repo.join("dotted"), "my_sensor", "v0.1.0");
+
+        let err = generate_repository_index(&repo).expect_err("a dotted tag is refused");
+        assert!(matches!(err, IndexError::Unrepresentable(_)));
+        let message = err.to_string();
+        assert!(message.contains("dotted/peppy.json5"), "{message}");
+        assert!(message.contains("v0.1.0"), "{message}");
+    }
+
+    /// A repository that publishes nothing gets an index with no sections,
+    /// which is valid. Only a missing index means it has not adopted one.
+    #[test]
+    fn generate_produces_an_empty_index_for_an_empty_repository() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("empty");
+        std::fs::create_dir_all(&repo).unwrap();
+
+        let index = generate_repository_index(&repo).expect("generates");
+        assert_eq!(index.declared_count(), 0);
+
+        write_repository_index(&repo, &index).expect("writes");
+        assert!(check_repository_index(&repo).expect("checks").is_empty());
+    }
+
+    /// The load-bearing test for the migration: what the index reader
+    /// resolves from a generated index is exactly what the walk found,
+    /// identity for identity, path for path, byte for byte.
+    #[test]
+    fn generate_write_read_round_trip_matches_the_walk() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("hub");
+        write_node_json5(&repo.join("nodes/a"), "a", "v1");
+        write_node_json5(&repo.join("nodes/b"), "b", "v2");
+        write_launcher_json5(&repo.join("teleop.json5"));
+        write_contract_json5(&repo.join("interfaces/rgb.json5"), "rgb_camera", "v1");
+        write_pairing_json5(&repo.join("robot/joint.json5"), "joint_link", "v1");
+
+        let walked = walk_directory(&repo, &[]);
+        let index = generate_repository_index(&repo).expect("generates");
+        write_repository_index(&repo, &index).expect("writes");
+
+        let root = std::fs::canonicalize(&repo).unwrap();
+        let committed = read_repository_index(&root).expect("reads back");
+        let resolved: Vec<(&str, String, String, String)> = committed
+            .declared_items()
+            .map(|item| {
+                let bytes = resolve_declared_item(&root, &item).expect("resolves");
+                (
+                    item.kind.as_str(),
+                    identity_label(&item),
+                    item.path.as_str().to_owned(),
+                    fingerprint_for_bytes(&bytes),
+                )
+            })
+            .collect();
+
+        let mut from_walk: Vec<(&str, String, String, String)> = walked
+            .items
+            .iter()
+            .map(|item| {
+                let id = if item.tag.is_empty() {
+                    item.name.clone()
+                } else {
+                    format!("{}:{}", item.name, item.tag)
+                };
+                (
+                    item.kind.as_str(),
+                    id,
+                    item.relative_path.clone(),
+                    item.sha256.clone(),
+                )
+            })
+            .collect();
+        from_walk.sort();
+        let mut from_index = resolved;
+        from_index.sort();
+        assert_eq!(from_index, from_walk);
+    }
+
+    /// A freshly generated index matches the repository it came from.
+    #[test]
+    fn check_passes_on_a_freshly_generated_index() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("hub");
+        write_node_json5(&repo.join("nodes/a"), "a", "v1");
+        write_launcher_json5(&repo.join("teleop.json5"));
+        let index = generate_repository_index(&repo).expect("generates");
+        write_repository_index(&repo, &index).expect("writes");
+
+        assert_eq!(check_repository_index(&repo).expect("checks"), vec![]);
+    }
+
+    /// The mistake people will actually make: add an item, forget the
+    /// index. The item would otherwise be silently invisible.
+    #[test]
+    fn check_reports_an_item_nobody_listed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("hub");
+        write_node_json5(&repo.join("nodes/a"), "a", "v1");
+        let index = generate_repository_index(&repo).expect("generates");
+        write_repository_index(&repo, &index).expect("writes");
+        write_pairing_json5(&repo.join("robot/wrist.json5"), "wrist_link", "v1");
+
+        let drifts = check_repository_index(&repo).expect("checks");
+
+        assert_eq!(
+            drifts,
+            vec![IndexDrift::Unlisted {
+                kind: RepoItemKind::Pairing,
+                id: "wrist_link:v1".to_owned(),
+                path: "robot/wrist.json5".to_owned(),
+            }]
+        );
+        assert!(
+            drifts[0].to_string().contains("peppy_repository.json5"),
+            "{}",
+            drifts[0]
+        );
+    }
+
+    /// An item moved without updating the index, and an entry whose file
+    /// is gone, are both named rather than silently resolving.
+    #[test]
+    fn check_reports_moved_and_unmatched_entries() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("hub");
+        write_node_json5(&repo.join("old"), "a", "v1");
+        write_contract_json5(&repo.join("gone.json5"), "rgb_camera", "v1");
+        let index = generate_repository_index(&repo).expect("generates");
+        write_repository_index(&repo, &index).expect("writes");
+
+        std::fs::remove_file(repo.join("gone.json5")).unwrap();
+        std::fs::remove_dir_all(repo.join("old")).unwrap();
+        write_node_json5(&repo.join("new"), "a", "v1");
+
+        let drifts = check_repository_index(&repo).expect("checks");
+
+        assert_eq!(
+            drifts
+                .iter()
+                .filter(|d| matches!(d, IndexDrift::Moved { .. }))
+                .cloned()
+                .collect::<Vec<_>>(),
+            vec![IndexDrift::Moved {
+                kind: RepoItemKind::Node,
+                id: "a:v1".to_owned(),
+                listed: "old/peppy.json5".to_owned(),
+                found: "new/peppy.json5".to_owned(),
+            },],
+            "a moved identity is reported once, as a move"
+        );
+        let unmatched = drifts
+            .iter()
+            .find_map(|d| match d {
+                IndexDrift::Unmatched { id, detail, .. } => Some((id, detail)),
+                _ => None,
+            })
+            .expect("the deleted contract");
+        assert_eq!(unmatched.0, "rgb_camera:v1");
+        assert!(unmatched.1.contains("cannot be read"), "{}", unmatched.1);
+    }
+
+    /// Kind is checked as much as identity: a contract filed under
+    /// `nodes` produces both an unmatched entry and an unlisted item,
+    /// because the comparison is per kind and the two cannot cancel out.
+    #[test]
+    fn check_reports_an_item_filed_under_the_wrong_kind() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("hub");
+        write_contract_json5(&repo.join("rgb.json5"), "rgb_camera", "v1");
+        std::fs::write(
+            repo.join(daemon_config::consts::REPOSITORY_INDEX_FILE),
+            r#"{
+  peppy_schema: "repository/v1",
+  nodes: { "rgb_camera": { "v1": { path: "rgb.json5" } } },
+}"#,
+        )
+        .unwrap();
+
+        let drifts = check_repository_index(&repo).expect("checks");
+
+        assert_eq!(drifts.len(), 2, "{drifts:?}");
+        assert!(drifts.iter().any(|d| matches!(
+            d,
+            IndexDrift::Unlisted {
+                kind: RepoItemKind::Contract,
+                ..
+            }
+        )));
+        assert!(drifts.iter().any(|d| matches!(
+            d,
+            IndexDrift::Unmatched {
+                kind: RepoItemKind::Node,
+                ..
+            }
+        )));
+    }
+
+    /// An entry pointing at the right kind but the wrong identity is
+    /// caught by re-reading the manifest, which is why the reader parses
+    /// rather than trusting the index.
+    #[test]
+    fn check_reports_an_entry_whose_manifest_declares_another_identity() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("hub");
+        write_node_json5(&repo.join("nodes/a"), "a", "v1");
+        std::fs::write(
+            repo.join(daemon_config::consts::REPOSITORY_INDEX_FILE),
+            r#"{
+  peppy_schema: "repository/v1",
+  nodes: { "renamed": { "v1": { path: "nodes/a/peppy.json5" } } },
+}"#,
+        )
+        .unwrap();
+
+        let drifts = check_repository_index(&repo).expect("checks");
+
+        let unmatched = drifts
+            .iter()
+            .find_map(|d| match d {
+                IndexDrift::Unmatched { id, detail, .. } => Some((id, detail)),
+                _ => None,
+            })
+            .expect("an unmatched entry");
+        assert_eq!(unmatched.0, "renamed:v1");
+        assert!(unmatched.1.contains("declares `a:v1`"), "{}", unmatched.1);
+    }
+
+    /// The one case comparing alone would miss: the walk does not follow
+    /// a symlinked directory, but reading a symlinked file does follow
+    /// it, so regeneration reproduces the entry and only resolving the
+    /// path catches that it leaves the tree.
+    #[test]
+    #[cfg(unix)]
+    fn check_rejects_a_symlinked_file_that_escapes_the_repository() {
+        let tmp = tempfile::tempdir().unwrap();
+        let outside = tmp.path().join("outside");
+        write_node_json5(&outside, "smuggled", "v1");
+
+        let repo = tmp.path().join("hub");
+        std::fs::create_dir_all(repo.join("nodes")).unwrap();
+        std::os::unix::fs::symlink(
+            outside.join(NODE_CONFIG_FILE),
+            repo.join("nodes/peppy.json5"),
+        )
+        .unwrap();
+
+        let index = generate_repository_index(&repo).expect("the walk reads through the symlink");
+        write_repository_index(&repo, &index).expect("writes");
+
+        let drifts = check_repository_index(&repo).expect("checks");
+        let detail = drifts
+            .iter()
+            .find_map(|d| match d {
+                IndexDrift::Unmatched { detail, .. } => Some(detail.clone()),
+                _ => None,
+            })
+            .expect("the escaping entry is refused");
+        assert!(detail.contains("outside the repository"), "{detail}");
+    }
+
+    /// A missing index is not the same as an empty one, and the message
+    /// says which file was looked for.
+    #[test]
+    fn check_fails_when_the_repository_has_no_index() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("hub");
+        write_node_json5(&repo.join("nodes/a"), "a", "v1");
+
+        let err = check_repository_index(&repo).expect_err("a missing index is refused");
+        assert!(err.to_string().contains("peppy_repository.json5"), "{err}");
+    }
+}

--- a/crates/core-node-internal/src/services/repo/index.rs
+++ b/crates/core-node-internal/src/services/repo/index.rs
@@ -86,14 +86,21 @@ pub struct RepoConflict {
     pub paths: Vec<String>,
 }
 
+/// `name:tag`, or the bare name when the tag is empty. The empty string is
+/// how the walk and caches spell an untagged identity (launchers), so this is
+/// the single place that renders a `(name, tag)` pair as its label.
+fn format_identity(name: &str, tag: &str) -> String {
+    if tag.is_empty() {
+        name.to_owned()
+    } else {
+        format!("{name}:{tag}")
+    }
+}
+
 impl RepoConflict {
     /// `name:tag` label, or the bare name for untagged kinds.
     fn display_id(&self) -> String {
-        if self.tag.is_empty() {
-            self.name.clone()
-        } else {
-            format!("{}:{}", self.name, self.tag)
-        }
+        format_identity(&self.name, &self.tag)
     }
 }
 
@@ -356,11 +363,7 @@ pub(crate) fn resolve_declared_item(
     let (name, tag) = declared_identity(item.kind, content, item.path.as_path())?;
     let expected_tag = item.tag.map(ItemTag::as_str).unwrap_or_default();
     if name != item.name.as_str() || tag != expected_tag {
-        let found = if tag.is_empty() {
-            name
-        } else {
-            format!("{name}:{tag}")
-        };
+        let found = format_identity(&name, &tag);
         return Err(format!("declares `{found}`"));
     }
 
@@ -495,10 +498,10 @@ pub fn check_repository_index(root: &Path) -> Result<Vec<IndexDrift>, IndexError
 }
 
 fn identity_label(item: &DeclaredItem<'_>) -> String {
-    match item.tag {
-        Some(tag) => format!("{}:{tag}", item.name),
-        None => item.name.to_string(),
-    }
+    format_identity(
+        item.name.as_str(),
+        item.tag.map(ItemTag::as_str).unwrap_or_default(),
+    )
 }
 
 /// Walk a repository's working tree for the files that declare items.
@@ -891,13 +894,7 @@ mod tests {
             .items
             .iter()
             .filter(|item| item.kind == kind)
-            .map(|item| {
-                if item.tag.is_empty() {
-                    item.name.clone()
-                } else {
-                    format!("{}:{}", item.name, item.tag)
-                }
-            })
+            .map(|item| format_identity(&item.name, &item.tag))
             .collect()
     }
 
@@ -1287,14 +1284,9 @@ mod tests {
             .items
             .iter()
             .map(|item| {
-                let id = if item.tag.is_empty() {
-                    item.name.clone()
-                } else {
-                    format!("{}:{}", item.name, item.tag)
-                };
                 (
                     item.kind.as_str(),
-                    id,
+                    format_identity(&item.name, &item.tag),
                     item.relative_path.clone(),
                     item.sha256.clone(),
                 )

--- a/crates/core-node-internal/src/services/repo/refresh.rs
+++ b/crates/core-node-internal/src/services/repo/refresh.rs
@@ -3,48 +3,30 @@ use crate::services::action_loop::{GoalHandler, accept_goal, reject_goal, run_ac
 use crate::services::node::clone_with_progress;
 use crate::services::node::gate::{Admission, ConcurrencyGate};
 use crate::services::repo::cache::{
-    ContractCacheEntry, DiscoveredEntry, LauncherCacheEntry, NodeCacheEntry, PairingCacheEntry,
-    RepoCacheEntry, write_repo_cache,
+    ContractCacheEntry, LauncherCacheEntry, NodeCacheEntry, PairingCacheEntry, RepoCacheEntry,
+    RepoItems, write_repo_cache,
 };
 use crate::services::repo::exclude::ExclusionSet;
+use crate::services::repo::index::{WalkResult, build_cache_entries, walk_directory};
 use crate::services::repo::status::{self, RepoStatus, RepoStatusFailure};
 use crate::services::repo::{normalize_repo_entries, source_identity};
-use config::consts::NODE_CONFIG_FILE;
-use config::fingerprint::fingerprint_for_bytes;
-use config::node::NodeConfigParser;
-use config::schema::PeppySchema;
 use core_node_api::ActionId;
 use core_node_api::encoding::{
-    RepoItemKind, RepoRefreshFeedback, RepoRefreshGoal, RepoRefreshGoalResponse, RepoRefreshResult,
-    RepoSource, RepoSourceKind,
+    RepoRefreshFeedback, RepoRefreshGoal, RepoRefreshGoalResponse, RepoRefreshResult, RepoSource,
+    RepoSourceKind,
 };
 use core_node_api::names;
 use daemon_config::consts::PeppyDirs;
-use daemon_config::contract::PeppyContractParser;
-use daemon_config::launcher::PeppyLauncherParser;
-use daemon_config::pairing::PeppyPairingParser;
 use peppylib::messaging::SenderTarget;
 use peppylib::messaging::{ConcurrentAction, PendingGoal};
 use peppylib::types::Payload;
 use peppylib::{MessengerHandle, PeppyError, PeppyResult};
-use serde::Deserialize;
 use serde_json::Value;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 use tokio::task::JoinHandle;
 use tracing::{debug, warn};
-
-/// Directory names that should never be descended into while searching for
-/// `peppy.json5` files.
-pub(crate) const PRUNED_DIR_NAMES: &[&str] = &[
-    ".git",
-    ".peppy",
-    "target",
-    "node_modules",
-    ".venv",
-    "__pycache__",
-];
 
 pub async fn listen_for_repo_refresh(
     messenger: &MessengerHandle,
@@ -411,17 +393,26 @@ pub(crate) fn write_all_caches(peppy_dirs: &PeppyDirs, refreshed: &RefreshedRepo
     status::write(peppy_dirs, &refreshed.statuses)
 }
 
-/// Source-and-file context shared by every `.json5` collector. The
-/// collectors only need read access; bundling these arguments keeps
-/// their signatures focused on the entry-specific state (seen set +
-/// output vector).
-struct EntryContext<'a> {
-    root: &'a Path,
+/// One repository as read, plus what the entries it yields should be
+/// attributed to. Reading is separated from attribution so the fs and git
+/// branches differ only in how they obtain the tree, not in what happens to
+/// the items afterwards.
+struct ReadRepo {
+    walked: WalkResult,
     source_type: RepoSourceKind,
-    source_uri: Option<&'a str>,
-    resolved_ref: Option<&'a str>,
-    config_path: &'a Path,
-    bytes: &'a [u8],
+    source_uri: Option<String>,
+    resolved_ref: Option<String>,
+}
+
+impl ReadRepo {
+    fn into_cache_entries(self) -> RepoItems {
+        build_cache_entries(
+            self.walked.items,
+            self.source_type,
+            self.source_uri.as_deref(),
+            self.resolved_ref.as_deref(),
+        )
+    }
 }
 
 /// Parse a JSON entry from repositories.json5 into a `RepoSource`.
@@ -577,13 +568,12 @@ pub(crate) fn process_refresh(
                     on_feedback(RepoRefreshFeedback::Progress {
                         message: format!("Scanning {}", path.display()),
                     });
-                    Ok(walk_directory(
-                        path,
-                        RepoSourceKind::Fs,
-                        None,
-                        None,
-                        &exclusions.fs_paths,
-                    ))
+                    Ok(ReadRepo {
+                        walked: walk_directory(path, &exclusions.fs_paths),
+                        source_type: RepoSourceKind::Fs,
+                        source_uri: None,
+                        resolved_ref: None,
+                    })
                 } else {
                     Err(format!("path does not exist: {}", path.display()))
                 }
@@ -606,9 +596,9 @@ pub(crate) fn process_refresh(
         // bug.
         let failure = match &read {
             Err(detail) => Some((RepoFailureKind::Unreachable, detail.clone())),
-            Ok(walked) if !walked.conflicts.is_empty() => Some((
+            Ok(read) if !read.walked.conflicts.is_empty() => Some((
                 RepoFailureKind::Conflict,
-                walked
+                read.walked
                     .conflicts
                     .iter()
                     .map(|c| c.to_string())
@@ -627,7 +617,7 @@ pub(crate) fn process_refresh(
             .find(|s| s.id == id && s.identity == identity)
             .and_then(|s| s.last_read_unix_secs);
 
-        let walked = match failure {
+        let items = match failure {
             None => {
                 statuses.push(RepoStatus {
                     id,
@@ -638,15 +628,14 @@ pub(crate) fn process_refresh(
                     // stops reporting an old failure.
                     last_failure: None,
                 });
-                read.expect("checked to be Ok above")
+                read.expect("checked to be Ok above").into_cache_entries()
             }
             Some((kind, detail)) => {
-                let retained = WalkResult {
+                let retained = RepoItems {
                     nodes: retained_entries(&previous.nodes, &repos, id),
                     launchers: retained_entries(&previous.launchers, &repos, id),
                     contracts: retained_entries(&previous.contracts, &repos, id),
                     pairings: retained_entries(&previous.pairings, &repos, id),
-                    conflicts: Vec::new(),
                 };
                 let count = retained.nodes.len()
                     + retained.launchers.len()
@@ -686,25 +675,25 @@ pub(crate) fn process_refresh(
         // retained or not, so priority order and the first-seen discovery
         // feedback stay exactly as they would have been.
         merge_walked(
-            walked.nodes,
+            items.nodes,
             &mut global_seen_nodes,
             &mut all_nodes,
             on_feedback,
         );
         merge_walked(
-            walked.launchers,
+            items.launchers,
             &mut global_seen_launchers,
             &mut all_launchers,
             on_feedback,
         );
         merge_walked(
-            walked.contracts,
+            items.contracts,
             &mut global_seen_contracts,
             &mut all_contracts,
             on_feedback,
         );
         merge_walked(
-            walked.pairings,
+            items.pairings,
             &mut global_seen_pairings,
             &mut all_pairings,
             on_feedback,
@@ -723,82 +712,6 @@ pub(crate) fn process_refresh(
 }
 
 /// Items discovered by walking a single repository's working tree.
-pub(crate) struct WalkResult {
-    pub nodes: Vec<NodeCacheEntry>,
-    pub launchers: Vec<LauncherCacheEntry>,
-    pub contracts: Vec<ContractCacheEntry>,
-    pub pairings: Vec<PairingCacheEntry>,
-    /// Identities claimed by more than one manifest in this repository.
-    /// Non-empty means the repository has no defensible answer for those
-    /// identities, so the caller refuses it rather than picking one.
-    pub conflicts: Vec<RepoConflict>,
-}
-
-/// An identity claimed by several manifests inside one repository. There
-/// is no priority rule that can settle this: the repository states two
-/// different answers to the same question.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct RepoConflict {
-    pub kind: RepoItemKind,
-    pub name: String,
-    /// Empty for untagged kinds (launchers).
-    pub tag: String,
-    /// Every claimant's path, sorted.
-    pub paths: Vec<String>,
-}
-
-impl RepoConflict {
-    /// `name:tag` label, or the bare name for untagged kinds.
-    fn display_id(&self) -> String {
-        if self.tag.is_empty() {
-            self.name.clone()
-        } else {
-            format!("{}:{}", self.name, self.tag)
-        }
-    }
-}
-
-impl std::fmt::Display for RepoConflict {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{} {} manifests claim `{}`: {}",
-            self.paths.len(),
-            self.kind,
-            self.display_id(),
-            self.paths.join(", ")
-        )
-    }
-}
-
-/// Every path that claimed a given `(name, tag)` during one repository
-/// walk, in the order the walker met them. Recording all of them (rather
-/// than remembering only that the identity was seen) is what lets a
-/// conflict name both files instead of silently keeping one.
-type ClaimMap = HashMap<(String, String), Vec<String>>;
-
-/// Turns one kind's claim map into the conflicts it holds: every identity
-/// with more than one claimant. Sorted by identity, with sorted paths, so
-/// the report never inherits the filesystem's walk order and stays
-/// comparable between machines.
-fn conflicts_from_claims(kind: RepoItemKind, claims: ClaimMap) -> Vec<RepoConflict> {
-    let mut conflicts: Vec<RepoConflict> = claims
-        .into_iter()
-        .filter(|(_, paths)| paths.len() > 1)
-        .map(|((name, tag), mut paths)| {
-            paths.sort();
-            RepoConflict {
-                kind,
-                name,
-                tag,
-                paths,
-            }
-        })
-        .collect();
-    conflicts.sort_by(|a, b| (&a.name, &a.tag).cmp(&(&b.name, &b.tag)));
-    conflicts
-}
-
 /// Appends one repository's walked entries to the running cross-repo
 /// collection, emitting a `Discovered` feedback the first time each
 /// `(name, tag)` identity is seen. Every entry is kept (including
@@ -831,320 +744,6 @@ fn merge_walked<E: RepoCacheEntry>(
 fn count_unique<E: RepoCacheEntry>(entries: &[E]) -> u32 {
     let set: HashSet<(&str, &str)> = entries.iter().map(|e| (e.name(), e.tag())).collect();
     set.len() as u32
-}
-
-/// Walk a directory looking for `peppy.json5` (node) and any `.json5`
-/// file whose body declares `peppy_schema: "launcher/v1"` (launcher),
-/// collecting discovered nodes and launchers.
-///
-/// Any directory whose path matches one of the `excluded_paths` entries is
-/// pruned from the walk (neither descended into nor scanned for config files).
-///
-/// Each `.json5` file is read once. Files named `peppy.json5` are tried
-/// as nodes first (preserves filename-driven node ergonomics); any
-/// `.json5` whose body declares a `peppy_schema` value is dispatched to
-/// the matching collector.
-///
-/// A given `(name, tag)` (or launcher name) reaches the entry vectors at
-/// most once per walk, but every claimant is recorded: an identity with
-/// several claimants comes back in `conflicts` for the caller to refuse
-/// the repository over. The cross-repo merge, where several repositories
-/// claiming one identity is a supported feature rather than a conflict,
-/// happens in `process_refresh`.
-pub(crate) fn walk_directory(
-    root: &Path,
-    source_type: RepoSourceKind,
-    source_uri: Option<&str>,
-    resolved_ref: Option<&str>,
-    excluded_paths: &[PathBuf],
-) -> WalkResult {
-    // Canonicalize the root so that paths emitted by the walker share a
-    // common prefix representation with the excluded paths (which come from
-    // `ExclusionSet::load` already canonicalized). Without this, macOS
-    // `/var/...` symlinks break subdirectory exclusion: the walker emits
-    // `/var/...` while excluded paths resolve to `/private/var/...`.
-    let root = std::fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
-    let excluded = excluded_paths.to_vec();
-    let walker = ignore::WalkBuilder::new(&root)
-        .hidden(true)
-        .filter_entry(move |entry| {
-            if !entry.file_type().is_some_and(|ft| ft.is_dir()) {
-                return true;
-            }
-            if entry.depth() == 0 {
-                return true;
-            }
-            let name = entry.file_name().to_string_lossy();
-            if PRUNED_DIR_NAMES.iter().any(|pruned| name == *pruned) {
-                return false;
-            }
-            let entry_path = entry.path();
-            !excluded.iter().any(|exc| entry_path.starts_with(exc))
-        })
-        .build();
-
-    let mut nodes_seen = ClaimMap::new();
-    let mut launchers_seen = ClaimMap::new();
-    let mut contracts_seen = ClaimMap::new();
-    let mut pairings_seen = ClaimMap::new();
-    let mut nodes: Vec<NodeCacheEntry> = Vec::new();
-    let mut launchers: Vec<LauncherCacheEntry> = Vec::new();
-    let mut contracts: Vec<ContractCacheEntry> = Vec::new();
-    let mut pairings: Vec<PairingCacheEntry> = Vec::new();
-
-    for entry in walker.flatten() {
-        let file_name = entry.file_name().to_string_lossy();
-        let config_path = entry.path();
-        if !has_json5_extension(config_path) {
-            continue;
-        }
-        let bytes = match std::fs::read(config_path) {
-            Ok(bytes) if !bytes.is_empty() => bytes,
-            Ok(_) => continue,
-            Err(e) => {
-                debug!(
-                    "Skipping unreadable .json5 at {}: {}",
-                    config_path.display(),
-                    e
-                );
-                continue;
-            }
-        };
-        let ctx = EntryContext {
-            root: &root,
-            source_type,
-            source_uri,
-            resolved_ref,
-            config_path,
-            bytes: &bytes,
-        };
-        if file_name == NODE_CONFIG_FILE {
-            // Try node parse first to preserve the documented filename
-            // convention for nodes. If the file's schema doesn't match,
-            // fall through to the launcher/contract dispatch; that
-            // way a non-node `peppy.json5` is still discoverable.
-            if try_collect_node_entry(&ctx, &mut nodes_seen, &mut nodes) {
-                continue;
-            }
-        }
-        let Some(schema) = peek_peppy_schema(&bytes) else {
-            continue;
-        };
-        match schema {
-            PeppySchema::NodeV1 => {
-                // A non-`peppy.json5` file declaring `node/v1` is unusual
-                // but we still parse it strictly: matches the documented
-                // "schema dispatch" rule for any `.json5`.
-                try_collect_node_entry(&ctx, &mut nodes_seen, &mut nodes);
-            }
-            PeppySchema::LauncherV1 => {
-                collect_launcher_entry(&ctx, &mut launchers_seen, &mut launchers);
-            }
-            PeppySchema::ContractV1 => {
-                collect_contract_entry(&ctx, &mut contracts_seen, &mut contracts);
-            }
-            PeppySchema::PairingV1 => {
-                collect_pairing_entry(&ctx, &mut pairings_seen, &mut pairings);
-            }
-        }
-    }
-
-    let mut conflicts = conflicts_from_claims(RepoItemKind::Node, nodes_seen);
-    conflicts.extend(conflicts_from_claims(
-        RepoItemKind::Launcher,
-        launchers_seen,
-    ));
-    conflicts.extend(conflicts_from_claims(
-        RepoItemKind::Contract,
-        contracts_seen,
-    ));
-    conflicts.extend(conflicts_from_claims(RepoItemKind::Pairing, pairings_seen));
-
-    WalkResult {
-        nodes,
-        launchers,
-        contracts,
-        pairings,
-        conflicts,
-    }
-}
-
-fn has_json5_extension(path: &Path) -> bool {
-    path.extension().is_some_and(|ext| ext == "json5")
-}
-
-/// Cheap schema sniff over the raw bytes. Returns `None` when the file
-/// either doesn't declare a `peppy_schema` field or declares one we
-/// don't know about; the caller treats both as "skip silently".
-fn peek_peppy_schema(bytes: &[u8]) -> Option<PeppySchema> {
-    #[derive(Deserialize)]
-    struct SchemaPeek {
-        peppy_schema: PeppySchema,
-    }
-    let content = std::str::from_utf8(bytes).ok()?;
-    serde_json5::from_str::<SchemaPeek>(content)
-        .ok()
-        .map(|p| p.peppy_schema)
-}
-
-/// Shared body of the four collectors: UTF-8 check, strict parse via
-/// `identity`, claim recording, then entry construction through
-/// [`RepoCacheEntry::from_discovered`]. The strict parse catches
-/// structural problems (unknown fields, malformed sections) that the
-/// cheap schema peek can't.
-///
-/// `identity` returns the document's `(name, tag)` — `Ok(None)` to skip
-/// the file silently (wrong schema variant, unusable file stem), or
-/// `Err` when the content does not parse as `E`'s document kind at all.
-/// `parse_failure_label` words that last case: a `peppy.json5` failing
-/// the node parse is usually a different document kind rather than a
-/// malformed node, so the node collector logs "non-node".
-///
-/// Every claimant is recorded in `claims`, including the second and
-/// later ones that are not pushed to `out`; the caller turns identities
-/// with several claimants into [`RepoConflict`]s and refuses the whole
-/// repository. Which claimant reaches `out` is walk-order dependent and
-/// deliberately not relied upon.
-///
-/// Returns `false` only on parse failure, so the node collector can
-/// fall back to schema dispatch; repeat claimants return `true` because
-/// the file is a valid document of the kind.
-fn collect_repo_entry<E: RepoCacheEntry>(
-    ctx: &EntryContext<'_>,
-    parse_failure_label: &str,
-    claims: &mut ClaimMap,
-    out: &mut Vec<E>,
-    identity: impl FnOnce(&str) -> std::result::Result<Option<(String, String)>, String>,
-) -> bool {
-    let content = match std::str::from_utf8(ctx.bytes) {
-        Ok(s) => s,
-        Err(e) => {
-            debug!(
-                "Skipping non-utf8 {} .json5 at {}: {}",
-                E::KIND,
-                ctx.config_path.display(),
-                e
-            );
-            return false;
-        }
-    };
-    let (name, tag) = match identity(content) {
-        Ok(Some(identity)) => identity,
-        Ok(None) => return true,
-        Err(e) => {
-            debug!(
-                "Skipping {} .json5 at {}: {}",
-                parse_failure_label,
-                ctx.config_path.display(),
-                e
-            );
-            return false;
-        }
-    };
-
-    let path = relative_or_absolute_file_path(ctx.root, ctx.config_path, ctx.source_type);
-    let claimants = claims.entry((name.clone(), tag.clone())).or_default();
-    claimants.push(path.clone());
-    if claimants.len() > 1 {
-        return true;
-    }
-
-    out.push(E::from_discovered(DiscoveredEntry {
-        name,
-        tag,
-        sha256: fingerprint_for_bytes(ctx.bytes),
-        path,
-        source_type: ctx.source_type,
-        source_uri: ctx.source_uri.map(str::to_owned),
-        resolved_ref: ctx.resolved_ref.map(str::to_owned),
-    }));
-    true
-}
-
-/// Returns `true` when the file parsed cleanly as a node and its claim
-/// was recorded. `false` means parsing failed; the caller can fall back
-/// to a different schema dispatch.
-fn try_collect_node_entry(
-    ctx: &EntryContext<'_>,
-    claims: &mut ClaimMap,
-    nodes: &mut Vec<NodeCacheEntry>,
-) -> bool {
-    collect_repo_entry(ctx, "non-node", claims, nodes, |content| {
-        let parsed = NodeConfigParser::from_content(content).map_err(|e| e.to_string())?;
-        Ok(Some((
-            parsed.manifest.name.as_str().to_string(),
-            parsed.manifest.tag.clone(),
-        )))
-    })
-}
-
-fn collect_launcher_entry(
-    ctx: &EntryContext<'_>,
-    claims: &mut ClaimMap,
-    launchers: &mut Vec<LauncherCacheEntry>,
-) {
-    collect_repo_entry(ctx, "malformed launcher", claims, launchers, |content| {
-        let parsed = PeppyLauncherParser::from_content(content).map_err(|e| e.to_string())?;
-        if parsed.peppy_schema != PeppySchema::LauncherV1 {
-            return Ok(None);
-        }
-        // Launcher name = basename without `.json5` (launcher documents
-        // carry no manifest name). This matches `resolve_launcher_path`,
-        // which appends `.json5` to a bare name when looking up a
-        // launcher file.
-        Ok(ctx
-            .config_path
-            .file_stem()
-            .and_then(|s| s.to_str())
-            .filter(|stem| !stem.is_empty())
-            .map(|stem| (stem.to_string(), String::new())))
-    });
-}
-
-fn collect_contract_entry(
-    ctx: &EntryContext<'_>,
-    claims: &mut ClaimMap,
-    contracts: &mut Vec<ContractCacheEntry>,
-) {
-    collect_repo_entry(ctx, "malformed contract", claims, contracts, |content| {
-        let parsed = PeppyContractParser::from_content(content).map_err(|e| e.to_string())?;
-        Ok(Some((
-            parsed.manifest.name.as_str().to_string(),
-            parsed.manifest.tag.clone(),
-        )))
-    });
-}
-
-fn collect_pairing_entry(
-    ctx: &EntryContext<'_>,
-    claims: &mut ClaimMap,
-    pairings: &mut Vec<PairingCacheEntry>,
-) {
-    collect_repo_entry(ctx, "malformed pairing", claims, pairings, |content| {
-        let parsed = PeppyPairingParser::from_content(content).map_err(|e| e.to_string())?;
-        Ok(Some((
-            parsed.manifest.name.as_str().to_string(),
-            parsed.manifest.tag.clone(),
-        )))
-    });
-}
-
-/// Returns the path of the manifest file itself (not its parent
-/// directory). For git repos the result is relative to the repo root;
-/// for fs repos it is the absolute path.
-fn relative_or_absolute_file_path(
-    root: &Path,
-    config_path: &Path,
-    source_type: RepoSourceKind,
-) -> String {
-    if source_type == RepoSourceKind::Git {
-        config_path
-            .strip_prefix(root)
-            .map(|p| p.to_string_lossy().into_owned())
-            .unwrap_or_default()
-    } else {
-        config_path.to_string_lossy().into_owned()
-    }
 }
 
 /// Shallow-clone a git repository into `dst` and check out `repo_ref` if set,
@@ -1197,7 +796,7 @@ fn clone_and_walk_git_repo(
     repo_ref: Option<&str>,
     peppy_dirs: &PeppyDirs,
     on_feedback: &mut dyn FnMut(RepoRefreshFeedback),
-) -> std::result::Result<WalkResult, String> {
+) -> std::result::Result<ReadRepo, String> {
     let tmp_dir = peppy_dirs.tmp_dir();
     std::fs::create_dir_all(&tmp_dir).map_err(|e| format!("failed to create tmp dir: {}", e))?;
     let tmp =
@@ -1206,19 +805,22 @@ fn clone_and_walk_git_repo(
     let repo = clone_shallow(repo_url, repo_ref, tmp.path(), on_feedback)?;
     let resolved_ref = resolve_ref_for_cache(&repo, repo_ref);
 
-    Ok(walk_directory(
-        tmp.path(),
-        RepoSourceKind::Git,
-        Some(repo_url),
-        Some(&resolved_ref),
-        &[],
-    ))
+    // A git repository is read whole: subtree exclusions are expressed as
+    // filesystem paths and have no meaning against a temporary clone.
+    Ok(ReadRepo {
+        walked: walk_directory(tmp.path(), &[]),
+        source_type: RepoSourceKind::Git,
+        source_uri: Some(repo_url.to_owned()),
+        resolved_ref: Some(resolved_ref),
+    })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::services::repo::cache::repositories_list_path;
+    use config::consts::NODE_CONFIG_FILE;
+    use config::fingerprint::fingerprint_for_bytes;
 
     /// A fixed instant for every refresh under test, so nothing depends
     /// on the host clock or on how fast the test runs.
@@ -2148,169 +1750,6 @@ mod tests {
             "first listed repo should win the feedback: {}",
             discovered_paths[0]
         );
-    }
-
-    /// `walk_directory` dispatches `.json5` files by `peppy_schema`:
-    /// a node manifest, a launcher, and a contract coexisting in the
-    /// same repository each land in the matching collector.
-    #[test]
-    fn walk_directory_dispatches_by_schema() {
-        let tmp = tempfile::tempdir().unwrap();
-        let repo = tmp.path().join("mixed");
-        write_peppy_json5(&repo.join("nodes/my_sensor"), "my_sensor", "v1");
-        write_launcher_json5(&repo.join("teleop.json5"));
-        write_contract_json5(
-            &repo.join("interfaces/uvc_camera.json5"),
-            "uvc_camera",
-            "v1",
-        );
-
-        let walked = walk_directory(&repo, RepoSourceKind::Fs, None, None, &[]);
-        assert_eq!(walked.nodes.len(), 1, "one node");
-        assert_eq!(walked.nodes[0].node_name, "my_sensor");
-        assert_eq!(walked.launchers.len(), 1, "one launcher");
-        assert_eq!(walked.launchers[0].launcher_name, "teleop");
-        assert_eq!(walked.contracts.len(), 1, "one contract");
-        assert_eq!(walked.contracts[0].contract_name, "uvc_camera");
-        assert!(walked.conflicts.is_empty(), "nothing claimed twice");
-    }
-
-    /// Helper: write a minimal valid pairing manifest at `path`.
-    fn write_pairing_json5(path: &Path, name: &str, tag: &str) {
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent).unwrap();
-        }
-        std::fs::write(
-            path,
-            format!(
-                r#"{{
-  peppy_schema: "pairing/v1",
-  manifest: {{ name: "{name}", tag: "{tag}" }},
-  roles: ["leader", "follower"],
-  topics: [
-    {{ emitted_by: "leader", name: "setpoints" }},
-    {{ emitted_by: "follower", name: "states" }}
-  ]
-}}"#
-            ),
-        )
-        .unwrap();
-    }
-
-    /// The motivating case: one repository declaring one node identity
-    /// twice. Both claimants are named, so the report points at the two
-    /// files to look at rather than silently keeping whichever the
-    /// filesystem happened to yield first.
-    #[test]
-    fn walk_directory_reports_node_claimed_twice() {
-        let tmp = tempfile::tempdir().unwrap();
-        let repo = tmp.path().join("nodes-hub");
-        write_peppy_json5(&repo.join("uvc_recon/rust"), "uvc_recon", "v1");
-        write_peppy_json5(&repo.join("uvc_recon/python"), "uvc_recon", "v1");
-
-        let walked = walk_directory(&repo, RepoSourceKind::Fs, None, None, &[]);
-
-        assert_eq!(walked.conflicts.len(), 1, "one contested identity");
-        let conflict = &walked.conflicts[0];
-        assert_eq!(conflict.kind, RepoItemKind::Node);
-        assert_eq!(conflict.name, "uvc_recon");
-        assert_eq!(conflict.tag, "v1");
-        assert_eq!(conflict.paths.len(), 2, "both claimants named");
-        assert!(
-            conflict.paths.iter().any(|p| p.contains("rust")),
-            "got: {:?}",
-            conflict.paths
-        );
-        assert!(
-            conflict.paths.iter().any(|p| p.contains("python")),
-            "got: {:?}",
-            conflict.paths
-        );
-        // Only one claimant reaches the entry vector; which one is walk
-        // order and deliberately not asserted.
-        assert_eq!(walked.nodes.len(), 1);
-    }
-
-    /// Launchers are keyed by file stem, so two identically named
-    /// launcher files in one repository contest the same identity even
-    /// though they live in different directories.
-    #[test]
-    fn walk_directory_reports_launcher_stem_claimed_twice() {
-        let tmp = tempfile::tempdir().unwrap();
-        let repo = tmp.path().join("launchers-hub");
-        write_launcher_json5(&repo.join("sim/bringup.json5"));
-        write_launcher_json5(&repo.join("real/bringup.json5"));
-
-        let walked = walk_directory(&repo, RepoSourceKind::Fs, None, None, &[]);
-
-        assert_eq!(walked.conflicts.len(), 1);
-        assert_eq!(walked.conflicts[0].kind, RepoItemKind::Launcher);
-        assert_eq!(walked.conflicts[0].name, "bringup");
-        assert_eq!(walked.conflicts[0].tag, "", "launchers carry no tag");
-        assert_eq!(walked.conflicts[0].paths.len(), 2);
-    }
-
-    /// Contracts and pairings are contested the same way as nodes, so a
-    /// duplicate in either is caught rather than silently resolved.
-    #[test]
-    fn walk_directory_reports_contract_and_pairing_claimed_twice() {
-        let tmp = tempfile::tempdir().unwrap();
-        let repo = tmp.path().join("contracts-hub");
-        write_contract_json5(&repo.join("a/rgb.json5"), "rgb_camera", "v1");
-        write_contract_json5(&repo.join("b/rgb.json5"), "rgb_camera", "v1");
-        write_pairing_json5(&repo.join("a/joint.json5"), "joint_link", "v1");
-        write_pairing_json5(&repo.join("b/joint.json5"), "joint_link", "v1");
-
-        let walked = walk_directory(&repo, RepoSourceKind::Fs, None, None, &[]);
-
-        let kinds: Vec<RepoItemKind> = walked.conflicts.iter().map(|c| c.kind).collect();
-        assert_eq!(
-            kinds,
-            vec![RepoItemKind::Contract, RepoItemKind::Pairing],
-            "one conflict per kind, grouped by kind"
-        );
-        assert_eq!(walked.conflicts[0].name, "rgb_camera");
-        assert_eq!(walked.conflicts[1].name, "joint_link");
-    }
-
-    /// The report is ordered by identity with sorted paths, so it is
-    /// reproducible in a test and comparable between two machines whose
-    /// filesystems hand back directories in different orders.
-    #[test]
-    fn walk_directory_conflicts_are_ordered_independently_of_walk_order() {
-        let tmp = tempfile::tempdir().unwrap();
-        let repo = tmp.path().join("repo");
-        for dir in ["zzz", "aaa", "mmm"] {
-            write_peppy_json5(&repo.join(dir), "beta", "v1");
-        }
-        write_peppy_json5(&repo.join("one"), "alpha", "v1");
-        write_peppy_json5(&repo.join("two"), "alpha", "v1");
-
-        let walked = walk_directory(&repo, RepoSourceKind::Fs, None, None, &[]);
-
-        let names: Vec<&str> = walked.conflicts.iter().map(|c| c.name.as_str()).collect();
-        assert_eq!(names, vec!["alpha", "beta"], "sorted by identity");
-
-        let beta_paths = &walked.conflicts[1].paths;
-        assert_eq!(beta_paths.len(), 3, "every claimant is named, not just two");
-        let mut sorted = beta_paths.clone();
-        sorted.sort();
-        assert_eq!(beta_paths, &sorted, "paths sorted");
-    }
-
-    /// Same name under different tags is two identities, not a conflict.
-    /// This is the guard against the check firing on ordinary versioning.
-    #[test]
-    fn walk_directory_same_name_different_tags_is_not_a_conflict() {
-        let tmp = tempfile::tempdir().unwrap();
-        let repo = tmp.path().join("repo");
-        write_peppy_json5(&repo.join("v1"), "my_sensor", "v1");
-        write_peppy_json5(&repo.join("v2"), "my_sensor", "v2");
-
-        let walked = walk_directory(&repo, RepoSourceKind::Fs, None, None, &[]);
-
-        assert!(walked.conflicts.is_empty(), "{:?}", walked.conflicts);
-        assert_eq!(walked.nodes.len(), 2);
     }
 
     /// Process_refresh discovers launcher files (any `.json5` filename

--- a/crates/core-node-internal/src/services/repo/refresh.rs
+++ b/crates/core-node-internal/src/services/repo/refresh.rs
@@ -1339,10 +1339,14 @@ mod tests {
             refreshed.failures[0].retained, 1,
             "only `from_two` is retained, not `from_one`"
         );
+        // Node paths are stored canonicalized, so compare against the
+        // canonical form of the repo root (on macOS the tempdir `two` is a
+        // `/var` symlink to `/private/var`).
+        let two_root = std::fs::canonicalize(&two).unwrap();
         let retained: Vec<&str> = refreshed
             .nodes
             .iter()
-            .filter(|n| n.path.starts_with(two.to_string_lossy().as_ref()))
+            .filter(|n| n.path.starts_with(two_root.to_string_lossy().as_ref()))
             .map(|n| n.node_name.as_str())
             .collect();
         assert_eq!(retained, vec!["from_two"]);

--- a/crates/daemon-config-internal/src/consts.rs
+++ b/crates/daemon-config-internal/src/consts.rs
@@ -6,6 +6,11 @@ pub const PEPPYLIB_OUTPUT_PATH: &str = ".peppy/libs/peppylib";
 /// login` flow; never committed and never world-readable.
 pub const CREDENTIALS_FILE: &str = "credentials.json5";
 
+/// Filename of a repository's index, at the root of the tree peppy is
+/// configured to scan. A repository states there what it publishes and where
+/// each item is declared; without it the repository does not resolve.
+pub const REPOSITORY_INDEX_FILE: &str = "peppy_repository.json5";
+
 pub const PEPPY_MESSAGING_PORT_VAR_NAME: &str = "PEPPY_MESSAGING_PORT";
 
 /// Default base container image for Rust nodes (Ubuntu 24.04 + Rust via rustup, build-essential).

--- a/crates/daemon-config-internal/src/lib.rs
+++ b/crates/daemon-config-internal/src/lib.rs
@@ -34,6 +34,7 @@ mod internal {
     pub mod launcher;
     pub mod pairing;
     pub mod peppy_config;
+    pub mod repository;
     pub mod source;
 }
 
@@ -70,7 +71,8 @@ pub mod consts {
     pub use crate::internal::consts::{
         AppEnv, CREDENTIALS_FILE, DEFAULT_ALPINE_BASE_IMAGE, DEFAULT_PYTHON_BASE_IMAGE,
         DEFAULT_RUST_BASE_IMAGE, PEPPY_MESSAGING_PORT_VAR_NAME, PEPPY_OUTPUT_DIR,
-        PEPPYLIB_OUTPUT_PATH, PeppyDirs, non_empty_env_path, peppy_root_dir, set_app_env,
+        PEPPYLIB_OUTPUT_PATH, PeppyDirs, REPOSITORY_INDEX_FILE, non_empty_env_path, peppy_root_dir,
+        set_app_env,
     };
 }
 
@@ -105,6 +107,14 @@ pub mod contract {
 // -- pairing --
 pub mod pairing {
     pub use crate::internal::pairing::{PairingTopic, PeppyPairing, PeppyPairingParser};
+}
+
+// -- repository --
+pub mod repository {
+    pub use crate::internal::repository::{
+        DeclaredItem, DeclaredPaths, IndexedItem, ItemName, ItemTag, PeppyRepositoryIndexParser,
+        RepoItemKind, RepoPathError, RepoRelativePath, RepositoryIndex, TaggedSection, UniqueMap,
+    };
 }
 
 // -- source --

--- a/crates/daemon-config-internal/src/repository.rs
+++ b/crates/daemon-config-internal/src/repository.rs
@@ -1,0 +1,17 @@
+mod parse;
+mod types;
+
+pub use core_node_api::encoding::RepoItemKind;
+
+// Defines the repository index (`peppy_schema: "repository/v1"`), the
+// `peppy_repository.json5` document at the root of the tree peppy scans.
+// A repository states there what it publishes and where each item is
+// declared, so resolution reads one file and the paths it names instead of
+// discovering identities by walking a directory tree. The nesting is the
+// uniqueness rule: a second claim on one identity has nowhere to go except a
+// key that is already taken.
+pub use parse::PeppyRepositoryIndexParser;
+pub use types::{
+    DeclaredItem, DeclaredPaths, IndexedItem, ItemName, ItemTag, RepoPathError, RepoRelativePath,
+    RepositoryIndex, TaggedSection, UniqueMap,
+};

--- a/crates/daemon-config-internal/src/repository.rs
+++ b/crates/daemon-config-internal/src/repository.rs
@@ -6,10 +6,9 @@ pub use core_node_api::encoding::RepoItemKind;
 // Defines the repository index (`peppy_schema: "repository/v1"`), the
 // `peppy_repository.json5` document at the root of the tree peppy scans.
 // A repository states there what it publishes and where each item is
-// declared, so resolution reads one file and the paths it names instead of
-// discovering identities by walking a directory tree. The nesting is the
-// uniqueness rule: a second claim on one identity has nowhere to go except a
-// key that is already taken.
+// declared, and `peppy repo index` writes that statement and checks it back
+// against the tree. The nesting is the uniqueness rule: a second claim on one
+// identity has nowhere to go except a key that is already taken.
 pub use parse::PeppyRepositoryIndexParser;
 pub use types::{
     DeclaredItem, DeclaredPaths, IndexedItem, ItemName, ItemTag, RepoPathError, RepoRelativePath,

--- a/crates/daemon-config-internal/src/repository/parse.rs
+++ b/crates/daemon-config-internal/src/repository/parse.rs
@@ -1,0 +1,202 @@
+use super::types::RepositoryIndex;
+use crate::{error::Result, parsing::read_non_empty_file};
+use std::path::Path;
+
+/// Parser for a repository's `peppy_repository.json5` index.
+///
+/// Unlike the item documents, an index is identified by its filename and its
+/// position at the root of the scanned tree, so a caller never has to try
+/// parsing one speculatively: it is either there and readable or the
+/// repository does not resolve.
+pub struct PeppyRepositoryIndexParser;
+
+impl PeppyRepositoryIndexParser {
+    pub fn from_path(file: impl AsRef<Path>) -> Result<RepositoryIndex> {
+        let path = file.as_ref();
+        let content = read_non_empty_file(path)?;
+        Self::from_content(&content)
+    }
+
+    pub fn from_content(content: &str) -> Result<RepositoryIndex> {
+        crate::error::deserialize_json5_with_path(content)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        error::{Error, ParsingError},
+        repository::RepoItemKind,
+    };
+    use tempfile::NamedTempFile;
+
+    const EVERY_KIND: &str = r#"{
+        peppy_schema: "repository/v1",
+        nodes: {
+          "uvc_camera": {
+            "v1": { path: "uvc_camera/rust/peppy.json5" },
+            "v2": { path: "uvc_camera/python/peppy.json5" },
+          },
+        },
+        launchers: { "openarm_v1_teleop": { path: "openarm/openarm_v1_teleop.json5" } },
+        contracts: { "rgb_camera": { "v1": { path: "cameras/rgb_camera.json5" } } },
+        pairings: { "joint_link": { "v1": { path: "robot/joint_link.json5" } } },
+    }"#;
+
+    #[test]
+    fn parses_every_kind_in_a_deterministic_order() {
+        let index = PeppyRepositoryIndexParser::from_content(EVERY_KIND).expect("parses");
+        let declared: Vec<String> = index
+            .declared_items()
+            .map(|item| format!("{item} -> {}", item.path))
+            .collect();
+        assert_eq!(
+            declared,
+            vec![
+                "node `uvc_camera:v1` -> uvc_camera/rust/peppy.json5",
+                "node `uvc_camera:v2` -> uvc_camera/python/peppy.json5",
+                "launcher `openarm_v1_teleop` -> openarm/openarm_v1_teleop.json5",
+                "contract `rgb_camera:v1` -> cameras/rgb_camera.json5",
+                "pairing `joint_link:v1` -> robot/joint_link.json5",
+            ]
+        );
+    }
+
+    /// A repository that publishes nothing is a valid repository. Only a
+    /// missing index means it has not adopted one, and the two need
+    /// different answers.
+    #[test]
+    fn an_empty_index_is_valid() {
+        let index =
+            PeppyRepositoryIndexParser::from_content(r#"{ peppy_schema: "repository/v1" }"#)
+                .expect("an empty index parses");
+        assert_eq!(index.declared_count(), 0);
+    }
+
+    #[test]
+    fn missing_file_rejected() {
+        assert!(matches!(
+            PeppyRepositoryIndexParser::from_path("/path/does/not/exist.json5").unwrap_err(),
+            Error::Parsing(ParsingError::CannotRead(..))
+        ));
+    }
+
+    #[test]
+    fn empty_file_rejected() {
+        let tmp = NamedTempFile::new().expect("temp file");
+        std::fs::write(tmp.path(), b"").expect("write");
+        assert!(matches!(
+            PeppyRepositoryIndexParser::from_path(tmp.path()).unwrap_err(),
+            Error::Parsing(ParsingError::EmptyContent(_))
+        ));
+    }
+
+    #[test]
+    fn from_path_loads_file() {
+        let tmp = NamedTempFile::new().expect("temp file");
+        std::fs::write(tmp.path(), EVERY_KIND).expect("write");
+        let index = PeppyRepositoryIndexParser::from_path(tmp.path()).expect("parses");
+        assert_eq!(index.declared_count(), 5);
+    }
+
+    /// An index peppy does not understand is refused rather than read on a
+    /// best-effort basis, which would resolve whatever subset it recognized
+    /// and call that the repository's contents.
+    #[test]
+    fn an_unknown_index_version_is_refused() {
+        let err = PeppyRepositoryIndexParser::from_content(r#"{ peppy_schema: "repository/v2" }"#)
+            .expect_err("an unknown version must be refused");
+        assert!(err.to_string().contains("repository/v2"), "{err}");
+    }
+
+    #[test]
+    fn a_node_document_is_not_an_index() {
+        let err = PeppyRepositoryIndexParser::from_content(
+            r#"{ peppy_schema: "node/v1", manifest: { name: "a", tag: "v1" } }"#,
+        )
+        .expect_err("a node document must not parse as an index");
+        assert!(err.to_string().contains("repository/v1"), "{err}");
+    }
+
+    #[test]
+    fn rejects_an_unknown_section() {
+        let err = PeppyRepositoryIndexParser::from_content(
+            r#"{ peppy_schema: "repository/v1", plugins: {} }"#,
+        )
+        .expect_err("an unknown section must be refused");
+        assert!(err.to_string().contains("plugins"), "{err}");
+    }
+
+    /// The error names the identity and both files, because the point of
+    /// refusing here is that the author can see which two claims collide.
+    #[test]
+    fn rejects_one_identity_claimed_twice() {
+        let err = PeppyRepositoryIndexParser::from_content(
+            r#"{
+                 peppy_schema: "repository/v1",
+                 nodes: {
+                   "uvc_camera": {
+                     "v1": { path: "rust/peppy.json5" },
+                     "v1": { path: "python/peppy.json5" },
+                   },
+                 },
+               }"#,
+        )
+        .expect_err("a repeated tag must be refused");
+        let message = err.to_string();
+        assert!(message.contains("duplicate key `v1`"), "{message}");
+        assert!(message.contains("rust/peppy.json5"), "{message}");
+        assert!(message.contains("python/peppy.json5"), "{message}");
+        assert!(message.contains("nodes.uvc_camera"), "{message}");
+    }
+
+    #[test]
+    fn rejects_a_path_that_leaves_the_repository() {
+        let err = PeppyRepositoryIndexParser::from_content(
+            r#"{
+                 peppy_schema: "repository/v1",
+                 nodes: { "a": { "v1": { path: "../../etc/passwd" } } },
+               }"#,
+        )
+        .expect_err("an escaping path must be refused");
+        assert!(err.to_string().contains("leaves the repository"), "{err}");
+    }
+
+    #[test]
+    fn declares_each_kind_into_its_own_section() {
+        let mut index = RepositoryIndex::default();
+        let name = |raw: &str| super::super::types::ItemName::parse(raw).expect("valid name");
+        let tag = |raw: &str| super::super::types::ItemTag::parse(raw).expect("valid tag");
+        let path =
+            |raw: &str| super::super::types::RepoRelativePath::parse(raw).expect("valid path");
+
+        index
+            .declare(
+                RepoItemKind::Node,
+                name("a"),
+                Some(tag("v1")),
+                path("a.json5"),
+            )
+            .expect("declares a node");
+        index
+            .declare(RepoItemKind::Launcher, name("b"), None, path("b.json5"))
+            .expect("declares a launcher");
+        assert_eq!(index.declared_count(), 2);
+
+        let err = index
+            .declare(
+                RepoItemKind::Launcher,
+                name("c"),
+                Some(tag("v1")),
+                path("c.json5"),
+            )
+            .expect_err("a launcher cannot carry a tag");
+        assert!(err.contains("cannot carry a tag"), "{err}");
+
+        let err = index
+            .declare(RepoItemKind::Node, name("d"), None, path("d.json5"))
+            .expect_err("a node needs a tag");
+        assert!(err.contains("has no tag"), "{err}");
+    }
+}

--- a/crates/daemon-config-internal/src/repository/parse.rs
+++ b/crates/daemon-config-internal/src/repository/parse.rs
@@ -6,8 +6,8 @@ use std::path::Path;
 ///
 /// Unlike the item documents, an index is identified by its filename and its
 /// position at the root of the scanned tree, so a caller never has to try
-/// parsing one speculatively: it is either there and readable or the
-/// repository does not resolve.
+/// parsing one speculatively: it is either there and readable or reading it
+/// is an error.
 pub struct PeppyRepositoryIndexParser;
 
 impl PeppyRepositoryIndexParser {

--- a/crates/daemon-config-internal/src/repository/types.rs
+++ b/crates/daemon-config-internal/src/repository/types.rs
@@ -1,0 +1,643 @@
+use config::schema::PeppySchema;
+use core_node_api::encoding::RepoItemKind;
+use serde::{
+    Deserialize, Serialize,
+    de::{self, Deserializer, MapAccess, Visitor},
+};
+use std::{
+    collections::{BTreeMap, btree_map::Entry},
+    fmt,
+    marker::PhantomData,
+    path::{Component, Path},
+};
+use thiserror::Error;
+
+/// A repository-relative path to the file that declares one item.
+///
+/// Every path peppy resolved from used to be produced by its own directory
+/// walk. An index path arrives instead from a file somebody merged, so it is
+/// untrusted input and the rules below are enforced at parse time: a value of
+/// this type is already known to stay inside the repository.
+///
+/// Parsing is canonical, which is what lets `peppy repo index --check`
+/// compare a committed path against a freshly generated one with `==`
+/// instead of reporting `./a.json5` as a move of `a.json5`.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+#[serde(transparent)]
+pub struct RepoRelativePath(String);
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum RepoPathError {
+    #[error("path is empty")]
+    Empty,
+    #[error(
+        "path contains a backslash, which separates directories on Windows \
+         and is an ordinary filename character elsewhere: {0}"
+    )]
+    Backslash(String),
+    #[error("path leaves the repository: {0}")]
+    NotInside(String),
+    #[error("path is not normalized (it contains `.` or a repeated separator): {0}")]
+    NotNormalized(String),
+    #[error("path names a directory, but an entry must name the file that declares the item: {0}")]
+    NotAFile(String),
+}
+
+impl RepoRelativePath {
+    /// The one statement of the path rules. Both the generator and
+    /// `Deserialize` go through it, so a generated index can never hold a
+    /// path that reading an index would refuse.
+    pub fn parse(raw: &str) -> Result<Self, RepoPathError> {
+        let path = raw.trim();
+        if path.is_empty() {
+            return Err(RepoPathError::Empty);
+        }
+        if path.contains('\\') {
+            return Err(RepoPathError::Backslash(path.to_owned()));
+        }
+        if path.starts_with('/') {
+            return Err(RepoPathError::NotInside(path.to_owned()));
+        }
+        if path.ends_with('/') {
+            return Err(RepoPathError::NotAFile(path.to_owned()));
+        }
+        for segment in path.split('/') {
+            match segment {
+                ".." => return Err(RepoPathError::NotInside(path.to_owned())),
+                "" | "." => return Err(RepoPathError::NotNormalized(path.to_owned())),
+                _ => {}
+            }
+        }
+        // Backstop for platforms where a root or a drive prefix is not
+        // spelled with a leading `/`. The textual checks above cover the
+        // hosts peppy runs on; this covers the type's promise everywhere.
+        if Path::new(path)
+            .components()
+            .any(|component| !matches!(component, Component::Normal(_)))
+        {
+            return Err(RepoPathError::NotInside(path.to_owned()));
+        }
+        Ok(Self(path.to_owned()))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn as_path(&self) -> &Path {
+        Path::new(&self.0)
+    }
+}
+
+impl fmt::Display for RepoRelativePath {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for RepoRelativePath {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        let raw = String::deserialize(deserializer)?;
+        Self::parse(&raw).map_err(de::Error::custom)
+    }
+}
+
+/// Declares a validated string newtype whose `Deserialize` runs `$validate`,
+/// so an index cannot state an identity the repository caches could never
+/// key on. The two identity halves differ only in which shared validator
+/// they call, so the surrounding boilerplate is written once.
+macro_rules! validated_identity {
+    ($(#[$meta:meta])* $name:ident, $validate:path, $label:literal) => {
+        $(#[$meta])*
+        #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+        #[serde(transparent)]
+        pub struct $name(String);
+
+        impl $name {
+            pub fn parse(raw: &str) -> Result<Self, String> {
+                $validate(raw, $label)?;
+                Ok(Self(raw.to_owned()))
+            }
+
+            pub fn as_str(&self) -> &str {
+                &self.0
+            }
+        }
+
+        impl fmt::Display for $name {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str(&self.0)
+            }
+        }
+
+        impl<'de> Deserialize<'de> for $name {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                let raw = String::deserialize(deserializer)?;
+                Self::parse(&raw).map_err(de::Error::custom)
+            }
+        }
+    };
+}
+
+validated_identity!(
+    /// The name half of an item's identity, held to the same charset the
+    /// rest of peppy resolves `name:tag` with.
+    ItemName,
+    config::repo_node_id::validate_repo_node_name,
+    "name"
+);
+
+validated_identity!(
+    /// The tag half of an item's identity. Launchers carry no tag and are
+    /// indexed one level deep instead of borrowing an empty one.
+    ItemTag,
+    config::repo_node_id::validate_repo_node_tag,
+    "tag"
+);
+
+/// Where one published identity is declared.
+///
+/// An object rather than a bare path string so an entry reads without
+/// knowing the format, and so a field can be added later as an additive
+/// diff instead of a rewrite of every entry in every repository. Only facts
+/// about the repository's publication of an identity belong here; facts
+/// about the item itself live in the file `path` names and are read from
+/// there, because a copy of them here would drift.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct IndexedItem {
+    pub path: RepoRelativePath,
+}
+
+/// A section keyed by name and then by tag. The nesting is the uniqueness
+/// rule: a second claim on one identity has nowhere to go except a key that
+/// is already taken.
+pub type TaggedSection = UniqueMap<ItemName, UniqueMap<ItemTag, IndexedItem>>;
+
+/// Reject any `peppy_schema` value other than `repository/v1`, so a node or
+/// launcher document dropped at a repository root is not read as an index.
+fn deserialize_repository_v1_schema<'de, D>(deserializer: D) -> Result<PeppySchema, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    PeppySchema::deserialize_expecting(deserializer, PeppySchema::RepositoryV1)
+}
+
+/// What a repository publishes and where each item is declared.
+///
+/// Lives at the root of the tree peppy is configured to scan, so two entries
+/// pointing at two subtrees of one repository are two independently indexed
+/// repositories. A repository that publishes nothing has empty sections: an
+/// index that is present and empty is valid, while a missing one is not,
+/// because "publishes nothing" and "has no index" need different answers.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RepositoryIndex {
+    #[serde(deserialize_with = "deserialize_repository_v1_schema")]
+    pub peppy_schema: PeppySchema,
+    #[serde(default, skip_serializing_if = "UniqueMap::is_empty")]
+    pub nodes: TaggedSection,
+    /// One level deep, because a launcher is identified by its file stem and
+    /// carries no tag.
+    #[serde(default, skip_serializing_if = "UniqueMap::is_empty")]
+    pub launchers: UniqueMap<ItemName, IndexedItem>,
+    #[serde(default, skip_serializing_if = "UniqueMap::is_empty")]
+    pub contracts: TaggedSection,
+    #[serde(default, skip_serializing_if = "UniqueMap::is_empty")]
+    pub pairings: TaggedSection,
+}
+
+/// Flattens one two-level section into items. A free function rather than a
+/// closure so the borrow of `section` is tied to the items it yields.
+fn tagged_items(
+    kind: RepoItemKind,
+    section: &TaggedSection,
+) -> impl Iterator<Item = DeclaredItem<'_>> {
+    section.iter().flat_map(move |(name, tags)| {
+        tags.iter().map(move |(tag, item)| DeclaredItem {
+            kind,
+            name,
+            tag: Some(tag),
+            path: &item.path,
+        })
+    })
+}
+
+/// One identity a repository publishes, flattened out of whichever section
+/// declares it so callers iterate items rather than sections.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DeclaredItem<'a> {
+    pub kind: RepoItemKind,
+    pub name: &'a ItemName,
+    /// `None` for a launcher, which is the only kind without a tag.
+    pub tag: Option<&'a ItemTag>,
+    pub path: &'a RepoRelativePath,
+}
+
+impl fmt::Display for DeclaredItem<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.tag {
+            Some(tag) => write!(f, "{} `{}:{}`", self.kind, self.name, tag),
+            None => write!(f, "{} `{}`", self.kind, self.name),
+        }
+    }
+}
+
+impl Default for RepositoryIndex {
+    fn default() -> Self {
+        Self {
+            peppy_schema: PeppySchema::RepositoryV1,
+            nodes: UniqueMap::default(),
+            launchers: UniqueMap::default(),
+            contracts: UniqueMap::default(),
+            pairings: UniqueMap::default(),
+        }
+    }
+}
+
+impl RepositoryIndex {
+    /// Records one published identity, refusing a second claim on it.
+    ///
+    /// `tag` must be `Some` for every kind except a launcher. A mismatch is
+    /// a caller bug rather than something a file can express, so it is
+    /// reported the same way a duplicate is instead of being silently
+    /// coerced into the wrong section.
+    pub fn declare(
+        &mut self,
+        kind: RepoItemKind,
+        name: ItemName,
+        tag: Option<ItemTag>,
+        path: RepoRelativePath,
+    ) -> Result<(), String> {
+        let item = IndexedItem { path };
+        let RepoItemKind::Launcher = kind else {
+            let Some(tag) = tag else {
+                return Err(format!("{kind} `{name}` has no tag"));
+            };
+            let section = match kind {
+                RepoItemKind::Node => &mut self.nodes,
+                RepoItemKind::Contract => &mut self.contracts,
+                RepoItemKind::Pairing => &mut self.pairings,
+                RepoItemKind::Launcher => unreachable!("handled by the let-else above"),
+            };
+            let tags = section.entry_or_default(name);
+            return tags.try_insert(tag, item);
+        };
+        if tag.is_some() {
+            return Err(format!("launcher `{name}` cannot carry a tag"));
+        }
+        self.launchers.try_insert(name, item)
+    }
+
+    /// Every identity the repository publishes, in a deterministic order that
+    /// never inherits the order a directory tree happened to be read in.
+    pub fn declared_items(&self) -> impl Iterator<Item = DeclaredItem<'_>> {
+        tagged_items(RepoItemKind::Node, &self.nodes)
+            .chain(self.launchers.iter().map(|(name, item)| DeclaredItem {
+                kind: RepoItemKind::Launcher,
+                name,
+                tag: None,
+                path: &item.path,
+            }))
+            .chain(tagged_items(RepoItemKind::Contract, &self.contracts))
+            .chain(tagged_items(RepoItemKind::Pairing, &self.pairings))
+    }
+
+    pub fn declared_count(&self) -> usize {
+        self.declared_items().count()
+    }
+}
+
+/// Every path a value declares, so a duplicate key can be reported by the
+/// files it points at rather than by the key alone.
+pub trait DeclaredPaths {
+    fn declared_paths(&self) -> Vec<&RepoRelativePath>;
+}
+
+impl DeclaredPaths for IndexedItem {
+    fn declared_paths(&self) -> Vec<&RepoRelativePath> {
+        vec![&self.path]
+    }
+}
+
+impl<K, V: DeclaredPaths> DeclaredPaths for UniqueMap<K, V> {
+    fn declared_paths(&self) -> Vec<&RepoRelativePath> {
+        self.0
+            .values()
+            .flat_map(DeclaredPaths::declared_paths)
+            .collect()
+    }
+}
+
+/// A map that refuses a key stated twice.
+///
+/// A conventional map deserializer accepts a repeated key and silently keeps
+/// the last one. For an index that is exactly the mistake worth failing on:
+/// the file would then say two things about one identity while peppy quietly
+/// believed one of them, which is harder to find than a loud refusal because
+/// nothing reports and nothing diverges.
+///
+/// The `BTreeMap` inside also gives generation its deterministic order, so a
+/// generated index is byte-identical for a given tree on every machine.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(transparent)]
+pub struct UniqueMap<K, V>(BTreeMap<K, V>);
+
+// Written out rather than derived: a derived `Default` would demand
+// `K: Default, V: Default`, which an empty map does not need.
+impl<K, V> Default for UniqueMap<K, V> {
+    fn default() -> Self {
+        Self(BTreeMap::new())
+    }
+}
+
+impl<K: Ord + fmt::Display, V: DeclaredPaths> UniqueMap<K, V> {
+    /// Inserts `key`, refusing a second claim on it. Generation and reading
+    /// share this so both report a duplicate the same way.
+    pub fn try_insert(&mut self, key: K, value: V) -> Result<(), String> {
+        match self.0.entry(key) {
+            Entry::Occupied(existing) => Err(duplicate_key_message(
+                existing.key(),
+                existing.get(),
+                &value,
+            )),
+            Entry::Vacant(slot) => {
+                slot.insert(value);
+                Ok(())
+            }
+        }
+    }
+}
+
+impl<K: Ord, V: Default> UniqueMap<K, V> {
+    /// The nested section a name owns, created empty on first use. Only the
+    /// two-level sections need it, where a name is a container rather than a
+    /// claim in its own right.
+    fn entry_or_default(&mut self, key: K) -> &mut V {
+        self.0.entry(key).or_default()
+    }
+}
+
+impl<K, V> UniqueMap<K, V> {
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&K, &V)> {
+        self.0.iter()
+    }
+}
+
+fn duplicate_key_message<K: fmt::Display, V: DeclaredPaths>(
+    key: &K,
+    first: &V,
+    second: &V,
+) -> String {
+    format!(
+        "duplicate key `{key}`: already declared at {}, declared again at {}",
+        describe_paths(&first.declared_paths()),
+        describe_paths(&second.declared_paths())
+    )
+}
+
+fn describe_paths(paths: &[&RepoRelativePath]) -> String {
+    if paths.is_empty() {
+        return "no path".to_owned();
+    }
+    paths
+        .iter()
+        .map(|path| path.as_str())
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+struct UniqueMapVisitor<K, V>(PhantomData<(K, V)>);
+
+impl<'de, K, V> Visitor<'de> for UniqueMapVisitor<K, V>
+where
+    K: Deserialize<'de> + Ord + fmt::Display,
+    V: Deserialize<'de> + DeclaredPaths,
+{
+    type Value = UniqueMap<K, V>;
+
+    fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("a map with no repeated key")
+    }
+
+    fn visit_map<A: MapAccess<'de>>(self, mut access: A) -> Result<Self::Value, A::Error> {
+        let mut map = UniqueMap::default();
+        while let Some(key) = access.next_key::<K>()? {
+            let value = access.next_value::<V>()?;
+            map.try_insert(key, value).map_err(de::Error::custom)?;
+        }
+        Ok(map)
+    }
+}
+
+impl<'de, K, V> Deserialize<'de> for UniqueMap<K, V>
+where
+    K: Deserialize<'de> + Ord + fmt::Display,
+    V: Deserialize<'de> + DeclaredPaths,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        deserializer.deserialize_map(UniqueMapVisitor(PhantomData))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Records every entry the deserializer hands it, repeats included.
+    /// Exists only to pin the third-party behavior `UniqueMap` rests on.
+    #[derive(Debug, Default)]
+    struct CountingMap(Vec<(String, u32)>);
+
+    impl<'de> Deserialize<'de> for CountingMap {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: de::Deserializer<'de>,
+        {
+            struct CountingVisitor;
+
+            impl<'de> Visitor<'de> for CountingVisitor {
+                type Value = CountingMap;
+
+                fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    f.write_str("any map")
+                }
+
+                fn visit_map<A: MapAccess<'de>>(
+                    self,
+                    mut access: A,
+                ) -> Result<Self::Value, A::Error> {
+                    let mut seen = Vec::new();
+                    while let Some(entry) = access.next_entry::<String, u32>()? {
+                        seen.push(entry);
+                    }
+                    Ok(CountingMap(seen))
+                }
+            }
+
+            deserializer.deserialize_map(CountingVisitor)
+        }
+    }
+
+    /// Pins the one third-party behavior `UniqueMap` rests on: `serde_json5`
+    /// must hand both halves of a repeated key to the visitor rather than
+    /// collapsing them before serde sees them. If this ever fails, duplicate
+    /// rejection is silently dead everywhere and a syntactic pre-pass over
+    /// the raw text has to take over.
+    #[test]
+    fn serde_json5_streams_duplicate_object_keys_to_the_visitor() {
+        let seen: CountingMap = serde_json5::from_str("{ a: 1, a: 2 }").expect("parses");
+        assert_eq!(
+            seen.0,
+            vec![("a".to_owned(), 1), ("a".to_owned(), 2)],
+            "serde_json5 collapsed a duplicate key before the visitor saw it"
+        );
+    }
+
+    fn item(path: &str) -> IndexedItem {
+        IndexedItem {
+            path: RepoRelativePath::parse(path).expect("valid path"),
+        }
+    }
+
+    #[test]
+    fn rejects_a_duplicate_key_naming_both_paths() {
+        let err = serde_json5::from_str::<UniqueMap<ItemTag, IndexedItem>>(
+            r#"{ "v1": { path: "a/peppy.json5" }, "v1": { path: "b/peppy.json5" } }"#,
+        )
+        .expect_err("a repeated tag must be refused");
+        let message = err.to_string();
+        assert!(message.contains("duplicate key `v1`"), "{message}");
+        assert!(message.contains("a/peppy.json5"), "{message}");
+        assert!(message.contains("b/peppy.json5"), "{message}");
+    }
+
+    #[test]
+    fn rejects_a_duplicate_name_naming_every_path_below_it() {
+        let err = serde_json5::from_str::<UniqueMap<ItemName, UniqueMap<ItemTag, IndexedItem>>>(
+            r#"{
+                 "uvc": { "v1": { path: "a/peppy.json5" } },
+                 "uvc": { "v2": { path: "b/peppy.json5" } },
+               }"#,
+        )
+        .expect_err("a repeated name must be refused");
+        let message = err.to_string();
+        assert!(message.contains("duplicate key `uvc`"), "{message}");
+        assert!(message.contains("a/peppy.json5"), "{message}");
+        assert!(message.contains("b/peppy.json5"), "{message}");
+    }
+
+    #[test]
+    fn accepts_distinct_keys() {
+        let map: UniqueMap<ItemTag, IndexedItem> = serde_json5::from_str(
+            r#"{ "v1": { path: "a/peppy.json5" }, "v2": { path: "b/peppy.json5" } }"#,
+        )
+        .expect("distinct tags parse");
+        assert_eq!(map.len(), 2);
+    }
+
+    #[test]
+    fn try_insert_refuses_a_second_claim() {
+        let mut map: UniqueMap<ItemTag, IndexedItem> = UniqueMap::default();
+        let tag = ItemTag::parse("v1").expect("valid tag");
+        map.try_insert(tag.clone(), item("a/peppy.json5"))
+            .expect("first claim");
+        let err = map
+            .try_insert(tag, item("b/peppy.json5"))
+            .expect_err("second claim");
+        assert!(
+            err.contains("a/peppy.json5") && err.contains("b/peppy.json5"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn rejects_an_unknown_field_on_an_entry() {
+        let err =
+            serde_json5::from_str::<IndexedItem>(r#"{ path: "a/peppy.json5", description: "no" }"#)
+                .expect_err("an unknown field must be refused");
+        assert!(err.to_string().contains("description"), "{err}");
+    }
+
+    #[test]
+    fn parses_a_repository_relative_path() {
+        let path = RepoRelativePath::parse("uvc_camera/rust/peppy.json5").expect("valid");
+        assert_eq!(path.as_str(), "uvc_camera/rust/peppy.json5");
+    }
+
+    #[test]
+    fn trims_surrounding_whitespace_so_parsing_is_canonical() {
+        let path = RepoRelativePath::parse("  a/peppy.json5  ").expect("valid");
+        assert_eq!(path.as_str(), "a/peppy.json5");
+    }
+
+    #[test]
+    fn refuses_paths_that_do_not_locate_a_file_inside_the_repository() {
+        let cases = [
+            ("", RepoPathError::Empty),
+            ("   ", RepoPathError::Empty),
+            (
+                "a\\b.json5",
+                RepoPathError::Backslash("a\\b.json5".to_owned()),
+            ),
+            (
+                "/etc/passwd",
+                RepoPathError::NotInside("/etc/passwd".to_owned()),
+            ),
+            (
+                "../../etc/passwd",
+                RepoPathError::NotInside("../../etc/passwd".to_owned()),
+            ),
+            (
+                "a/../b.json5",
+                RepoPathError::NotInside("a/../b.json5".to_owned()),
+            ),
+            (
+                "./a.json5",
+                RepoPathError::NotNormalized("./a.json5".to_owned()),
+            ),
+            (
+                "a/./b.json5",
+                RepoPathError::NotNormalized("a/./b.json5".to_owned()),
+            ),
+            (
+                "a//b.json5",
+                RepoPathError::NotNormalized("a//b.json5".to_owned()),
+            ),
+            ("a/", RepoPathError::NotAFile("a/".to_owned())),
+        ];
+        for (raw, expected) in cases {
+            let err =
+                RepoRelativePath::parse(raw).expect_err(&format!("expected `{raw}` to be refused"));
+            assert_eq!(err, expected, "wrong error for `{raw}`");
+        }
+    }
+
+    #[test]
+    fn refuses_an_identity_the_caches_could_never_key_on() {
+        assert!(ItemName::parse("foo/bar").is_err());
+        assert!(ItemName::parse("").is_err());
+        assert!(ItemTag::parse("").is_err());
+        assert!(ItemTag::parse("1v").is_err());
+        assert!(ItemTag::parse("v0.1.0").is_err());
+        assert!(ItemName::parse("uvc_camera").is_ok());
+        assert!(ItemTag::parse("v1").is_ok());
+    }
+}

--- a/crates/daemon-config-internal/src/repository/types.rs
+++ b/crates/daemon-config-internal/src/repository/types.rs
@@ -276,23 +276,21 @@ impl RepositoryIndex {
         path: RepoRelativePath,
     ) -> Result<(), String> {
         let item = IndexedItem { path };
-        let RepoItemKind::Launcher = kind else {
-            let Some(tag) = tag else {
-                return Err(format!("{kind} `{name}` has no tag"));
-            };
-            let section = match kind {
-                RepoItemKind::Node => &mut self.nodes,
-                RepoItemKind::Contract => &mut self.contracts,
-                RepoItemKind::Pairing => &mut self.pairings,
-                RepoItemKind::Launcher => unreachable!("handled by the let-else above"),
-            };
-            let tags = section.entry_or_default(name);
-            return tags.try_insert(tag, item);
+        let section = match kind {
+            RepoItemKind::Launcher => {
+                if tag.is_some() {
+                    return Err(format!("launcher `{name}` cannot carry a tag"));
+                }
+                return self.launchers.try_insert(name, item);
+            }
+            RepoItemKind::Node => &mut self.nodes,
+            RepoItemKind::Contract => &mut self.contracts,
+            RepoItemKind::Pairing => &mut self.pairings,
         };
-        if tag.is_some() {
-            return Err(format!("launcher `{name}` cannot carry a tag"));
-        }
-        self.launchers.try_insert(name, item)
+        let Some(tag) = tag else {
+            return Err(format!("{kind} `{name}` has no tag"));
+        };
+        section.entry_or_default(name).try_insert(tag, item)
     }
 
     /// Every identity the repository publishes, in a deterministic order that

--- a/crates/peppy/src/commands/repo.rs
+++ b/crates/peppy/src/commands/repo.rs
@@ -1,16 +1,19 @@
 mod add;
 mod exclude;
+mod index;
 mod init;
 mod list;
 mod refresh;
 mod remove;
 
+pub use index::repo_index;
 pub use init::repo_init_with_dirs;
 
 use std::sync::Arc;
 
 use clap::Subcommand;
 use core_node_api::encoding::RepoSource;
+use std::path::PathBuf;
 
 use super::Command;
 use crate::{context::AppContext, error::Result};
@@ -28,6 +31,24 @@ pub enum RepoCommands {
     /// entries that are missing without touching existing user entries.
     /// Operates on the local config file directly; no daemon required.
     Init,
+    /// Write a repository's `peppy_repository.json5` index, or verify it.
+    ///
+    /// Walks the repository, then records every identity it publishes and
+    /// the file that declares each one. Refuses, naming both files, when one
+    /// identity is claimed twice.
+    ///
+    /// With `--check`, verifies the committed index instead of writing it:
+    /// every item in the tree must be listed, and every listed path must be
+    /// a file inside the repository declaring exactly what it is filed
+    /// under. Run it in CI so a repository cannot merge an index that has
+    /// drifted from its contents. Needs no daemon.
+    Index {
+        /// Repository root to index (defaults to the current directory).
+        path: Option<PathBuf>,
+        /// Verify the committed index instead of writing it.
+        #[arg(long)]
+        check: bool,
+    },
     /// List configured repositories
     List,
     /// Update repository indexes
@@ -79,6 +100,7 @@ impl Command for RepoCommand {
     fn execute(self, ctx: &Arc<AppContext>) -> Result<()> {
         match self.command {
             RepoCommands::Init => init::repo_init(ctx),
+            RepoCommands::Index { path, check } => index::repo_index(path, check),
             RepoCommands::List => list::list_repos(ctx),
             RepoCommands::Refresh => refresh::repo_refresh(ctx),
             RepoCommands::Add {

--- a/crates/peppy/src/commands/repo/index.rs
+++ b/crates/peppy/src/commands/repo/index.rs
@@ -1,0 +1,64 @@
+use std::path::{Path, PathBuf};
+
+use core_node::{check_repository_index, generate_repository_index, write_repository_index};
+use daemon_config::consts::REPOSITORY_INDEX_FILE;
+use tracing::info;
+
+use crate::error::{Error, Result};
+
+/// `peppy repo index`: write a repository's `peppy_repository.json5`, or
+/// verify the committed one against the repository with `--check`.
+///
+/// Operates on a directory on disk and needs no daemon, so it runs in a hub's
+/// CI and on a contributor's branch before anything is merged. That is the
+/// point of it: an identity claimed twice is caught by the person who claimed
+/// it rather than by every machine that later updates.
+pub fn repo_index(path: Option<PathBuf>, check: bool) -> Result<()> {
+    let root = path.unwrap_or_else(|| PathBuf::from("."));
+    if !root.is_dir() {
+        return Err(Error::ExecutionFailed(format!(
+            "not a directory: {}",
+            root.display()
+        )));
+    }
+    if check {
+        return check_index(&root);
+    }
+    write_index(&root)
+}
+
+fn write_index(root: &Path) -> Result<()> {
+    let index = generate_repository_index(root).map_err(index_failure)?;
+    let count = index.declared_count();
+    write_repository_index(root, &index).map_err(index_failure)?;
+    info!(
+        "Indexed {count} item{} into {}",
+        if count == 1 { "" } else { "s" },
+        root.join(REPOSITORY_INDEX_FILE).display()
+    );
+    Ok(())
+}
+
+fn check_index(root: &Path) -> Result<()> {
+    let drifts = check_repository_index(root).map_err(index_failure)?;
+    if drifts.is_empty() {
+        info!(
+            "{} matches the repository",
+            root.join(REPOSITORY_INDEX_FILE).display()
+        );
+        return Ok(());
+    }
+    let report = drifts
+        .iter()
+        .map(|drift| format!("\n  - {drift}"))
+        .collect::<String>();
+    Err(Error::ExecutionFailed(format!(
+        "{} does not match the repository:{report}\n\nRun `peppy repo index {}` and commit the result.",
+        root.join(REPOSITORY_INDEX_FILE).display(),
+        root.display()
+    )))
+}
+
+fn index_failure(e: core_node::IndexError) -> Error {
+    Error::ExecutionFailed(e.to_string())
+}

--- a/crates/peppy/tests/main.rs
+++ b/crates/peppy/tests/main.rs
@@ -16,6 +16,7 @@ mod peppy_config_env;
 mod platform_flow;
 mod repo_add;
 mod repo_exclude;
+mod repo_index;
 mod repo_init;
 mod repo_list;
 mod repo_refresh;

--- a/crates/peppy/tests/repo_index.rs
+++ b/crates/peppy/tests/repo_index.rs
@@ -1,0 +1,147 @@
+use daemon_config::consts::REPOSITORY_INDEX_FILE;
+use peppy::commands::repo::repo_index;
+use std::path::Path;
+use tempfile::TempDir;
+
+/// Helper: write a minimal valid node manifest under `dir`.
+fn write_node(dir: &Path, name: &str, tag: &str) {
+    std::fs::create_dir_all(dir).unwrap();
+    std::fs::write(
+        dir.join("peppy.json5"),
+        format!(
+            r#"{{
+  peppy_schema: "node/v1",
+  manifest: {{ name: "{name}", tag: "{tag}" }},
+  interfaces: {{}},
+  execution: {{ language: "rust", build_cmd: ["true"], run_cmd: ["true"] }},
+}}"#
+        ),
+    )
+    .unwrap();
+}
+
+/// Helper: write a minimal valid contract manifest at `path`.
+fn write_contract(path: &Path, name: &str, tag: &str) {
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(
+        path,
+        format!(
+            r#"{{
+  peppy_schema: "contract/v1",
+  manifest: {{ name: "{name}", tag: "{tag}" }},
+  interfaces: {{}}
+}}"#
+        ),
+    )
+    .unwrap();
+}
+
+#[test]
+fn repo_index_writes_the_file() {
+    let tmp = TempDir::new().unwrap();
+    let repo = tmp.path().join("hub");
+    write_node(&repo.join("nodes/uvc_camera"), "uvc_camera", "v1");
+    write_contract(&repo.join("interfaces/rgb.json5"), "rgb_camera", "v1");
+
+    repo_index(Some(repo.clone()), false).expect("indexing should succeed");
+
+    let content = std::fs::read_to_string(repo.join(REPOSITORY_INDEX_FILE)).unwrap();
+    assert!(
+        content.contains(r#"peppy_schema: "repository/v1""#),
+        "{content}"
+    );
+    assert!(
+        content.contains("nodes/uvc_camera/peppy.json5"),
+        "{content}"
+    );
+    assert!(content.contains("interfaces/rgb.json5"), "{content}");
+}
+
+#[test]
+fn repo_index_check_passes_on_a_generated_index() {
+    let tmp = TempDir::new().unwrap();
+    let repo = tmp.path().join("hub");
+    write_node(&repo.join("nodes/a"), "a", "v1");
+
+    repo_index(Some(repo.clone()), false).expect("indexing should succeed");
+    repo_index(Some(repo), true).expect("the index it just wrote should check out");
+}
+
+/// Writing twice produces the same file, so re-running generation after an
+/// unrelated change never shows up as a spurious diff in a pull request.
+#[test]
+fn repo_index_is_idempotent() {
+    let tmp = TempDir::new().unwrap();
+    let repo = tmp.path().join("hub");
+    write_node(&repo.join("nodes/a"), "a", "v1");
+    write_node(&repo.join("nodes/b"), "b", "v1");
+
+    repo_index(Some(repo.clone()), false).expect("first run");
+    let first = std::fs::read_to_string(repo.join(REPOSITORY_INDEX_FILE)).unwrap();
+    repo_index(Some(repo.clone()), false).expect("second run");
+    let second = std::fs::read_to_string(repo.join(REPOSITORY_INDEX_FILE)).unwrap();
+
+    assert_eq!(first, second);
+}
+
+/// The mistake people will actually make: add an item, forget the index.
+/// The check names the file and the identity, and says how to fix it.
+#[test]
+fn repo_index_check_names_the_unlisted_item() {
+    let tmp = TempDir::new().unwrap();
+    let repo = tmp.path().join("hub");
+    write_node(&repo.join("nodes/a"), "a", "v1");
+    repo_index(Some(repo.clone()), false).expect("indexing should succeed");
+    write_contract(&repo.join("robot/wrist.json5"), "wrist_link", "v1");
+
+    let err = repo_index(Some(repo), true).expect_err("an unlisted item must fail the check");
+
+    let message = err.to_string();
+    assert!(message.contains("robot/wrist.json5"), "{message}");
+    assert!(message.contains("wrist_link:v1"), "{message}");
+    assert!(message.contains("peppy repo index"), "{message}");
+}
+
+/// A repository with no index does not check out, and the message names
+/// the file that was looked for.
+#[test]
+fn repo_index_check_fails_when_the_index_is_missing() {
+    let tmp = TempDir::new().unwrap();
+    let repo = tmp.path().join("hub");
+    write_node(&repo.join("nodes/a"), "a", "v1");
+
+    let err = repo_index(Some(repo), true).expect_err("a missing index must fail the check");
+    assert!(err.to_string().contains(REPOSITORY_INDEX_FILE), "{err}");
+}
+
+/// Generation refuses a repository that claims one identity twice, on the
+/// branch of the person who claimed it, naming both files.
+#[test]
+fn repo_index_refuses_an_identity_claimed_twice() {
+    let tmp = TempDir::new().unwrap();
+    let repo = tmp.path().join("hub");
+    write_node(&repo.join("uvc/rust"), "uvc_camera", "v1");
+    write_node(&repo.join("uvc/python"), "uvc_camera", "v1");
+
+    let err =
+        repo_index(Some(repo.clone()), false).expect_err("a contested identity must be refused");
+
+    let message = err.to_string();
+    assert!(message.contains("uvc_camera:v1"), "{message}");
+    assert!(message.contains("uvc/rust/peppy.json5"), "{message}");
+    assert!(message.contains("uvc/python/peppy.json5"), "{message}");
+    assert!(
+        !repo.join(REPOSITORY_INDEX_FILE).exists(),
+        "no index is written when the repository contradicts itself"
+    );
+}
+
+#[test]
+fn repo_index_rejects_a_path_that_is_not_a_directory() {
+    let tmp = TempDir::new().unwrap();
+    let file = tmp.path().join("not_a_dir");
+    std::fs::write(&file, "").unwrap();
+
+    let err = repo_index(Some(file), false).expect_err("a file is not a repository");
+    assert!(err.to_string().contains("not a directory"), "{err}");
+}

--- a/docs/src/content/docs/advanced_guides/repositories.mdx
+++ b/docs/src/content/docs/advanced_guides/repositories.mdx
@@ -184,22 +184,15 @@ peppy repo exclude /home/user/projects/private-nodes
 
 ## The repository index
 
-:::caution[Breaking change ahead]
-A future release will require every repository to carry a `peppy_repository.json5` index at
-the root of the tree Peppy scans. A repository without a valid one will not resolve, and there
-will be no fallback to walking. Generate one now for every repository you own, and commit it:
+A repository index is a `peppy_repository.json5` at the root of the tree Peppy scans, stating what
+the repository publishes and where each item is declared. [`peppy repo index`](#index-a-repository)
+writes it and `--check` verifies it against the tree, and it is committed alongside the items it
+lists, so a contested identity is caught on the branch that created it rather than on every machine
+that later refreshes.
 
-```sh
-peppy repo index /path/to/my/nodes
-```
-
-The file is ignored by the current release, so it is safe to commit ahead of time.
-:::
-
-A repository index states what a repository publishes and where each item is declared, instead of
-leaving Peppy to work it out by walking directories. The nesting is the uniqueness rule: name, then
-tag, then the file that declares the item. A second claim on one identity has nowhere to go except a
-key that is already taken, so a repository cannot state two answers to the same question.
+The nesting is the uniqueness rule: name, then tag, then the file that declares the item. A second
+claim on one identity has nowhere to go except a key that is already taken, so a repository cannot
+state two answers to the same question.
 
 ```json5
 // peppy_repository.json5, at the root of the tree Peppy scans
@@ -231,11 +224,11 @@ Rules worth knowing before you hand-edit one:
   out of the tree.
 - **Only the mapping belongs here.** Nothing is copied out of an item's own manifest, because a copy
   would drift from the thing it copied.
-- **Unknown fields and unknown versions are refused** rather than ignored, so an older Peppy never
-  silently drops part of a newer index.
+- **Unknown fields and unknown versions are refused** rather than ignored, so an index Peppy does not
+  fully understand is rejected outright instead of silently losing part of itself.
 - **An empty index is valid; a missing one is not.** A repository that publishes nothing has an index
-  with no sections. "Publishes nothing" and "has no index" are different situations and get different
-  answers.
+  with no sections, and `--check` fails on a repository that carries no index at all. "Publishes
+  nothing" and "has no index" are different situations and get different answers.
 - **The file is generated.** Comments survive `--check`, but the next `peppy repo index` run
   discards them.
 
@@ -339,15 +332,15 @@ dep `gps_module:v2` not found in node stack or repository cache; run `peppy repo
 When a node depends on another node you maintain locally, registering your workspace directory as a `fs` repository removes the need to `peppy node add` every dependency just to regenerate peppygen for a downstream node:
 
 ```sh
-peppy repo index ~/code/my-nodes    # writes ~/code/my-nodes/peppy_repository.json5
 peppy repo add ~/code/my-nodes
 peppy repo refresh
 peppy node sync -r       # picks up uvc_camera, lidar_sensor, ... from ~/code/my-nodes
 ```
 
-Re-run `peppy repo index` after adding, moving, or renaming a node in that directory. Today a missing
-index only costs you the index; from the release that requires one, `peppy repo add` will refuse a
-directory that has none.
+Re-run `peppy repo refresh` after adding, moving, or renaming a node in that directory: `repo list`
+and `node sync -r` both read the cache, not the filesystem. If you also publish that directory to
+others, keep its index current with `peppy repo index ~/code/my-nodes`, the same as for any
+repository others consume.
 
 Particularly useful during the early phase of a multi-node project, when the dependency graph is still in flux and you don't want to re-add nodes after every interface change.
 

--- a/docs/src/content/docs/advanced_guides/repositories.mdx
+++ b/docs/src/content/docs/advanced_guides/repositories.mdx
@@ -182,6 +182,94 @@ peppy repo exclude https://github.com/org/repo.git
 peppy repo exclude /home/user/projects/private-nodes
 ```
 
+## The repository index
+
+:::caution[Breaking change ahead]
+A future release will require every repository to carry a `peppy_repository.json5` index at
+the root of the tree Peppy scans. A repository without a valid one will not resolve, and there
+will be no fallback to walking. Generate one now for every repository you own, and commit it:
+
+```sh
+peppy repo index /path/to/my/nodes
+```
+
+The file is ignored by the current release, so it is safe to commit ahead of time.
+:::
+
+A repository index states what a repository publishes and where each item is declared, instead of
+leaving Peppy to work it out by walking directories. The nesting is the uniqueness rule: name, then
+tag, then the file that declares the item. A second claim on one identity has nowhere to go except a
+key that is already taken, so a repository cannot state two answers to the same question.
+
+```json5
+// peppy_repository.json5, at the root of the tree Peppy scans
+{
+  peppy_schema: "repository/v1",
+
+  nodes: {
+    uvc_camera: {
+      v1: { path: "uvc_camera/rust/peppy.json5" },
+      v2: { path: "uvc_camera/python/peppy.json5" },
+    },
+  },
+  contracts: { rgb_camera: { v1: { path: "cameras/rgb_camera.json5" } } },
+  pairings: { joint_link: { v1: { path: "robot/joint_link.json5" } } },
+
+  // One level deep: a launcher is identified by its file stem and carries no tag.
+  launchers: { openarm_v1_teleop: { path: "openarm/openarm_v1_teleop.json5" } },
+}
+```
+
+Rules worth knowing before you hand-edit one:
+
+- **`path` names the declaring file, not a directory.** One rule across all four kinds, since only
+  nodes are directory-shaped.
+- **A repeated key is an error**, not a last-one-wins overwrite. The message names the identity and
+  both files.
+- **Paths stay inside the repository.** Absolute paths, `..`, `.`, repeated separators, backslashes
+  and trailing separators are all refused, as is a path that reaches its target through a symlink
+  out of the tree.
+- **Only the mapping belongs here.** Nothing is copied out of an item's own manifest, because a copy
+  would drift from the thing it copied.
+- **Unknown fields and unknown versions are refused** rather than ignored, so an older Peppy never
+  silently drops part of a newer index.
+- **An empty index is valid; a missing one is not.** A repository that publishes nothing has an index
+  with no sections. "Publishes nothing" and "has no index" are different situations and get different
+  answers.
+- **The file is generated.** Comments survive `--check`, but the next `peppy repo index` run
+  discards them.
+
+### Index a repository
+
+```sh
+peppy repo index [PATH]           # write PATH/peppy_repository.json5 (PATH defaults to .)
+peppy repo index [PATH] --check   # verify the committed index instead of writing it
+```
+
+Neither form needs a running daemon, so both work in CI and on a branch before anything is merged.
+
+Writing walks the repository and records what it finds. If one identity is claimed twice, generation
+refuses and names both files:
+
+```
+two manifests claim `uvc_camera_video_reconstruction:v1`:
+  uvc_camera_video_reconstruction/python/peppy.json5,
+  uvc_camera_video_reconstruction/rust/peppy.json5
+```
+
+`--check` verifies three things against the repository, and reports everything it finds at once:
+
+- every item in the tree is listed (the mistake people actually make is adding an item and
+  forgetting the index, which would otherwise leave it silently invisible);
+- every listed path is a real file inside the repository;
+- every listed path declares exactly the kind and identity it is filed under.
+
+Run it on every pull request to a repository others consume. Catching a contested identity on the
+branch of the person who caused it is the entire point: the alternative is every machine in the
+fleet reporting it the next morning, none of which can fix it.
+
+The remedy for any failure is the same: re-run `peppy repo index` and commit the result.
+
 ## Using a repository-indexed node
 
 Once a node appears in `peppy repo list`, you can add it by its `name:tag` without supplying a path or URL; Peppy resolves the source through the cached index at `~/.peppy/cache/nodes.json5`:
@@ -251,16 +339,22 @@ dep `gps_module:v2` not found in node stack or repository cache; run `peppy repo
 When a node depends on another node you maintain locally, registering your workspace directory as a `fs` repository removes the need to `peppy node add` every dependency just to regenerate peppygen for a downstream node:
 
 ```sh
+peppy repo index ~/code/my-nodes    # writes ~/code/my-nodes/peppy_repository.json5
 peppy repo add ~/code/my-nodes
 peppy repo refresh
 peppy node sync -r       # picks up uvc_camera, lidar_sensor, ... from ~/code/my-nodes
 ```
 
+Re-run `peppy repo index` after adding, moving, or renaming a node in that directory. Today a missing
+index only costs you the index; from the release that requires one, `peppy repo add` will refuse a
+directory that has none.
+
 Particularly useful during the early phase of a multi-node project, when the dependency graph is still in flux and you don't want to re-add nodes after every interface change.
 
 ## Directory pruning
 
-When scanning local and git repositories, Peppy automatically skips the following directories:
+When scanning a repository, whether to refresh its cache or to write its index with
+`peppy repo index`, Peppy skips the following directories:
 
 - `.git`
 - `.peppy`
@@ -268,3 +362,7 @@ When scanning local and git repositories, Peppy automatically skips the followin
 - `node_modules`
 - `.venv`
 - `__pycache__`
+
+A repository's own `.gitignore` and `.ignore` files are honoured too. Machine-local git settings are
+not: a global gitignore or a clone's `.git/info/exclude` would otherwise let one contributor's setup
+change the index they generate and commit.

--- a/docs/src/content/docs/guides/sharing_nodes.mdx
+++ b/docs/src/content/docs/guides/sharing_nodes.mdx
@@ -85,6 +85,19 @@ We can see the video has been saved to a temporary folder. Go ahead and open it;
 In the same way, you can share your own nodes by hosting them in a Git repository so others can pull them into their own stacks.
 A node can also be pulled in the same way if it's in a `.tar.zst` archive.
 
+Publishing a node has a second step that is easy to forget: claiming its identity in the repository's
+index. After adding, moving, or renaming a node, run `peppy repo index` at the root of the repository
+and commit the result alongside the node:
+
+```sh
+peppy repo index .
+peppy repo index . --check   # what CI runs on your pull request
+```
+
+The index is what makes `name:tag` unambiguous within a repository. Generation refuses, naming both
+files, if your new node claims an identity another one already publishes. See
+[the repository index](/advanced_guides/repositories/#the-repository-index).
+
 :::note
 Archive downloads over HTTP tolerate flaky networks: a transient failure (a connection error or a `5xx` response) is retried automatically, up to three attempts with a short backoff. A checksum mismatch or a client (`4xx`) error fails immediately, without retrying.
 :::

--- a/docs/tests/integration/tests/snippet_configs.rs
+++ b/docs/tests/integration/tests/snippet_configs.rs
@@ -97,6 +97,15 @@ fn assert_parses_with_matching_schema(path: &Path) {
                 result.unwrap_err()
             );
         }
+        PeppySchema::RepositoryV1 => {
+            let result = daemon_config::repository::PeppyRepositoryIndexParser::from_path(path);
+            assert!(
+                result.is_ok(),
+                "failed to parse repository index {}: {:?}",
+                path.display(),
+                result.unwrap_err()
+            );
+        }
     }
 }
 


### PR DESCRIPTION
> **Blocked on [public-peppy-libs#75](https://github.com/Peppy-bot/public-peppy-libs/pull/75).** That PR adds `PeppySchema::RepositoryV1`, which this branch uses. CI here will be red until it merges and this branch takes a `cargo update` for the git deps. Verified locally against that branch via `scripts/local-libs.sh on`.

## Why

peppy discovers what a repository publishes by walking its directory tree, so the set of identities a repository offers is an emergent property of its layout rather than something anyone wrote down, reviewed, or can point at. An identity claimed twice is therefore only catchable once every file is on disk together: at refresh time, on every machine in the fleet simultaneously, in front of people who did not cause it and cannot fix it without a pull request in someone else's repository. A machine that has never synced cannot onboard at all until someone merges a fix.

The fix is for a repository to state what it publishes. This PR ships the format and the tooling; a later PR makes resolution read it.

## Scope: tooling only, nothing breaks

The walk stays authoritative for `repo refresh`. No repository has to adopt anything yet, and behaviour is unchanged. The ordering is deliberate: hub CI needs a released binary carrying `peppy repo index` before the release that *requires* an index can land, so that enforcement never reaches a fleet whose hubs are unguarded.

## What

**`daemon-config::repository`** — the `peppy_repository.json5` document model.

`UniqueMap` is the whole point of the format. A conventional map deserializer accepts a repeated key and silently keeps the last one, which would reintroduce the exact defect the index exists to remove, and worse than the current behaviour, because nothing would refuse and there would be no report to act on. It errors instead, naming the identity and both files. That one third-party assumption is pinned by its own test.

`ItemName`, `ItemTag` and `RepoRelativePath` parse rather than validate, so an index cannot state an identity the caches could never key on, nor a path that is absolute, contains `..`, or otherwise leaves the repository.

**`core-node::services::repo::index`** — the walk moves here whole, behind a new `WalkedItem` seam. It now finds identities; one shared `build_cache_entries` turns them into cache entries. That seam is what lets the index reader replace the walk later by swapping a single producer, and it is why `refresh.rs` loses 600 lines with no behaviour change. On top of it: generation (refuses a contested identity, naming both files) and the check.

**`peppy repo index [PATH] [--check]`** — daemon-free, following `repo init`'s precedent, so it runs on a contributor's branch and in a hub's CI.

## Why `--check` is one command and not two

Parse, then resolve, then compare against a fresh walk. That is strictly stronger than a separate completeness and accuracy pair, and it cannot disagree with the daemon because it runs the same reader. The step that matters most is resolving: a symlinked *file* pointing outside the tree round-trips through the walk (`follow_links(false)` still lets `fs::read` follow it), so comparing two indexes would pass while `repo refresh` refused the repository.

## Two behaviour notes worth reviewing

- The walk now ignores machine-local git settings (a global gitignore, a clone's `.git/info/exclude`) while still honouring the repository's own `.gitignore` and `.ignore`. The walk's output is a committed artifact now, so one contributor's git config must not change the index they generate.
- Generation **refuses** an identity the index cannot state, such as a node with a dotted tag, rather than skipping it. A silent skip would write an index that `--check` calls correct while the item is invisible to peppy, which is the failure this feature exists to make impossible.

## Test plan

- `cargo test -p daemon-config --lib` — 281 pass, incl. 21 new (duplicate keys at every level naming both paths, the path rule table, unknown fields and versions, empty-vs-missing index).
- `cargo test -p core-node --lib` — 356 pass, incl. 25 new. The load-bearing one is `generate_write_read_round_trip_matches_the_walk`: what the reader resolves from a generated index equals what the walk found, identity for identity, path for path, fingerprint for fingerprint. It is expressible only because the walk survives as the generator.
- `cargo test -p peppy --test integration repo_` — 37 pass, incl. 7 new for the command.
- Every repo integration suite passes unchanged (`listen_for_repo_{refresh,list,add,remove,exclude}`, `listen_for_node_add`), which is the evidence the seam is behaviour-preserving.
- `cargo test -p docs-integration-tests` passes; `cargo clippy` clean on the touched crates.
- Against the four real hubs: generation produced **46 items** (18 + 11 + 8 + 9), matching their contents exactly, none refused, and `--check` passes on all four. Those indexes are up as nodes-hub#42, openarm-nodes#96, contracts-hub#29, launchers-hub#23.

## Follow-ups, not in this PR

1. Hub CI running `peppy repo index --check` against a pinned release, plus branch protection on all four. Needs the release this PR feeds.
2. The enforcement PR: index-driven refresh, `repo add` validation, `RepoFailureKind::Conflict` becoming `Invalid`, and the `repositories.mdx` rewrite.

The release notes announcing the breaking change belong in this release's GitHub release body, since `docs/src/content/releases/` is generated from it. The durable warning is already in the docs as a caution block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added repository index generation and validation.
  - Added `peppy repo index` to create or check `peppy_repository.json5`.
  - Added validation for repository paths, item identities, duplicates, and index drift.
  - Added support for repository index parsing and structured declarations.

- **Documentation**
  - Documented repository index setup, schema rules, generation, and CI checks.
  - Clarified that published nodes must be claimed in the repository index.

- **Bug Fixes**
  - Improved repository handling for symlinked roots and protected against paths escaping the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->