### PR TITLE
Resolve every launch once, on the coordinator, and ship pins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,7 +573,7 @@ dependencies = [
 [[package]]
 name = "build-helpers"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#026710ae5673da66875d54b0f2c9746f4f190bb8"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#78a9b4d3ad5b284da5b01552aeac8596d4ee3d0f"
 dependencies = [
  "sha2",
 ]
@@ -765,7 +765,7 @@ dependencies = [
 [[package]]
 name = "config-test-support"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#026710ae5673da66875d54b0f2c9746f4f190bb8"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#78a9b4d3ad5b284da5b01552aeac8596d4ee3d0f"
 dependencies = [
  "askama",
  "git2",
@@ -909,7 +909,7 @@ dependencies = [
 [[package]]
 name = "core-node-api"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#026710ae5673da66875d54b0f2c9746f4f190bb8"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#78a9b4d3ad5b284da5b01552aeac8596d4ee3d0f"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -1248,7 +1248,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1396,7 +1396,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2581,7 +2581,7 @@ dependencies = [
 [[package]]
 name = "json5-pretty"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#026710ae5673da66875d54b0f2c9746f4f190bb8"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#78a9b4d3ad5b284da5b01552aeac8596d4ee3d0f"
 dependencies = [
  "serde",
  "serde_json",
@@ -2985,7 +2985,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3371,7 +3371,7 @@ dependencies = [
 [[package]]
 name = "peppy-config-model"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#026710ae5673da66875d54b0f2c9746f4f190bb8"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#78a9b4d3ad5b284da5b01552aeac8596d4ee3d0f"
 dependencies = [
  "capnp",
  "clap",
@@ -3394,7 +3394,7 @@ version = "0.0.1"
 [[package]]
 name = "peppylib-rs"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#026710ae5673da66875d54b0f2c9746f4f190bb8"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#78a9b4d3ad5b284da5b01552aeac8596d4ee3d0f"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -3589,7 +3589,7 @@ dependencies = [
 [[package]]
 name = "pmi"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#026710ae5673da66875d54b0f2c9746f4f190bb8"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#78a9b4d3ad5b284da5b01552aeac8596d4ee3d0f"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -3807,7 +3807,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.5",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4057,7 +4057,7 @@ dependencies = [
  "pin-project-lite",
  "rustls",
  "rustls-pki-types",
- "rustls-platform-verifier 0.6.2",
+ "rustls-platform-verifier 0.7.0",
  "serde",
  "serde_json",
  "sync_wrapper",
@@ -4243,7 +4243,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4311,7 +4311,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4332,7 +4332,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4708,7 +4708,7 @@ version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
 dependencies = [
- "dirs 4.0.0",
+ "dirs 6.0.0",
 ]
 
 [[package]]
@@ -5044,7 +5044,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5947,7 +5947,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/core-node-internal/src/services.rs
+++ b/crates/core-node-internal/src/services.rs
@@ -429,7 +429,6 @@ impl CoreNode {
         federation::FederationServiceContext {
             messenger: self.messenger.clone(),
             core_node_name: ctx.core_node_name.to_owned(),
-            peppy_dirs: self.peppy_dirs.clone(),
             ownership: Arc::clone(&self.slice_ownership),
             relationships: ctx.relationships.clone(),
             node_stack: Arc::clone(&self.node_stack),

--- a/crates/core-node-internal/src/services/federation/service.rs
+++ b/crates/core-node-internal/src/services/federation/service.rs
@@ -15,19 +15,16 @@
 
 use super::{ReserveOutcome, SliceOwnership};
 use crate::Result;
-use crate::services::node::{
-    RelationshipCoordinators, manifest_fingerprint_of_json5, resolve_node_config,
-};
+use crate::services::node::RelationshipCoordinators;
 use crate::services::response::into_service_response;
 use core_node_api::ServiceId;
 use core_node_api::encoding::{
     FederationVerdict, LaunchIdentity, PairCommitRequest, ParticipantReleaseRequest,
     ParticipantReserveRequest, ParticipantReserveResponse, ParticipantSliceBeginRequest,
-    RelationshipEvent, RelationshipNotification, RelationshipNotificationAck, ResolvedManifest,
+    RelationshipEvent, RelationshipNotification, RelationshipNotificationAck,
 };
 use core_node_api::names;
-use daemon_config::consts::PeppyDirs;
-use daemon_config::launcher::DeploymentSource;
+use daemon_config::repository::DeploymentPins;
 use peppylib::messaging::{SenderTarget, ServiceRequestContext};
 use peppylib::types::Payload;
 use peppylib::{CoreNodePresenceMessenger, LivelinessEvent, MessengerHandle, ServiceMessenger};
@@ -41,7 +38,6 @@ use tracing::{debug, warn};
 pub(crate) struct FederationServiceContext {
     pub(crate) messenger: MessengerHandle,
     pub(crate) core_node_name: String,
-    pub(crate) peppy_dirs: PeppyDirs,
     pub(crate) ownership: Arc<SliceOwnership>,
     pub(crate) relationships: RelationshipCoordinators,
     /// This daemon's stack, so `participant_slice_begin` can replace the slice
@@ -164,64 +160,54 @@ async fn reserve_inner(
         ReserveOutcome::AlreadyHeld => {}
     }
 
-    // Resolve this slice's manifests here rather than accepting the
-    // coordinator's. The coordinator then needs no reachability to sources it
-    // does not itself use, and the manifest it validates is provably the one
-    // this daemon will spawn from, because it is this daemon's own cache.
-    let manifests = match resolve_slice_manifests(context, &decoded.deployment_sources_json5).await
-    {
-        Ok(manifests) => manifests,
-        Err(reason) => {
-            // A resolution failure is this participant's refusal, so drop the
-            // reservation we just took rather than holding a machine hostage
-            // to a launch that cannot proceed.
-            context.ownership.release(&decoded.launch_id);
-            return ParticipantReserveResponse::rejected(reason, &context.peppy_version)
-                .encode()
-                .map_err(Into::into);
-        }
-    };
+    // Validate the pins the coordinator resolved for this slice while the
+    // reservation is still non-destructive. Decoding runs every structural
+    // rule (a traversal path, a truncated commit, a malformed fingerprint
+    // all fail there), and the origin check refuses a pin no machine but
+    // the coordinator could read. Nothing here touches the filesystem, the
+    // network, or this daemon's caches: the bytes are materialized at add
+    // time, and which bytes those are was decided on the coordinator.
+    if let Err(reason) = validate_deployment_pins(&decoded.deployment_pins_json5) {
+        // A validation failure is this participant's refusal, so drop the
+        // reservation we just took rather than holding a machine hostage
+        // to a launch that cannot proceed.
+        context.ownership.release(&decoded.launch_id);
+        return ParticipantReserveResponse::rejected(reason, &context.peppy_version)
+            .encode()
+            .map_err(Into::into);
+    }
 
-    ParticipantReserveResponse::accepted(
-        &context.peppy_version,
-        &context.root_instance_id,
-        manifests,
-    )
-    .encode()
-    .map_err(Into::into)
+    ParticipantReserveResponse::accepted(&context.peppy_version, &context.root_instance_id)
+        .encode()
+        .map_err(Into::into)
 }
 
-/// Resolves one manifest per requested deployment source, in request order, so
-/// the coordinator can align them with the deployments it asked about.
+/// Decodes every deployment's pins and refuses any that could not be
+/// materialized here: a pin that arrived over the wire must carry a git
+/// origin, because a filesystem origin names a tree on the machine that
+/// minted it.
 ///
-/// Concurrently: each source is a distinct git clone, download, or cache read
-/// with nothing shared between them, and the whole call has to fit inside the
-/// coordinator's preflight budget. Resolving them one at a time would spend
-/// that budget on the sum of every fetch rather than the slowest one.
-/// `try_join_all` preserves request order, which is what the alignment relies
-/// on.
-async fn resolve_slice_manifests(
-    context: &FederationServiceContext,
-    sources_json5: &[String],
-) -> std::result::Result<Vec<ResolvedManifest>, String> {
-    futures::future::try_join_all(sources_json5.iter().enumerate().map(
-        |(index, source_json5)| async move {
-            let source: DeploymentSource = serde_json5::from_str(source_json5)
-                .map_err(|e| format!("deployment source #{index} is not decodable: {e}"))?;
-            let source = crate::services::stack::portable_node_source(&source)?;
-            let config = resolve_node_config(source, &context.peppy_dirs)
-                .await
-                .map_err(|e| format!("deployment source #{index} failed to resolve: {e}"))?;
-            // Serialize once: the fingerprint is defined over exactly these
-            // bytes, so hashing them is the same answer `manifest_fingerprint`
-            // would reach after re-serializing.
-            let config_json5 = json5_pretty::to_string_pretty(&config)
-                .map_err(|e| format!("deployment source #{index} failed to serialize: {e}"))?;
-            let fingerprint = manifest_fingerprint_of_json5(&config_json5);
-            Ok(ResolvedManifest::new(config_json5, fingerprint))
-        },
-    ))
-    .await
+/// A path arriving from a coordinator is untrusted input. Not because the
+/// coordinator is assumed hostile, but because a daemon that trusts a path
+/// it was handed cannot distinguish a coordinator from anything else able
+/// to reach it; the decode is where every structural rule fires, before any
+/// filesystem or network is touched.
+fn validate_deployment_pins(pins_json5: &[String]) -> std::result::Result<(), String> {
+    for (index, raw) in pins_json5.iter().enumerate() {
+        let pins: DeploymentPins = serde_json5::from_str(raw)
+            .map_err(|e| format!("deployment pins #{index} are not decodable: {e}"))?;
+        for pin in pins.items() {
+            if pin.origin.checkout().is_none() {
+                return Err(format!(
+                    "{} arrived pinned to a filesystem path, which only the machine that \
+                     minted it could read; a pin that crosses a machine boundary must name a \
+                     git repository",
+                    pin.label()
+                ));
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Turns the reservation into a LEASE: while this daemon holds a reservation
@@ -471,4 +457,53 @@ async fn notify_inner(
     RelationshipNotificationAck::new()
         .encode()
         .map_err(Into::into)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pins_json5(origin: &str) -> String {
+        format!(
+            r#"{{ root: {{ kind: "node", name: "camera", tag: "v1", sha256: "{}",
+                      origin: {origin} }} }}"#,
+            "c".repeat(64)
+        )
+    }
+
+    /// Decoding is the validation: a structurally valid, git-pinned set is
+    /// accepted without touching this machine's filesystem or caches.
+    #[test]
+    fn a_git_pinned_deployment_validates() {
+        let raw = pins_json5(&format!(
+            r#"{{ source_type: "git", repo_url: "https://example.com/hub",
+                  commit: "{}", path: "camera/peppy.json5" }}"#,
+            "d".repeat(40)
+        ));
+        assert!(validate_deployment_pins(&[raw]).is_ok());
+    }
+
+    /// A pin that arrived over the wire carrying a filesystem origin names a
+    /// tree only its minting machine could read, so it is refused while the
+    /// reservation is still non-destructive.
+    #[test]
+    fn a_filesystem_pinned_deployment_is_refused() {
+        let raw = pins_json5(r#"{ source_type: "fs", path: "/repo/camera/peppy.json5" }"#);
+        let err = validate_deployment_pins(&[raw]).expect_err("an fs pin cannot cross machines");
+        assert!(err.contains("filesystem path"), "{err}");
+        assert!(err.contains("git repository"), "{err}");
+    }
+
+    /// The structural rules fire at decode: a traversal path is refused
+    /// before any filesystem or network is touched, whoever sent it.
+    #[test]
+    fn a_pin_that_does_not_decode_is_refused() {
+        let raw = pins_json5(&format!(
+            r#"{{ source_type: "git", repo_url: "https://example.com/hub",
+                  commit: "{}", path: "../../etc/passwd" }}"#,
+            "d".repeat(40)
+        ));
+        let err = validate_deployment_pins(&[raw]).expect_err("a traversal path must be refused");
+        assert!(err.contains("not decodable"), "{err}");
+    }
 }

--- a/crates/core-node-internal/src/services/federation/service.rs
+++ b/crates/core-node-internal/src/services/federation/service.rs
@@ -196,14 +196,12 @@ fn validate_deployment_pins(pins_json5: &[String]) -> std::result::Result<(), St
     for (index, raw) in pins_json5.iter().enumerate() {
         let pins: DeploymentPins = serde_json5::from_str(raw)
             .map_err(|e| format!("deployment pins #{index} are not decodable: {e}"))?;
+        // The same rule the coordinator applied before it ever dispatched,
+        // stated once: a misconfiguration must not read as two different
+        // problems depending on which machine caught it.
         for pin in pins.items() {
-            if pin.origin.checkout().is_none() {
-                return Err(format!(
-                    "{} arrived pinned to a filesystem path, which only the machine that \
-                     minted it could read; a pin that crosses a machine boundary must name a \
-                     git repository",
-                    pin.label()
-                ));
+            if let Some(reason) = crate::services::node::pins::portable_pin_refusal(pin) {
+                return Err(reason);
             }
         }
     }
@@ -490,7 +488,7 @@ mod tests {
     fn a_filesystem_pinned_deployment_is_refused() {
         let raw = pins_json5(r#"{ source_type: "fs", path: "/repo/camera/peppy.json5" }"#);
         let err = validate_deployment_pins(&[raw]).expect_err("an fs pin cannot cross machines");
-        assert!(err.contains("filesystem path"), "{err}");
+        assert!(err.contains("coordinator's filesystem"), "{err}");
         assert!(err.contains("git repository"), "{err}");
     }
 

--- a/crates/core-node-internal/src/services/federation/service.rs
+++ b/crates/core-node-internal/src/services/federation/service.rs
@@ -128,6 +128,21 @@ async fn reserve_inner(
         decoded.launch_id, decoded.coordinator_core_node
     );
 
+    // Validate the pins the coordinator resolved for this slice BEFORE taking
+    // the reservation. Decoding runs every structural rule (a traversal path,
+    // a truncated commit, a malformed fingerprint all fail there), and the
+    // origin check refuses a pin no machine but the coordinator could read.
+    // Nothing here touches the filesystem, the network, or this daemon's
+    // caches: the bytes are materialized at add time, and which bytes those
+    // are was decided on the coordinator. Refusing first means a rejected
+    // slice never took ownership and never spawned a presence watch, so there
+    // is nothing to unwind.
+    if let Err(reason) = validate_deployment_pins(&decoded.deployment_pins_json5) {
+        return ParticipantReserveResponse::rejected(reason, &context.peppy_version)
+            .encode()
+            .map_err(Into::into);
+    }
+
     match context
         .ownership
         .try_reserve(&decoded.launch_id, &decoded.coordinator_core_node)
@@ -158,23 +173,6 @@ async fn reserve_inner(
             watch_coordinator_presence(context, &decoded.coordinator_core_node)
         }
         ReserveOutcome::AlreadyHeld => {}
-    }
-
-    // Validate the pins the coordinator resolved for this slice while the
-    // reservation is still non-destructive. Decoding runs every structural
-    // rule (a traversal path, a truncated commit, a malformed fingerprint
-    // all fail there), and the origin check refuses a pin no machine but
-    // the coordinator could read. Nothing here touches the filesystem, the
-    // network, or this daemon's caches: the bytes are materialized at add
-    // time, and which bytes those are was decided on the coordinator.
-    if let Err(reason) = validate_deployment_pins(&decoded.deployment_pins_json5) {
-        // A validation failure is this participant's refusal, so drop the
-        // reservation we just took rather than holding a machine hostage
-        // to a launch that cannot proceed.
-        context.ownership.release(&decoded.launch_id);
-        return ParticipantReserveResponse::rejected(reason, &context.peppy_version)
-            .encode()
-            .map_err(Into::into);
     }
 
     ParticipantReserveResponse::accepted(&context.peppy_version, &context.root_instance_id)

--- a/crates/core-node-internal/src/services/node.rs
+++ b/crates/core-node-internal/src/services/node.rs
@@ -13,6 +13,7 @@ mod init;
 mod logging;
 pub(crate) mod observation;
 pub(crate) mod pairing;
+pub(crate) mod pins;
 mod relationship_notify;
 mod remove;
 mod run;

--- a/crates/core-node-internal/src/services/node/add.rs
+++ b/crates/core-node-internal/src/services/node/add.rs
@@ -801,7 +801,16 @@ pub(crate) fn log_label_from_source(source: &NodeSource) -> String {
                 .to_string()
         }
         NodeSource::Git { .. } | NodeSource::Http { .. } => generate_random_id(),
-        NodeSource::RepoNode { name, tag, .. } => format!("{name}_{tag}"),
+        // The pin embeds the identity; decoding it here only to label a log
+        // file would fail the whole goal on a malformed pin before the
+        // executor can report it properly, so a cheap identity probe is
+        // enough and falls back to a generic label.
+        NodeSource::Pinned { pin_json5 } => {
+            serde_json5::from_str::<daemon_config::repository::PinnedItem>(pin_json5)
+                .map(|pin| format!("{}_{}", pin.name, pin.tag))
+                .unwrap_or_else(|_| generate_random_id())
+        }
+        NodeSource::ResolveRef { name, tag } => format!("{name}_{tag}"),
     }
 }
 
@@ -873,11 +882,12 @@ async fn resolve_node_add_source(
             )
             .await
         }
-        NodeSource::RepoNode { .. } => {
-            // RepoNode goals are routed to `add_batch::run_repo_node_add` by
-            // [`dispatch_node_add`] and never reach `run_node_add`, so this
-            // arm should be unreachable by construction.
-            Err("internal error: RepoNode reached the single-source add path".to_owned())
+        NodeSource::Pinned { .. } | NodeSource::ResolveRef { .. } => {
+            // Pinned and resolve-ref goals are routed to
+            // `add_batch::run_pinned_add` by [`dispatch_node_add`] and never
+            // reach `run_node_add`, so this arm should be unreachable by
+            // construction.
+            Err("internal error: a pinned source reached the single-source add path".to_owned())
         }
     }
 }
@@ -890,9 +900,10 @@ fn encode_rejected_goal(reason: impl Into<String>) -> PeppyResult<Payload> {
     )
 }
 
-/// The one place a node-add goal picks its pipeline: a repository source
-/// expands into a closure of nodes and takes the batch path, every other
-/// source names one thing to add and takes the single-source path.
+/// The one place a node-add goal picks its pipeline: a pinned source (or a
+/// `name:tag` reference this daemon resolves into one) is a closure of
+/// nodes and takes the batch path, every other source names one thing to
+/// add and takes the single-source path.
 ///
 /// Both the action-server path ([`handle_goal_request`]) and the direct
 /// call from `stack_launch` go through here, so no caller can send a
@@ -905,8 +916,11 @@ pub(crate) async fn dispatch_node_add(
     log_path: PathBuf,
     timestamp: String,
 ) -> NodeAddResult {
-    if matches!(goal.source, NodeSource::RepoNode { .. }) {
-        super::add_batch::run_repo_node_add(goal, action_context, feedback_tx, log_file, log_path)
+    if matches!(
+        goal.source,
+        NodeSource::Pinned { .. } | NodeSource::ResolveRef { .. }
+    ) {
+        super::add_batch::run_pinned_add(goal, action_context, feedback_tx, log_file, log_path)
             .await
     } else {
         run_node_add(
@@ -1169,8 +1183,12 @@ async fn handle_goal_request(
             "Received `node_add` goal from {sender_instance_id}, source=http:{}",
             url
         ),
-        NodeSource::RepoNode { name, tag, .. } => debug!(
-            "Received `node_add` goal from {sender_instance_id}, source=repo:{}:{}",
+        NodeSource::Pinned { .. } => debug!(
+            "Received `node_add` goal from {sender_instance_id}, source=pinned ({} closure pin(s))",
+            goal.pins_json5.len()
+        ),
+        NodeSource::ResolveRef { name, tag } => debug!(
+            "Received `node_add` goal from {sender_instance_id}, source=resolve:{}:{}",
             name, tag
         ),
     }
@@ -1441,11 +1459,22 @@ async fn process_node_add_inner(
             line: line.to_string(),
         });
     };
+    // A goal carrying pins fixes which bytes its contract and pairing
+    // documents are: the launch (or the resolve-ref lowering) decided them
+    // once, and this machine's own cache picks must not override that.
+    // A goal without pins keeps the local resolution rules.
+    let doc_pins = if goal.pins_json5.is_empty() {
+        None
+    } else {
+        let decoded = super::pins::decode_pins(&goal.pins_json5)?;
+        Some(super::pins::DocPins::from_pins(&decoded))
+    };
     let consumed_interfaces = collect_all_deployment_interfaces(
         &node_config.manifest,
         &node_config.interfaces,
         stack_resolver(&ctx.action.node_stack),
         &ctx.action.peppy_dirs,
+        doc_pins.as_ref(),
         &interface_feedback,
     )?;
     generate_peppygen_for_node(

--- a/crates/core-node-internal/src/services/node/add_batch.rs
+++ b/crates/core-node-internal/src/services/node/add_batch.rs
@@ -394,13 +394,17 @@ async fn execute_pinned_batch(
         });
     }
 
-    // Batch succeeded; defuse rollback and report.
+    // Batch succeeded; defuse rollback and report. Counted from what rollback
+    // recorded rather than from the pin set: a dependency the stack already
+    // held with an identical manifest was skipped, and reporting it as added
+    // would describe work this batch did not do.
+    let added = rollback.added.len();
     rollback.disarm();
 
     emit(
         &feedback_tx,
         FeedbackStream::Stdout,
-        format!("Batch add complete: {} node(s) added", nodes.len()),
+        format!("Batch add complete: {added} node(s) added"),
     );
 
     let effective_log = last_sub_log_path.unwrap_or(log_path);

--- a/crates/core-node-internal/src/services/node/add_batch.rs
+++ b/crates/core-node-internal/src/services/node/add_batch.rs
@@ -1,101 +1,263 @@
-//! Batch-add pipeline for `NodeSource::RepoNode` goals.
+//! Pinned batch-add pipeline for `NodeSource::Pinned` and
+//! `NodeSource::ResolveRef` goals.
 //!
-//! Resolves a `(name, tag)` target against `~/.peppy/cache/nodes.json5`,
-//! walks its transitive deps, materializes every node through the
-//! persistent git/http caches, topologically sorts them via
-//! [`VirtualDeptree`], then feeds each to [`super::add::run_node_add`].
+//! A pinned goal arrives with its whole closure decided: the root pin in the
+//! source, dependency-node and document pins in `pins_json5`. This executor
+//! materializes exactly that set through [`super::pins`], reusing local
+//! content when its fingerprint matches and fetching the pinned commit when
+//! it does not, then topologically sorts the batch via [`VirtualDeptree`]
+//! and feeds each node to [`super::add::run_node_add`]. Nothing here looks a
+//! name up: an identity the pins do not cover and the stack does not hold is
+//! a refusal, never a lookup.
+//!
+//! A `ResolveRef` goal is the entry arm for `peppy node add <name>:<tag>`:
+//! the receiving daemon resolves the closure against its own caches, minting
+//! the same pins a launch coordinator would, and continues down the
+//! identical pinned pipeline. Name resolution therefore exists in exactly
+//! one place ([`super::pins::resolve_pinned_closure`]) whichever machine
+//! runs it.
+//!
 //! Mid-batch failure rolls back every node pushed during the batch via a
 //! drop guard.
 
-use super::super::repo::cache::{self, NodeCacheEntry};
 use super::super::stack::STACK_LAUNCH_GIT_HASH;
 use super::add::{NodeAddActionContext, run_node_add};
-use super::cache as node_cache;
+use super::pins::{self, MaterializedPin};
 use super::{FeedbackLine, FeedbackStream, create_action_log_file};
+use crate::services::repo::cache as repo_cache;
 use chrono::Local;
 use config::node::NodeConfig;
-use core_node_api::encoding::{NodeAddGoal, NodeAddResult, NodeSource, RepoSourceKind};
-use daemon_config::consts::PeppyDirs;
-use futures::future::BoxFuture;
-use futures::stream::{FuturesUnordered, StreamExt};
+use core_node_api::encoding::{NodeAddGoal, NodeAddResult, NodeSource};
+use daemon_config::repository::PinKind;
 use node_stack::{VirtualDeptree, WorkingDirGuard};
 use parking_lot::Mutex as StdMutex;
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::path::PathBuf;
 use std::sync::Arc;
-use tokio::sync::{Semaphore, mpsc};
+use tokio::sync::mpsc;
 use tracing::{debug, warn};
 
-/// Upper bound on concurrently-running `materialize_entry` tasks inside a
-/// single batch. Bundles are materialized through git clones and HTTP
-/// downloads; spawning an unbounded number of them at once thrashes disk
-/// and network. 8 is empirical: enough to overlap IO latency, low
-/// enough to avoid saturating a developer laptop.
-const MATERIALIZE_CONCURRENCY: usize = 8;
-
 /// Entry point [`super::add::dispatch_node_add`] routes to when
-/// `goal.source` is `NodeSource::RepoNode`.
-pub(crate) async fn run_repo_node_add(
+/// `goal.source` is `NodeSource::Pinned` or `NodeSource::ResolveRef`.
+pub(crate) async fn run_pinned_add(
     goal: NodeAddGoal,
     action_context: NodeAddActionContext,
     feedback_tx: mpsc::UnboundedSender<FeedbackLine>,
     log_file: Arc<StdMutex<File>>,
     log_path: PathBuf,
 ) -> NodeAddResult {
-    let (root_name, root_tag) = match &goal.source {
-        NodeSource::RepoNode { name, tag } => (name.clone(), tag.clone()),
-        _ => {
-            return NodeAddResult::failure(
-                &log_path,
-                "internal error: run_repo_node_add called with non-RepoNode source".to_owned(),
-            );
-        }
+    let peppy_dirs = action_context.peppy_dirs.clone();
+    let on_feedback: super::cache::MaterializeFeedback = {
+        let fb = feedback_tx.clone();
+        Arc::new(move |line: &str| {
+            let _ = fb.send(FeedbackLine {
+                stream: FeedbackStream::Stdout,
+                line: line.to_owned(),
+            });
+        })
     };
 
-    emit(
-        &feedback_tx,
-        FeedbackStream::Stdout,
-        format!("Resolving {}:{} from repo cache", root_name, root_tag),
-    );
+    let (nodes, doc_pins_json5) = match &goal.source {
+        NodeSource::Pinned { pin_json5 } => {
+            let root: daemon_config::repository::PinnedItem = match serde_json5::from_str(pin_json5)
+            {
+                Ok(pin) => pin,
+                Err(e) => {
+                    return fail(
+                        &log_file,
+                        &log_path,
+                        format!("the goal's root pin is not decodable: {e}"),
+                    );
+                }
+            };
+            if root.kind != PinKind::Node {
+                return fail(
+                    &log_file,
+                    &log_path,
+                    format!("the goal's root pin is {}, not a node", root.label()),
+                );
+            }
+            let closure = match pins::decode_pins(&goal.pins_json5) {
+                Ok(closure) => closure,
+                Err(e) => return fail(&log_file, &log_path, e),
+            };
+            let doc_pins_json5: Vec<String> = goal
+                .pins_json5
+                .iter()
+                .zip(&closure)
+                .filter(|(_, pin)| pin.kind != PinKind::Node)
+                .map(|(raw, _)| raw.clone())
+                .collect();
+            let node_pins: Vec<_> = closure
+                .into_iter()
+                .filter(|pin| pin.kind == PinKind::Node)
+                .collect();
 
-    let peppy_dirs = action_context.peppy_dirs.clone();
+            emit(
+                &feedback_tx,
+                FeedbackStream::Stdout,
+                format!(
+                    "Materializing {} pinned node(s) for {}",
+                    node_pins.len() + 1,
+                    root.label()
+                ),
+            );
 
-    let entries = match cache::load_node_cache(&peppy_dirs) {
-        Ok(loaded) => loaded,
-        Err(e) => {
+            // An ABSENT cache is not a problem here: content this machine
+            // does not hold is fetched from each pin's own origin, which is
+            // what lets a freshly-provisioned peer join a launch. A cache
+            // that exists but does not parse still refuses, because a
+            // machine with broken state should say so rather than quietly
+            // re-fetching everything on every launch.
+            let entries = match repo_cache::load_node_cache(&peppy_dirs) {
+                Ok(loaded) => loaded,
+                Err(e) => {
+                    return fail(
+                        &log_file,
+                        &log_path,
+                        format!("Failed to read nodes cache: {}", e),
+                    );
+                }
+            };
+            let nodes = match pins::materialize_pin_set(
+                &peppy_dirs,
+                &entries,
+                root,
+                node_pins,
+                on_feedback,
+            )
+            .await
+            {
+                Ok(nodes) => nodes,
+                Err(e) => return fail(&log_file, &log_path, e),
+            };
+            (nodes, doc_pins_json5)
+        }
+        NodeSource::ResolveRef { name, tag } => {
+            emit(
+                &feedback_tx,
+                FeedbackStream::Stdout,
+                format!("Resolving {}:{} from repo cache", name, tag),
+            );
+            let entries = match repo_cache::load_node_cache(&peppy_dirs) {
+                Ok(loaded) => loaded,
+                Err(e) => {
+                    return fail(
+                        &log_file,
+                        &log_path,
+                        format!("Failed to read nodes cache: {}", e),
+                    );
+                }
+            };
+            if entries.is_empty() {
+                return fail(
+                    &log_file,
+                    &log_path,
+                    format!(
+                        "nodes.json5 not found or empty at {}; run `peppy repo refresh` to \
+                         populate it",
+                        repo_cache::nodes_repo_cache_path(&peppy_dirs).display()
+                    ),
+                );
+            }
+            let closure = match pins::resolve_pinned_closure(
+                &peppy_dirs,
+                &entries,
+                name,
+                tag,
+                Arc::clone(&on_feedback),
+            )
+            .await
+            {
+                Ok(closure) => closure,
+                Err(e) => return fail(&log_file, &log_path, e),
+            };
+            let doc_pins = {
+                let dirs = peppy_dirs.clone();
+                let manifests = closure.manifests();
+                let feedback = Arc::clone(&on_feedback);
+                let minted = tokio::task::spawn_blocking(move || {
+                    pins::doc_pins_for_manifests(&dirs, &manifests, &|line| feedback(line))
+                })
+                .await
+                .map_err(|e| format!("doc pin minting task failed: {e}"))
+                .and_then(|result| result);
+                match minted {
+                    Ok(doc_pins) => doc_pins,
+                    Err(e) => return fail(&log_file, &log_path, e),
+                }
+            };
+            let doc_pins_json5 = match pins::encode_pins(&doc_pins) {
+                Ok(encoded) => encoded,
+                Err(e) => return fail(&log_file, &log_path, e),
+            };
+            (closure.nodes, doc_pins_json5)
+        }
+        _ => {
             return fail(
                 &log_file,
                 &log_path,
-                format!("Failed to read nodes cache: {}", e),
+                "internal error: run_pinned_add called with a non-pinned source".to_owned(),
             );
         }
     };
-    if entries.is_empty() {
-        return fail(
-            &log_file,
-            &log_path,
-            format!(
-                "nodes.json5 not found or empty at {}; run `peppy repo refresh` to populate it",
-                cache::nodes_repo_cache_path(&peppy_dirs).display()
+
+    execute_pinned_batch(
+        nodes,
+        doc_pins_json5,
+        goal,
+        action_context,
+        feedback_tx,
+        log_file,
+        log_path,
+    )
+    .await
+}
+
+/// Adds a materialized pin set to the stack in dependency order.
+///
+/// The batch is exactly the pin set. A dependency an entry declares that the
+/// pins do not cover must already be in the stack (a launch adds
+/// deployments in dependency order, so a dependency planned as its own
+/// deployment landed earlier); one that is in neither is refused as an
+/// incomplete closure rather than looked up by name.
+async fn execute_pinned_batch(
+    nodes: Vec<MaterializedPin>,
+    doc_pins_json5: Vec<String>,
+    goal: NodeAddGoal,
+    action_context: NodeAddActionContext,
+    feedback_tx: mpsc::UnboundedSender<FeedbackLine>,
+    log_file: Arc<StdMutex<File>>,
+    log_path: PathBuf,
+) -> NodeAddResult {
+    let root_label = {
+        let root = nodes.first().filter(|node| node.is_root);
+        match root {
+            Some(root) => (
+                root.pin.name.as_str().to_owned(),
+                root.pin.tag.as_str().to_owned(),
             ),
-        );
+            None => {
+                return fail(
+                    &log_file,
+                    &log_path,
+                    "internal error: a pinned batch arrived without its root".to_owned(),
+                );
+            }
+        }
+    };
+
+    let gaps = closure_gaps(&nodes, |name, tag| {
+        action_context.node_stack.find(name, tag).is_some()
+    });
+    if !gaps.is_empty() {
+        return fail(&log_file, &log_path, daemon_config::format_bulleted(&gaps));
     }
 
-    let resolution_ctx = BatchResolutionCtx {
-        peppy_dirs: &peppy_dirs,
-        entries: &entries,
-        feedback_tx: &feedback_tx,
-    };
-    let resolution = match resolve_transitive_closure(resolution_ctx, &root_name, &root_tag).await {
-        Ok(r) => r,
-        Err(msg) => return fail(&log_file, &log_path, msg),
-    };
-
-    let tree_input: Vec<(PathBuf, config::node::NodeConfig)> = resolution
-        .to_add
+    let tree_input: Vec<(PathBuf, NodeConfig)> = nodes
         .iter()
-        .map(|n| (n.root_dir.clone(), n.config_resolved.clone()))
+        .map(|node| (node.root_dir.clone(), node.config.clone()))
         .collect();
     let tree = match VirtualDeptree::build(tree_input) {
         Ok(t) => t,
@@ -108,10 +270,17 @@ pub(crate) async fn run_repo_node_add(
         }
     };
 
-    let node_lookup: HashMap<(String, String), &ResolvedBatchNode> = resolution
-        .to_add
+    let node_lookup: HashMap<(String, String), &MaterializedPin> = nodes
         .iter()
-        .map(|n| ((n.name.clone(), n.tag.clone()), n))
+        .map(|node| {
+            (
+                (
+                    node.pin.name.as_str().to_owned(),
+                    node.pin.tag.as_str().to_owned(),
+                ),
+                node,
+            )
+        })
         .collect();
 
     emit(
@@ -119,11 +288,10 @@ pub(crate) async fn run_repo_node_add(
         FeedbackStream::Stdout,
         format!(
             "Batch resolved: {} node(s) to add: {}",
-            resolution.to_add.len(),
-            resolution
-                .to_add
+            nodes.len(),
+            nodes
                 .iter()
-                .map(|n| format!("{}:{}", n.name, n.tag))
+                .map(|node| format!("{}:{}", node.pin.name, node.pin.tag))
                 .collect::<Vec<_>>()
                 .join(", ")
         ),
@@ -159,7 +327,7 @@ pub(crate) async fn run_repo_node_add(
                 FeedbackStream::Stdout,
                 format!(
                     "Skipping {}:{}: already in the stack with an identical manifest",
-                    node.name, node.tag
+                    node.pin.name, node.pin.tag
                 ),
             );
             continue;
@@ -170,9 +338,9 @@ pub(crate) async fn run_repo_node_add(
             FeedbackStream::Stdout,
             format!(
                 "Adding {}:{} ({})",
-                node.name,
-                node.tag,
-                node.source_kind.as_str()
+                node.pin.name,
+                node.pin.tag,
+                node.pin.origin.kind().as_str()
             ),
         );
 
@@ -189,7 +357,7 @@ pub(crate) async fn run_repo_node_add(
         // removed before rollback ever runs.
         let previous = action_context
             .node_stack
-            .find(&node.name, &node.tag)
+            .find(node.pin.name.as_str(), node.pin.tag.as_str())
             .map(|handle| {
                 let guard = handle.read();
                 PreviousConfig {
@@ -199,17 +367,24 @@ pub(crate) async fn run_repo_node_add(
                 }
             });
 
-        let sub_result =
-            match run_single_batched_add(node, &goal, &action_context, &feedback_tx).await {
-                Ok(r) => r,
-                Err(msg) => {
-                    return fail(
-                        &log_file,
-                        &log_path,
-                        format!("Failed to add {}:{}: {}", node.name, node.tag, msg),
-                    );
-                }
-            };
+        let sub_result = match run_single_batched_add(
+            node,
+            &doc_pins_json5,
+            &goal,
+            &action_context,
+            &feedback_tx,
+        )
+        .await
+        {
+            Ok(r) => r,
+            Err(msg) => {
+                return fail(
+                    &log_file,
+                    &log_path,
+                    format!("Failed to add {}:{}: {}", node.pin.name, node.pin.tag, msg),
+                );
+            }
+        };
 
         if !sub_result.success {
             let msg = sub_result
@@ -218,14 +393,14 @@ pub(crate) async fn run_repo_node_add(
             return fail(
                 &log_file,
                 &log_path,
-                format!("Failed to add {}:{}: {}", node.name, node.tag, msg),
+                format!("Failed to add {}:{}: {}", node.pin.name, node.pin.tag, msg),
             );
         }
 
         last_sub_log_path = Some(sub_result.log_path.clone());
         rollback.added.push(RollbackEntry {
-            name: node.name.clone(),
-            tag: node.tag.clone(),
+            name: node.pin.name.as_str().to_owned(),
+            tag: node.pin.tag.as_str().to_owned(),
             previous,
         });
     }
@@ -236,14 +411,59 @@ pub(crate) async fn run_repo_node_add(
     emit(
         &feedback_tx,
         FeedbackStream::Stdout,
-        format!(
-            "Batch add complete: {} node(s) added",
-            resolution.to_add.len()
-        ),
+        format!("Batch add complete: {} node(s) added", nodes.len()),
     );
 
     let effective_log = last_sub_log_path.unwrap_or(log_path);
-    NodeAddResult::success(effective_log, root_name, root_tag)
+    NodeAddResult::success(effective_log, root_label.0, root_label.1)
+}
+
+/// Dependencies the batch can neither add nor find: named by a materialized
+/// manifest, absent from the pin set, and absent from the stack.
+///
+/// The batch is exactly the pin set, so this is the boundary where "never
+/// resolve a name" bites: a gap is refused as an incomplete closure rather
+/// than looked up. A dependency in the stack is not a gap, because a launch
+/// adds deployments in dependency order and a dependency planned as its own
+/// deployment landed there before this batch ran.
+fn closure_gaps(nodes: &[MaterializedPin], in_stack: impl Fn(&str, &str) -> bool) -> Vec<String> {
+    let pinned_keys: HashSet<(String, String)> = nodes
+        .iter()
+        .map(|node| {
+            (
+                node.pin.name.as_str().to_owned(),
+                node.pin.tag.as_str().to_owned(),
+            )
+        })
+        .collect();
+    let mut gaps: Vec<String> = Vec::new();
+    for node in nodes {
+        let Some(deps) = node.config.manifest.depends_on.as_ref() else {
+            continue;
+        };
+        for dep in &deps.nodes {
+            let key = (dep.name.as_str().to_owned(), dep.tag.clone());
+            if pinned_keys.contains(&key) || in_stack(&key.0, &key.1) {
+                continue;
+            }
+            gaps.push(format!(
+                "{} depends on `{}:{}`, which is neither pinned nor in the stack",
+                node.pin.label(),
+                key.0,
+                key.1
+            ));
+        }
+    }
+    if !gaps.is_empty() {
+        gaps.sort();
+        gaps.insert(
+            0,
+            "this add's pins do not cover its closure; the coordinator that minted them \
+             shipped an incomplete set"
+                .to_owned(),
+        );
+    }
+    gaps
 }
 
 /// Whether the stack already holds `node`'s identity with a config whose
@@ -252,186 +472,30 @@ pub(crate) async fn run_repo_node_add(
 /// Compared by [`super::manifest_fingerprint`] rather than by identity
 /// alone: an entry whose pin moved to a different manifest must still be
 /// replaced, or the batch would keep satisfying dependents with a config
-/// the repository no longer describes. A fingerprint that fails to
+/// the launch no longer describes. A fingerprint that fails to
 /// compute reports "different", falling back to the replace path.
-fn stack_holds_identical(node_stack: &node_stack::NodeStack, node: &ResolvedBatchNode) -> bool {
-    let Some(handle) = node_stack.find(&node.name, &node.tag) else {
+fn stack_holds_identical(node_stack: &node_stack::NodeStack, node: &MaterializedPin) -> bool {
+    let Some(handle) = node_stack.find(node.pin.name.as_str(), node.pin.tag.as_str()) else {
         return false;
     };
     let existing = { handle.read().config().clone() };
     match (
         super::manifest_fingerprint(&existing),
-        super::manifest_fingerprint(&node.config_resolved),
+        super::manifest_fingerprint(&node.config),
     ) {
         (Ok(existing), Ok(incoming)) => existing == incoming,
         _ => false,
     }
 }
 
-/// One node that's been materialized on disk and is ready to be fed to
-/// the per-node add pipeline.
-struct ResolvedBatchNode {
-    name: String,
-    tag: String,
-    root_dir: PathBuf,
-    config_resolved: config::node::NodeConfig,
-    source_kind: RepoSourceKind,
-    /// Only set to `true` for the root of the batch. Controls whether
-    /// the env_vars / force from the original goal apply.
-    is_root: bool,
-}
-
-struct Resolution {
-    /// Every node we need to push onto the stack, in discovery order.
-    /// Topological order is applied later via VirtualDeptree.
-    to_add: Vec<ResolvedBatchNode>,
-}
-
-type MaterializeOutput = (
-    String,
-    String,
-    bool,
-    RepoSourceKind,
-    Result<(PathBuf, NodeConfig), String>,
-);
-
-/// Bundles the cache/IO dependencies threaded through the batch-resolution
-/// pipeline so callers don't juggle half a dozen parallel borrows.
-#[derive(Clone, Copy)]
-struct BatchResolutionCtx<'a> {
-    peppy_dirs: &'a PeppyDirs,
-    entries: &'a [NodeCacheEntry],
-    feedback_tx: &'a mpsc::UnboundedSender<FeedbackLine>,
-}
-
-async fn resolve_transitive_closure<'a>(
-    ctx: BatchResolutionCtx<'a>,
-    root_name: &str,
-    root_tag: &str,
-) -> Result<Resolution, String> {
-    let BatchResolutionCtx {
-        peppy_dirs,
-        entries,
-        feedback_tx,
-    } = ctx;
-
-    let mut to_add: Vec<ResolvedBatchNode> = Vec::new();
-    let mut seen: HashSet<(String, String)> = HashSet::new();
-    let mut missing: Vec<(String, String)> = Vec::new();
-    let mut ambiguous: Vec<String> = Vec::new();
-    let mut pending: Vec<(String, String, bool)> =
-        vec![(root_name.to_owned(), root_tag.to_owned(), true)];
-    let mut in_flight: FuturesUnordered<BoxFuture<'a, MaterializeOutput>> = FuturesUnordered::new();
-    let semaphore = Arc::new(Semaphore::new(MATERIALIZE_CONCURRENCY));
-
-    loop {
-        while let Some((name, tag, is_root)) = pending.pop() {
-            let key = (name.clone(), tag.clone());
-            if !seen.insert(key.clone()) {
-                continue;
-            }
-            // Every resolved node (root and deps alike) is materialized and
-            // pushed. `push_config_impl` handles in-place replacement for
-            // keys already in the stack, including the live-instance and
-            // dependents safety gates.
-            // An identity claimed twice is present, not absent, so it is
-            // kept out of `missing`: telling the user it is missing sends
-            // them to add a node that is already there twice.
-            let resolved = match cache::lookup(entries, &name, &tag) {
-                Ok(resolved) => resolved,
-                Err(ambiguity) => {
-                    ambiguous.push(ambiguity.to_string());
-                    continue;
-                }
-            };
-            let Some(entry) = resolved else {
-                missing.push(key);
-                continue;
-            };
-            let entry = entry.clone();
-            let source_kind = entry.origin.kind();
-            let permit_source = Arc::clone(&semaphore);
-            let fb = feedback_tx.clone();
-            let on_feedback: node_cache::MaterializeFeedback = Arc::new(move |line: &str| {
-                let _ = fb.send(FeedbackLine {
-                    stream: FeedbackStream::Stdout,
-                    line: line.to_owned(),
-                });
-            });
-            in_flight.push(Box::pin(async move {
-                let _permit = permit_source
-                    .acquire_owned()
-                    .await
-                    .expect("materialize semaphore is never closed");
-                let result = node_cache::materialize_entry(&entry, peppy_dirs, on_feedback).await;
-                (name, tag, is_root, source_kind, result)
-            }));
-        }
-
-        let Some((name, tag, is_root, source_kind, result)) = in_flight.next().await else {
-            break;
-        };
-
-        let (root_dir, parsed) = match result {
-            Ok(pair) => pair,
-            Err(e) => {
-                return Err(format!(
-                    "Failed to materialize {}:{} from repo cache: {}",
-                    name, tag, e
-                ));
-            }
-        };
-
-        if let Some(deps) = parsed.manifest.depends_on.as_ref() {
-            for dep in &deps.nodes {
-                let dep_name = dep.name.as_str().to_owned();
-                let dep_tag = dep.tag.clone();
-                if seen.contains(&(dep_name.clone(), dep_tag.clone())) {
-                    continue;
-                }
-                pending.push((dep_name, dep_tag, false));
-            }
-        }
-
-        to_add.push(ResolvedBatchNode {
-            name,
-            tag,
-            root_dir,
-            config_resolved: parsed,
-            source_kind,
-            is_root,
-        });
-    }
-
-    // Everything wrong with the closure is reported in one pass, sorted,
-    // so a user with several problems fixes them all after one run.
-    let mut problems: Vec<String> = Vec::new();
-    ambiguous.sort();
-    problems.append(&mut ambiguous);
-    if !missing.is_empty() {
-        missing.sort();
-        let list = missing
-            .iter()
-            .map(|(n, t)| format!("{}:{}", n, t))
-            .collect::<Vec<_>>()
-            .join(", ");
-        problems.push(format!(
-            "Dependencies missing from nodes cache ({}): {list}. Run `peppy repo refresh` or add the missing nodes to a configured repository.",
-            cache::nodes_repo_cache_path(peppy_dirs).display()
-        ));
-    }
-    if !problems.is_empty() {
-        return Err(daemon_config::format_bulleted(&problems));
-    }
-
-    Ok(Resolution { to_add })
-}
-
 /// Run a single node-add step inside the batch. Each sub-add gets its
 /// own log file; the returned `NodeAddResult.log_path` is propagated up
-/// so the user can still find the most recent log.
+/// so the user can still find the most recent log. The batch's doc pins
+/// ride on every sub-goal, so each node's contract and pairing documents
+/// resolve to the launch's bytes rather than this machine's cache picks.
 async fn run_single_batched_add(
-    node: &ResolvedBatchNode,
+    node: &MaterializedPin,
+    doc_pins_json5: &[String],
     batch_goal: &NodeAddGoal,
     action_context: &NodeAddActionContext,
     batch_feedback_tx: &mpsc::UnboundedSender<FeedbackLine>,
@@ -440,7 +504,8 @@ async fn run_single_batched_add(
         node.root_dir.clone(),
         STACK_LAUNCH_GIT_HASH,
         batch_goal.timeout_secs,
-    );
+    )
+    .with_pins(doc_pins_json5.to_vec());
 
     if node.is_root {
         // Env vars / force only apply to the root entity.
@@ -452,7 +517,7 @@ async fn run_single_batched_add(
     // Each sub-add gets its own log file derived from `{name}_{tag}`.
     let log_dir = action_context.peppy_dirs.logs_dir_add();
     let timestamp = Local::now().format("%Y%m%d_%H%M%S_%3f").to_string();
-    let log_filename = format!("{}_{}_{}.log", node.name, node.tag, timestamp);
+    let log_filename = format!("{}_{}_{}.log", node.pin.name, node.pin.tag, timestamp);
     let (log_file, log_path) = create_action_log_file(&log_dir, &log_filename)
         .map_err(|e| format!("Failed to create sub-add log: {}", e))?;
 
@@ -581,4 +646,83 @@ fn fail(log_file: &Arc<StdMutex<File>>, log_path: &std::path::Path, msg: String)
 
 fn emit(feedback_tx: &mpsc::UnboundedSender<FeedbackLine>, stream: FeedbackStream, line: String) {
     let _ = feedback_tx.send(FeedbackLine { stream, line });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use daemon_config::repository::{
+        EntryOrigin, GitCommit, ItemName, ItemTag, ManifestFingerprint, PinKind, PinnedItem,
+        RepoRelativePath,
+    };
+
+    fn materialized(
+        name: &str,
+        tag: &str,
+        deps: &[(&str, &str)],
+        is_root: bool,
+    ) -> MaterializedPin {
+        let depends_on = if deps.is_empty() {
+            String::new()
+        } else {
+            let list = deps
+                .iter()
+                .map(|(dep_name, dep_tag)| {
+                    format!(r#"{{ name: "{dep_name}", tag: "{dep_tag}", link_id: "{dep_name}" }}"#)
+                })
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!(", depends_on: {{ nodes: [{list}] }}")
+        };
+        let config: NodeConfig = config::node::NodeConfigParser::from_content(&format!(
+            r#"{{ peppy_schema: "node/v1",
+                  manifest: {{ name: "{name}", tag: "{tag}"{depends_on} }},
+                  execution: {{ language: "python", build_cmd: ["true"], run_cmd: ["true"] }} }}"#
+        ))
+        .expect("test config parses");
+        MaterializedPin {
+            pin: PinnedItem {
+                kind: PinKind::Node,
+                name: ItemName::parse(name).expect("valid name"),
+                tag: ItemTag::parse(tag).expect("valid tag"),
+                sha256: ManifestFingerprint::of_bytes(name.as_bytes()),
+                origin: EntryOrigin::Git {
+                    repo_url: "https://example.com/hub".to_owned(),
+                    repo_ref: Some("main".to_owned()),
+                    commit: GitCommit::parse(&"a".repeat(40)).expect("valid commit"),
+                    path: RepoRelativePath::parse(&format!("{name}/peppy.json5"))
+                        .expect("valid path"),
+                },
+            },
+            root_dir: std::path::PathBuf::from("/unused"),
+            config,
+            is_root,
+        }
+    }
+
+    /// A batch whose pins cover every declared dependency has no gaps, and
+    /// a dependency satisfied by the stack (an earlier deployment of the
+    /// same launch) is not a gap either.
+    #[test]
+    fn a_covered_closure_has_no_gaps() {
+        let nodes = vec![
+            materialized("camera", "v1", &[("driver", "v1"), ("planner", "v1")], true),
+            materialized("driver", "v1", &[], false),
+        ];
+        let gaps = closure_gaps(&nodes, |name, _| name == "planner");
+        assert!(gaps.is_empty(), "got: {gaps:?}");
+    }
+
+    /// The refusal this executor exists to give instead of a name lookup: a
+    /// dependency in neither the pin set nor the stack names the gap and
+    /// blames the pin set, never resolves the name.
+    #[test]
+    fn an_uncovered_dependency_is_an_incomplete_closure_refusal() {
+        let nodes = vec![materialized("camera", "v1", &[("driver", "v2")], true)];
+        let gaps = closure_gaps(&nodes, |_, _| false);
+        assert_eq!(gaps.len(), 2, "a header plus one gap: {gaps:?}");
+        assert!(gaps[0].contains("incomplete set"), "got: {gaps:?}");
+        assert!(gaps[1].contains("`driver:v2`"), "got: {gaps:?}");
+        assert!(gaps[1].contains("camera:v1"), "got: {gaps:?}");
+    }
 }

--- a/crates/core-node-internal/src/services/node/add_batch.rs
+++ b/crates/core-node-internal/src/services/node/add_batch.rs
@@ -58,6 +58,24 @@ pub(crate) async fn run_pinned_add(
         })
     };
 
+    // An ABSENT cache is not a problem on the pinned path: content this
+    // machine does not hold is fetched from each pin's own origin, which is
+    // what lets a freshly-provisioned peer join a launch. A cache that exists
+    // but does not parse still refuses, because a machine with broken state
+    // should say so rather than quietly re-fetching everything on every
+    // launch. Loaded once, before the arms, and shared with every
+    // materialization rather than copied per pin.
+    let entries = match repo_cache::load_node_cache(&peppy_dirs) {
+        Ok(loaded) => Arc::new(loaded),
+        Err(e) => {
+            return fail(
+                &log_file,
+                &log_path,
+                format!("Failed to read nodes cache: {}", e),
+            );
+        }
+    };
+
     let (nodes, doc_pins_json5) = match &goal.source {
         NodeSource::Pinned { pin_json5 } => {
             let root: daemon_config::repository::PinnedItem = match serde_json5::from_str(pin_json5)
@@ -82,17 +100,18 @@ pub(crate) async fn run_pinned_add(
                 Ok(closure) => closure,
                 Err(e) => return fail(&log_file, &log_path, e),
             };
-            let doc_pins_json5: Vec<String> = goal
-                .pins_json5
-                .iter()
-                .zip(&closure)
-                .filter(|(_, pin)| pin.kind != PinKind::Node)
-                .map(|(raw, _)| raw.clone())
-                .collect();
-            let node_pins: Vec<_> = closure
+            // Re-encoded from the decoded pins rather than sliced out of the
+            // raw input by position: the split is stated over the values that
+            // carry the kind, not over an assumed correspondence between two
+            // collections, and it is the same round-trip the `ResolveRef` arm
+            // performs below.
+            let (node_pins, doc_pins): (Vec<_>, Vec<_>) = closure
                 .into_iter()
-                .filter(|pin| pin.kind == PinKind::Node)
-                .collect();
+                .partition(|pin| pin.kind == PinKind::Node);
+            let doc_pins_json5 = match pins::encode_pins(&doc_pins) {
+                Ok(encoded) => encoded,
+                Err(e) => return fail(&log_file, &log_path, e),
+            };
 
             emit(
                 &feedback_tx,
@@ -104,22 +123,6 @@ pub(crate) async fn run_pinned_add(
                 ),
             );
 
-            // An ABSENT cache is not a problem here: content this machine
-            // does not hold is fetched from each pin's own origin, which is
-            // what lets a freshly-provisioned peer join a launch. A cache
-            // that exists but does not parse still refuses, because a
-            // machine with broken state should say so rather than quietly
-            // re-fetching everything on every launch.
-            let entries = match repo_cache::load_node_cache(&peppy_dirs) {
-                Ok(loaded) => loaded,
-                Err(e) => {
-                    return fail(
-                        &log_file,
-                        &log_path,
-                        format!("Failed to read nodes cache: {}", e),
-                    );
-                }
-            };
             let nodes = match pins::materialize_pin_set(
                 &peppy_dirs,
                 &entries,
@@ -140,16 +143,6 @@ pub(crate) async fn run_pinned_add(
                 FeedbackStream::Stdout,
                 format!("Resolving {}:{} from repo cache", name, tag),
             );
-            let entries = match repo_cache::load_node_cache(&peppy_dirs) {
-                Ok(loaded) => loaded,
-                Err(e) => {
-                    return fail(
-                        &log_file,
-                        &log_path,
-                        format!("Failed to read nodes cache: {}", e),
-                    );
-                }
-            };
             if entries.is_empty() {
                 return fail(
                     &log_file,
@@ -173,20 +166,16 @@ pub(crate) async fn run_pinned_add(
                 Ok(closure) => closure,
                 Err(e) => return fail(&log_file, &log_path, e),
             };
-            let doc_pins = {
-                let dirs = peppy_dirs.clone();
-                let manifests = closure.manifests();
-                let feedback = Arc::clone(&on_feedback);
-                let minted = tokio::task::spawn_blocking(move || {
-                    pins::doc_pins_for_manifests(&dirs, &manifests, &|line| feedback(line))
-                })
-                .await
-                .map_err(|e| format!("doc pin minting task failed: {e}"))
-                .and_then(|result| result);
-                match minted {
-                    Ok(doc_pins) => doc_pins,
-                    Err(e) => return fail(&log_file, &log_path, e),
-                }
+            let minted = pins::doc_pins_for_manifest_sets_async(
+                &peppy_dirs,
+                vec![closure.manifests()],
+                Arc::clone(&on_feedback),
+            )
+            .await
+            .and_then(|mut sets| sets.remove(0));
+            let doc_pins = match minted {
+                Ok(doc_pins) => doc_pins,
+                Err(e) => return fail(&log_file, &log_path, e),
             };
             let doc_pins_json5 = match pins::encode_pins(&doc_pins) {
                 Ok(encoded) => encoded,

--- a/crates/core-node-internal/src/services/node/cache.rs
+++ b/crates/core-node-internal/src/services/node/cache.rs
@@ -10,4 +10,4 @@ mod key;
 mod keyed_lock;
 pub(super) mod materialize;
 
-pub(super) use materialize::{MaterializeFeedback, materialize_entry, silent_feedback};
+pub(crate) use materialize::{MaterializeFeedback, materialize_entry, silent_feedback};

--- a/crates/core-node-internal/src/services/node/info.rs
+++ b/crates/core-node-internal/src/services/node/info.rs
@@ -2,7 +2,6 @@ use super::{
     checkout_repo_ref, is_supported_fs_archive, resolve_local_archive_source, sanitize_repo_path,
 };
 use crate::Result;
-use crate::services::repo::cache as repo_cache;
 use config::consts::NODE_CONFIG_FILE;
 use config::node::{NodeConfig, NodeConfigParser};
 use core_node_api::ServiceId;
@@ -246,17 +245,11 @@ async fn resolve_node_config_with_source_path(
         NodeSource::Http { url, sha256 } => {
             parse_node_config_from_http_with_path(url, sha256, peppy_dirs).await
         }
-        NodeSource::RepoNode { name, tag } => {
-            let entry = repo_cache::resolve_repo_node_entry(&name, &tag, peppy_dirs)?;
-            let (source_dir, config) = crate::services::node::cache::materialize_entry(
-                &entry,
-                peppy_dirs,
-                crate::services::node::cache::silent_feedback(),
-            )
-            .await?;
-            // The checkout cache owns the directory and keys it by commit, so
-            // nothing here is a temporary the caller has to keep alive.
-            Ok((config, source_dir, None))
+        NodeSource::Pinned { .. } | NodeSource::ResolveRef { .. } => {
+            // Pinned sources resolve through `node::pins`, whose executor
+            // owns the content-match-or-fetch rules; nothing routes them
+            // through this single-source resolver.
+            Err("internal error: a pinned source reached the single-source resolver".to_owned())
         }
     }
 }

--- a/crates/core-node-internal/src/services/node/pins.rs
+++ b/crates/core-node-internal/src/services/node/pins.rs
@@ -75,12 +75,6 @@ impl PinnedClosure {
             .map(|node| node.config.manifest.clone())
             .collect()
     }
-
-    pub fn root(&self) -> &MaterializedPin {
-        self.nodes
-            .first()
-            .expect("a resolved closure always holds its root")
-    }
 }
 
 /// The pin a nodes-cache entry mints: the entry already records the content
@@ -105,7 +99,7 @@ pub(crate) fn pin_for_node_entry(entry: &NodeCacheEntry) -> PinnedItem {
 /// refusals rather than something to run.
 pub(crate) async fn materialize_pinned_node(
     peppy_dirs: &PeppyDirs,
-    entries: &[NodeCacheEntry],
+    entries: &Arc<Vec<NodeCacheEntry>>,
     pin: &PinnedItem,
     on_feedback: node_cache::MaterializeFeedback,
 ) -> std::result::Result<(PathBuf, NodeConfig), String> {
@@ -117,7 +111,10 @@ pub(crate) async fn materialize_pinned_node(
 
     let (manifest_path, bytes) = if may_block {
         let dirs = peppy_dirs.clone();
-        let entries = entries.to_vec();
+        // The index is SHARED with the blocking task, not copied into it:
+        // up to `MATERIALIZE_CONCURRENCY` of these run at once and the index
+        // holds every node the machine's repositories know about.
+        let entries = Arc::clone(entries);
         let pin = pin.clone();
         tokio::task::spawn_blocking(move || {
             repo_cache::resolve_pin_to_bytes(&dirs, &entries, &pin, &|line| on_feedback(line))
@@ -161,12 +158,37 @@ type MaterializeOutput = (
     std::result::Result<(PathBuf, NodeConfig), String>,
 );
 
+/// One bounded materialization, ready to push onto a `FuturesUnordered`.
+///
+/// Both closure walkers below go through this, so the concurrency policy —
+/// how a permit is taken and what a completed materialization reports back —
+/// is stated once rather than restated per walker.
+fn spawn_materialize<'a>(
+    semaphore: &Arc<Semaphore>,
+    peppy_dirs: &'a PeppyDirs,
+    entries: &'a Arc<Vec<NodeCacheEntry>>,
+    pin: PinnedItem,
+    is_root: bool,
+    on_feedback: &node_cache::MaterializeFeedback,
+) -> BoxFuture<'a, MaterializeOutput> {
+    let permit_source = Arc::clone(semaphore);
+    let feedback = Arc::clone(on_feedback);
+    Box::pin(async move {
+        let _permit = permit_source
+            .acquire_owned()
+            .await
+            .expect("materialize semaphore is never closed");
+        let result = materialize_pinned_node(peppy_dirs, entries, &pin, feedback).await;
+        (pin, is_root, result)
+    })
+}
+
 /// Materializes a set of already-minted pins concurrently, root first in the
 /// returned order. The pinned executor's front half: no name is looked up,
 /// no dependency is discovered, the pin set IS the batch.
 pub(crate) async fn materialize_pin_set(
     peppy_dirs: &PeppyDirs,
-    entries: &[NodeCacheEntry],
+    entries: &Arc<Vec<NodeCacheEntry>>,
     root: PinnedItem,
     dep_pins: Vec<PinnedItem>,
     on_feedback: node_cache::MaterializeFeedback,
@@ -177,16 +199,14 @@ pub(crate) async fn materialize_pin_set(
     for (pin, is_root) in
         std::iter::once((root, true)).chain(dep_pins.into_iter().map(|p| (p, false)))
     {
-        let permit_source = Arc::clone(&semaphore);
-        let feedback = Arc::clone(&on_feedback);
-        in_flight.push(Box::pin(async move {
-            let _permit = permit_source
-                .acquire_owned()
-                .await
-                .expect("materialize semaphore is never closed");
-            let result = materialize_pinned_node(peppy_dirs, entries, &pin, feedback).await;
-            (pin, is_root, result)
-        }));
+        in_flight.push(spawn_materialize(
+            &semaphore,
+            peppy_dirs,
+            entries,
+            pin,
+            is_root,
+            &on_feedback,
+        ));
     }
 
     let mut nodes: Vec<MaterializedPin> = Vec::new();
@@ -216,7 +236,7 @@ pub(crate) async fn materialize_pin_set(
 /// all after one run.
 pub(crate) async fn resolve_pinned_closure(
     peppy_dirs: &PeppyDirs,
-    entries: &[NodeCacheEntry],
+    entries: &Arc<Vec<NodeCacheEntry>>,
     root_name: &str,
     root_tag: &str,
     on_feedback: node_cache::MaterializeFeedback,
@@ -251,16 +271,14 @@ pub(crate) async fn resolve_pinned_closure(
                 continue;
             };
             let pin = pin_for_node_entry(entry);
-            let permit_source = Arc::clone(&semaphore);
-            let feedback = Arc::clone(&on_feedback);
-            in_flight.push(Box::pin(async move {
-                let _permit = permit_source
-                    .acquire_owned()
-                    .await
-                    .expect("materialize semaphore is never closed");
-                let result = materialize_pinned_node(peppy_dirs, entries, &pin, feedback).await;
-                (pin, is_root, result)
-            }));
+            in_flight.push(spawn_materialize(
+                &semaphore,
+                peppy_dirs,
+                entries,
+                pin,
+                is_root,
+                &on_feedback,
+            ));
         }
 
         let Some((pin, is_root, result)) = in_flight.next().await else {
@@ -388,9 +406,17 @@ impl DocPins {
 /// The refusal names both fingerprints so the author can align the sha pins.
 #[derive(Default)]
 struct DocPinMinter {
-    by_identity: HashMap<(PinKind, String, String), PinnedItem>,
-    order: Vec<(PinKind, String, String)>,
+    /// Minted pins in first-reference order. A closure references tens of
+    /// documents at most, so the dedup scan is linear over a tiny set and
+    /// the order needs no second container to preserve it.
+    pins: Vec<PinnedItem>,
 }
+
+/// One document reference in a manifest, reduced to what minting needs. The
+/// four reference lists are four types over the same three fields, so they
+/// are normalized here and walked as one contract stream and one pairing
+/// stream.
+type DocRef<'a> = (&'a str, &'a str, Option<&'a str>);
 
 impl DocPinMinter {
     fn mint_for_manifest(
@@ -401,65 +427,54 @@ impl DocPinMinter {
         pairings: &[PairingCacheEntry],
         on_feedback: &dyn Fn(&str),
     ) -> std::result::Result<(), String> {
-        for entry in &manifest.implements {
+        let depends_on = manifest.depends_on.as_ref();
+        let contract_refs = manifest
+            .implements
+            .iter()
+            .map(|e| (e.name.as_str(), e.tag.as_str(), e.sha256.as_deref()))
+            .chain(depends_on.into_iter().flat_map(|d| {
+                d.contracts
+                    .iter()
+                    .map(|e| (e.name.as_str(), e.tag.as_str(), e.sha256.as_deref()))
+            }));
+        for (name, tag, sha256) in contract_refs {
             self.mint::<ContractCacheEntry>(
                 peppy_dirs,
                 contracts,
                 PinKind::Contract,
-                entry.name.as_str(),
-                &entry.tag,
-                entry.sha256.as_deref(),
+                (name, tag, sha256),
                 on_feedback,
             )?;
         }
-        let Some(depends_on) = manifest.depends_on.as_ref() else {
-            return Ok(());
-        };
-        for entry in &depends_on.contracts {
-            self.mint::<ContractCacheEntry>(
-                peppy_dirs,
-                contracts,
-                PinKind::Contract,
-                entry.name.as_str(),
-                &entry.tag,
-                entry.sha256.as_deref(),
-                on_feedback,
-            )?;
-        }
-        for slot in &depends_on.pairings {
+
+        let pairing_refs = depends_on.into_iter().flat_map(|d| {
+            d.pairings
+                .iter()
+                .map(|s| (s.name.as_str(), s.tag.as_str(), s.sha256.as_deref()))
+                .chain(
+                    d.pairing_observers
+                        .iter()
+                        .map(|s| (s.name.as_str(), s.tag.as_str(), s.sha256.as_deref())),
+                )
+        });
+        for (name, tag, sha256) in pairing_refs {
             self.mint::<PairingCacheEntry>(
                 peppy_dirs,
                 pairings,
                 PinKind::Pairing,
-                slot.name.as_str(),
-                &slot.tag,
-                slot.sha256.as_deref(),
-                on_feedback,
-            )?;
-        }
-        for slot in &depends_on.pairing_observers {
-            self.mint::<PairingCacheEntry>(
-                peppy_dirs,
-                pairings,
-                PinKind::Pairing,
-                slot.name.as_str(),
-                &slot.tag,
-                slot.sha256.as_deref(),
+                (name, tag, sha256),
                 on_feedback,
             )?;
         }
         Ok(())
     }
 
-    #[allow(clippy::too_many_arguments)] // One reference, spelled out.
     fn mint<E: RepoCacheEntry>(
         &mut self,
         peppy_dirs: &PeppyDirs,
         entries: &[E],
         kind: PinKind,
-        name: &str,
-        tag: &str,
-        author_sha256: Option<&str>,
+        (name, tag, author_sha256): DocRef<'_>,
         on_feedback: &dyn Fn(&str),
     ) -> std::result::Result<(), String> {
         let (entry, _bytes) = repo_cache::resolve_cached_doc_entry(
@@ -477,50 +492,80 @@ impl DocPinMinter {
             sha256: entry.sha256().clone(),
             origin: entry.origin().clone(),
         };
-        let key = (kind, name.to_owned(), tag.to_owned());
-        match self.by_identity.get(&key) {
+        let existing = self
+            .pins
+            .iter()
+            .find(|p| p.kind == kind && p.name.as_str() == name && p.tag.as_str() == tag)
+            .map(|p| p.sha256.clone());
+        match existing {
             None => {
-                self.order.push(key.clone());
-                self.by_identity.insert(key, pin);
+                self.pins.push(pin);
                 Ok(())
             }
-            Some(existing) if existing.sha256 == pin.sha256 => Ok(()),
+            Some(existing) if existing == pin.sha256 => Ok(()),
             Some(existing) => Err(format!(
                 "{kind} `{name}:{tag}` is needed at two different contents in one closure \
                  (`{}` and `{}`); align the manifests' sha256 pins so one set of bytes serves \
                  every reference",
-                existing.sha256, pin.sha256
+                existing, pin.sha256
             )),
         }
     }
-
-    fn into_pins(self) -> Vec<PinnedItem> {
-        let mut by_identity = self.by_identity;
-        self.order
-            .into_iter()
-            .filter_map(|key| by_identity.remove(&key))
-            .collect()
-    }
 }
 
-/// Mints the doc pins for a set of manifests against this machine's caches:
-/// one pin per contract and pairing document they reference, deduplicated,
-/// refusing one identity at two different contents. Blocking (a drift check
-/// may materialize a checkout); wrap in `spawn_blocking` inside Tokio.
-pub(crate) fn doc_pins_for_manifests(
+/// Mints the doc pins of several manifest sets against ONE load of this
+/// machine's document caches: one pin per contract and pairing document each
+/// set references, deduplicated within the set, refusing one identity at two
+/// different contents.
+///
+/// Batched over sets rather than called per set because the caller is a
+/// launch minting for every deployment, and both caches are read from disk
+/// and parsed on each load. Each set keeps its own result so a deployment
+/// whose documents are missing does not suppress the report for the others.
+///
+/// Blocking (a drift check may materialize a checkout); use
+/// [`doc_pins_for_manifest_sets_async`] inside Tokio.
+pub(crate) fn doc_pins_for_manifest_sets(
     peppy_dirs: &PeppyDirs,
-    manifests: &[Manifest],
+    sets: &[Vec<Manifest>],
     on_feedback: &dyn Fn(&str),
-) -> std::result::Result<Vec<PinnedItem>, String> {
+) -> std::result::Result<Vec<std::result::Result<Vec<PinnedItem>, String>>, String> {
     let contracts = repo_cache::load_contract_cache(peppy_dirs)
         .map_err(|e| format!("failed to load contract cache: {e}"))?;
     let pairings = repo_cache::load_pairing_cache(peppy_dirs)
         .map_err(|e| format!("failed to load pairing cache: {e}"))?;
-    let mut minted = DocPinMinter::default();
-    for manifest in manifests {
-        minted.mint_for_manifest(peppy_dirs, manifest, &contracts, &pairings, on_feedback)?;
-    }
-    Ok(minted.into_pins())
+    Ok(sets
+        .iter()
+        .map(|manifests| {
+            let mut minted = DocPinMinter::default();
+            for manifest in manifests {
+                minted.mint_for_manifest(
+                    peppy_dirs,
+                    manifest,
+                    &contracts,
+                    &pairings,
+                    on_feedback,
+                )?;
+            }
+            Ok(minted.pins)
+        })
+        .collect())
+}
+
+/// [`doc_pins_for_manifest_sets`] on a blocking thread, with the feedback
+/// sink every async caller already holds. Both minting sites go through
+/// this, so the join-error wording has one owner.
+pub(crate) async fn doc_pins_for_manifest_sets_async(
+    peppy_dirs: &PeppyDirs,
+    sets: Vec<Vec<Manifest>>,
+    on_feedback: node_cache::MaterializeFeedback,
+) -> std::result::Result<Vec<std::result::Result<Vec<PinnedItem>, String>>, String> {
+    let dirs = peppy_dirs.clone();
+    tokio::task::spawn_blocking(move || {
+        doc_pins_for_manifest_sets(&dirs, &sets, &|line| on_feedback(line))
+    })
+    .await
+    .map_err(|e| format!("doc pin minting task failed: {e}"))?
 }
 
 /// Resolves a launcher's `git:` deployment to a pinned root: clones the

--- a/crates/core-node-internal/src/services/node/pins.rs
+++ b/crates/core-node-internal/src/services/node/pins.rs
@@ -1,0 +1,759 @@
+//! Launch-pin closure resolution: the one place a `name:tag` becomes a set
+//! of pins.
+//!
+//! A launch coordinator (and `peppy node add <name>:<tag>`, where the
+//! receiving daemon coordinates its own add) resolves a root node here: the
+//! root, its transitive node dependencies through the nodes cache, and the
+//! contract and pairing documents every resolved manifest names. Each
+//! resolved item becomes a [`PinnedItem`], and everything downstream,
+//! including every other daemon in a federated launch, consumes pins and
+//! never resolves a name.
+//!
+//! Materialization is shared with the pinned executor in `add_batch`:
+//! [`materialize_pinned_node`] reuses local content when its fingerprint
+//! matches the pin and fetches the pinned commit when it does not, so the
+//! machine that minted a pin and a machine that has never seen the bytes
+//! run exactly the same code.
+
+use super::cache as node_cache;
+use crate::services::repo::cache::{
+    self as repo_cache, ContractCacheEntry, EntryOrigin, NodeCacheEntry, PairingCacheEntry,
+    RepoCacheEntry,
+};
+use config::node::{Manifest, NodeConfig, NodeConfigParser};
+use daemon_config::consts::PeppyDirs;
+use daemon_config::repository::{ItemName, ItemTag, PinKind, PinnedItem};
+use futures::future::BoxFuture;
+use futures::stream::{FuturesUnordered, StreamExt};
+use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::sync::Semaphore;
+
+/// Upper bound on concurrently-running materializations inside one closure
+/// resolution. Git entries materialize through clones and fetches; spawning
+/// an unbounded number of them at once thrashes disk and network. 8 is
+/// empirical: enough to overlap IO latency, low enough to avoid saturating
+/// a developer laptop.
+pub(crate) const MATERIALIZE_CONCURRENCY: usize = 8;
+
+/// One pinned node, materialized: the pin that names it and the on-disk
+/// tree the add pipeline stages it from.
+pub(crate) struct MaterializedPin {
+    pub pin: PinnedItem,
+    pub root_dir: PathBuf,
+    pub config: NodeConfig,
+    /// `true` only for the root of the closure. Controls which node the
+    /// original goal's env vars and force flag apply to.
+    pub is_root: bool,
+}
+
+/// A root's resolved node closure: every node to add, root first, then in
+/// discovery order. The contract and pairing documents their manifests name
+/// are minted separately ([`doc_pins_for_manifests`]) so a launch can run
+/// its graph validation, whose refusals are the more actionable ones,
+/// before any document is looked up.
+pub(crate) struct PinnedClosure {
+    pub nodes: Vec<MaterializedPin>,
+}
+
+impl PinnedClosure {
+    /// The dependency-node pins, i.e. everything except the root, for
+    /// `NodeAddGoal.pins_json5` and `DeploymentPins.closure`.
+    pub fn dep_pins(&self) -> Vec<PinnedItem> {
+        self.nodes
+            .iter()
+            .filter(|node| !node.is_root)
+            .map(|node| node.pin.clone())
+            .collect()
+    }
+
+    /// Every manifest in the closure, root first, for doc-pin minting.
+    pub fn manifests(&self) -> Vec<Manifest> {
+        self.nodes
+            .iter()
+            .map(|node| node.config.manifest.clone())
+            .collect()
+    }
+
+    pub fn root(&self) -> &MaterializedPin {
+        self.nodes
+            .first()
+            .expect("a resolved closure always holds its root")
+    }
+}
+
+/// The pin a nodes-cache entry mints: the entry already records the content
+/// fingerprint and the origin, so pinning is a restatement, not a decision.
+pub(crate) fn pin_for_node_entry(entry: &NodeCacheEntry) -> PinnedItem {
+    PinnedItem {
+        kind: PinKind::Node,
+        name: entry.node_name.clone(),
+        tag: entry.node_tag.clone(),
+        sha256: entry.sha256.clone(),
+        origin: entry.origin.clone(),
+    }
+}
+
+/// Materializes one pinned node to `(root_dir, parsed config)`.
+///
+/// Content decides: a local cache entry whose fingerprint matches the pin is
+/// used whatever repository or identity it arrived under, and a miss or a
+/// drifted local copy fetches the pin's own origin. The parsed manifest must
+/// declare the pinned identity; bytes that fingerprint-match but declare
+/// another node mean a poisoned cache or a mis-minted pin, and both are
+/// refusals rather than something to run.
+pub(crate) async fn materialize_pinned_node(
+    peppy_dirs: &PeppyDirs,
+    entries: &[NodeCacheEntry],
+    pin: &PinnedItem,
+    on_feedback: node_cache::MaterializeFeedback,
+) -> std::result::Result<(PathBuf, NodeConfig), String> {
+    let label = pin.label();
+    let may_block = pin.origin.resolution_may_block()
+        || repo_cache::lookup_by_content(entries, pin)
+            .map(|entry| entry.origin.resolution_may_block())
+            .unwrap_or(true);
+
+    let (manifest_path, bytes) = if may_block {
+        let dirs = peppy_dirs.clone();
+        let entries = entries.to_vec();
+        let pin = pin.clone();
+        tokio::task::spawn_blocking(move || {
+            repo_cache::resolve_pin_to_bytes(&dirs, &entries, &pin, &|line| on_feedback(line))
+        })
+        .await
+        .map_err(|e| format!("materialization task for {label} failed: {e}"))?
+    } else {
+        repo_cache::resolve_pin_to_bytes(peppy_dirs, entries, pin, &|line| on_feedback(line))
+    }?;
+
+    let content = std::str::from_utf8(&bytes)
+        .map_err(|e| format!("pinned {label} content is not UTF-8: {e}"))?;
+    let config = NodeConfigParser::from_content(content)
+        .map_err(|e| format!("failed to parse pinned {label}: {e}"))?;
+    if config.manifest.name.as_str() != pin.name.as_str() || config.manifest.tag != pin.tag.as_str()
+    {
+        return Err(format!(
+            "pinned {label} resolved to bytes declaring `{}:{}`; the cache or the pin is wrong",
+            config.manifest.name.as_str(),
+            config.manifest.tag
+        ));
+    }
+
+    // The pin names the file that declares the node; a node is built from
+    // the directory holding it.
+    let root_dir = manifest_path
+        .parent()
+        .ok_or_else(|| {
+            format!(
+                "pinned {label} resolved to {}, which has no parent directory",
+                manifest_path.display()
+            )
+        })?
+        .to_path_buf();
+    Ok((root_dir, config))
+}
+
+type MaterializeOutput = (
+    PinnedItem,
+    bool,
+    std::result::Result<(PathBuf, NodeConfig), String>,
+);
+
+/// Materializes a set of already-minted pins concurrently, root first in the
+/// returned order. The pinned executor's front half: no name is looked up,
+/// no dependency is discovered, the pin set IS the batch.
+pub(crate) async fn materialize_pin_set(
+    peppy_dirs: &PeppyDirs,
+    entries: &[NodeCacheEntry],
+    root: PinnedItem,
+    dep_pins: Vec<PinnedItem>,
+    on_feedback: node_cache::MaterializeFeedback,
+) -> std::result::Result<Vec<MaterializedPin>, String> {
+    let semaphore = Arc::new(Semaphore::new(MATERIALIZE_CONCURRENCY));
+    let mut in_flight: FuturesUnordered<BoxFuture<'_, MaterializeOutput>> = FuturesUnordered::new();
+
+    for (pin, is_root) in
+        std::iter::once((root, true)).chain(dep_pins.into_iter().map(|p| (p, false)))
+    {
+        let permit_source = Arc::clone(&semaphore);
+        let feedback = Arc::clone(&on_feedback);
+        in_flight.push(Box::pin(async move {
+            let _permit = permit_source
+                .acquire_owned()
+                .await
+                .expect("materialize semaphore is never closed");
+            let result = materialize_pinned_node(peppy_dirs, entries, &pin, feedback).await;
+            (pin, is_root, result)
+        }));
+    }
+
+    let mut nodes: Vec<MaterializedPin> = Vec::new();
+    while let Some((pin, is_root, result)) = in_flight.next().await {
+        let (root_dir, config) = result?;
+        nodes.push(MaterializedPin {
+            pin,
+            root_dir,
+            config,
+            is_root,
+        });
+    }
+    // Root first, so `PinnedClosure::root` and the executor's is-root
+    // handling do not depend on completion order.
+    nodes.sort_by_key(|node| !node.is_root);
+    Ok(nodes)
+}
+
+/// Resolves `root_name:root_tag` and its transitive closure through this
+/// machine's caches, minting a pin per resolved item.
+///
+/// The ONE place a name becomes bytes. A launch coordinator runs it for
+/// every `repo:` deployment, and `peppy node add <name>:<tag>` runs it on
+/// the daemon that receives the goal; everything downstream consumes the
+/// pins it mints. Every missing or ambiguous identity in the closure is
+/// aggregated into one report, so a user with several problems fixes them
+/// all after one run.
+pub(crate) async fn resolve_pinned_closure(
+    peppy_dirs: &PeppyDirs,
+    entries: &[NodeCacheEntry],
+    root_name: &str,
+    root_tag: &str,
+    on_feedback: node_cache::MaterializeFeedback,
+) -> std::result::Result<PinnedClosure, String> {
+    let mut nodes: Vec<MaterializedPin> = Vec::new();
+    let mut seen: HashSet<(String, String)> = HashSet::new();
+    let mut missing: Vec<(String, String)> = Vec::new();
+    let mut ambiguous: Vec<String> = Vec::new();
+    let mut pending: Vec<(String, String, bool)> =
+        vec![(root_name.to_owned(), root_tag.to_owned(), true)];
+    let mut in_flight: FuturesUnordered<BoxFuture<'_, MaterializeOutput>> = FuturesUnordered::new();
+    let semaphore = Arc::new(Semaphore::new(MATERIALIZE_CONCURRENCY));
+
+    loop {
+        while let Some((name, tag, is_root)) = pending.pop() {
+            let key = (name.clone(), tag.clone());
+            if !seen.insert(key.clone()) {
+                continue;
+            }
+            // An identity claimed twice is present, not absent, so it is
+            // kept out of `missing`: telling the user it is missing sends
+            // them to add a node that is already there twice.
+            let resolved = match repo_cache::lookup(entries, &name, &tag) {
+                Ok(resolved) => resolved,
+                Err(ambiguity) => {
+                    ambiguous.push(ambiguity.to_string());
+                    continue;
+                }
+            };
+            let Some(entry) = resolved else {
+                missing.push(key);
+                continue;
+            };
+            let pin = pin_for_node_entry(entry);
+            let permit_source = Arc::clone(&semaphore);
+            let feedback = Arc::clone(&on_feedback);
+            in_flight.push(Box::pin(async move {
+                let _permit = permit_source
+                    .acquire_owned()
+                    .await
+                    .expect("materialize semaphore is never closed");
+                let result = materialize_pinned_node(peppy_dirs, entries, &pin, feedback).await;
+                (pin, is_root, result)
+            }));
+        }
+
+        let Some((pin, is_root, result)) = in_flight.next().await else {
+            break;
+        };
+
+        let (root_dir, config) = result?;
+
+        if let Some(deps) = config.manifest.depends_on.as_ref() {
+            for dep in &deps.nodes {
+                let dep_name = dep.name.as_str().to_owned();
+                let dep_tag = dep.tag.clone();
+                if seen.contains(&(dep_name.clone(), dep_tag.clone())) {
+                    continue;
+                }
+                pending.push((dep_name, dep_tag, false));
+            }
+        }
+
+        nodes.push(MaterializedPin {
+            pin,
+            root_dir,
+            config,
+            is_root,
+        });
+    }
+
+    let mut problems: Vec<String> = Vec::new();
+    ambiguous.sort();
+    problems.append(&mut ambiguous);
+    if !missing.is_empty() {
+        missing.sort();
+        let list = missing
+            .iter()
+            .map(|(n, t)| format!("{}:{}", n, t))
+            .collect::<Vec<_>>()
+            .join(", ");
+        problems.push(format!(
+            "Dependencies missing from nodes cache ({}): {list}. Run `peppy repo refresh` or \
+             add the missing nodes to a configured repository{}.",
+            repo_cache::nodes_repo_cache_path(peppy_dirs).display(),
+            repo_cache::excluded_repositories_hint(peppy_dirs)
+        ));
+    }
+    if !problems.is_empty() {
+        return Err(daemon_config::format_bulleted(&problems));
+    }
+
+    nodes.sort_by_key(|node| !node.is_root);
+    Ok(PinnedClosure { nodes })
+}
+
+/// The launch pins for contract and pairing documents, keyed by identity, as
+/// the pinned add consumes them.
+///
+/// One pin per `(kind, name, tag)`: the closure that minted these refused a
+/// second content for one identity, so a lookup is never ambiguous. An
+/// author `sha256` pin in a manifest is checked against the launch pin at
+/// use, not consulted for resolution.
+pub(crate) struct DocPins {
+    by_identity: HashMap<(PinKind, String, String), PinnedItem>,
+}
+
+impl DocPins {
+    /// Builds the lookup from a goal's decoded pin list, ignoring node pins.
+    pub fn from_pins(pins: &[PinnedItem]) -> Self {
+        let by_identity = pins
+            .iter()
+            .filter(|pin| pin.kind != PinKind::Node)
+            .map(|pin| {
+                (
+                    (
+                        pin.kind,
+                        pin.name.as_str().to_owned(),
+                        pin.tag.as_str().to_owned(),
+                    ),
+                    pin.clone(),
+                )
+            })
+            .collect();
+        Self { by_identity }
+    }
+
+    /// The launch pin for one doc reference, checked against the manifest's
+    /// own optional sha pin.
+    ///
+    /// A reference absent from the pin set means the coordinator shipped an
+    /// incomplete closure; an author pin disagreeing with the launch pin
+    /// means the closure was minted from different bytes than this manifest.
+    /// Both are refusals, never a fall back to resolving the name here.
+    pub fn require(
+        &self,
+        kind: PinKind,
+        name: &str,
+        tag: &str,
+        author_sha256: Option<&str>,
+    ) -> std::result::Result<&PinnedItem, String> {
+        let pin = self
+            .by_identity
+            .get(&(kind, name.to_owned(), tag.to_owned()))
+            .ok_or_else(|| {
+                format!(
+                    "{kind} `{name}:{tag}` is not in this launch's pins; the coordinator \
+                     shipped an incomplete closure"
+                )
+            })?;
+        if let Some(author) = author_sha256
+            && pin.sha256 != author
+        {
+            return Err(format!(
+                "{kind} `{name}:{tag}` is pinned to `{author}` by the manifest but the launch \
+                 pinned `{}`; the closure was minted from different bytes than this manifest",
+                pin.sha256
+            ));
+        }
+        Ok(pin)
+    }
+}
+
+/// Mints doc pins for manifests, refusing one identity at two contents.
+///
+/// Within one closure every reference to a document must agree on its
+/// bytes: the pinned add resolves references by identity, so two contents
+/// under one identity would make that lookup ambiguous on another machine.
+/// The refusal names both fingerprints so the author can align the sha pins.
+#[derive(Default)]
+struct DocPinMinter {
+    by_identity: HashMap<(PinKind, String, String), PinnedItem>,
+    order: Vec<(PinKind, String, String)>,
+}
+
+impl DocPinMinter {
+    fn mint_for_manifest(
+        &mut self,
+        peppy_dirs: &PeppyDirs,
+        manifest: &Manifest,
+        contracts: &[ContractCacheEntry],
+        pairings: &[PairingCacheEntry],
+        on_feedback: &dyn Fn(&str),
+    ) -> std::result::Result<(), String> {
+        for entry in &manifest.implements {
+            self.mint::<ContractCacheEntry>(
+                peppy_dirs,
+                contracts,
+                PinKind::Contract,
+                entry.name.as_str(),
+                &entry.tag,
+                entry.sha256.as_deref(),
+                on_feedback,
+            )?;
+        }
+        let Some(depends_on) = manifest.depends_on.as_ref() else {
+            return Ok(());
+        };
+        for entry in &depends_on.contracts {
+            self.mint::<ContractCacheEntry>(
+                peppy_dirs,
+                contracts,
+                PinKind::Contract,
+                entry.name.as_str(),
+                &entry.tag,
+                entry.sha256.as_deref(),
+                on_feedback,
+            )?;
+        }
+        for slot in &depends_on.pairings {
+            self.mint::<PairingCacheEntry>(
+                peppy_dirs,
+                pairings,
+                PinKind::Pairing,
+                slot.name.as_str(),
+                &slot.tag,
+                slot.sha256.as_deref(),
+                on_feedback,
+            )?;
+        }
+        for slot in &depends_on.pairing_observers {
+            self.mint::<PairingCacheEntry>(
+                peppy_dirs,
+                pairings,
+                PinKind::Pairing,
+                slot.name.as_str(),
+                &slot.tag,
+                slot.sha256.as_deref(),
+                on_feedback,
+            )?;
+        }
+        Ok(())
+    }
+
+    #[allow(clippy::too_many_arguments)] // One reference, spelled out.
+    fn mint<E: RepoCacheEntry>(
+        &mut self,
+        peppy_dirs: &PeppyDirs,
+        entries: &[E],
+        kind: PinKind,
+        name: &str,
+        tag: &str,
+        author_sha256: Option<&str>,
+        on_feedback: &dyn Fn(&str),
+    ) -> std::result::Result<(), String> {
+        let (entry, _bytes) = repo_cache::resolve_cached_doc_entry(
+            peppy_dirs,
+            entries,
+            name,
+            tag,
+            author_sha256,
+            on_feedback,
+        )?;
+        let pin = PinnedItem {
+            kind,
+            name: ItemName::parse(name).map_err(|e| format!("{kind} `{name}:{tag}`: {e}"))?,
+            tag: ItemTag::parse(tag).map_err(|e| format!("{kind} `{name}:{tag}`: {e}"))?,
+            sha256: entry.sha256().clone(),
+            origin: entry.origin().clone(),
+        };
+        let key = (kind, name.to_owned(), tag.to_owned());
+        match self.by_identity.get(&key) {
+            None => {
+                self.order.push(key.clone());
+                self.by_identity.insert(key, pin);
+                Ok(())
+            }
+            Some(existing) if existing.sha256 == pin.sha256 => Ok(()),
+            Some(existing) => Err(format!(
+                "{kind} `{name}:{tag}` is needed at two different contents in one closure \
+                 (`{}` and `{}`); align the manifests' sha256 pins so one set of bytes serves \
+                 every reference",
+                existing.sha256, pin.sha256
+            )),
+        }
+    }
+
+    fn into_pins(self) -> Vec<PinnedItem> {
+        let mut by_identity = self.by_identity;
+        self.order
+            .into_iter()
+            .filter_map(|key| by_identity.remove(&key))
+            .collect()
+    }
+}
+
+/// Mints the doc pins for a set of manifests against this machine's caches:
+/// one pin per contract and pairing document they reference, deduplicated,
+/// refusing one identity at two different contents. Blocking (a drift check
+/// may materialize a checkout); wrap in `spawn_blocking` inside Tokio.
+pub(crate) fn doc_pins_for_manifests(
+    peppy_dirs: &PeppyDirs,
+    manifests: &[Manifest],
+    on_feedback: &dyn Fn(&str),
+) -> std::result::Result<Vec<PinnedItem>, String> {
+    let contracts = repo_cache::load_contract_cache(peppy_dirs)
+        .map_err(|e| format!("failed to load contract cache: {e}"))?;
+    let pairings = repo_cache::load_pairing_cache(peppy_dirs)
+        .map_err(|e| format!("failed to load pairing cache: {e}"))?;
+    let mut minted = DocPinMinter::default();
+    for manifest in manifests {
+        minted.mint_for_manifest(peppy_dirs, manifest, &contracts, &pairings, on_feedback)?;
+    }
+    Ok(minted.into_pins())
+}
+
+/// Resolves a launcher's `git:` deployment to a pinned root: clones the
+/// repository at the requested ref, records the commit that ref resolved to,
+/// donates the clone to the commit-keyed checkout cache, and mints the pin
+/// from the manifest bytes it read.
+///
+/// A `git:` ref is usually a branch, which is a moving name; capturing the
+/// commit here is what makes every machine in the launch read the tree this
+/// machine read, rather than whatever the branch points at when each of
+/// them clones.
+pub(crate) async fn resolve_git_deployment(
+    peppy_dirs: &PeppyDirs,
+    repo_url: &str,
+    repo_path: &str,
+    repo_ref: Option<&str>,
+    on_feedback: node_cache::MaterializeFeedback,
+) -> std::result::Result<MaterializedPin, String> {
+    let dirs = peppy_dirs.clone();
+    let url = repo_url.to_owned();
+    let path_spec = repo_path.to_owned();
+    let git_ref = repo_ref.map(str::to_owned);
+
+    tokio::task::spawn_blocking(move || {
+        let sanitized = super::git_utils::sanitize_repo_path(&path_spec)?;
+
+        on_feedback(&format!("Cloning repository {url}..."));
+        let temp_dir = tempfile::Builder::new()
+            .prefix("peppy-git-deploy-")
+            .tempdir()
+            .map_err(|e| format!("Failed to create temporary directory: {e}"))?;
+        let repo = super::git_utils::clone_repo_with_deadline(&url, temp_dir.path(), None)?;
+        if let Some(reference) = git_ref.as_deref() {
+            super::git_utils::checkout_repo_ref(&repo, reference)
+                .map_err(|e| format!("Failed to checkout git ref '{reference}': {e}"))?;
+        }
+        let commit = super::git_utils::head_commit(&repo)?;
+        drop(repo);
+
+        // Donate the clone, then resolve the checkout back through the same
+        // cache the pinned adds use: the donation makes this the one clone
+        // any machine-local consumer of the pin ever pays for.
+        node_cache::git::adopt_checkout(&dirs, &url, &commit, temp_dir.keep());
+        let checkout = node_cache::git::ensure_checkout_at_commit(
+            &dirs,
+            &url,
+            git_ref.as_deref(),
+            &commit,
+            &|line| on_feedback(line),
+        )?;
+
+        // The pin names the file that declares the node, so a directory
+        // deployment path gains the manifest filename.
+        let manifest_rel = if sanitized
+            .extension()
+            .and_then(|ext| ext.to_str())
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("json5"))
+        {
+            sanitized
+        } else {
+            sanitized.join(config::consts::NODE_CONFIG_FILE)
+        };
+        let manifest_rel =
+            daemon_config::repository::RepoRelativePath::parse(manifest_rel.to_str().ok_or_else(
+                || format!("deployment path {} is not UTF-8", manifest_rel.display()),
+            )?)
+            .map_err(|e| format!("deployment path does not stay inside the repository: {e}"))?;
+
+        let manifest_path = checkout.join(manifest_rel.as_path());
+        let bytes = std::fs::read(&manifest_path).map_err(|e| {
+            format!(
+                "no node manifest at `{}` in {url} at {commit}: {e}",
+                manifest_rel.as_str()
+            )
+        })?;
+        let content = std::str::from_utf8(&bytes)
+            .map_err(|e| format!("manifest at `{}` is not UTF-8: {e}", manifest_rel.as_str()))?;
+        let config = NodeConfigParser::from_content(content).map_err(|e| {
+            format!(
+                "Failed to parse node config at {}: {e}",
+                manifest_path.display()
+            )
+        })?;
+
+        let pin = PinnedItem {
+            kind: PinKind::Node,
+            name: ItemName::parse(config.manifest.name.as_str()).map_err(|e| {
+                format!(
+                    "node `{}` cannot be pinned: {e}",
+                    config.manifest.name.as_str()
+                )
+            })?,
+            tag: ItemTag::parse(&config.manifest.tag)
+                .map_err(|e| format!("tag `{}` cannot be pinned: {e}", config.manifest.tag))?,
+            sha256: daemon_config::repository::ManifestFingerprint::of_bytes(&bytes),
+            origin: EntryOrigin::Git {
+                repo_url: url,
+                repo_ref: git_ref,
+                commit,
+                path: manifest_rel,
+            },
+        };
+        let root_dir = manifest_path
+            .parent()
+            .ok_or_else(|| {
+                format!(
+                    "manifest at {} has no parent directory",
+                    manifest_path.display()
+                )
+            })?
+            .to_path_buf();
+        Ok(MaterializedPin {
+            pin,
+            root_dir,
+            config,
+            is_root: true,
+        })
+    })
+    .await
+    .map_err(|e| format!("git deployment resolution task failed: {e}"))?
+}
+
+/// Decodes the JSON5 pins of a goal, refusing the batch on the first pin
+/// that does not validate.
+pub(crate) fn decode_pins(pins_json5: &[String]) -> std::result::Result<Vec<PinnedItem>, String> {
+    pins_json5
+        .iter()
+        .enumerate()
+        .map(|(index, raw)| {
+            serde_json5::from_str::<PinnedItem>(raw)
+                .map_err(|e| format!("pin #{index} is not decodable: {e}"))
+        })
+        .collect()
+}
+
+/// Serializes pins for the wire. The inverse of [`decode_pins`].
+pub(crate) fn encode_pins(pins: &[PinnedItem]) -> std::result::Result<Vec<String>, String> {
+    pins.iter()
+        .map(|pin| {
+            serde_json5::to_string(pin)
+                .map_err(|e| format!("could not encode the pin for {}: {e}", pin.label()))
+        })
+        .collect()
+}
+
+/// A materialized origin check for pins that must be portable: a pin whose
+/// origin is a tree on this machine cannot back a deployment placed on
+/// another one.
+pub(crate) fn portable_pin_refusal(pin: &PinnedItem) -> Option<String> {
+    match &pin.origin {
+        EntryOrigin::Git { .. } => None,
+        EntryOrigin::Fs { path } => Some(format!(
+            "{} resolves to a filesystem repository entry at {}, which cannot be placed on \
+             another core node: the path names a tree on the coordinator's filesystem. Keep the \
+             deployment's instances on one core node, or serve the node from a git repository.",
+            pin.label(),
+            path.display()
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use daemon_config::repository::GitCommit;
+    use daemon_config::repository::RepoRelativePath;
+
+    fn doc_pin(kind: PinKind, name: &str, sha_seed: &str) -> PinnedItem {
+        PinnedItem {
+            kind,
+            name: ItemName::parse(name).expect("valid name"),
+            tag: ItemTag::parse("v1").expect("valid tag"),
+            sha256: daemon_config::repository::ManifestFingerprint::of_bytes(sha_seed.as_bytes()),
+            origin: EntryOrigin::Git {
+                repo_url: "https://example.com/hub".to_owned(),
+                repo_ref: Some("main".to_owned()),
+                commit: GitCommit::parse(&"b".repeat(40)).expect("valid commit"),
+                path: RepoRelativePath::parse(&format!("{name}.json5")).expect("valid path"),
+            },
+        }
+    }
+
+    /// A pinned add resolves a doc reference through the launch pin: present
+    /// and unconflicted resolves, absent refuses as an incomplete closure,
+    /// and an author sha pin disagreeing with the launch pin refuses naming
+    /// both. Nothing here consults a cache by name.
+    #[test]
+    fn doc_pin_lookup_resolves_refuses_gaps_and_refuses_author_conflicts() {
+        let pin = doc_pin(PinKind::Contract, "frames", "the contract body");
+        let pins = DocPins::from_pins(std::slice::from_ref(&pin));
+
+        let resolved = pins
+            .require(PinKind::Contract, "frames", "v1", None)
+            .expect("a pinned reference resolves");
+        assert_eq!(resolved.sha256, pin.sha256);
+
+        let matching_author = pin.sha256.as_str().to_owned();
+        assert!(
+            pins.require(PinKind::Contract, "frames", "v1", Some(&matching_author))
+                .is_ok(),
+            "an author pin agreeing with the launch pin resolves"
+        );
+
+        let err = pins
+            .require(PinKind::Pairing, "frames", "v1", None)
+            .expect_err("the wrong kind is not the same identity");
+        assert!(err.contains("incomplete closure"), "{err}");
+
+        let err = pins
+            .require(PinKind::Contract, "absent", "v1", None)
+            .expect_err("a missing reference is a gap");
+        assert!(err.contains("incomplete closure"), "{err}");
+
+        let other = "f".repeat(64);
+        let err = pins
+            .require(PinKind::Contract, "frames", "v1", Some(&other))
+            .expect_err("a disagreeing author pin must refuse");
+        assert!(err.contains(&other), "names the author pin: {err}");
+        assert!(
+            err.contains(pin.sha256.as_str()),
+            "names the launch pin: {err}"
+        );
+    }
+
+    /// Node pins never enter the doc lookup: a contract that happens to
+    /// share a node's name must not resolve through the node's pin.
+    #[test]
+    fn node_pins_stay_out_of_the_doc_lookup() {
+        let pins = DocPins::from_pins(&[doc_pin(PinKind::Node, "frames", "a node body")]);
+        assert!(
+            pins.require(PinKind::Contract, "frames", "v1", None)
+                .is_err(),
+            "a node pin must not serve a contract reference"
+        );
+    }
+}

--- a/crates/core-node-internal/src/services/node/run.rs
+++ b/crates/core-node-internal/src/services/node/run.rs
@@ -694,14 +694,14 @@ fn encode_rejected_start_goal(reason: impl Into<String>) -> PeppyResult<Payload>
     )
 }
 
-/// Closes the preflight-to-dispatch window.
+/// Closes the add-to-start window.
 ///
 /// A federated coordinator validated this instance's whole plan (slots,
-/// cardinality, pairing roles, sha pins) against the manifest THIS daemon
-/// resolved during preflight. If the add phase has since replaced that
-/// manifest, the plan was never checked against what is about to be spawned,
-/// so refuse rather than start a node under a validation that no longer
-/// applies.
+/// cardinality, pairing roles, sha pins) against the manifest it resolved
+/// for the launch, and the add phase staged exactly those bytes here. If
+/// something has since replaced the entity in this stack, the plan was never
+/// checked against what is about to be spawned, so refuse rather than start
+/// a node under a validation that no longer applies.
 ///
 /// `planned` is `None` on the in-process launch path, where planner and spawner
 /// are the same daemon reading the same entity and there is no window to close.

--- a/crates/core-node-internal/src/services/node/sync.rs
+++ b/crates/core-node-internal/src/services/node/sync.rs
@@ -246,6 +246,7 @@ async fn handle_node_sync_request_inner(
                     &node_config.interfaces,
                     resolve_dep,
                     &peppy_dirs,
+                    None,
                     &interface_feedback,
                 ) {
                     Ok(v) => v,

--- a/crates/core-node-internal/src/services/node/sync/codegen.rs
+++ b/crates/core-node-internal/src/services/node/sync/codegen.rs
@@ -173,6 +173,7 @@ pub fn auto_sync_if_missing(
                 params.interfaces,
                 stack_resolver(node_stack),
                 peppy_dirs,
+                None,
                 params.on_feedback,
             )
             .map_err(|reason| crate::Error::Io(std::io::Error::other(reason)))?;

--- a/crates/core-node-internal/src/services/node/sync/interfaces.rs
+++ b/crates/core-node-internal/src/services/node/sync/interfaces.rs
@@ -32,13 +32,20 @@ pub fn collect_all_deployment_interfaces(
     interfaces_cfg: &config::node::Interfaces,
     resolve: impl Fn(&str, &str) -> Option<config::node::NodeConfig>,
     peppy_dirs: &PeppyDirs,
+    doc_pins: Option<&crate::services::node::pins::DocPins>,
     on_feedback: &dyn Fn(&str),
 ) -> std::result::Result<Vec<DeploymentInterface>, String> {
-    let mut interfaces =
-        collect_consumed_interfaces(manifest, interfaces_cfg, resolve, peppy_dirs, on_feedback)
-            .map_err(|reason| format!("failed to resolve consumed interfaces: {reason}"))?;
+    let mut interfaces = collect_consumed_interfaces(
+        manifest,
+        interfaces_cfg,
+        resolve,
+        peppy_dirs,
+        doc_pins,
+        on_feedback,
+    )
+    .map_err(|reason| format!("failed to resolve consumed interfaces: {reason}"))?;
     interfaces.extend(
-        resolve_implements(manifest, interfaces_cfg, peppy_dirs, on_feedback)
+        resolve_implements(manifest, interfaces_cfg, peppy_dirs, doc_pins, on_feedback)
             .map_err(|reason| format!("failed to resolve `manifest.implements`: {reason}"))?,
     );
     interfaces.extend(
@@ -46,6 +53,7 @@ pub fn collect_all_deployment_interfaces(
             manifest,
             interfaces_cfg,
             peppy_dirs,
+            doc_pins,
             on_feedback,
         )
         .map_err(|reason| format!("failed to resolve pairing slots: {reason}"))?,
@@ -89,6 +97,7 @@ pub fn collect_consumed_interfaces(
     interfaces_cfg: &config::node::Interfaces,
     resolve: impl Fn(&str, &str) -> Option<config::node::NodeConfig>,
     peppy_dirs: &PeppyDirs,
+    doc_pins: Option<&crate::services::node::pins::DocPins>,
     on_feedback: &dyn Fn(&str),
 ) -> std::result::Result<Vec<DeploymentInterface>, String> {
     let mut interfaces = Vec::new();
@@ -122,6 +131,7 @@ pub fn collect_consumed_interfaces(
                     &entry.name,
                     &entry.tag,
                     entry.sha256.as_deref(),
+                    doc_pins,
                     on_feedback,
                 )?;
                 deps.contract_docs.insert(link_id.clone(), parsed);
@@ -386,21 +396,36 @@ pub(crate) fn resolve_contract_doc(
     name: &str,
     tag: &str,
     sha256_pin: Option<&str>,
+    doc_pins: Option<&crate::services::node::pins::DocPins>,
     on_feedback: &dyn Fn(&str),
 ) -> std::result::Result<daemon_config::contract::PeppyContract, String> {
     let cache = repo_cache::load_contract_cache(peppy_dirs)
         .map_err(|e| format!("failed to load contract cache: {e}"))?;
+    let parse = |content: &str| {
+        daemon_config::contract::PeppyContractParser::from_content(content)
+            .map_err(|e| e.to_string())
+    };
 
+    // A launch pin fixes the bytes: this machine reuses its own copy on a
+    // content match and fetches the pin's origin otherwise, but its own
+    // priority rules never pick the document. Without one, the local rules
+    // apply, with the manifest's own optional sha pin.
+    if let Some(pins) = doc_pins {
+        let pin = pins.require(
+            daemon_config::repository::PinKind::Contract,
+            name,
+            tag,
+            sha256_pin,
+        )?;
+        return repo_cache::resolve_pinned_doc(peppy_dirs, &cache, pin, parse, on_feedback);
+    }
     repo_cache::resolve_cached_doc(
         peppy_dirs,
         &cache,
         name,
         tag,
         sha256_pin,
-        |content| {
-            daemon_config::contract::PeppyContractParser::from_content(content)
-                .map_err(|e| e.to_string())
-        },
+        parse,
         on_feedback,
     )
 }
@@ -473,6 +498,7 @@ pub fn resolve_implements(
     manifest: &config::node::Manifest,
     interfaces_cfg: &config::node::Interfaces,
     peppy_dirs: &PeppyDirs,
+    doc_pins: Option<&crate::services::node::pins::DocPins>,
     on_feedback: &dyn Fn(&str),
 ) -> std::result::Result<Vec<DeploymentInterface>, ImplementsError> {
     if manifest.implements.is_empty() {
@@ -495,6 +521,7 @@ pub fn resolve_implements(
             slot.name.as_str(),
             &slot.tag,
             slot.sha256.as_deref(),
+            doc_pins,
             on_feedback,
         )?;
         docs.insert(slot.link_id.as_str(), (slot, parsed));
@@ -741,8 +768,8 @@ mod implements_tests {
     fn returns_empty_when_no_implements() {
         let dirs = PeppyDirs::new(TempDir::new().unwrap().path().to_path_buf());
         let manifest: Manifest = serde_json5::from_str(r#"{ name: "plain", tag: "v1" }"#).unwrap();
-        let out =
-            resolve_implements(&manifest, &Interfaces::default(), &dirs, &|_| {}).expect("ok");
+        let out = resolve_implements(&manifest, &Interfaces::default(), &dirs, None, &|_| {})
+            .expect("ok");
         assert!(out.is_empty());
     }
 
@@ -761,7 +788,8 @@ mod implements_tests {
         let interfaces =
             interfaces_from(r#"{ topics: { emits: [{ link_id: "cam", name: "video_stream" }] } }"#);
 
-        let out = resolve_implements(&manifest, &interfaces, &dirs, &|_| {}).expect("happy path");
+        let out =
+            resolve_implements(&manifest, &interfaces, &dirs, None, &|_| {}).expect("happy path");
         assert_eq!(out.len(), 1, "should pull the one video_stream topic");
         match out[0].interface() {
             InterfaceVariant::EmittedTopic {
@@ -807,7 +835,7 @@ mod implements_tests {
             }"#,
         );
 
-        let err = resolve_implements(&manifest, &interfaces, &dirs, &|_| {})
+        let err = resolve_implements(&manifest, &interfaces, &dirs, None, &|_| {})
             .expect_err("partial coverage must error");
         let ImplementsError::Coverage(mismatches) = &err else {
             panic!("coverage failure must carry structured mismatches, got {err:?}");
@@ -841,7 +869,7 @@ mod implements_tests {
             r#"{ services: { exposes: [{ link_id: "cam", name: "video_stream" }] } }"#,
         );
 
-        let err = resolve_implements(&manifest, &interfaces, &dirs, &|_| {})
+        let err = resolve_implements(&manifest, &interfaces, &dirs, None, &|_| {})
             .expect_err("wrong-kind entry must error")
             .to_string();
         assert!(
@@ -876,7 +904,7 @@ mod implements_tests {
         let interfaces =
             interfaces_from(r#"{ topics: { emits: [{ link_id: "cam", name: "video_stream" }] } }"#);
 
-        let err = resolve_implements(&manifest, &interfaces, &dirs, &|_| {})
+        let err = resolve_implements(&manifest, &interfaces, &dirs, None, &|_| {})
             .expect_err("broken slot must error")
             .to_string();
         assert!(
@@ -904,7 +932,7 @@ mod implements_tests {
 
         let manifest =
             manifest_with_implements(r#"{ name: "empty_contract", tag: "v1", link_id: "noop" }"#);
-        let out = resolve_implements(&manifest, &Interfaces::default(), &dirs, &|_| {})
+        let out = resolve_implements(&manifest, &Interfaces::default(), &dirs, None, &|_| {})
             .expect("degenerate coverage passes");
         assert!(out.is_empty());
     }
@@ -916,7 +944,7 @@ mod implements_tests {
         let manifest =
             manifest_with_implements(r#"{ name: "depth_camera", tag: "v1", link_id: "cam" }"#);
 
-        let err = resolve_implements(&manifest, &Interfaces::default(), &dirs, &|_| {})
+        let err = resolve_implements(&manifest, &Interfaces::default(), &dirs, None, &|_| {})
             .expect_err("miss must error")
             .to_string();
         assert!(
@@ -950,7 +978,8 @@ mod implements_tests {
             }"#,
         );
 
-        let out = resolve_implements(&manifest, &interfaces, &dirs, &|_| {}).expect("happy path");
+        let out =
+            resolve_implements(&manifest, &interfaces, &dirs, None, &|_| {}).expect("happy path");
 
         let mut saw_service = false;
         let mut saw_action = false;
@@ -1001,7 +1030,7 @@ mod implements_tests {
             manifest_with_implements(r#"{ name: "depth_camera", tag: "v1", link_id: "cam" }"#);
         let interfaces =
             interfaces_from(r#"{ topics: { emits: [{ link_id: "cam", name: "video_stream" }] } }"#);
-        let err = resolve_implements(&manifest, &interfaces, &dirs, &|_| {})
+        let err = resolve_implements(&manifest, &interfaces, &dirs, None, &|_| {})
             .expect_err("drift must error")
             .to_string();
         assert!(
@@ -1098,7 +1127,7 @@ mod implements_tests {
         let interfaces =
             interfaces_from(r#"{ topics: { emits: [{ link_id: "cam", name: "video_stream" }] } }"#);
 
-        let out = resolve_implements(&manifest, &interfaces, &dirs, &|_| {})
+        let out = resolve_implements(&manifest, &interfaces, &dirs, None, &|_| {})
             .expect("git-sourced implements should resolve");
         assert_eq!(out.len(), 1, "should pull the one video_stream topic");
         match out[0].interface() {
@@ -1163,7 +1192,7 @@ mod implements_tests {
         let interfaces =
             interfaces_from(r#"{ topics: { emits: [{ link_id: "cam", name: "video_stream" }] } }"#);
 
-        let err = resolve_implements(&manifest, &interfaces, &dirs, &|_| {})
+        let err = resolve_implements(&manifest, &interfaces, &dirs, None, &|_| {})
             .expect_err("git-sourced drift must error")
             .to_string();
         assert!(
@@ -1218,7 +1247,7 @@ mod implements_tests {
         )
         .expect("interfaces parses");
 
-        let out = collect_consumed_interfaces(&manifest, &cfg, |_, _| None, &dirs, &|_| {})
+        let out = collect_consumed_interfaces(&manifest, &cfg, |_, _| None, &dirs, None, &|_| {})
             .expect("response-only service must resolve");
 
         assert_eq!(
@@ -1321,8 +1350,9 @@ mod implements_tests {
             } }"#,
         );
 
-        let out = collect_all_deployment_interfaces(&manifest, &cfg, |_, _| None, &dirs, &|_| {})
-            .expect("all three kinds resolve together");
+        let out =
+            collect_all_deployment_interfaces(&manifest, &cfg, |_, _| None, &dirs, None, &|_| {})
+                .expect("all three kinds resolve together");
 
         let mut emitted_topics = Vec::new();
         let mut peer_emitted = Vec::new();
@@ -1383,7 +1413,7 @@ mod implements_tests {
             r#"{ topics: { consumes: [{ link_id: "cam", name: "video_strem" }] } }"#,
         );
 
-        let err = collect_consumed_interfaces(&manifest, &cfg, |_, _| None, &dirs, &|_| {})
+        let err = collect_consumed_interfaces(&manifest, &cfg, |_, _| None, &dirs, None, &|_| {})
             .expect_err("a name absent from the contract must not be dropped silently");
         for needle in [
             "video_strem",
@@ -1433,6 +1463,7 @@ mod implements_tests {
             &cfg,
             |name, _| (name == "producer_node").then(|| producer.clone()),
             &dirs,
+            None,
             &|_| {},
         )
         .expect("collection itself must not fail for a node dep");
@@ -1498,6 +1529,7 @@ mod implements_tests {
             &native_cfg,
             |name, _| (name == "hybrid").then(|| producer.clone()),
             &dirs,
+            None,
             &|_| {},
         )
         .expect("native consumption resolves");
@@ -1524,6 +1556,7 @@ mod implements_tests {
             &contract_backed_cfg,
             |name, _| (name == "hybrid").then(|| producer.clone()),
             &dirs,
+            None,
             &|_| {},
         )
         .expect("collection itself does not fail");

--- a/crates/core-node-internal/src/services/node/sync/pairings.rs
+++ b/crates/core-node-internal/src/services/node/sync/pairings.rs
@@ -24,31 +24,38 @@ fn resolve_pairing_doc(
 ) -> std::result::Result<PeppyPairing, String> {
     let cache = repo_cache::load_pairing_cache(peppy_dirs)
         .map_err(|e| format!("failed to load pairing cache: {e}"))?;
-    resolve_pairing_doc_cached(&cache, peppy_dirs, name, tag, sha256_pin, on_feedback)
+    resolve_pairing_doc_cached(&cache, peppy_dirs, name, tag, sha256_pin, None, on_feedback)
 }
 
 /// Resolves one pairing document against an already-loaded cache, so
 /// multi-slot validation doesn't re-read `pairings.json5` per entry.
+///
+/// A launch pin fixes the bytes: this machine reuses its own copy on a
+/// content match and fetches the pin's origin otherwise, but its own
+/// priority rules never pick the document. Without one, the local rules
+/// apply, with the manifest's own optional sha pin.
 fn resolve_pairing_doc_cached(
     cache: &[repo_cache::PairingCacheEntry],
     peppy_dirs: &PeppyDirs,
     name: &str,
     tag: &str,
     sha256_pin: Option<&str>,
+    doc_pins: Option<&crate::services::node::pins::DocPins>,
     on_feedback: &dyn Fn(&str),
 ) -> std::result::Result<PeppyPairing, String> {
-    repo_cache::resolve_cached_doc(
-        peppy_dirs,
-        cache,
-        name,
-        tag,
-        sha256_pin,
-        |content| {
-            daemon_config::pairing::PeppyPairingParser::from_content(content)
-                .map_err(|e| e.to_string())
-        },
-        on_feedback,
-    )
+    let parse = |content: &str| {
+        daemon_config::pairing::PeppyPairingParser::from_content(content).map_err(|e| e.to_string())
+    };
+    if let Some(pins) = doc_pins {
+        let pin = pins.require(
+            daemon_config::repository::PinKind::Pairing,
+            name,
+            tag,
+            sha256_pin,
+        )?;
+        return repo_cache::resolve_pinned_doc(peppy_dirs, cache, pin, parse, on_feedback);
+    }
+    repo_cache::resolve_cached_doc(peppy_dirs, cache, name, tag, sha256_pin, parse, on_feedback)
 }
 
 /// Validates every pairing slot of a manifest, participant and observer alike,
@@ -67,6 +74,7 @@ fn resolve_pairing_doc_cached(
 pub(crate) fn validate_pairing_specs(
     manifest: &config::node::Manifest,
     peppy_dirs: &PeppyDirs,
+    doc_pins: Option<&crate::services::node::pins::DocPins>,
     on_feedback: &dyn Fn(&str),
 ) -> std::result::Result<HashMap<String, PeppyPairing>, String> {
     let slots = pairing_slots(manifest);
@@ -90,6 +98,7 @@ pub(crate) fn validate_pairing_specs(
                 slot.name,
                 slot.tag,
                 slot.sha256,
+                doc_pins,
                 on_feedback,
             )?),
         };
@@ -208,6 +217,7 @@ pub fn collect_pairing_interfaces(
     manifest: &config::node::Manifest,
     interfaces_cfg: &config::node::Interfaces,
     peppy_dirs: &PeppyDirs,
+    doc_pins: Option<&crate::services::node::pins::DocPins>,
     on_feedback: &dyn Fn(&str),
 ) -> std::result::Result<Vec<generator::DeploymentInterface>, PairingError> {
     let Some(depends_on) = manifest.depends_on.as_ref() else {
@@ -216,7 +226,7 @@ pub fn collect_pairing_interfaces(
     if depends_on.pairings.is_empty() && depends_on.pairing_observers.is_empty() {
         return Ok(Vec::new());
     }
-    let docs = validate_pairing_specs(manifest, peppy_dirs, on_feedback)?;
+    let docs = validate_pairing_specs(manifest, peppy_dirs, doc_pins, on_feedback)?;
     let doc_of = |link_id: &str| {
         docs.get(link_id)
             .expect("validate_pairing_specs returns a doc per declared slot")
@@ -575,7 +585,7 @@ mod tests {
         interfaces_cfg: &config::node::Interfaces,
         dirs: &PeppyDirs,
     ) -> std::result::Result<Vec<generator::DeploymentInterface>, PairingError> {
-        collect_pairing_interfaces(manifest, interfaces_cfg, dirs, &|_| {})
+        collect_pairing_interfaces(manifest, interfaces_cfg, dirs, None, &|_| {})
     }
 
     /// The `(module_path, is_emitted)` of each produced interface, so tests
@@ -917,7 +927,7 @@ mod tests {
                 }
             }"#,
         );
-        let docs = validate_pairing_specs(&m, &dirs, &|_| {}).expect("valid role resolves");
+        let docs = validate_pairing_specs(&m, &dirs, None, &|_| {}).expect("valid role resolves");
         let doc = docs.get("controller").expect("doc keyed by link_id");
         assert_eq!(doc.manifest.name.as_str(), "arm_link");
         assert!(doc.has_role("arm") && doc.has_role("controller"));
@@ -937,7 +947,7 @@ mod tests {
                 }
             }"#,
         );
-        let err = validate_pairing_specs(&m, &dirs, &|_| {}).expect_err("bad role rejected");
+        let err = validate_pairing_specs(&m, &dirs, None, &|_| {}).expect_err("bad role rejected");
         assert!(
             err.contains("gripper") && err.contains("controller") && err.contains("arm"),
             "error should name the bad role and the declared roles: {err}"
@@ -955,7 +965,7 @@ mod tests {
                 }
             }"#,
         );
-        let err = validate_pairing_specs(&m, &dirs, &|_| {}).expect_err("miss must error");
+        let err = validate_pairing_specs(&m, &dirs, None, &|_| {}).expect_err("miss must error");
         assert!(
             err.contains("arm_link:v1") && err.contains("peppy repo refresh"),
             "error should name the entry and suggest refresh: {err}"

--- a/crates/core-node-internal/src/services/repo/cache.rs
+++ b/crates/core-node-internal/src/services/repo/cache.rs
@@ -24,125 +24,19 @@
 use crate::Result;
 use crate::services::repo::RepoOwners;
 use crate::services::repo::refresh::read_or_create_repos;
-use core_node_api::encoding::{RepoItemKind, RepoSourceKind};
+use core_node_api::encoding::RepoItemKind;
 use daemon_config::consts::PeppyDirs;
-use daemon_config::repository::{
-    GitCommit, ItemName, ItemTag, ManifestFingerprint, RepoRelativePath,
-};
+use daemon_config::repository::{ItemName, ItemTag, ManifestFingerprint, PinnedItem};
 use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock};
 use std::time::SystemTime;
 
-/// Where a cached item's bytes live, and which revision they were read at.
-///
-/// A branch name is not a revision: two machines following `main` a week
-/// apart hold different trees while recording the same string. The commit
-/// is what makes an entry mean one set of bytes rather than "whatever that
-/// branch pointed at when this machine last looked".
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[serde(tag = "source_type", rename_all = "lowercase")]
-pub enum EntryOrigin {
-    /// A tree on this machine. Nothing off this machine can read it, which
-    /// is why a deployment placed on another core node cannot be backed by
-    /// one.
-    Fs {
-        /// Absolute path to the file that declares the item.
-        path: PathBuf,
-    },
-    Git {
-        repo_url: String,
-        /// The ref the repository is configured to follow, absent when it
-        /// follows whatever the remote's default branch is. Kept beside the
-        /// commit because a fetch starts from a ref before it can reach a
-        /// commit, and because `entry_belongs_to_repo` attributes an entry
-        /// to its configured repository by url and ref.
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        repo_ref: Option<String>,
-        /// The commit the tree was read at.
-        commit: GitCommit,
-        /// Path within the repository to the file that declares the item.
-        path: RepoRelativePath,
-    },
-}
-
-impl EntryOrigin {
-    pub fn kind(&self) -> RepoSourceKind {
-        match self {
-            EntryOrigin::Fs { .. } => RepoSourceKind::Fs,
-            EntryOrigin::Git { .. } => RepoSourceKind::Git,
-        }
-    }
-
-    /// The path as the cache spells it: absolute for fs, repository-relative
-    /// for git. What error messages quote and what repository attribution
-    /// matches against.
-    pub fn path_str(&self) -> &str {
-        match self {
-            // A path that is not valid UTF-8 renders lossily rather than
-            // failing the whole cache: this is display and attribution, and
-            // a lossy rendering still names the file the user has to look at.
-            EntryOrigin::Fs { path } => path.to_str().unwrap_or("<non-UTF-8 path>"),
-            EntryOrigin::Git { path, .. } => path.as_str(),
-        }
-    }
-
-    /// The `(repo_url, commit)` this origin resolves through the checkout
-    /// cache, and `None` for a filesystem origin, which resolves in place.
-    ///
-    /// The one statement of what keeps a cached checkout reachable, so
-    /// pruning them cannot go looking in a different place than resolution
-    /// does.
-    pub fn checkout(&self) -> Option<(&str, &GitCommit)> {
-        match self {
-            EntryOrigin::Fs { .. } => None,
-            EntryOrigin::Git {
-                repo_url, commit, ..
-            } => Some((repo_url, commit)),
-        }
-    }
-
-    /// Whether resolving this origin to an on-disk path can block on the
-    /// network: a git origin may clone or fetch, while a filesystem origin
-    /// already names a file on this machine. Callers inside tokio use it to
-    /// decide whether [`resolve_cached_artifact_path`] needs
-    /// [`tokio::task::spawn_blocking`].
-    pub fn resolution_may_block(&self) -> bool {
-        self.checkout().is_some()
-    }
-
-    /// The remote a git origin was read from. `None` for a filesystem
-    /// origin, which has no remote.
-    #[cfg(test)]
-    pub fn repo_url(&self) -> Option<&str> {
-        match self {
-            EntryOrigin::Fs { .. } => None,
-            EntryOrigin::Git { repo_url, .. } => Some(repo_url),
-        }
-    }
-
-    /// The ref a git origin is configured to follow. `None` for a
-    /// filesystem origin, and for a git origin that follows the remote's
-    /// default branch.
-    #[cfg(test)]
-    pub fn repo_ref(&self) -> Option<&str> {
-        match self {
-            EntryOrigin::Fs { .. } => None,
-            EntryOrigin::Git { repo_ref, .. } => repo_ref.as_deref(),
-        }
-    }
-
-    /// The commit a git origin was read at. `None` for a filesystem
-    /// origin, which has no revision to record.
-    #[cfg(test)]
-    pub fn commit(&self) -> Option<&GitCommit> {
-        match self {
-            EntryOrigin::Fs { .. } => None,
-            EntryOrigin::Git { commit, .. } => Some(commit),
-        }
-    }
-}
+// One vocabulary for "where bytes live and which revision they were read
+// at", shared with the launch pins (`daemon_config::repository::pins`) so
+// what a cache records and what a coordinator ships cannot drift.
+pub use daemon_config::repository::EntryOrigin;
 
 /// One entry as it appears in `nodes.json5`.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -552,7 +446,7 @@ pub fn lookup_launcher<'a>(
 /// An excluded repository is never scanned, so peppy cannot know whether
 /// it would have provided the identity; the wording says so instead of
 /// implying it did.
-fn excluded_repositories_hint(peppy_dirs: &PeppyDirs) -> String {
+pub(crate) fn excluded_repositories_hint(peppy_dirs: &PeppyDirs) -> String {
     let excluded = crate::services::repo::exclude::ExclusionSet::load(peppy_dirs);
     if excluded.entries.is_empty() {
         return String::new();
@@ -602,31 +496,6 @@ pub fn load_contract_cache(peppy_dirs: &PeppyDirs) -> Result<Vec<ContractCacheEn
 /// sync-time event, not a hot path).
 pub fn load_pairing_cache(peppy_dirs: &PeppyDirs) -> Result<Vec<PairingCacheEntry>> {
     load_repo_cache(peppy_dirs)
-}
-
-/// Looks up `(name, tag)` in the nodes cache and returns the entry that
-/// wins repository priority.
-///
-/// Returns the entry rather than a materialized source: what the entry
-/// says about where the bytes are and which commit they came from is what
-/// callers need, and one of them ships it to another machine.
-pub(crate) fn resolve_repo_node_entry(
-    name: &str,
-    tag: &str,
-    peppy_dirs: &PeppyDirs,
-) -> std::result::Result<NodeCacheEntry, String> {
-    let entries =
-        load_node_cache(peppy_dirs).map_err(|e| format!("failed to load nodes cache: {e}"))?;
-    lookup(&entries, name, tag)
-        .map_err(|ambiguity| ambiguity.to_string())?
-        .cloned()
-        .ok_or_else(|| {
-            format!(
-                "repo-node `{name}:{tag}` not found in {}{}",
-                nodes_repo_cache_path(peppy_dirs).display(),
-                excluded_repositories_hint(peppy_dirs)
-            )
-        })
 }
 
 /// Looks up `name` in the launcher cache and resolves it to a concrete
@@ -715,6 +584,30 @@ pub(crate) fn resolve_cached_doc<E: RepoCacheEntry, T>(
 ) -> std::result::Result<T, String> {
     let kind = E::KIND;
     let id = format!("{name}:{tag}");
+    let (_entry, bytes) =
+        resolve_cached_doc_entry(peppy_dirs, entries, name, tag, sha256_pin, on_feedback)?;
+    let content = std::str::from_utf8(&bytes)
+        .map_err(|e| format!("cached {kind} `{id}` is not UTF-8: {e}"))?;
+    parse(content).map_err(|e| format!("failed to parse cached {kind} `{id}`: {e}"))
+}
+
+/// The entry-returning core of [`resolve_cached_doc`]: everything up to the
+/// parse, handing back the winning entry beside the verified bytes.
+///
+/// Split out so a launch coordinator can mint a pin from the entry (its
+/// fingerprint and origin) through exactly the rules a plain resolution
+/// uses, rather than restating the pin validation, the priority tiebreak
+/// and the drift check a second way.
+pub(crate) fn resolve_cached_doc_entry<'a, E: RepoCacheEntry>(
+    peppy_dirs: &PeppyDirs,
+    entries: &'a [E],
+    name: &str,
+    tag: &str,
+    sha256_pin: Option<&str>,
+    on_feedback: &dyn Fn(&str),
+) -> std::result::Result<(&'a E, Vec<u8>), String> {
+    let kind = E::KIND;
+    let id = format!("{name}:{tag}");
 
     // A manifest is hand-written, so the pin is a claim until it is parsed.
     // A malformed one is refused by name here rather than silently matching
@@ -761,10 +654,155 @@ pub(crate) fn resolve_cached_doc<E: RepoCacheEntry, T>(
             entry.sha256()
         ));
     }
+    Ok((entry, bytes))
+}
 
-    let content = std::str::from_utf8(&bytes)
-        .map_err(|e| format!("cached {kind} `{id}` is not UTF-8: {e}"))?;
-    parse(content).map_err(|e| format!("failed to parse cached {kind} `{id}`: {e}"))
+/// Materializes a launch pin's bytes from its own origin: the fetch half of
+/// pin resolution, taken when no local content matches.
+///
+/// For a git origin this checks out the pinned commit (blocking; wrap in
+/// `spawn_blocking` inside Tokio), re-checks that the pinned path stays
+/// inside the checkout after symlink resolution, reads the bytes, and
+/// compares their fingerprint against the pin. A mismatch is a refusal
+/// naming both fingerprints: it means the remote moved under the pin or the
+/// path resolved to something else, and neither may be papered over. There
+/// is no fallback to resolving the pin's name.
+///
+/// The path re-check mirrors `resolve_declared_item` in `repo/index.rs`:
+/// [`daemon_config::repository::RepoRelativePath`] already refused traversal
+/// at decode, so what is left is a symlink inside the fetched tree pointing
+/// out of it.
+pub(crate) fn resolve_pinned_bytes(
+    peppy_dirs: &PeppyDirs,
+    pin: &PinnedItem,
+    on_feedback: &dyn Fn(&str),
+) -> std::result::Result<(PathBuf, Vec<u8>), String> {
+    let label = pin.label();
+    let resolved_path = match &pin.origin {
+        EntryOrigin::Fs { path } => path.clone(),
+        EntryOrigin::Git {
+            repo_url,
+            repo_ref,
+            commit,
+            path,
+        } => {
+            let checkout = crate::services::node::cache::git::ensure_checkout_at_commit(
+                peppy_dirs,
+                repo_url,
+                repo_ref.as_deref(),
+                commit,
+                on_feedback,
+            )
+            .map_err(|e| format!("{label}: {e}"))?;
+            let candidate = checkout.join(path.as_path());
+            let canonical_root = checkout.canonicalize().map_err(|e| {
+                format!(
+                    "{label}: checkout {} is unreadable: {e}",
+                    checkout.display()
+                )
+            })?;
+            let canonical = candidate.canonicalize().map_err(|e| {
+                format!(
+                    "{label}: pinned path {} is absent from commit {commit}: {e}",
+                    path.as_str()
+                )
+            })?;
+            if !canonical.starts_with(&canonical_root) {
+                return Err(format!(
+                    "{label}: pinned path {} escapes the fetched tree (resolves to {})",
+                    path.as_str(),
+                    canonical.display()
+                ));
+            }
+            canonical
+        }
+    };
+
+    let bytes = std::fs::read(&resolved_path)
+        .map_err(|e| format!("{label}: failed to read {}: {e}", resolved_path.display()))?;
+    let actual = ManifestFingerprint::of_bytes(&bytes);
+    if actual != pin.sha256 {
+        return Err(format!(
+            "{label}: content at {} does not match its pin (pinned `{}`, got `{actual}`); \
+             the remote moved under the pin or the location resolved to something else",
+            resolved_path.display(),
+            pin.sha256
+        ));
+    }
+    Ok((resolved_path, bytes))
+}
+
+/// The entry whose content matches `pin`, whatever identity or repository it
+/// arrived under.
+///
+/// Content is what authorises reuse, not provenance: a machine holding the
+/// pinned bytes from another repository uses its own copy rather than
+/// fetching. Matching by fingerprint alone (not name-first) also keeps two
+/// same-named entries with different content from shadowing the right one.
+pub(crate) fn lookup_by_content<'a, E: RepoCacheEntry>(
+    entries: &'a [E],
+    pin: &PinnedItem,
+) -> Option<&'a E> {
+    entries.iter().find(|e| e.sha256() == &pin.sha256)
+}
+
+/// Resolves a launch pin to its bytes: the local content match first, the
+/// pin's own origin second, a name lookup never.
+///
+/// The content-match half re-reads and re-fingerprints the local copy, so a
+/// cache whose file drifted since refresh falls through to the fetch instead
+/// of shipping the wrong bytes. Blocking (the fetch half may clone); wrap in
+/// `spawn_blocking` inside Tokio.
+pub(crate) fn resolve_pin_to_bytes<E: RepoCacheEntry>(
+    peppy_dirs: &PeppyDirs,
+    entries: &[E],
+    pin: &PinnedItem,
+    on_feedback: &dyn Fn(&str),
+) -> std::result::Result<(PathBuf, Vec<u8>), String> {
+    if let Some(entry) = lookup_by_content(entries, pin) {
+        match resolve_cached_artifact_path(peppy_dirs, entry.origin(), on_feedback).and_then(
+            |path| match std::fs::read(&path) {
+                Ok(bytes) => Ok((path, bytes)),
+                Err(e) => Err(format!("failed to read {}: {e}", path.display())),
+            },
+        ) {
+            Ok((path, bytes)) if ManifestFingerprint::of_bytes(&bytes) == pin.sha256 => {
+                return Ok((path, bytes));
+            }
+            Ok(_) => on_feedback(&format!(
+                "Local copy of {} drifted from its fingerprint; fetching the pin",
+                pin.label()
+            )),
+            Err(reason) => on_feedback(&format!(
+                "Local copy of {} is unusable ({reason}); fetching the pin",
+                pin.label()
+            )),
+        }
+    }
+    resolve_pinned_bytes(peppy_dirs, pin, on_feedback)
+}
+
+/// Resolves a pinned contract or pairing document to a parsed value, through
+/// [`resolve_pin_to_bytes`]. The pinned counterpart of [`resolve_cached_doc`]:
+/// where that function turns a manifest's `name:tag[@sha256]` reference into
+/// a document via this machine's own cache rules, this one consumes a
+/// coordinator's decision and never consults them.
+pub(crate) fn resolve_pinned_doc<E: RepoCacheEntry, T>(
+    peppy_dirs: &PeppyDirs,
+    entries: &[E],
+    pin: &PinnedItem,
+    parse: impl FnOnce(&str) -> std::result::Result<T, String>,
+    on_feedback: &dyn Fn(&str),
+) -> std::result::Result<T, String> {
+    let (path, bytes) = resolve_pin_to_bytes(peppy_dirs, entries, pin, on_feedback)?;
+    let content = std::str::from_utf8(&bytes).map_err(|e| {
+        format!(
+            "{}: content at {} is not UTF-8: {e}",
+            pin.label(),
+            path.display()
+        )
+    })?;
+    parse(content).map_err(|e| format!("failed to parse pinned {}: {e}", pin.label()))
 }
 
 struct MemoEntry {
@@ -806,6 +844,7 @@ fn memo_put(path: &Path, mtime: SystemTime, repos_mtime: SystemTime, entries: Ve
 #[cfg(test)]
 pub(crate) mod test_support {
     use super::*;
+    use daemon_config::repository::{GitCommit, RepoRelativePath};
 
     /// A distinct, valid fingerprint per `seed`. Deterministic, so a test
     /// that asserts on one reads the same way twice.
@@ -877,6 +916,7 @@ pub(crate) mod test_support {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use daemon_config::repository::{GitCommit, RepoRelativePath};
 
     use super::test_support::*;
 
@@ -1120,59 +1160,6 @@ mod tests {
         assert_eq!(hit.repo_id, UNOWNED_REPO_ID);
     }
 
-    // -- resolve_repo_node_entry tests --
-
-    #[test]
-    fn resolve_returns_the_entry_with_its_origin() {
-        let tmp = tempfile::tempdir().unwrap();
-        let peppy_dirs = PeppyDirs::new(tmp.path());
-        let entry = node_entry(
-            "g",
-            "v1",
-            git_origin(
-                "https://example.com/repo.git",
-                "main",
-                "g",
-                "nodes/example/peppy.json5",
-            ),
-        );
-        write_repo_cache(&peppy_dirs, std::slice::from_ref(&entry)).unwrap();
-
-        let resolved = resolve_repo_node_entry("g", "v1", &peppy_dirs).unwrap();
-        assert_eq!(
-            resolved.origin, entry.origin,
-            "the commit and path the cache recorded are what resolution returns"
-        );
-    }
-
-    #[test]
-    fn resolve_reports_ambiguity_rather_than_picking_one() {
-        let tmp = tempfile::tempdir().unwrap();
-        let peppy_dirs = PeppyDirs::new(tmp.path());
-        write_repo_cache(
-            &peppy_dirs,
-            &[
-                mk_fs_entry("a", "v1", "/repo/rust/peppy.json5"),
-                mk_fs_entry("a", "v1", "/repo/python/peppy.json5"),
-            ],
-        )
-        .unwrap();
-
-        let err = resolve_repo_node_entry("a", "v1", &peppy_dirs).unwrap_err();
-        assert!(err.contains("claim `a:v1`"), "unexpected error: {err}");
-        assert!(!err.contains("not found"), "unexpected error: {err}");
-    }
-
-    #[test]
-    fn resolve_not_found() {
-        let tmp = tempfile::tempdir().unwrap();
-        let peppy_dirs = PeppyDirs::new(tmp.path());
-        write_repo_cache::<NodeCacheEntry>(&peppy_dirs, &[]).unwrap();
-
-        let err = resolve_repo_node_entry("missing", "v1", &peppy_dirs).unwrap_err();
-        assert!(err.contains("not found"), "unexpected error: {err}");
-    }
-
     // -- launcher cache tests --
 
     /// `write_repo_cache` writes launcher entries to the path returned by
@@ -1374,6 +1361,188 @@ mod tests {
             resolved.exists(),
             "resolved path should exist on disk after ensure_checkout"
         );
+    }
+
+    // -- pin resolution tests --
+
+    use daemon_config::repository::{PinKind, PinnedItem};
+
+    fn pin_for(
+        name: &str,
+        tag: &str,
+        sha256: ManifestFingerprint,
+        origin: EntryOrigin,
+    ) -> PinnedItem {
+        PinnedItem {
+            kind: PinKind::Node,
+            name: ItemName::parse(name).expect("valid name"),
+            tag: ItemTag::parse(tag).expect("valid tag"),
+            sha256,
+            origin,
+        }
+    }
+
+    /// Content authorises reuse, provenance does not: a machine holding the
+    /// pinned bytes as an entry of ANOTHER repository under another identity
+    /// serves them from its own disk, and the pin's own remote is never
+    /// contacted. The unreachable URL in the pin is what proves it: a fetch
+    /// attempt would fail loudly.
+    #[test]
+    fn a_pin_reuses_local_content_from_another_repository_without_fetching() {
+        let tmp = tempfile::tempdir().unwrap();
+        let peppy_dirs = PeppyDirs::new(tmp.path());
+        let local_file = tmp.path().join("other_repo").join("peppy.json5");
+        std::fs::create_dir_all(local_file.parent().unwrap()).unwrap();
+        std::fs::write(&local_file, b"{ pinned bytes }").unwrap();
+        let sha = ManifestFingerprint::of_bytes(b"{ pinned bytes }");
+
+        let mut local_entry = node_entry(
+            "other_name",
+            "v9",
+            fs_origin(local_file.to_string_lossy().as_ref()),
+        );
+        local_entry.sha256 = sha.clone();
+
+        let pin = pin_for(
+            "camera",
+            "v1",
+            sha,
+            git_origin(
+                "https://unreachable.invalid/hub.git",
+                "main",
+                "camera:v1",
+                "camera/peppy.json5",
+            ),
+        );
+
+        let (path, bytes) = resolve_pin_to_bytes(
+            &peppy_dirs,
+            std::slice::from_ref(&local_entry),
+            &pin,
+            &|_| {},
+        )
+        .expect("local content serves the pin");
+        assert_eq!(path, local_file);
+        assert_eq!(bytes, b"{ pinned bytes }");
+    }
+
+    /// A local entry whose file drifted from its recorded fingerprint is a
+    /// miss, not an answer: the pin falls through to its own origin rather
+    /// than shipping bytes that no longer match anything.
+    #[test]
+    fn a_drifted_local_copy_falls_through_to_the_pins_origin() {
+        let peppy_tmp = tempfile::tempdir().unwrap();
+        let peppy_dirs = PeppyDirs::new(peppy_tmp.path());
+
+        let source_parent = tempfile::tempdir().unwrap();
+        let source_repo_dir = source_parent.path().join("hub");
+        std::fs::create_dir_all(&source_repo_dir).unwrap();
+        let pinned_body = "{ the pinned bytes }";
+        let (branch, commit) =
+            init_repo_with_file(&source_repo_dir, "camera/peppy.json5", pinned_body);
+        let sha = ManifestFingerprint::of_bytes(pinned_body.as_bytes());
+
+        // A local entry claims the same content but its file says otherwise.
+        let drifted = peppy_tmp.path().join("drifted.json5");
+        std::fs::write(&drifted, b"{ something else }").unwrap();
+        let mut local_entry = node_entry(
+            "camera",
+            "v1",
+            fs_origin(drifted.to_string_lossy().as_ref()),
+        );
+        local_entry.sha256 = sha.clone();
+
+        let pin = pin_for(
+            "camera",
+            "v1",
+            sha,
+            EntryOrigin::Git {
+                repo_url: source_repo_dir.display().to_string(),
+                repo_ref: Some(branch),
+                commit,
+                path: RepoRelativePath::parse("camera/peppy.json5").unwrap(),
+            },
+        );
+
+        let (path, bytes) = resolve_pin_to_bytes(
+            &peppy_dirs,
+            std::slice::from_ref(&local_entry),
+            &pin,
+            &|_| {},
+        )
+        .expect("the pin's own origin serves it");
+        assert_ne!(path, drifted);
+        assert_eq!(bytes, pinned_body.as_bytes());
+    }
+
+    /// Content fetched from the pin's origin that does not fingerprint to
+    /// the pin is a refusal naming both fingerprints: the remote moved under
+    /// the pin or the location resolved to something else, and neither may
+    /// be papered over by running what was found.
+    #[test]
+    fn fetched_content_that_does_not_match_its_pin_is_refused_naming_both() {
+        let peppy_tmp = tempfile::tempdir().unwrap();
+        let peppy_dirs = PeppyDirs::new(peppy_tmp.path());
+
+        let source_parent = tempfile::tempdir().unwrap();
+        let source_repo_dir = source_parent.path().join("hub");
+        std::fs::create_dir_all(&source_repo_dir).unwrap();
+        let (branch, commit) =
+            init_repo_with_file(&source_repo_dir, "camera/peppy.json5", "{ actual bytes }");
+
+        let pinned_sha = ManifestFingerprint::of_bytes(b"{ some other bytes }");
+        let actual_sha = ManifestFingerprint::of_bytes(b"{ actual bytes }");
+        let pin = pin_for(
+            "camera",
+            "v1",
+            pinned_sha.clone(),
+            EntryOrigin::Git {
+                repo_url: source_repo_dir.display().to_string(),
+                repo_ref: Some(branch),
+                commit,
+                path: RepoRelativePath::parse("camera/peppy.json5").unwrap(),
+            },
+        );
+
+        let err = resolve_pinned_bytes(&peppy_dirs, &pin, &|_| {})
+            .expect_err("a fingerprint mismatch must refuse");
+        assert!(err.contains(pinned_sha.as_str()), "names the pin: {err}");
+        assert!(
+            err.contains(actual_sha.as_str()),
+            "names what was found: {err}"
+        );
+        assert!(err.contains("moved under the pin"), "{err}");
+    }
+
+    /// A pinned path that is absent from the pinned commit refuses naming
+    /// the path and the commit, so the operator can see whether the pin or
+    /// the repository is wrong.
+    #[test]
+    fn a_pinned_path_absent_from_the_commit_is_refused() {
+        let peppy_tmp = tempfile::tempdir().unwrap();
+        let peppy_dirs = PeppyDirs::new(peppy_tmp.path());
+
+        let source_parent = tempfile::tempdir().unwrap();
+        let source_repo_dir = source_parent.path().join("hub");
+        std::fs::create_dir_all(&source_repo_dir).unwrap();
+        let (branch, commit) = init_repo_with_file(&source_repo_dir, "camera/peppy.json5", "{}");
+
+        let pin = pin_for(
+            "camera",
+            "v1",
+            fingerprint("whatever"),
+            EntryOrigin::Git {
+                repo_url: source_repo_dir.display().to_string(),
+                repo_ref: Some(branch),
+                commit,
+                path: RepoRelativePath::parse("elsewhere/peppy.json5").unwrap(),
+            },
+        );
+
+        let err = resolve_pinned_bytes(&peppy_dirs, &pin, &|_| {})
+            .expect_err("an absent pinned path must refuse");
+        assert!(err.contains("elsewhere/peppy.json5"), "{err}");
+        assert!(err.contains("absent from commit"), "{err}");
     }
 
     /// The write is atomic: the final file is created via a tmp + rename

--- a/crates/core-node-internal/src/services/stack.rs
+++ b/crates/core-node-internal/src/services/stack.rs
@@ -6,7 +6,6 @@ mod reset;
 pub use benchmark::listen_for_stack_benchmark;
 pub use launch::STACK_LAUNCH_GIT_HASH;
 pub use launch::listen_for_stack_launch;
-pub(crate) use launch::portable_node_source;
 pub use launch::{StackLaunchDefaults, StackLaunchTimeouts};
 pub use list::listen_for_stack_list;
 pub(crate) use reset::clear_stack_slice;

--- a/crates/core-node-internal/src/services/stack/benchmark.rs
+++ b/crates/core-node-internal/src/services/stack/benchmark.rs
@@ -415,8 +415,14 @@ fn resolve_contract_topic_qos(
         let doc = cache
             .entry((contract_name.clone(), contract_tag.clone()))
             .or_insert_with(|| {
-                match resolve_contract_doc(peppy_dirs, &contract_name, &contract_tag, None, &|_| {})
-                {
+                match resolve_contract_doc(
+                    peppy_dirs,
+                    &contract_name,
+                    &contract_tag,
+                    None,
+                    None,
+                    &|_| {},
+                ) {
                     Ok(doc) => Some(doc),
                     Err(e) => {
                         emit_feedback(
@@ -474,7 +480,7 @@ fn resolve_probe_sizes(
                 let doc = contract_cache
                     .entry((name.clone(), tag.clone()))
                     .or_insert_with(|| {
-                        resolve_contract_doc(peppy_dirs, name, tag, None, &|_| {}).ok()
+                        resolve_contract_doc(peppy_dirs, name, tag, None, None, &|_| {}).ok()
                     });
                 formats_from_contract(doc.as_ref(), edge.kind, &edge.interface)
             }

--- a/crates/core-node-internal/src/services/stack/launch.rs
+++ b/crates/core-node-internal/src/services/stack/launch.rs
@@ -4,8 +4,6 @@ mod orchestrate;
 mod phases;
 mod resolve;
 
-pub(crate) use resolve::portable_node_source;
-
 use self::feedback::{publish_stderr, publish_stdout};
 use self::orchestrate::{
     add_node_directly, build_node_directly, fail_and_clear_stack, start_node_directly,
@@ -235,15 +233,21 @@ struct PlannedDeployment {
     node_name: String,
     node_tag: String,
     config: config::node::NodeConfig,
-    /// Where this deployment sat in the launcher's list. Carried so a
-    /// participant's per-deployment answers (its manifest, its hash) can be
-    /// matched back to the entry they belong to.
-    deployment_index: usize,
-    /// This daemon's own fingerprint of the manifest, when this daemon read it.
-    /// `None` for a deployment whose manifest a participant resolved instead,
-    /// which is what keeps the straddle cross-check from comparing a peer's
-    /// answer against itself.
-    manifest_sha256: Option<String>,
+    /// This daemon's fingerprint of the resolved manifest, echoed onto every
+    /// instance dispatched to a peer so a peer whose entity moved between
+    /// dispatch and start refuses rather than running a config the plan was
+    /// never checked against.
+    config_sha256: String,
+    /// The root pin for a pinned source (`repo:` and `git:`); `None` for a
+    /// `local:` tree or a content-addressed `url:` archive.
+    root_pin: Option<daemon_config::repository::PinnedItem>,
+    /// The rest of the closure: dependency-node pins plus, once
+    /// `mint_doc_pins` has run, the contract and pairing document pins every
+    /// add of this deployment carries.
+    closure_pins: Vec<daemon_config::repository::PinnedItem>,
+    /// Every manifest in the deployment's closure, root first. What the
+    /// doc-pin minting walks after the graph validation has had first say.
+    pin_manifests: Vec<config::node::Manifest>,
 }
 
 /// Marker git_hash used for stack-launch operations.
@@ -371,9 +375,20 @@ async fn add_and_build_group(
             continue;
         }
 
-        let node_add_goal =
-            NodeAddGoal::for_internal_execution(item.source.clone(), STACK_LAUNCH_GIT_HASH)
-                .with_env_vars(ctx.env_vars.clone());
+        // The identical source and pins a peer would receive: a launch adds
+        // one set of bytes wherever a deployment lands, so the local arm
+        // must not get to differ from the dispatched one.
+        let node_add_goal = match closure_pins_json5(item) {
+            Ok(pins) => {
+                NodeAddGoal::for_internal_execution(item.source.clone(), STACK_LAUNCH_GIT_HASH)
+                    .with_env_vars(ctx.env_vars.clone())
+                    .with_pins(pins)
+            }
+            Err(reason) => {
+                outcome.failure = Some(reason);
+                return outcome;
+            }
+        };
 
         let (result, log_path) = add_node_directly(ctx, node_add_goal).await;
 
@@ -432,7 +447,19 @@ async fn add_and_build_group(
     outcome
 }
 
+/// The wire form of a deployment's closure pins, shared by the local and
+/// remote add arms so the two cannot drift on what a deployment's adds
+/// carry.
+fn closure_pins_json5(item: &PlannedDeployment) -> std::result::Result<Vec<String>, String> {
+    crate::services::node::pins::encode_pins(&item.closure_pins)
+}
+
 /// Adds and builds one node on a peer, over the wire.
+///
+/// The goal carries the same pinned source and closure pins the local arm
+/// uses: the peer materializes the coordinator's decision, reusing its own
+/// content on a fingerprint match and fetching the pinned commit otherwise,
+/// and never resolves a name against its own cache.
 ///
 /// The peer's own log paths are not folded into this launch's log lists: they
 /// name files on that machine, and a path the operator cannot open is worse
@@ -444,17 +471,17 @@ async fn add_and_build_remotely(
     core_node: &str,
     item: &PlannedDeployment,
 ) -> std::result::Result<(), String> {
-    let source = crate::services::stack::portable_node_source(&item.deployment.source)?;
     // A real budget, unlike the in-process path's zero: this goal passes
     // through the peer's own concurrency gate, which reports the remaining time
     // when it refuses a second caller.
     let add_goal = NodeAddGoal::from_source(
-        source,
+        item.source.clone(),
         STACK_LAUNCH_GIT_HASH,
         ctx.idle_timeouts.add.as_secs(),
     )
     .with_env_vars(ctx.env_vars.clone())
-    .with_launch_id(&goal.launch_id);
+    .with_launch_id(&goal.launch_id)
+    .with_pins(closure_pins_json5(item)?);
     let added = federated::run_remote_goal(ctx, core_node, &add_goal, ctx.idle_timeouts.add)
         .await
         .map_err(|reason| format!("failed to add node {}: {reason}", item.node_name))?;
@@ -963,14 +990,7 @@ async fn start_node_instances(
             let outcome = if local {
                 start_locally(ctx, key, instance_id, node_run_goal, run_log_paths).await
             } else {
-                start_remotely(
-                    ctx,
-                    goal,
-                    &core_node,
-                    node_run_goal,
-                    federated.manifest_sha256(&core_node, item.deployment_index),
-                )
-                .await
+                start_remotely(ctx, goal, &core_node, node_run_goal, &item.config_sha256).await
             };
 
             if let Err(reason) = outcome {
@@ -1019,25 +1039,25 @@ async fn start_locally(
     }
 }
 
-/// Starts one instance on a peer, pinning the manifest that peer reported
-/// during preflight.
+/// Starts one instance on a peer, pinning the manifest this coordinator
+/// resolved for its deployment.
 ///
-/// The hash is the whole point of pinning: the peer re-resolves the manifest
-/// from its own cache when the goal lands, and refuses if it no longer hashes
-/// the same. That closes the window between preflight and dispatch in which a
-/// `repo refresh` on the peer could have moved the node out from under a plan
-/// that was validated against the old one.
+/// The hash closes the window between add and start: the peer compares it
+/// against the entity now in its stack and refuses if the two no longer
+/// hash the same, so an entity replaced out from under the plan fails
+/// loudly instead of starting a node the plan was never checked against.
+/// Every remote instance carries it, straddling deployments included,
+/// because the coordinator resolved every deployment itself.
 async fn start_remotely(
     ctx: &ProcessLaunchContext,
     goal: &LaunchGoal,
     core_node: &str,
     node_run_goal: NodeRunGoal,
-    manifest_sha256: Option<&str>,
+    config_sha256: &str,
 ) -> std::result::Result<(), String> {
-    let mut node_run_goal = node_run_goal.with_launch_id(&goal.launch_id);
-    if let Some(sha) = manifest_sha256 {
-        node_run_goal = node_run_goal.with_manifest_sha256(sha);
-    }
+    let node_run_goal = node_run_goal
+        .with_launch_id(&goal.launch_id)
+        .with_manifest_sha256(config_sha256);
     federated::run_remote_goal(ctx, core_node, &node_run_goal, ctx.idle_timeouts.run).await
 }
 
@@ -1201,12 +1221,13 @@ async fn handle_goal_request(
 ///
 /// This function orchestrates the complete launch sequence:
 /// 1. Parse launcher configuration
-/// 2. Resolve deployments
-/// 3. Validate dependencies and compute order
-/// 4. Snapshot and clear stack
-/// 5. Add nodes in dependency order
-/// 6. Prepare stack-wide container host mounts
-/// 7. Start instances in dependency order
+/// 2. Resolve deployments and mint their node pins
+/// 3. Validate dependencies and compute order, then mint the doc pins
+/// 4. Federated preflight, carrying the pins
+/// 5. Snapshot and clear stack
+/// 6. Add nodes in dependency order
+/// 7. Prepare stack-wide container host mounts
+/// 8. Start instances in dependency order
 async fn process_launch(goal: LaunchGoal, ctx: ProcessLaunchContext) -> LaunchResult {
     // Step 1: Parse the launcher and bind its core node links to machines.
     let (deployments, nodes_directory, placements) = match parse_launcher_config(&ctx, &goal).await
@@ -1215,59 +1236,57 @@ async fn process_launch(goal: LaunchGoal, ctx: ProcessLaunchContext) -> LaunchRe
         Err(launch_result) => return launch_result,
     };
 
-    // Step 2: Federated preflight. Reachability, reservations, and each
-    // participant's own manifests, all BEFORE anything is resolved or torn
-    // down. Reserving first is what makes every later refusal free: no machine,
-    // including this one, has been touched yet.
-    let federated =
-        match federated::preflight(&ctx, &goal.launch_id, &deployments, &placements).await {
-            Ok(federated) => federated,
-            Err(reason) => {
-                publish_stderr(&ctx, reason.clone(), LaunchFeedbackStep::LauncherStep).await;
-                return LaunchResult::failure(&ctx.log_path, reason);
-            }
+    // Step 2: Resolve every deployment, once, on this daemon, minting the
+    // node pins the whole launch runs. Resolution touches no other machine
+    // and tears nothing down, so refusing here is free, and the
+    // reservations below need the pins to carry.
+    let mut planned =
+        match resolve_deployments(&ctx, deployments, &nodes_directory, &placements).await {
+            Ok(result) => result,
+            Err(launch_result) => return launch_result,
         };
-    let participants = federated.core_nodes();
 
-    // Step 3: Resolve deployments. Anything placed wholly on a peer takes the
-    // manifest that peer resolved; the rest this daemon resolves itself.
-    let planned = match resolve_deployments(
-        &ctx,
-        deployments,
-        &nodes_directory,
-        &federated.delegated_manifests(),
-    )
-    .await
-    {
-        Ok(result) => result,
-        Err(launch_result) => {
-            return release_and_fail(&ctx, &goal, &participants, launch_result).await;
+    // Step 3: Validate dependencies and compute one global topological order,
+    // across every machine. There is exactly one planner. Runs before the
+    // doc pins are minted so a graph refusal, which points at the launcher
+    // and the manifests, has first say over a document missing from this
+    // machine's caches.
+    let root_config = ctx.node_stack.root().read().config().clone();
+    let (ordered, resolved_slot_bindings, planned_pairings, planned_observations) =
+        match validate_and_order_dependencies(&ctx, &planned, &root_config, &placements).await {
+            Ok(result) => result,
+            Err(launch_result) => return launch_result,
+        };
+
+    // Step 3b: Pin the contract and pairing documents every manifest in the
+    // launch names. Still before any reservation, so a document this
+    // machine cannot pin refuses the launch while it has cost nothing.
+    if let Err(launch_result) = resolve::mint_doc_pins(&ctx, &mut planned, &placements).await {
+        return launch_result;
+    }
+
+    // Step 4: Federated preflight. Reachability and reservations, each
+    // carrying its participant's pins, all BEFORE anything is torn down: a
+    // refusal at this point has cost no machine, including this one, its
+    // stack.
+    let federated = match federated::preflight(&ctx, &goal.launch_id, &planned, &placements).await {
+        Ok(federated) => federated,
+        Err(reason) => {
+            publish_stderr(&ctx, reason.clone(), LaunchFeedbackStep::LauncherStep).await;
+            return LaunchResult::failure(&ctx.log_path, reason);
         }
     };
+    let participants = federated.core_nodes();
 
-    // Step 3b: A node whose instances straddle two machines must be the same
-    // node on both, or the graph validated below describes neither. A planned
-    // instance id must also not collide with a participant's own root entity,
-    // which occupies that machine's namespace before this launch touches it.
-    let mut refusals = federated.root_instance_collisions(
+    // Step 4b: A planned instance id must not collide with a participant's
+    // own root entity, which occupies that machine's namespace before this
+    // launch touches it.
+    let refusals = federated.root_instance_collisions(
         &planned
             .iter()
             .flat_map(|item| &item.deployment.instances)
             .map(|instance| instance.instance_id.as_str())
             .collect(),
-    );
-    refusals.extend(
-        federated.disagreeing_manifests(
-            ctx.bound_core_node.as_str(),
-            &planned
-                .iter()
-                .filter_map(|item| {
-                    item.manifest_sha256
-                        .as_ref()
-                        .map(|sha| (item.deployment_index, sha.clone()))
-                })
-                .collect(),
-        ),
     );
     if !refusals.is_empty() {
         let msg = daemon_config::format_bulleted(&refusals);
@@ -1280,17 +1299,6 @@ async fn process_launch(goal: LaunchGoal, ctx: ProcessLaunchContext) -> LaunchRe
         )
         .await;
     }
-
-    // Step 4: Validate dependencies and compute one global topological order,
-    // across every machine. There is exactly one planner.
-    let root_config = ctx.node_stack.root().read().config().clone();
-    let (ordered, resolved_slot_bindings, planned_pairings, planned_observations) =
-        match validate_and_order_dependencies(&ctx, &planned, &root_config, &placements).await {
-            Ok(result) => result,
-            Err(launch_result) => {
-                return release_and_fail(&ctx, &goal, &participants, launch_result).await;
-            }
-        };
 
     // Step 5: The commit point. Every participant is reserved and the whole
     // plan is validated, so now, and only now, do stacks get replaced. Peers

--- a/crates/core-node-internal/src/services/stack/launch.rs
+++ b/crates/core-node-internal/src/services/stack/launch.rs
@@ -378,7 +378,7 @@ async fn add_and_build_group(
         // The identical source and pins a peer would receive: a launch adds
         // one set of bytes wherever a deployment lands, so the local arm
         // must not get to differ from the dispatched one.
-        let node_add_goal = match closure_pins_json5(item) {
+        let node_add_goal = match crate::services::node::pins::encode_pins(&item.closure_pins) {
             Ok(pins) => {
                 NodeAddGoal::for_internal_execution(item.source.clone(), STACK_LAUNCH_GIT_HASH)
                     .with_env_vars(ctx.env_vars.clone())
@@ -447,13 +447,6 @@ async fn add_and_build_group(
     outcome
 }
 
-/// The wire form of a deployment's closure pins, shared by the local and
-/// remote add arms so the two cannot drift on what a deployment's adds
-/// carry.
-fn closure_pins_json5(item: &PlannedDeployment) -> std::result::Result<Vec<String>, String> {
-    crate::services::node::pins::encode_pins(&item.closure_pins)
-}
-
 /// Adds and builds one node on a peer, over the wire.
 ///
 /// The goal carries the same pinned source and closure pins the local arm
@@ -481,7 +474,9 @@ async fn add_and_build_remotely(
     )
     .with_env_vars(ctx.env_vars.clone())
     .with_launch_id(&goal.launch_id)
-    .with_pins(closure_pins_json5(item)?);
+    .with_pins(crate::services::node::pins::encode_pins(
+        &item.closure_pins,
+    )?);
     let added = federated::run_remote_goal(ctx, core_node, &add_goal, ctx.idle_timeouts.add)
         .await
         .map_err(|reason| format!("failed to add node {}: {reason}", item.node_name))?;

--- a/crates/core-node-internal/src/services/stack/launch/federated/mod.rs
+++ b/crates/core-node-internal/src/services/stack/launch/federated/mod.rs
@@ -24,6 +24,17 @@
 //! own single-threaded plan. Daemons never run distributed transactions among
 //! themselves; daemon-to-daemon runtime traffic is best-effort idempotent
 //! notification only.
+//!
+//! # One launch, one set of bytes
+//!
+//! The reservation carries the launch's pins: the coordinator resolved every
+//! deployment, its transitive dependencies, and its contract and pairing
+//! documents before this preflight ran, and each participant receives that
+//! decision rather than a name to look up. A participant validates the pins
+//! while the reservation is still non-destructive, and materializes them at
+//! add time, reusing its own content on a fingerprint match and fetching the
+//! pinned commit otherwise. Its own cache freshness, repository priorities
+//! and exclusions never influence what this launch runs.
 
 mod dispatch;
 
@@ -34,34 +45,22 @@ use std::time::Duration;
 
 use core_node_api::encoding::{
     ParticipantReleaseRequest, ParticipantReserveRequest, ParticipantReserveResponse,
-    ResolvedManifest,
 };
 use daemon_config::format_quoted_list;
-use daemon_config::launcher::{Deployment, DeploymentSource, Placements};
+use daemon_config::launcher::{Deployment, Placements};
+use daemon_config::repository::{DeploymentPins, PinnedItem};
 use futures::future::join_all;
 use peppylib::core_node::transport::poll;
 use peppylib::{CoreNodePresenceMessenger, MessengerHandle};
 
-/// Bound on one daemon-to-daemon preflight call. The peer answers from its own
-/// caches, so a healthy one answers well inside this; the budget exists so an
-/// unreachable peer fails the launch instead of hanging it.
+/// Bound on one daemon-to-daemon preflight call. The peer validates decoded
+/// pins in memory, so a healthy one answers well inside this; the budget
+/// exists so an unreachable peer fails the launch instead of hanging it.
 const PREFLIGHT_TIMEOUT: Duration = Duration::from_secs(30);
 
-/// Bound on a release. Shorter than a reserve because it does no resolution
+/// Bound on a release. Shorter than a reserve because it does no validation
 /// work, and it runs on the unwind path where waiting helps nobody.
 const RELEASE_TIMEOUT: Duration = Duration::from_secs(10);
-
-/// One deployment as placed on one core node: only that machine's share of the
-/// instances, plus where it sat in the coordinator's full deployment list.
-///
-/// The index is what lets a participant's answers be aligned back with the
-/// plan. Without it a straddling deployment (instances on two machines) would
-/// have no way to say "this manifest is for THAT entry".
-#[derive(Debug, Clone)]
-struct PlacedDeployment {
-    index: usize,
-    deployment: Deployment,
-}
 
 /// What a coordinator learned from one participant during preflight.
 #[derive(Debug, Clone)]
@@ -70,65 +69,41 @@ struct ParticipantSlice {
     /// This participant's root-entity instance id, folded into the
     /// coordinator's stack-wide instance-id uniqueness check.
     root_instance_id: String,
-    /// What this participant resolved, keyed by the deployment's index in the
-    /// coordinator's plan. Keying on the index rather than pairing two
-    /// position-aligned lists is what lets a straddling deployment say "this
-    /// manifest is for THAT entry" without an alignment invariant to keep.
-    manifests: BTreeMap<usize, ResolvedManifest>,
 }
 
-/// A manifest the coordinator did not resolve itself, and the participant that
-/// did.
+/// The pins each peer participant receives with its reservation, one
+/// serialized [`DeploymentPins`] per pinned deployment with at least one
+/// instance on it.
 ///
-/// The coordinator VALIDATES against this. That is the point of delegating:
-/// what it checks is provably what the participant will spawn, because the
-/// participant read it from the same cache it will spawn from, rather than the
-/// coordinator guessing from its own.
-#[derive(Debug, Clone)]
-pub(super) struct DelegatedManifest {
-    pub(super) core_node: String,
-    pub(super) config_json5: String,
-}
-
-/// Which deployments each participant hosts.
-///
-/// A deployment goes to every core node hosting at least one of its instances,
-/// because that daemon must add and build the node before starting its share.
-/// One node split across daemons is therefore added on both, which is exactly
-/// what "several placed instances under one deployment" means operationally.
-fn partition_deployments(
-    deployments: &[Deployment],
+/// Every off-coordinator host of any instance appears as a key, because
+/// every one of them must be reserved; a host whose share is only
+/// content-addressed sources (`url:`) is reserved with no pins to validate.
+/// The coordinator itself never appears: it holds no reservation on itself.
+fn partition_reservations<'a>(
+    items: impl Iterator<Item = (&'a Deployment, Option<&'a PinnedItem>, &'a [PinnedItem])>,
     placements: &Placements,
-    coordinator: &str,
-) -> BTreeMap<String, Vec<PlacedDeployment>> {
-    let mut by_core_node: BTreeMap<String, Vec<PlacedDeployment>> = BTreeMap::new();
-    for (index, deployment) in deployments.iter().enumerate() {
-        let mut hosts: BTreeMap<String, Vec<_>> = BTreeMap::new();
-        for instance in &deployment.instances {
-            hosts
-                .entry(placements.of(instance.instance_id.as_str()).to_owned())
-                .or_default()
-                .push(instance.clone());
-        }
-        // A deployment with no instances at all still belongs somewhere; put it
-        // on the coordinator so it is added rather than silently dropped.
-        if hosts.is_empty() {
-            hosts.insert(coordinator.to_owned(), Vec::new());
-        }
-        for (core_node, instances) in hosts {
-            by_core_node
-                .entry(core_node)
-                .or_default()
-                .push(PlacedDeployment {
-                    index,
-                    deployment: Deployment {
-                        source: deployment.source.clone(),
-                        instances,
-                    },
-                });
+) -> std::result::Result<BTreeMap<String, Vec<String>>, String> {
+    let coordinator = placements.coordinator();
+    let mut by_core_node: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for (deployment, root_pin, closure_pins) in items {
+        let hosts: BTreeSet<&str> = deployment
+            .instances
+            .iter()
+            .map(|instance| placements.of(instance.instance_id.as_str()))
+            .filter(|host| *host != coordinator)
+            .collect();
+        for host in hosts {
+            let entry = by_core_node.entry(host.to_owned()).or_default();
+            if let Some(root) = root_pin {
+                let pins = DeploymentPins::new(root.clone(), closure_pins.to_vec())?;
+                entry.push(
+                    serde_json5::to_string(&pins)
+                        .map_err(|e| format!("could not encode a deployment's pins: {e}"))?,
+                );
+            }
         }
     }
-    by_core_node
+    Ok(by_core_node)
 }
 
 /// Refuses any wired core node that is not live on the federation.
@@ -168,7 +143,8 @@ async fn reject_unreachable_core_nodes(
     ))
 }
 
-/// Reserves every peer participant and collects what only they can report.
+/// Reserves every peer participant, hands each its pins, and collects what
+/// only they can report.
 ///
 /// All-or-nothing: on any refusal the reservations already obtained are
 /// released before the error returns, so a failed preflight leaves no machine
@@ -178,26 +154,24 @@ async fn reserve_participants(
     coordinator: &str,
     caller_instance_id: &str,
     launch_id: &str,
-    peers: BTreeMap<String, Vec<PlacedDeployment>>,
+    peers: BTreeMap<String, Vec<String>>,
     own_version: &str,
 ) -> std::result::Result<Vec<ParticipantSlice>, String> {
-    let acks = join_all(peers.into_iter().map(|(core_node, deployments)| {
-        let request = build_reserve_request(launch_id, coordinator, &deployments);
+    let acks = join_all(peers.into_iter().map(|(core_node, pins)| {
+        let request =
+            ParticipantReserveRequest::new(launch_id, coordinator).with_deployment_pins(pins);
         async move {
-            let outcome = match request {
-                Ok(request) => poll(
-                    &request,
-                    messenger,
-                    coordinator,
-                    caller_instance_id,
-                    &core_node,
-                    PREFLIGHT_TIMEOUT,
-                )
-                .await
-                .map_err(|e| format!("`{core_node}` did not answer the reservation: {e}")),
-                Err(reason) => Err(format!("`{core_node}`: {reason}")),
-            };
-            (core_node, deployments, outcome)
+            let outcome = poll(
+                &request,
+                messenger,
+                coordinator,
+                caller_instance_id,
+                &core_node,
+                PREFLIGHT_TIMEOUT,
+            )
+            .await
+            .map_err(|e| format!("`{core_node}` did not answer the reservation: {e}"));
+            (core_node, outcome)
         }
     }))
     .await;
@@ -206,36 +180,16 @@ async fn reserve_participants(
     let mut reserved: Vec<String> = Vec::new();
     let mut refusals: Vec<String> = Vec::new();
 
-    for (core_node, deployments, outcome) in acks {
+    for (core_node, outcome) in acks {
         match outcome {
             Ok(response) if response.accepted => {
                 reserved.push(core_node.clone());
-                // The positional mapping below is the ONLY thing tying a
-                // manifest to the deployment it describes, so a count mismatch
-                // is not a partial answer to salvage: zipping would silently
-                // pair manifests with the wrong deployments, or drop the tail
-                // and let this daemon resolve those sources itself against a
-                // plan the peer validated differently. The reservation is
-                // already recorded above, so failing here still releases it.
-                let counts_agree = deployments.len() == response.manifests.len();
+                // The reservation is already recorded above, so a version
+                // refusal here still releases it.
                 match check_version(&core_node, &response, own_version) {
-                    Ok(()) if !counts_agree => refusals.push(format!(
-                        "`{core_node}` was asked about {} deployment(s) but answered with {} \
-                         manifest(s); the reply cannot be matched to what was asked",
-                        deployments.len(),
-                        response.manifests.len()
-                    )),
-                    // The peer answers in the order it was asked, so zipping the
-                    // requested deployments back onto the manifests is what
-                    // recovers each one's index in the coordinator's plan.
                     Ok(()) => slices.push(ParticipantSlice {
                         core_node,
                         root_instance_id: response.root_instance_id,
-                        manifests: deployments
-                            .into_iter()
-                            .map(|placed| placed.index)
-                            .zip(response.manifests)
-                            .collect(),
                     }),
                     Err(reason) => refusals.push(reason),
                 }
@@ -291,25 +245,6 @@ fn check_version(
     ))
 }
 
-fn build_reserve_request(
-    launch_id: &str,
-    coordinator: &str,
-    deployments: &[PlacedDeployment],
-) -> std::result::Result<ParticipantReserveRequest, String> {
-    let mut sources = Vec::with_capacity(deployments.len());
-    for placed in deployments {
-        let deployment = &placed.deployment;
-        if let DeploymentSource::Local(spec) = &deployment.source {
-            return Err(super::resolve::local_source_refusal(spec));
-        }
-        sources.push(
-            serde_json5::to_string(&deployment.source)
-                .map_err(|e| format!("could not encode a deployment source: {e}"))?,
-        );
-    }
-    Ok(ParticipantReserveRequest::new(launch_id, coordinator).with_deployment_sources(sources))
-}
-
 /// Best-effort release of every named participant. Failures are logged, not
 /// returned: this runs on paths that are already failing or already finished,
 /// and a release that does not land is covered by the presence lease.
@@ -356,60 +291,52 @@ pub(crate) async fn release_participants(
 pub(super) struct FederatedLaunch {
     /// Empty for a single-machine launch.
     participants: Vec<ParticipantSlice>,
-    /// Plan indices of the deployments the coordinator hosts at least one
-    /// instance of. Needed to tell a wholly-remote deployment (whose manifest is
-    /// delegated) from a straddling one (which the coordinator must resolve for
-    /// itself anyway).
-    coordinator_indices: BTreeSet<usize>,
 }
 
 /// The whole preflight, in the order the plan requires.
 ///
-/// Runs BEFORE the teardown that a launch performs, so every refusal here
-/// leaves the coordinator's existing stack, and every participant's, exactly as
-/// it was. That ordering is the feature: a launch that cannot succeed must not
-/// cost you the stack you already had.
+/// Runs AFTER this daemon resolved every deployment (so the reservations can
+/// carry the pins) and BEFORE the teardown that a launch performs, so every
+/// refusal here leaves the coordinator's existing stack, and every
+/// participant's, exactly as it was. That ordering is the feature: a launch
+/// that cannot succeed must not cost you the stack you already had.
 pub(super) async fn preflight(
     ctx: &super::ProcessLaunchContext,
     launch_id: &str,
-    deployments: &[Deployment],
+    planned: &[super::PlannedDeployment],
     placements: &Placements,
 ) -> std::result::Result<FederatedLaunch, String> {
     if !placements.is_federated() {
         return Ok(FederatedLaunch::default());
     }
 
-    let mut slices = partition_deployments(deployments, placements, ctx.bound_core_node.as_str());
-
-    // Splitting the coordinator's own share out first leaves `slices` holding
-    // exactly the peers, so each one's deployments can be moved into its
-    // reservation rather than cloned.
-    let coordinator_indices: BTreeSet<usize> = slices
-        .remove(ctx.bound_core_node.as_str())
-        .unwrap_or_default()
-        .into_iter()
-        .map(|placed| placed.index)
-        .collect();
+    let peers = partition_reservations(
+        planned.iter().map(|item| {
+            (
+                &item.deployment,
+                item.root_pin.as_ref(),
+                item.closure_pins.as_slice(),
+            )
+        }),
+        placements,
+    )?;
 
     // A wired core node is validated by live zenoh presence, not the platform
     // HTTP roster: what a launch needs is to be able to talk to the machine
     // right now, which the roster does not attest.
-    reject_unreachable_core_nodes(&ctx.messenger, &slices.keys().cloned().collect()).await?;
+    reject_unreachable_core_nodes(&ctx.messenger, &peers.keys().cloned().collect()).await?;
 
     let participants = reserve_participants(
         &ctx.messenger,
         ctx.bound_core_node.as_str(),
         ctx.core_instance_id.as_str(),
         launch_id,
-        slices,
+        peers,
         &ctx.peppy_version,
     )
     .await?;
 
-    Ok(FederatedLaunch {
-        participants,
-        coordinator_indices,
-    })
+    Ok(FederatedLaunch { participants })
 }
 
 impl FederatedLaunch {
@@ -420,32 +347,6 @@ impl FederatedLaunch {
             .iter()
             .map(|slice| slice.core_node.clone())
             .collect()
-    }
-
-    /// The manifests the coordinator will validate against instead of
-    /// resolving them itself, keyed by deployment index.
-    ///
-    /// A deployment that straddles the coordinator and a peer is deliberately
-    /// NOT delegated: the coordinator has to resolve it anyway to add it
-    /// locally, so it resolves it and [`Self::disagreeing_manifests`] then
-    /// checks that both machines read the same thing.
-    pub(super) fn delegated_manifests(&self) -> BTreeMap<usize, DelegatedManifest> {
-        let mut delegated = BTreeMap::new();
-        for slice in &self.participants {
-            for (index, manifest) in &slice.manifests {
-                if self.coordinator_indices.contains(index) {
-                    continue;
-                }
-                delegated.insert(
-                    *index,
-                    DelegatedManifest {
-                        core_node: slice.core_node.clone(),
-                        config_json5: manifest.config_json5.clone(),
-                    },
-                );
-            }
-        }
-        delegated
     }
 
     /// Instance ids in the plan that collide with a participant's own root
@@ -473,54 +374,15 @@ impl FederatedLaunch {
             })
             .collect()
     }
-
-    /// The manifest hash a participant reported for the deployment at `index`,
-    /// echoed onto every instance the coordinator dispatches to it.
-    pub(super) fn manifest_sha256(&self, core_node: &str, index: usize) -> Option<&str> {
-        self.participants
-            .iter()
-            .find(|slice| slice.core_node == core_node)?
-            .manifests
-            .get(&index)
-            .map(|manifest| manifest.config_sha256.as_str())
-    }
-
-    /// Straddling deployments whose two machines resolved DIFFERENT manifests.
-    ///
-    /// One node running on two machines under one launcher entry must be the
-    /// same node on both, or the graph the coordinator validated describes
-    /// neither. Two caches that have drifted is exactly how that happens, and
-    /// it is silent unless something compares them.
-    pub(super) fn disagreeing_manifests(
-        &self,
-        coordinator: &str,
-        own_fingerprints: &BTreeMap<usize, String>,
-    ) -> Vec<String> {
-        let mut disagreements = Vec::new();
-        for slice in &self.participants {
-            for (index, manifest) in &slice.manifests {
-                let Some(own) = own_fingerprints.get(index) else {
-                    continue;
-                };
-                if own == &manifest.config_sha256 {
-                    continue;
-                }
-                disagreements.push(format!(
-                    "one deployment places instances on both `{coordinator}` and `{}`, but the \
-                     two resolve different manifests for it ({own} here, {} there). Refresh both \
-                     machines' caches so they agree, or split the deployment.",
-                    slice.core_node, manifest.config_sha256
-                ));
-            }
-        }
-        disagreements
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use daemon_config::launcher::DeploymentInstance;
+    use daemon_config::repository::{
+        EntryOrigin, GitCommit, ItemName, ItemTag, ManifestFingerprint, PinKind, RepoRelativePath,
+    };
 
     fn instance(id: &str) -> DeploymentInstance {
         DeploymentInstance::empty(config::runtime::Name::new(id).expect("valid name"))
@@ -534,8 +396,19 @@ mod tests {
         }
     }
 
-    fn placed(index: usize, deployment: Deployment) -> PlacedDeployment {
-        PlacedDeployment { index, deployment }
+    fn pin(name: &str) -> PinnedItem {
+        PinnedItem {
+            kind: PinKind::Node,
+            name: ItemName::parse(name).expect("valid name"),
+            tag: ItemTag::parse("v1").expect("valid tag"),
+            sha256: ManifestFingerprint::parse(&"a".repeat(64)).expect("valid sha"),
+            origin: EntryOrigin::Git {
+                repo_url: "https://example.com/hub".to_owned(),
+                repo_ref: Some("main".to_owned()),
+                commit: GitCommit::parse(&"b".repeat(40)).expect("valid commit"),
+                path: RepoRelativePath::parse(&format!("{name}/peppy.json5")).expect("valid path"),
+            },
+        }
     }
 
     fn core_node(name: &str) -> daemon_config::core_node_name::CoreNodeName {
@@ -552,128 +425,106 @@ mod tests {
         )
     }
 
-    #[test]
-    fn a_single_machine_launch_partitions_onto_the_coordinator() {
-        let deployments = vec![deployment("uvc_camera", vec![instance("cam_1")])];
-        let partitioned = partition_deployments(
-            &deployments,
-            &Placements::all_on(core_node("cn-robot")),
-            "cn-robot",
-        );
-        assert_eq!(partitioned.len(), 1);
-        assert_eq!(partitioned["cn-robot"].len(), 1);
-        assert_eq!(partitioned["cn-robot"][0].index, 0);
+    fn partition<'a>(
+        items: &'a [(Deployment, Option<PinnedItem>, Vec<PinnedItem>)],
+        placements: &Placements,
+    ) -> BTreeMap<String, Vec<String>> {
+        partition_reservations(
+            items
+                .iter()
+                .map(|(deployment, root, closure)| (deployment, root.as_ref(), closure.as_slice())),
+            placements,
+        )
+        .expect("partitions")
     }
 
+    /// A single-machine launch reserves nobody: the coordinator holds no
+    /// reservation on itself, so none of the federation machinery costs
+    /// anything when nothing is placed elsewhere.
     #[test]
-    fn instances_are_partitioned_by_their_placement() {
-        let deployments = vec![
+    fn a_single_machine_launch_reserves_no_peers() {
+        let items = vec![(
             deployment("uvc_camera", vec![instance("cam_1")]),
-            deployment("planner", vec![instance("planner_1")]),
+            Some(pin("uvc_camera")),
+            Vec::new(),
+        )];
+        let partitioned = partition(&items, &Placements::all_on(core_node("cn-robot")));
+        assert!(partitioned.is_empty());
+    }
+
+    /// A peer receives the pins of exactly the deployments it hosts: the
+    /// whole closure of each, and nothing about deployments elsewhere.
+    #[test]
+    fn a_peer_is_reserved_with_the_pins_of_its_own_deployments() {
+        let items = vec![
+            (
+                deployment("uvc_camera", vec![instance("cam_1")]),
+                Some(pin("uvc_camera")),
+                Vec::new(),
+            ),
+            (
+                deployment("planner", vec![instance("planner_1")]),
+                Some(pin("planner")),
+                vec![pin("planner_dep")],
+            ),
         ];
-        let partitioned = partition_deployments(
-            &deployments,
-            &placements(&[("planner_1", "cn-atlas")]),
-            "cn-robot",
-        );
+        let partitioned = partition(&items, &placements(&[("planner_1", "cn-atlas")]));
         assert_eq!(
             partitioned.keys().cloned().collect::<Vec<_>>(),
-            ["cn-atlas", "cn-robot"]
+            ["cn-atlas"]
         );
-        assert_eq!(
-            partitioned["cn-robot"][0].deployment.instances[0]
-                .instance_id
-                .as_str(),
-            "cam_1"
-        );
-        // The index is what lets a participant's answers be matched back to
-        // the coordinator's plan, so it must survive partitioning.
-        assert_eq!(partitioned["cn-robot"][0].index, 0);
-        assert_eq!(
-            partitioned["cn-atlas"][0].deployment.instances[0]
-                .instance_id
-                .as_str(),
-            "planner_1"
-        );
-        assert_eq!(partitioned["cn-atlas"][0].index, 1);
-    }
-
-    /// One node whose instances straddle two participants is added on both,
-    /// each with only its own share of the instances. That is what makes "a
-    /// node split across daemons is several placed instances under one
-    /// deployment" work: both daemons need the node present to start theirs.
-    #[test]
-    fn a_deployment_straddling_two_daemons_lands_on_both_with_its_own_instances() {
-        let deployments = vec![deployment(
-            "uvc_camera",
-            vec![instance("cam_robot"), instance("cam_cloud")],
-        )];
-        let partitioned = partition_deployments(
-            &deployments,
-            &placements(&[("cam_cloud", "cn-atlas")]),
-            "cn-robot",
-        );
-
-        assert_eq!(partitioned["cn-robot"].len(), 1);
-        assert_eq!(partitioned["cn-robot"][0].deployment.instances.len(), 1);
-        assert_eq!(
-            partitioned["cn-robot"][0].deployment.instances[0]
-                .instance_id
-                .as_str(),
-            "cam_robot"
-        );
-
         assert_eq!(partitioned["cn-atlas"].len(), 1);
-        assert_eq!(partitioned["cn-atlas"][0].deployment.instances.len(), 1);
+        let sent = &partitioned["cn-atlas"][0];
+        assert!(sent.contains("planner"), "got: {sent}");
+        assert!(sent.contains("planner_dep"), "got: {sent}");
+        assert!(!sent.contains("uvc_camera"), "got: {sent}");
+        // What crosses the wire decodes as the same pins that were sent.
+        let decoded: DeploymentPins = serde_json5::from_str(sent).expect("round trips");
+        assert_eq!(decoded.root.name, "planner");
+        assert_eq!(decoded.closure.len(), 1);
+    }
+
+    /// A deployment whose instances straddle the coordinator and a peer
+    /// sends the peer its pins too: both machines add from one decision.
+    #[test]
+    fn a_straddling_deployment_sends_its_pins_to_the_peer_half() {
+        let items = vec![(
+            deployment(
+                "uvc_camera",
+                vec![instance("cam_robot"), instance("cam_cloud")],
+            ),
+            Some(pin("uvc_camera")),
+            Vec::new(),
+        )];
+        let partitioned = partition(&items, &placements(&[("cam_cloud", "cn-atlas")]));
         assert_eq!(
-            partitioned["cn-atlas"][0].deployment.instances[0]
-                .instance_id
-                .as_str(),
-            "cam_cloud"
+            partitioned.keys().cloned().collect::<Vec<_>>(),
+            ["cn-atlas"]
         );
-        // Both halves point at the SAME entry in the coordinator's plan, which
-        // is what makes the straddle detectable at all.
-        assert_eq!(partitioned["cn-robot"][0].index, 0);
-        assert_eq!(partitioned["cn-atlas"][0].index, 0);
+        assert_eq!(partitioned["cn-atlas"].len(), 1);
+        assert!(partitioned["cn-atlas"][0].contains("uvc_camera"));
     }
 
+    /// A host whose share is only content-addressed sources is still
+    /// reserved: the reservation guards the machine, not the pins.
     #[test]
-    fn a_local_source_placed_off_coordinator_is_refused_before_dispatch() {
-        let local = Deployment {
-            source: serde_json5::from_str(r#"{ local: "./nodes/planner" }"#)
-                .expect("valid local source"),
-            instances: vec![instance("planner_1")],
-        };
-        let error = build_reserve_request("launch-a", "cn-robot", &[placed(0, local)])
-            .expect_err("a local source cannot cross machines");
-        assert!(error.contains("names a tree on"), "got: {error}");
-        assert!(error.contains("repo or url source"), "got: {error}");
-    }
-
-    #[test]
-    fn a_host_independent_source_is_sent_verbatim_for_the_peer_to_resolve() {
-        let request = build_reserve_request(
-            "launch-a",
-            "cn-robot",
-            &[placed(
-                0,
-                deployment("deliberative_planner", vec![instance("planner_1")]),
-            )],
-        )
-        .expect("a repo source crosses machines");
-        assert_eq!(request.launch_id, "launch-a");
-        assert_eq!(request.coordinator_core_node, "cn-robot");
-        assert_eq!(request.deployment_sources_json5.len(), 1);
-        assert!(
-            request.deployment_sources_json5[0].contains("deliberative_planner"),
-            "got: {:?}",
-            request.deployment_sources_json5
+    fn a_peer_hosting_only_unpinned_deployments_is_still_reserved() {
+        let items = vec![(
+            deployment("recorder", vec![instance("rec_1")]),
+            None,
+            Vec::new(),
+        )];
+        let partitioned = partition(&items, &placements(&[("rec_1", "cn-atlas")]));
+        assert_eq!(
+            partitioned.keys().cloned().collect::<Vec<_>>(),
+            ["cn-atlas"]
         );
+        assert!(partitioned["cn-atlas"].is_empty());
     }
 
     #[test]
     fn a_version_mismatch_is_refused_and_names_both_versions() {
-        let response = ParticipantReserveResponse::accepted("v0.19.0", "gen_1", Vec::new());
+        let response = ParticipantReserveResponse::accepted("v0.19.0", "gen_1");
         let error =
             check_version("cn-atlas", &response, "v0.20.0").expect_err("skew must be refused");
         assert!(error.contains("v0.19.0"), "got: {error}");
@@ -683,132 +534,15 @@ mod tests {
 
     #[test]
     fn a_matching_version_passes() {
-        let response = ParticipantReserveResponse::accepted("v0.20.0", "gen_1", Vec::new());
+        let response = ParticipantReserveResponse::accepted("v0.20.0", "gen_1");
         assert!(check_version("cn-atlas", &response, "v0.20.0").is_ok());
     }
 
-    // --- What the coordinator does with what preflight learned ---
-
-    fn slice(core_node: &str, entries: &[(usize, &str, &str)]) -> ParticipantSlice {
+    fn slice(core_node: &str) -> ParticipantSlice {
         ParticipantSlice {
             core_node: core_node.to_owned(),
             root_instance_id: format!("{core_node}_root"),
-            manifests: entries
-                .iter()
-                .map(|(index, config, sha)| (*index, ResolvedManifest::new(*config, *sha)))
-                .collect(),
         }
-    }
-
-    /// A deployment nothing local hosts is validated against the manifest the
-    /// participant read, not one this daemon went and fetched. That is what
-    /// makes the coordinator independent of sources it does not use.
-    #[test]
-    fn a_wholly_remote_deployment_takes_its_peers_manifest() {
-        let federated = FederatedLaunch {
-            participants: vec![slice("cn-atlas", &[(1, "{ manifest: {} }", "sha-cloud")])],
-            coordinator_indices: BTreeSet::from([0]),
-        };
-
-        let delegated = federated.delegated_manifests();
-        assert_eq!(
-            delegated.len(),
-            1,
-            "only the remote deployment is delegated"
-        );
-        assert_eq!(delegated[&1].core_node, "cn-atlas");
-        assert_eq!(delegated[&1].config_json5, "{ manifest: {} }");
-        assert!(
-            !delegated.contains_key(&0),
-            "a deployment this daemon hosts must be resolved here, not taken on trust"
-        );
-    }
-
-    /// A straddling deployment is NOT delegated: the coordinator has to resolve
-    /// it anyway to add it locally, so it resolves it and the answers are then
-    /// compared.
-    #[test]
-    fn a_straddling_deployment_is_resolved_locally_rather_than_delegated() {
-        let federated = FederatedLaunch {
-            participants: vec![slice("cn-atlas", &[(0, "{ manifest: {} }", "sha-cloud")])],
-            coordinator_indices: BTreeSet::from([0]),
-        };
-        assert!(
-            federated.delegated_manifests().is_empty(),
-            "a deployment with a local half must be read locally"
-        );
-    }
-
-    /// The silent failure this check exists to stop: one launcher entry, two
-    /// machines, two caches that have drifted, and a validated graph that
-    /// describes neither of the nodes actually running.
-    #[test]
-    fn two_machines_resolving_one_node_differently_is_refused() {
-        let federated = FederatedLaunch {
-            participants: vec![slice("cn-atlas", &[(0, "{ manifest: {} }", "sha-cloud")])],
-            coordinator_indices: BTreeSet::from([0]),
-        };
-
-        let own = BTreeMap::from([(0, "sha-robot".to_owned())]);
-        let disagreements = federated.disagreeing_manifests("cn-robot", &own);
-        assert_eq!(disagreements.len(), 1);
-        assert!(
-            disagreements[0].contains("sha-robot"),
-            "got: {disagreements:?}"
-        );
-        assert!(
-            disagreements[0].contains("sha-cloud"),
-            "got: {disagreements:?}"
-        );
-        assert!(
-            disagreements[0].contains("cn-atlas"),
-            "got: {disagreements:?}"
-        );
-    }
-
-    #[test]
-    fn two_machines_resolving_one_node_identically_is_accepted() {
-        let federated = FederatedLaunch {
-            participants: vec![slice("cn-atlas", &[(0, "{ manifest: {} }", "sha-same")])],
-            coordinator_indices: BTreeSet::from([0]),
-        };
-        let own = BTreeMap::from([(0, "sha-same".to_owned())]);
-        assert!(federated.disagreeing_manifests("cn-robot", &own).is_empty());
-    }
-
-    /// A delegated deployment contributes no local fingerprint, so it must not
-    /// be compared: comparing a peer's answer against itself would pass
-    /// vacuously and make the straddle check look like it was working.
-    #[test]
-    fn a_delegated_deployment_is_not_compared_against_itself() {
-        let federated = FederatedLaunch {
-            participants: vec![slice("cn-atlas", &[(1, "{ manifest: {} }", "sha-cloud")])],
-            coordinator_indices: BTreeSet::from([0]),
-        };
-        // Index 1 is absent from the local fingerprints: this daemon never read it.
-        let own = BTreeMap::from([(0, "sha-robot".to_owned())]);
-        assert!(federated.disagreeing_manifests("cn-robot", &own).is_empty());
-    }
-
-    /// The hash echoed onto a dispatched start, which the peer re-checks
-    /// against its own cache before spawning.
-    #[test]
-    fn the_dispatched_start_pins_the_hash_its_participant_reported() {
-        let federated = FederatedLaunch {
-            participants: vec![slice(
-                "cn-atlas",
-                &[(1, "{ a: 1 }", "sha-a"), (2, "{ b: 2 }", "sha-b")],
-            )],
-            coordinator_indices: BTreeSet::new(),
-        };
-        assert_eq!(federated.manifest_sha256("cn-atlas", 2), Some("sha-b"));
-        assert_eq!(federated.manifest_sha256("cn-atlas", 1), Some("sha-a"));
-        assert_eq!(
-            federated.manifest_sha256("cn-atlas", 9),
-            None,
-            "a deployment that participant does not host pins nothing"
-        );
-        assert_eq!(federated.manifest_sha256("cn-elsewhere", 1), None);
     }
 
     /// A peer's root entity holds its instance id across launches, so it is
@@ -817,8 +551,7 @@ mod tests {
     #[test]
     fn an_instance_id_colliding_with_a_peers_root_entity_is_refused() {
         let federated = FederatedLaunch {
-            participants: vec![slice("cn-atlas", &[])],
-            coordinator_indices: BTreeSet::new(),
+            participants: vec![slice("cn-atlas")],
         };
 
         let collisions =
@@ -837,18 +570,12 @@ mod tests {
         );
     }
 
-    /// A single-machine launch has no participants, so none of this applies and
-    /// none of it costs anything.
+    /// A single-machine launch has no participants, so none of this applies
+    /// and none of it costs anything.
     #[test]
-    fn a_single_machine_launch_delegates_nothing_and_refuses_nothing() {
+    fn a_single_machine_launch_refuses_nothing() {
         let federated = FederatedLaunch::default();
         assert!(federated.core_nodes().is_empty());
-        assert!(federated.delegated_manifests().is_empty());
-        assert!(
-            federated
-                .disagreeing_manifests("cn-robot", &BTreeMap::from([(0, "sha".to_owned())]))
-                .is_empty()
-        );
         assert!(
             federated
                 .root_instance_collisions(&BTreeSet::from(["anything"]))

--- a/crates/core-node-internal/src/services/stack/launch/federated/mod.rs
+++ b/crates/core-node-internal/src/services/stack/launch/federated/mod.rs
@@ -92,14 +92,23 @@ fn partition_reservations<'a>(
             .map(|instance| placements.of(instance.instance_id.as_str()))
             .filter(|host| *host != coordinator)
             .collect();
-        for host in hosts {
-            let entry = by_core_node.entry(host.to_owned()).or_default();
-            if let Some(root) = root_pin {
+        // Built and serialized ONCE per deployment, not once per host: every
+        // host of a deployment receives the same closure, and a closure holds
+        // every dependency node plus every contract and pairing document.
+        let encoded = match root_pin.filter(|_| !hosts.is_empty()) {
+            Some(root) => {
                 let pins = DeploymentPins::new(root.clone(), closure_pins.to_vec())?;
-                entry.push(
+                Some(
                     serde_json5::to_string(&pins)
                         .map_err(|e| format!("could not encode a deployment's pins: {e}"))?,
-                );
+                )
+            }
+            None => None,
+        };
+        for host in hosts {
+            let entry = by_core_node.entry(host.to_owned()).or_default();
+            if let Some(encoded) = &encoded {
+                entry.push(encoded.clone());
             }
         }
     }
@@ -425,8 +434,8 @@ mod tests {
         )
     }
 
-    fn partition<'a>(
-        items: &'a [(Deployment, Option<PinnedItem>, Vec<PinnedItem>)],
+    fn partition(
+        items: &[(Deployment, Option<PinnedItem>, Vec<PinnedItem>)],
         placements: &Placements,
     ) -> BTreeMap<String, Vec<String>> {
         partition_reservations(

--- a/crates/core-node-internal/src/services/stack/launch/resolve.rs
+++ b/crates/core-node-internal/src/services/stack/launch/resolve.rs
@@ -308,6 +308,26 @@ pub(super) async fn resolve_deployments(
     )
     .await;
 
+    // The node index, loaded ONCE for the whole launch. Every `repo:`
+    // deployment resolves against the same one, and every materialization
+    // shares it rather than copying it, so a launch pays one read of a file
+    // that lists every node this machine's repositories publish. Loaded
+    // lazily: a launcher with no `repo:` deployment never touches it.
+    let mut node_entries: Option<Arc<Vec<repo_cache::NodeCacheEntry>>> = None;
+    if deployments
+        .iter()
+        .any(|deployment| matches!(deployment.source, DeploymentSource::Repo(_)))
+    {
+        match repo_cache::load_node_cache(&ctx.peppy_dirs) {
+            Ok(entries) => node_entries = Some(Arc::new(entries)),
+            Err(e) => {
+                let msg = format!("failed to load nodes cache: {e}");
+                publish_stderr(ctx, msg.clone(), LaunchFeedbackStep::LauncherStep).await;
+                return Err(LaunchResult::failure(&ctx.log_path, msg));
+            }
+        }
+    }
+
     let mut planned: Vec<PlannedDeployment> = Vec::new();
     let mut planning_errors: Vec<String> = Vec::new();
     let mut planned_keys: HashSet<NodeKey> = HashSet::new();
@@ -326,12 +346,26 @@ pub(super) async fn resolve_deployments(
         // `resolve_launcher_origin` uses: quiet for cached entries, a few
         // clone lines for fresh fetches, published in order either way.
         let collected = Arc::new(StdMutex::new(Vec::<String>::new()));
-        let resolved = resolve_one(ctx, &deployment, nodes_directory, placements, &collected).await;
+        let resolved = resolve_one(
+            ctx,
+            &deployment,
+            nodes_directory,
+            placements,
+            node_entries.as_ref(),
+            &collected,
+        )
+        .await;
         let captured: Vec<String> = std::mem::take(&mut *collected.lock());
         for line in captured {
             publish_stdout(ctx, line, LaunchFeedbackStep::LauncherStep).await;
         }
-        let (source, config, root_pin, closure_pins, pin_manifests) = match resolved {
+        let ResolvedDeployment {
+            source,
+            config,
+            root_pin,
+            closure_pins,
+            pin_manifests,
+        } = match resolved {
             Ok(resolved) => resolved,
             Err(err) => {
                 planning_errors.push(err);
@@ -393,17 +427,22 @@ pub(super) async fn resolve_deployments(
     Ok(planned)
 }
 
-/// What one resolved deployment contributes to the plan: the source its adds
-/// dispatch with, its manifest, the root pin when the source is pinned, the
-/// dependency-node pins of its closure, and every manifest in that closure,
-/// from which the doc pins are minted after the graph is validated.
-type ResolvedDeployment = (
-    NodeSource,
-    config::node::NodeConfig,
-    Option<PinnedItem>,
-    Vec<PinnedItem>,
-    Vec<config::node::Manifest>,
-);
+/// What one resolved deployment contributes to the plan, before its identity
+/// and doc pins are folded in. Named fields rather than a tuple: four arms
+/// build one of these and `PlannedDeployment` copies it field by field, so a
+/// pin slot that swapped with another would otherwise do so silently.
+struct ResolvedDeployment {
+    /// The source its adds dispatch with.
+    source: NodeSource,
+    config: config::node::NodeConfig,
+    /// The root pin, when the source is pinned.
+    root_pin: Option<PinnedItem>,
+    /// The dependency-node pins of its closure.
+    closure_pins: Vec<PinnedItem>,
+    /// Every manifest in that closure, from which the doc pins are minted
+    /// after the graph is validated.
+    pin_manifests: Vec<config::node::Manifest>,
+}
 
 /// Whether any instance of `deployment` is placed off this daemon, which is
 /// what obliges every pin it resolves to to be portable.
@@ -433,6 +472,7 @@ async fn resolve_one(
     deployment: &Deployment,
     nodes_directory: &Path,
     placements: &Placements,
+    node_entries: Option<&Arc<Vec<repo_cache::NodeCacheEntry>>>,
     collected: &Arc<StdMutex<Vec<String>>>,
 ) -> std::result::Result<ResolvedDeployment, String> {
     let label = deployment_label(deployment);
@@ -464,14 +504,20 @@ async fn resolve_one(
                     format!("failed to retrieve node config for deployment {label}: {e}")
                 })?;
             let manifests = vec![config.manifest.clone()];
-            Ok((source, config, None, Vec::new(), manifests))
+            Ok(ResolvedDeployment {
+                source,
+                config,
+                root_pin: None,
+                closure_pins: Vec::new(),
+                pin_manifests: manifests,
+            })
         }
         DeploymentSource::Repo(spec) => {
-            let entries = repo_cache::load_node_cache(&ctx.peppy_dirs)
-                .map_err(|e| format!("deployment {label}: failed to load nodes cache: {e}"))?;
+            let entries = node_entries
+                .expect("a repo: deployment always resolves against a loaded node index");
             let closure = pins::resolve_pinned_closure(
                 &ctx.peppy_dirs,
-                &entries,
+                entries,
                 &spec.name,
                 &spec.tag,
                 shared_feedback(),
@@ -483,18 +529,18 @@ async fn resolve_one(
             }
             let dep_pins = closure.dep_pins();
             let manifests = closure.manifests();
-            let root = closure.root();
-            let source = NodeSource::Pinned {
-                pin_json5: serde_json5::to_string(&root.pin)
-                    .map_err(|e| format!("deployment {label}: could not encode its pin: {e}"))?,
-            };
-            Ok((
+            // The closure is owned here, so the root comes out by move: its
+            // config and pin are the two largest things in it.
+            let mut nodes = closure.nodes;
+            let root = nodes.remove(0);
+            let source = pinned_source(&label, &root.pin)?;
+            Ok(ResolvedDeployment {
                 source,
-                root.config.clone(),
-                Some(root.pin.clone()),
-                dep_pins,
-                manifests,
-            ))
+                config: root.config,
+                root_pin: Some(root.pin),
+                closure_pins: dep_pins,
+                pin_manifests: manifests,
+            })
         }
         DeploymentSource::Git(spec) => {
             let root = pins::resolve_git_deployment(
@@ -509,12 +555,15 @@ async fn resolve_one(
             if remote {
                 refuse_unportable_pins(&label, std::iter::once(&root.pin))?;
             }
-            let source = NodeSource::Pinned {
-                pin_json5: serde_json5::to_string(&root.pin)
-                    .map_err(|e| format!("deployment {label}: could not encode its pin: {e}"))?,
-            };
+            let source = pinned_source(&label, &root.pin)?;
             let manifests = vec![root.config.manifest.clone()];
-            Ok((source, root.config, Some(root.pin), Vec::new(), manifests))
+            Ok(ResolvedDeployment {
+                source,
+                config: root.config,
+                root_pin: Some(root.pin),
+                closure_pins: Vec::new(),
+                pin_manifests: manifests,
+            })
         }
         DeploymentSource::Url(spec) => {
             let source = NodeSource::Http {
@@ -528,9 +577,25 @@ async fn resolve_one(
                     format!("failed to retrieve node config for deployment {label}: {e}")
                 })?;
             let manifests = vec![config.manifest.clone()];
-            Ok((source, config, None, Vec::new(), manifests))
+            Ok(ResolvedDeployment {
+                source,
+                config,
+                root_pin: None,
+                closure_pins: Vec::new(),
+                pin_manifests: manifests,
+            })
         }
     }
+}
+
+/// The add source a pinned deployment dispatches with. Shared by the `repo:`
+/// and `git:` arms so the two cannot disagree on how a root pin reaches the
+/// machine that materializes it.
+fn pinned_source(label: &str, pin: &PinnedItem) -> std::result::Result<NodeSource, String> {
+    Ok(NodeSource::Pinned {
+        pin_json5: serde_json5::to_string(pin)
+            .map_err(|e| format!("deployment {label}: could not encode its pin: {e}"))?,
+    })
 }
 
 /// Mints the contract and pairing document pins of every planned deployment,
@@ -550,27 +615,36 @@ pub(super) async fn mint_doc_pins(
     planned: &mut [PlannedDeployment],
     placements: &Placements,
 ) -> std::result::Result<(), LaunchResult> {
-    let mut problems: Vec<String> = Vec::new();
-    for item in planned.iter_mut() {
-        let label = deployment_label(&item.deployment);
-        let collected = Arc::new(StdMutex::new(Vec::<String>::new()));
-        let minted = {
-            let dirs = ctx.peppy_dirs.clone();
-            let manifests = item.pin_manifests.clone();
-            let sink = Arc::clone(&collected);
-            tokio::task::spawn_blocking(move || {
-                pins::doc_pins_for_manifests(&dirs, &manifests, &|line| {
-                    sink.lock().push(line.to_owned())
-                })
-            })
-            .await
-            .map_err(|e| format!("doc pin minting task failed: {e}"))
-            .and_then(|result| result)
-        };
-        let captured: Vec<String> = std::mem::take(&mut *collected.lock());
-        for line in captured {
-            publish_stdout(ctx, line, LaunchFeedbackStep::LauncherStep).await;
+    // Every deployment mints against ONE load of the contract and pairing
+    // caches, on one blocking thread: both are read and parsed per load, and
+    // a launch with N deployments otherwise paid N of each, sequentially, on
+    // the critical path.
+    let collected = Arc::new(StdMutex::new(Vec::<String>::new()));
+    let sets: Vec<Vec<config::node::Manifest>> = planned
+        .iter()
+        .map(|item| item.pin_manifests.clone())
+        .collect();
+    let minted = pins::doc_pins_for_manifest_sets_async(&ctx.peppy_dirs, sets, {
+        let sink = Arc::clone(&collected);
+        Arc::new(move |line: &str| sink.lock().push(line.to_owned()))
+    })
+    .await;
+    let captured: Vec<String> = std::mem::take(&mut *collected.lock());
+    for line in captured {
+        publish_stdout(ctx, line, LaunchFeedbackStep::LauncherStep).await;
+    }
+
+    let minted = match minted {
+        Ok(minted) => minted,
+        Err(reason) => {
+            publish_stderr(ctx, reason.clone(), LaunchFeedbackStep::LauncherStep).await;
+            return Err(LaunchResult::failure(&ctx.log_path, reason));
         }
+    };
+
+    let mut problems: Vec<String> = Vec::new();
+    for (item, minted) in planned.iter_mut().zip(minted) {
+        let label = deployment_label(&item.deployment);
         match minted {
             Ok(doc_pins) => {
                 if has_remote_instances(&item.deployment, placements)

--- a/crates/core-node-internal/src/services/stack/launch/resolve.rs
+++ b/crates/core-node-internal/src/services/stack/launch/resolve.rs
@@ -1,69 +1,34 @@
 use super::feedback::{publish_stderr, publish_stdout};
 use super::{NodeKey, PlannedDeployment, ProcessLaunchContext};
+use crate::services::node::pins;
 use crate::services::node::resolve_node_config;
+use crate::services::repo::cache as repo_cache;
 use core_node_api::encoding::{
     LaunchFeedbackStep, LaunchGoal, LaunchResult, LauncherOrigin, NodeSource, PlacementSpec,
 };
 use daemon_config::core_node_name::CoreNodeName;
 use daemon_config::format_quoted_list;
 use daemon_config::launcher::{Deployment, DeploymentSource, PeppyLauncherParser, Placements};
+use daemon_config::repository::PinnedItem;
 use parking_lot::Mutex as StdMutex;
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-/// Translates a deployment source into one that any daemon in the federation
-/// can fetch for itself.
-///
-/// Two things make this different from
-/// [`node_source_from_deployment_source`], and both are about not letting one
-/// machine's filesystem leak into another's instructions:
-///
-/// - `local:` is REFUSED. Its path names a tree on the coordinator, so a peer
-///   resolving it would read a different tree or nothing at all.
-/// - `repo:` stays a `(name, tag)` reference instead of being resolved through
-///   the caller's own package cache. Resolving it here would pin whatever git
-///   URL or archive THIS machine happens to have cached and hand it to another
-///   machine as fact. Left as a reference, each daemon resolves it against its
-///   own cache, which is the same cache it will spawn from.
-///
-/// Called on both sides for that reason: by the coordinator when it builds a
-/// peer's `node_add`, and by the peer when it resolves its own manifests. Same
-/// function, so the two cannot drift into disagreeing about what a source means.
-pub(crate) fn portable_node_source(
-    source: &DeploymentSource,
-) -> std::result::Result<NodeSource, String> {
-    match source {
-        DeploymentSource::Local(spec) => Err(local_source_refusal(spec)),
-        DeploymentSource::Repo(spec) => NodeSource::repo_node(&spec.name, &spec.tag)
-            .map_err(|e| format!("invalid repo node `{}:{}`: {e}", spec.name, spec.tag)),
-        DeploymentSource::Git(spec) => Ok(NodeSource::Git {
-            repo_url: git_url_from_repo(&spec.repo)?,
-            repo_path: spec.path.clone(),
-            repo_ref: Some(spec.ref_.clone()),
-        }),
-        DeploymentSource::Url(spec) => Ok(NodeSource::Http {
-            url: url::Url::parse(&spec.url)
-                .map_err(|e| format!("invalid HTTP URL `{}`: {e}", spec.url))?,
-            sha256: Some(spec.sha256.clone()),
-        }),
-    }
-}
-
 /// Why a `local:` source cannot cross a machine boundary.
 ///
-/// Stated once because two sides refuse it at different moments: the
-/// coordinator before it even asks a peer to reserve, and
-/// [`portable_node_source`] when a source is translated for a peer. The two
-/// must say the same thing, or the same misconfiguration reads as two
-/// different problems depending on where it is caught.
+/// Reads as one rule with [`pins::portable_pin_refusal`]: whether the tree a
+/// deployment resolves to sits behind a `local:` path or a filesystem
+/// repository entry, it lives on the coordinator's disk and no other machine
+/// can read it.
 pub(crate) fn local_source_refusal(
     spec: &daemon_config::launcher::DeploymentLocalSource,
 ) -> String {
     format!(
         "`local:{}` cannot be placed on another core node: the path names a tree on the \
          coordinator's filesystem. A `local:` deployment must keep all of its instances on \
-         one core node; publish the node to a repo or url source to split it across machines.",
+         one core node; publish the node to a repo or git-backed source to split it across \
+         machines.",
         spec.local.display()
     )
 }
@@ -74,30 +39,6 @@ fn deployment_label(deployment: &Deployment) -> String {
         DeploymentSource::Git(spec) => format!("git:{}@{}:{}", spec.repo, spec.ref_, spec.path),
         DeploymentSource::Url(spec) => format!("url:{}", spec.url),
         DeploymentSource::Repo(spec) => format!("repo:{}:{}", spec.name, spec.tag),
-    }
-}
-
-fn git_url_from_repo(repo: &str) -> std::result::Result<gix_url::Url, String> {
-    gix_url::Url::try_from(repo)
-        .or_else(|_| gix_url::Url::try_from(std::path::Path::new(repo)))
-        .map_err(|e| format!("invalid git repo URL `{repo}`: {e}"))
-}
-
-pub(crate) fn node_source_from_deployment_source(
-    deployment: &Deployment,
-    nodes_directory: &std::path::Path,
-) -> std::result::Result<NodeSource, String> {
-    // `local:` is the only shape whose meaning depends on which machine
-    // reads it, so it is the only one handled here; everything else comes
-    // from `portable_node_source`, which cannot then drift apart from what
-    // a peer is told the same source means.
-    match &deployment.source {
-        DeploymentSource::Local(spec) => Ok(NodeSource::Fs(if spec.local.is_absolute() {
-            spec.local.clone()
-        } else {
-            nodes_directory.join(&spec.local)
-        })),
-        portable => portable_node_source(portable),
     }
 }
 
@@ -341,17 +282,24 @@ async fn resolve_launcher_origin(
     }
 }
 
-/// Step 2: Resolve deployments - retrieve node configs for each deployment.
+/// Step 2: Resolve every deployment, once, on this daemon.
 ///
-/// A deployment placed wholly on a peer is NOT resolved here. The peer already
-/// resolved it during preflight and `delegated` carries what it read, so this
-/// daemon needs no reachability to a source it will never fetch, and the
-/// manifest it validates is provably the one that peer will spawn from.
+/// The coordinator decides which bytes the whole launch runs: a `repo:`
+/// deployment resolves its transitive closure here and every resolved item
+/// becomes a pin, a `git:` deployment pins the commit its ref resolved to,
+/// and the contract and pairing documents every manifest names are pinned
+/// beside them. Peers receive those pins and never resolve a name, so their
+/// cache freshness, repository priorities and exclusions cannot change what
+/// this launch runs.
+///
+/// Runs BEFORE the federated preflight: resolution touches no other machine
+/// and tears nothing down, so every refusal here is free, and the pins must
+/// exist before a reservation can carry them.
 pub(super) async fn resolve_deployments(
     ctx: &ProcessLaunchContext,
     deployments: Vec<Deployment>,
     nodes_directory: &Path,
-    delegated: &BTreeMap<usize, super::federated::DelegatedManifest>,
+    placements: &Placements,
 ) -> std::result::Result<Vec<PlannedDeployment>, LaunchResult> {
     publish_stdout(
         ctx,
@@ -364,7 +312,7 @@ pub(super) async fn resolve_deployments(
     let mut planning_errors: Vec<String> = Vec::new();
     let mut planned_keys: HashSet<NodeKey> = HashSet::new();
 
-    for (index, deployment) in deployments.into_iter().enumerate() {
+    for deployment in deployments {
         if deployment.instances.is_empty() {
             planning_errors.push(format!(
                 "deployment {} must have at least one instance",
@@ -373,12 +321,25 @@ pub(super) async fn resolve_deployments(
             continue;
         }
 
-        let resolved = match delegated.get(&index) {
-            Some(manifest) => adopt_delegated_manifest(ctx, &deployment, manifest).await,
-            None => resolve_here(ctx, &deployment, nodes_directory).await,
-        };
-        let (source, config, manifest_sha256) = match resolved {
+        // Resolution runs partly on blocking threads, so progress lines are
+        // buffered through a shared Vec and flushed here, the same shape
+        // `resolve_launcher_origin` uses: quiet for cached entries, a few
+        // clone lines for fresh fetches, published in order either way.
+        let collected = Arc::new(StdMutex::new(Vec::<String>::new()));
+        let resolved = resolve_one(ctx, &deployment, nodes_directory, placements, &collected).await;
+        let captured: Vec<String> = std::mem::take(&mut *collected.lock());
+        for line in captured {
+            publish_stdout(ctx, line, LaunchFeedbackStep::LauncherStep).await;
+        }
+        let (source, config, root_pin, closure_pins, pin_manifests) = match resolved {
             Ok(resolved) => resolved,
+            Err(err) => {
+                planning_errors.push(err);
+                continue;
+            }
+        };
+        let config_sha256 = match crate::services::node::manifest_fingerprint(&config) {
+            Ok(fingerprint) => fingerprint,
             Err(err) => {
                 planning_errors.push(err);
                 continue;
@@ -416,8 +377,10 @@ pub(super) async fn resolve_deployments(
             node_name,
             node_tag,
             config,
-            deployment_index: index,
-            manifest_sha256,
+            config_sha256,
+            root_pin,
+            closure_pins,
+            pin_manifests,
         });
     }
 
@@ -430,150 +393,298 @@ pub(super) async fn resolve_deployments(
     Ok(planned)
 }
 
-/// What one resolved deployment contributes to the plan: how to fetch it, what
-/// its manifest says, and this daemon's own fingerprint of that manifest (only
-/// when this daemon read it, so a straddle can be cross-checked).
-type ResolvedDeployment = (NodeSource, config::node::NodeConfig, Option<String>);
+/// What one resolved deployment contributes to the plan: the source its adds
+/// dispatch with, its manifest, the root pin when the source is pinned, the
+/// dependency-node pins of its closure, and every manifest in that closure,
+/// from which the doc pins are minted after the graph is validated.
+type ResolvedDeployment = (
+    NodeSource,
+    config::node::NodeConfig,
+    Option<PinnedItem>,
+    Vec<PinnedItem>,
+    Vec<config::node::Manifest>,
+);
 
-/// Takes a peer's resolved manifest at face value, but still derives the
-/// portable source: what the coordinator needs from it is the instruction to
-/// send back, not a path on the peer's disk.
-async fn adopt_delegated_manifest(
-    ctx: &ProcessLaunchContext,
-    deployment: &Deployment,
-    manifest: &super::federated::DelegatedManifest,
-) -> std::result::Result<ResolvedDeployment, String> {
-    publish_stdout(
-        ctx,
-        format!(
-            "Using the manifest `{}` resolved for {}",
-            manifest.core_node,
-            deployment_label(deployment)
-        ),
-        LaunchFeedbackStep::LauncherStep,
-    )
-    .await;
-
-    let config: config::node::NodeConfig =
-        serde_json5::from_str(&manifest.config_json5).map_err(|e| {
-            format!(
-                "`{}` sent an undecodable manifest for deployment {}: {e}",
-                manifest.core_node,
-                deployment_label(deployment)
-            )
-        })?;
-    let source = portable_node_source(&deployment.source)?;
-    // No local fingerprint: this daemon did not read the manifest, so it has
-    // nothing of its own to compare, and the straddle check must not compare a
-    // peer's answer against itself.
-    Ok((source, config, None))
+/// Whether any instance of `deployment` is placed off this daemon, which is
+/// what obliges every pin it resolves to to be portable.
+fn has_remote_instances(deployment: &Deployment, placements: &Placements) -> bool {
+    deployment
+        .instances
+        .iter()
+        .any(|instance| placements.of(instance.instance_id.as_str()) != placements.coordinator())
 }
 
-async fn resolve_here(
+/// Refuses any pin in `pins` that another machine could not read, for a
+/// deployment with at least one instance placed elsewhere.
+fn refuse_unportable_pins<'a>(
+    label: &str,
+    pins: impl Iterator<Item = &'a PinnedItem>,
+) -> std::result::Result<(), String> {
+    for pin in pins {
+        if let Some(reason) = pins::portable_pin_refusal(pin) {
+            return Err(format!("deployment {label}: {reason}"));
+        }
+    }
+    Ok(())
+}
+
+async fn resolve_one(
     ctx: &ProcessLaunchContext,
     deployment: &Deployment,
     nodes_directory: &Path,
+    placements: &Placements,
+    collected: &Arc<StdMutex<Vec<String>>>,
 ) -> std::result::Result<ResolvedDeployment, String> {
-    let source =
-        node_source_from_deployment_source(deployment, nodes_directory).map_err(|err| {
-            format!(
-                "failed to resolve source for deployment {}: {err}",
-                deployment_label(deployment)
-            )
-        })?;
-
+    let label = deployment_label(deployment);
     publish_stdout(
         ctx,
-        format!(
-            "Retrieving node config for {}",
-            deployment_label(deployment)
-        ),
+        format!("Retrieving node config for {label}"),
         LaunchFeedbackStep::LauncherStep,
     )
     .await;
+    let remote = has_remote_instances(deployment, placements);
+    let shared_feedback = || -> crate::services::node::cache::MaterializeFeedback {
+        let sink = Arc::clone(collected);
+        Arc::new(move |line: &str| sink.lock().push(line.to_owned()))
+    };
 
-    let config = resolve_node_config(source.clone(), &ctx.peppy_dirs)
-        .await
-        .map_err(|err| {
-            format!(
-                "failed to retrieve node config for deployment {}: {err}",
-                deployment_label(deployment)
+    match &deployment.source {
+        DeploymentSource::Local(spec) => {
+            if remote {
+                return Err(local_source_refusal(spec));
+            }
+            let source = NodeSource::Fs(if spec.local.is_absolute() {
+                spec.local.clone()
+            } else {
+                nodes_directory.join(&spec.local)
+            });
+            let config = resolve_node_config(source.clone(), &ctx.peppy_dirs)
+                .await
+                .map_err(|e| {
+                    format!("failed to retrieve node config for deployment {label}: {e}")
+                })?;
+            let manifests = vec![config.manifest.clone()];
+            Ok((source, config, None, Vec::new(), manifests))
+        }
+        DeploymentSource::Repo(spec) => {
+            let entries = repo_cache::load_node_cache(&ctx.peppy_dirs)
+                .map_err(|e| format!("deployment {label}: failed to load nodes cache: {e}"))?;
+            let closure = pins::resolve_pinned_closure(
+                &ctx.peppy_dirs,
+                &entries,
+                &spec.name,
+                &spec.tag,
+                shared_feedback(),
             )
-        })?;
-    let fingerprint = crate::services::node::manifest_fingerprint(&config)?;
-    Ok((source, config, Some(fingerprint)))
+            .await
+            .map_err(|e| format!("deployment {label}: {e}"))?;
+            if remote {
+                refuse_unportable_pins(&label, closure.nodes.iter().map(|node| &node.pin))?;
+            }
+            let dep_pins = closure.dep_pins();
+            let manifests = closure.manifests();
+            let root = closure.root();
+            let source = NodeSource::Pinned {
+                pin_json5: serde_json5::to_string(&root.pin)
+                    .map_err(|e| format!("deployment {label}: could not encode its pin: {e}"))?,
+            };
+            Ok((
+                source,
+                root.config.clone(),
+                Some(root.pin.clone()),
+                dep_pins,
+                manifests,
+            ))
+        }
+        DeploymentSource::Git(spec) => {
+            let root = pins::resolve_git_deployment(
+                &ctx.peppy_dirs,
+                &spec.repo,
+                &spec.path,
+                Some(spec.ref_.as_str()),
+                shared_feedback(),
+            )
+            .await
+            .map_err(|e| format!("deployment {label}: {e}"))?;
+            if remote {
+                refuse_unportable_pins(&label, std::iter::once(&root.pin))?;
+            }
+            let source = NodeSource::Pinned {
+                pin_json5: serde_json5::to_string(&root.pin)
+                    .map_err(|e| format!("deployment {label}: could not encode its pin: {e}"))?,
+            };
+            let manifests = vec![root.config.manifest.clone()];
+            Ok((source, root.config, Some(root.pin), Vec::new(), manifests))
+        }
+        DeploymentSource::Url(spec) => {
+            let source = NodeSource::Http {
+                url: url::Url::parse(&spec.url)
+                    .map_err(|e| format!("invalid HTTP URL `{}`: {e}", spec.url))?,
+                sha256: Some(spec.sha256.clone()),
+            };
+            let config = resolve_node_config(source.clone(), &ctx.peppy_dirs)
+                .await
+                .map_err(|e| {
+                    format!("failed to retrieve node config for deployment {label}: {e}")
+                })?;
+            let manifests = vec![config.manifest.clone()];
+            Ok((source, config, None, Vec::new(), manifests))
+        }
+    }
+}
+
+/// Mints the contract and pairing document pins of every planned deployment,
+/// after the graph validation has run.
+///
+/// Deliberately a separate step from node resolution: the graph refusals
+/// (an unimplemented binding, an uncovered pairing slot) point at the
+/// launcher and the manifests, and are the more actionable ones when a
+/// document is also missing from this machine's caches. Minting after them
+/// keeps that precedence while still landing every doc refusal before any
+/// machine is reserved or torn down.
+///
+/// The pins land on each deployment's `closure_pins`, beside its
+/// dependency-node pins, so every add of the deployment carries them.
+pub(super) async fn mint_doc_pins(
+    ctx: &ProcessLaunchContext,
+    planned: &mut [PlannedDeployment],
+    placements: &Placements,
+) -> std::result::Result<(), LaunchResult> {
+    let mut problems: Vec<String> = Vec::new();
+    for item in planned.iter_mut() {
+        let label = deployment_label(&item.deployment);
+        let collected = Arc::new(StdMutex::new(Vec::<String>::new()));
+        let minted = {
+            let dirs = ctx.peppy_dirs.clone();
+            let manifests = item.pin_manifests.clone();
+            let sink = Arc::clone(&collected);
+            tokio::task::spawn_blocking(move || {
+                pins::doc_pins_for_manifests(&dirs, &manifests, &|line| {
+                    sink.lock().push(line.to_owned())
+                })
+            })
+            .await
+            .map_err(|e| format!("doc pin minting task failed: {e}"))
+            .and_then(|result| result)
+        };
+        let captured: Vec<String> = std::mem::take(&mut *collected.lock());
+        for line in captured {
+            publish_stdout(ctx, line, LaunchFeedbackStep::LauncherStep).await;
+        }
+        match minted {
+            Ok(doc_pins) => {
+                if has_remote_instances(&item.deployment, placements)
+                    && let Err(reason) = refuse_unportable_pins(&label, doc_pins.iter())
+                {
+                    problems.push(reason);
+                    continue;
+                }
+                item.closure_pins.extend(doc_pins);
+            }
+            Err(reason) => problems.push(format!("deployment {label}: {reason}")),
+        }
+    }
+    if !problems.is_empty() {
+        let msg = daemon_config::format_bulleted(&problems);
+        publish_stderr(ctx, msg.clone(), LaunchFeedbackStep::LauncherStep).await;
+        return Err(LaunchResult::failure(&ctx.log_path, msg));
+    }
+    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use daemon_config::launcher::DeploymentInstance;
+    use daemon_config::repository::{
+        EntryOrigin, GitCommit, ItemName, ItemTag, ManifestFingerprint, PinKind, RepoRelativePath,
+    };
 
     fn source(json5: &str) -> DeploymentSource {
         serde_json5::from_str(json5).expect("valid deployment source")
     }
 
-    /// The hazard this exists to avoid: resolving `repo:` through the caller's
-    /// own package cache would pin whatever git URL THIS machine happens to
-    /// have cached and hand it to another machine as fact. Left as a reference,
-    /// each daemon resolves it against the cache it will actually spawn from.
-    #[test]
-    fn a_repo_source_crosses_machines_as_a_reference_not_a_resolved_url() {
-        let resolved = portable_node_source(&source(r#"{ name: "planner", tag: "v1" }"#))
-            .expect("a repo source is portable");
-        assert_eq!(
-            resolved,
-            NodeSource::RepoNode {
-                name: "planner".to_owned(),
-                tag: "v1".to_owned(),
-            }
-        );
+    fn deployment(source_json5: &str, instance_ids: &[&str]) -> Deployment {
+        Deployment {
+            source: source(source_json5),
+            instances: instance_ids
+                .iter()
+                .map(|id| {
+                    DeploymentInstance::empty(config::runtime::Name::new(*id).expect("valid name"))
+                })
+                .collect(),
+        }
     }
 
+    fn placed(pairs: &[(&str, &str)]) -> Placements {
+        Placements::new(
+            core_node("cn-robot"),
+            pairs
+                .iter()
+                .map(|(id, target)| ((*id).to_owned(), core_node(target)))
+                .collect(),
+        )
+    }
+
+    fn test_pin(origin: EntryOrigin) -> PinnedItem {
+        PinnedItem {
+            kind: PinKind::Node,
+            name: ItemName::parse("planner").expect("valid name"),
+            tag: ItemTag::parse("v1").expect("valid tag"),
+            sha256: ManifestFingerprint::parse(&"a".repeat(64)).expect("valid sha"),
+            origin,
+        }
+    }
+
+    /// A deployment with every instance on the coordinator obliges its pins
+    /// to nothing; one with any instance elsewhere obliges every pin it
+    /// resolves to to be readable off this machine.
     #[test]
-    fn git_and_url_sources_name_the_same_bytes_from_any_machine() {
-        assert!(matches!(
-            portable_node_source(&source(
-                r#"{ repo: "https://example.com/r.git", ref: "main", path: "nodes/a" }"#
-            )),
-            Ok(NodeSource::Git { .. })
-        ));
-        assert!(matches!(
-            portable_node_source(&source(
-                r#"{ url: "https://example.com/a.tar.zst", sha256: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" }"#
-            )),
-            Ok(NodeSource::Http { .. })
-        ));
+    fn only_off_coordinator_instances_oblige_portable_pins() {
+        let local_only = deployment(r#"{ name: "planner", tag: "v1" }"#, &["planner_1"]);
+        let placements = placed(&[("cam_cloud", "cn-atlas")]);
+        assert!(!has_remote_instances(&local_only, &placements));
+
+        let split = deployment(
+            r#"{ name: "planner", tag: "v1" }"#,
+            &["planner_1", "cam_cloud"],
+        );
+        assert!(has_remote_instances(&split, &placements));
+    }
+
+    /// The refusal the portability rule produces: a filesystem repository
+    /// entry behind an off-coordinator placement names a tree only this
+    /// machine can read, exactly like a `local:` source, and the message
+    /// says what still works.
+    #[test]
+    fn a_filesystem_backed_pin_is_refused_for_a_remote_placement() {
+        let fs_pin = test_pin(EntryOrigin::Fs {
+            path: "/repo/planner/peppy.json5".into(),
+        });
+        let error = refuse_unportable_pins("repo:planner:v1", std::iter::once(&fs_pin))
+            .expect_err("a filesystem origin cannot cross machines");
+        assert!(error.contains("coordinator's filesystem"), "got: {error}");
+        assert!(error.contains("git repository"), "got: {error}");
+
+        let git_pin = test_pin(EntryOrigin::Git {
+            repo_url: "https://example.com/hub".to_owned(),
+            repo_ref: Some("main".to_owned()),
+            commit: GitCommit::parse(&"b".repeat(40)).expect("valid commit"),
+            path: RepoRelativePath::parse("planner/peppy.json5").expect("valid path"),
+        });
+        assert!(refuse_unportable_pins("repo:planner:v1", std::iter::once(&git_pin)).is_ok());
     }
 
     /// A path names a tree on the coordinator's disk, so a peer resolving it
     /// would read a different tree or nothing at all.
     #[test]
-    fn a_local_source_is_refused_rather_than_translated() {
-        let error = portable_node_source(&source(r#"{ local: "./nodes/planner" }"#))
-            .expect_err("a local path cannot cross machines");
+    fn the_local_source_refusal_names_the_tree_and_the_way_out() {
+        let DeploymentSource::Local(spec) = source(r#"{ local: "./nodes/planner" }"#) else {
+            panic!("expected a local source");
+        };
+        let error = local_source_refusal(&spec);
         assert!(error.contains("names a tree on"), "got: {error}");
-        assert!(error.contains("repo or url source"), "got: {error}");
-    }
-
-    /// The local resolver and the portable one must not drift apart on what a
-    /// host-independent source means, which is why the former delegates to the
-    /// latter for exactly those shapes.
-    #[test]
-    fn the_local_resolver_agrees_with_the_portable_one_on_host_independent_sources() {
-        for json5 in [
-            r#"{ repo: "https://example.com/r.git", ref: "main", path: "nodes/a" }"#,
-            r#"{ url: "https://example.com/a.tar.zst", sha256: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" }"#,
-        ] {
-            let deployment = Deployment {
-                source: source(json5),
-                instances: Vec::new(),
-            };
-            let local =
-                node_source_from_deployment_source(&deployment, std::path::Path::new("/nodes"))
-                    .expect("resolvable locally");
-            let portable = portable_node_source(&deployment.source).expect("portable");
-            assert_eq!(local, portable, "for {json5}");
-        }
+        assert!(error.contains("repo or git-backed source"), "got: {error}");
     }
 
     // --- Placement: binding a launcher's declared links to real machines ---

--- a/crates/core-node-internal/tests/common/actions.rs
+++ b/crates/core-node-internal/tests/common/actions.rs
@@ -40,7 +40,7 @@ pub enum NodeAddSource<'a> {
     },
     /// Add a node by `(name, tag)` against the repo cache; the daemon
     /// resolves transitive deps from `~/.peppy/cache/nodes.json5`.
-    RepoNode { name: &'a str, tag: &'a str },
+    ResolveRef { name: &'a str, tag: &'a str },
 }
 
 impl<'a> From<&'a Path> for NodeAddSource<'a> {
@@ -407,9 +407,9 @@ async fn send_node_add_and_wait_internal<'a>(
             TEST_GIT_HASH,
             result_timeout.as_secs(),
         ),
-        NodeAddSource::RepoNode { name, tag } => {
-            let src = NodeSource::repo_node(*name, *tag)
-                .map_err(|e| format!("invalid repo-node source in test: {e}"))?;
+        NodeAddSource::ResolveRef { name, tag } => {
+            let src = NodeSource::resolve_ref(*name, *tag)
+                .map_err(|e| format!("invalid resolve-ref source in test: {e}"))?;
             NodeAddGoal::from_source(src, TEST_GIT_HASH, result_timeout.as_secs())
         }
     }

--- a/crates/core-node-internal/tests/common/fixtures.rs
+++ b/crates/core-node-internal/tests/common/fixtures.rs
@@ -148,12 +148,20 @@ impl TestPackagesCache {
     /// `absolute_path` is the directory containing `peppy.json5`. The
     /// cache stores the manifest file path (path-points-at-file
     /// convention), so we join `NODE_CONFIG_FILE` here.
+    ///
+    /// The fingerprint is computed from the file when it exists, because a
+    /// pinned add verifies the bytes it materializes against the entry's
+    /// fingerprint; a fixture whose file is written later (or never, for a
+    /// lookup-only test) records a seeded one instead.
     pub fn fs_entry(mut self, name: &str, tag: &str, absolute_path: impl AsRef<Path>) -> Self {
         let manifest_path = absolute_path.as_ref().join(NODE_CONFIG_FILE);
+        let sha256 = std::fs::read(&manifest_path)
+            .map(|bytes| config::fingerprint::fingerprint_for_bytes(&bytes))
+            .unwrap_or_else(|_| seeded_sha(&format!("{name}:{tag}")));
         self.entries.push(serde_json::json!({
             "node_name": name,
             "node_tag": tag,
-            "sha256": seeded_sha(&format!("{name}:{tag}")),
+            "sha256": sha256,
             "origin": fs_origin(&manifest_path),
         }));
         self

--- a/crates/core-node-internal/tests/listen_for_node_add/failures.rs
+++ b/crates/core-node-internal/tests/listen_for_node_add/failures.rs
@@ -10,7 +10,7 @@ async fn repo_node_add_fails_when_packages_cache_missing() {
     let res = send_node_add_and_wait(
         &started.caller_handle,
         &started.core_node_name,
-        NodeAddSource::RepoNode {
+        NodeAddSource::ResolveRef {
             name: "ghost",
             tag: "v1",
         },
@@ -49,7 +49,7 @@ async fn repo_node_add_fails_when_root_node_unknown() {
     let res = send_node_add_and_wait(
         &started.caller_handle,
         &started.core_node_name,
-        NodeAddSource::RepoNode {
+        NodeAddSource::ResolveRef {
             name: "ghost",
             tag: "v1",
         },
@@ -89,7 +89,7 @@ async fn repo_node_add_fails_when_dep_missing_in_cache() {
     let res = send_node_add_and_wait(
         &started.caller_handle,
         &started.core_node_name,
-        NodeAddSource::RepoNode {
+        NodeAddSource::ResolveRef {
             name: "target",
             tag: "v1",
         },
@@ -128,7 +128,7 @@ async fn repo_node_add_fails_on_cycle() {
     let res = send_node_add_and_wait(
         &started.caller_handle,
         &started.core_node_name,
-        NodeAddSource::RepoNode {
+        NodeAddSource::ResolveRef {
             name: "a",
             tag: "v1",
         },
@@ -176,7 +176,7 @@ async fn repo_node_add_rolls_back_on_mid_batch_failure() {
     let res = send_node_add_and_wait(
         &started.caller_handle,
         &started.core_node_name,
-        NodeAddSource::RepoNode {
+        NodeAddSource::ResolveRef {
             name: "a",
             tag: "v1",
         },

--- a/crates/core-node-internal/tests/listen_for_node_add/repo_sources.rs
+++ b/crates/core-node-internal/tests/listen_for_node_add/repo_sources.rs
@@ -18,7 +18,7 @@ async fn repo_node_add_single_no_deps_fs_source() {
     let res = send_node_add_and_wait(
         &started.caller_handle,
         &started.core_node_name,
-        NodeAddSource::RepoNode {
+        NodeAddSource::ResolveRef {
             name: "standalone",
             tag: "v1",
         },
@@ -61,7 +61,7 @@ async fn repo_node_add_chain_of_three_fs() {
     let res = send_node_add_and_wait(
         &started.caller_handle,
         &started.core_node_name,
-        NodeAddSource::RepoNode {
+        NodeAddSource::ResolveRef {
             name: "c",
             tag: "v1",
         },
@@ -117,7 +117,7 @@ async fn repo_node_add_diamond() {
     let res = send_node_add_and_wait(
         &started.caller_handle,
         &started.core_node_name,
-        NodeAddSource::RepoNode {
+        NodeAddSource::ResolveRef {
             name: "d",
             tag: "v1",
         },
@@ -183,7 +183,7 @@ async fn repo_node_add_partial_stack_coverage() {
     let res = send_node_add_and_wait(
         &started.caller_handle,
         &started.core_node_name,
-        NodeAddSource::RepoNode {
+        NodeAddSource::ResolveRef {
             name: "a",
             tag: "v1",
         },
@@ -238,7 +238,7 @@ async fn repo_node_add_preserves_built_unchanged_dependency() {
     let pre = send_node_add_and_wait(
         &started.caller_handle,
         &started.core_node_name,
-        NodeAddSource::RepoNode {
+        NodeAddSource::ResolveRef {
             name: "dep",
             tag: "v1",
         },
@@ -259,7 +259,7 @@ async fn repo_node_add_preserves_built_unchanged_dependency() {
     let res = send_node_add_and_wait(
         &started.caller_handle,
         &started.core_node_name,
-        NodeAddSource::RepoNode {
+        NodeAddSource::ResolveRef {
             name: "top",
             tag: "v1",
         },
@@ -335,7 +335,7 @@ async fn repo_node_add_does_not_materialize_nodes_outside_declared_tree() {
     let res = send_node_add_and_wait(
         &started.caller_handle,
         &started.core_node_name,
-        NodeAddSource::RepoNode {
+        NodeAddSource::ResolveRef {
             name: "a",
             tag: "v1",
         },
@@ -431,7 +431,7 @@ async fn repo_node_add_deep_mixed_tree_stack_and_cache_at_multiple_levels() {
     let res = send_node_add_and_wait(
         &started.caller_handle,
         &started.core_node_name,
-        NodeAddSource::RepoNode {
+        NodeAddSource::ResolveRef {
             name: "a",
             tag: "v1",
         },

--- a/crates/daemon-config-internal/src/launcher/types.rs
+++ b/crates/daemon-config-internal/src/launcher/types.rs
@@ -1161,6 +1161,12 @@ impl Placements {
             .as_str()
     }
 
+    /// The daemon the launch was sent to, which is where an instance that
+    /// declared no `core_node` runs.
+    pub fn coordinator(&self) -> &str {
+        self.coordinator.as_str()
+    }
+
     /// Whether any instance is placed off the coordinator, i.e. whether this
     /// launch actually spans machines.
     pub fn is_federated(&self) -> bool {

--- a/crates/daemon-config-internal/src/lib.rs
+++ b/crates/daemon-config-internal/src/lib.rs
@@ -112,9 +112,10 @@ pub mod pairing {
 // -- repository --
 pub mod repository {
     pub use crate::internal::repository::{
-        DeclaredItem, DeclaredPaths, GitCommit, GitCommitError, IndexedItem, ItemName, ItemTag,
-        ManifestFingerprint, ManifestFingerprintError, PeppyRepositoryIndexParser, RepoItemKind,
-        RepoPathError, RepoRelativePath, RepositoryIndex, TaggedSection, UniqueMap,
+        DeclaredItem, DeclaredPaths, DeploymentPins, EntryOrigin, GitCommit, GitCommitError,
+        IndexedItem, ItemName, ItemTag, ManifestFingerprint, ManifestFingerprintError,
+        PeppyRepositoryIndexParser, PinKind, PinnedItem, RepoItemKind, RepoPathError,
+        RepoRelativePath, RepositoryIndex, TaggedSection, UniqueMap,
     };
 }
 

--- a/crates/daemon-config-internal/src/repository.rs
+++ b/crates/daemon-config-internal/src/repository.rs
@@ -1,8 +1,13 @@
+mod origin;
 mod parse;
+mod pins;
 mod types;
 
 pub use core_node_api::encoding::RepoItemKind;
 
+// Where an item's bytes live and which revision they were read at, shared by
+// the repo cache entries and the launch pins so the two cannot drift.
+pub use origin::EntryOrigin;
 // Defines the repository index (`peppy_schema: "repository/v1"`), the
 // `peppy_repository.json5` document at the root of the tree peppy scans.
 // A repository states there what it publishes and where each item is
@@ -10,6 +15,10 @@ pub use core_node_api::encoding::RepoItemKind;
 // against the tree. The nesting is the uniqueness rule: a second claim on one
 // identity has nowhere to go except a key that is already taken.
 pub use parse::PeppyRepositoryIndexParser;
+// The pin model a launch coordinator ships to every daemon in a launch: the
+// fingerprint of the bytes to run plus the origin any machine can read them
+// from. Decoding a pin is the receiving side's structural validation.
+pub use pins::{DeploymentPins, PinKind, PinnedItem};
 pub use types::{
     DeclaredItem, DeclaredPaths, GitCommit, GitCommitError, IndexedItem, ItemName, ItemTag,
     ManifestFingerprint, ManifestFingerprintError, RepoPathError, RepoRelativePath,

--- a/crates/daemon-config-internal/src/repository/origin.rs
+++ b/crates/daemon-config-internal/src/repository/origin.rs
@@ -1,0 +1,116 @@
+//! Where a cached or pinned item's bytes live, and which revision they were
+//! read at.
+//!
+//! One vocabulary for two consumers: the repo caches record an origin per
+//! entry, and a launch pin carries one to every daemon in the launch. Sharing
+//! the type is what keeps "what a cache knows" and "what a coordinator ships"
+//! from drifting apart.
+
+use super::types::{GitCommit, RepoRelativePath};
+use core_node_api::encoding::RepoSourceKind;
+use std::path::PathBuf;
+
+/// Where an item's bytes live, and which revision they were read at.
+///
+/// A branch name is not a revision: two machines following `main` a week
+/// apart hold different trees while recording the same string. The commit
+/// is what makes an entry mean one set of bytes rather than "whatever that
+/// branch pointed at when this machine last looked".
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "source_type", rename_all = "lowercase")]
+pub enum EntryOrigin {
+    /// A tree on this machine. Nothing off this machine can read it, which
+    /// is why a deployment placed on another core node cannot be backed by
+    /// one.
+    Fs {
+        /// Absolute path to the file that declares the item.
+        path: PathBuf,
+    },
+    Git {
+        repo_url: String,
+        /// The ref the repository is configured to follow, absent when it
+        /// follows whatever the remote's default branch is. Kept beside the
+        /// commit because a fetch starts from a ref before it can reach a
+        /// commit, and because `entry_belongs_to_repo` attributes an entry
+        /// to its configured repository by url and ref.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        repo_ref: Option<String>,
+        /// The commit the tree was read at.
+        commit: GitCommit,
+        /// Path within the repository to the file that declares the item.
+        path: RepoRelativePath,
+    },
+}
+
+impl EntryOrigin {
+    pub fn kind(&self) -> RepoSourceKind {
+        match self {
+            EntryOrigin::Fs { .. } => RepoSourceKind::Fs,
+            EntryOrigin::Git { .. } => RepoSourceKind::Git,
+        }
+    }
+
+    /// The path as the cache spells it: absolute for fs, repository-relative
+    /// for git. What error messages quote and what repository attribution
+    /// matches against.
+    pub fn path_str(&self) -> &str {
+        match self {
+            // A path that is not valid UTF-8 renders lossily rather than
+            // failing the whole cache: this is display and attribution, and
+            // a lossy rendering still names the file the user has to look at.
+            EntryOrigin::Fs { path } => path.to_str().unwrap_or("<non-UTF-8 path>"),
+            EntryOrigin::Git { path, .. } => path.as_str(),
+        }
+    }
+
+    /// The `(repo_url, commit)` this origin resolves through the checkout
+    /// cache, and `None` for a filesystem origin, which resolves in place.
+    ///
+    /// The one statement of what keeps a cached checkout reachable, so
+    /// pruning them cannot go looking in a different place than resolution
+    /// does.
+    pub fn checkout(&self) -> Option<(&str, &GitCommit)> {
+        match self {
+            EntryOrigin::Fs { .. } => None,
+            EntryOrigin::Git {
+                repo_url, commit, ..
+            } => Some((repo_url, commit)),
+        }
+    }
+
+    /// Whether resolving this origin to an on-disk path can block on the
+    /// network: a git origin may clone or fetch, while a filesystem origin
+    /// already names a file on this machine. Callers inside tokio use it to
+    /// decide whether resolution needs [`tokio::task::spawn_blocking`].
+    pub fn resolution_may_block(&self) -> bool {
+        self.checkout().is_some()
+    }
+
+    /// The remote a git origin was read from. `None` for a filesystem
+    /// origin, which has no remote.
+    pub fn repo_url(&self) -> Option<&str> {
+        match self {
+            EntryOrigin::Fs { .. } => None,
+            EntryOrigin::Git { repo_url, .. } => Some(repo_url),
+        }
+    }
+
+    /// The ref a git origin is configured to follow. `None` for a
+    /// filesystem origin, and for a git origin that follows the remote's
+    /// default branch.
+    pub fn repo_ref(&self) -> Option<&str> {
+        match self {
+            EntryOrigin::Fs { .. } => None,
+            EntryOrigin::Git { repo_ref, .. } => repo_ref.as_deref(),
+        }
+    }
+
+    /// The commit a git origin was read at. `None` for a filesystem
+    /// origin, which has no revision to record.
+    pub fn commit(&self) -> Option<&GitCommit> {
+        match self {
+            EntryOrigin::Fs { .. } => None,
+            EntryOrigin::Git { commit, .. } => Some(commit),
+        }
+    }
+}

--- a/crates/daemon-config-internal/src/repository/pins.rs
+++ b/crates/daemon-config-internal/src/repository/pins.rs
@@ -95,6 +95,24 @@ impl DeploymentPins {
                 root.label()
             ));
         }
+        // One identity, one content. The minting side already refuses a
+        // closure that needs `name:tag` at two different fingerprints; stating
+        // it here too means a document that arrived over the wire cannot carry
+        // an ambiguity the adds would resolve by whichever pin they read
+        // first. Repeated identical pins are fine: they are the same bytes.
+        for (index, pin) in closure.iter().enumerate() {
+            if let Some(other) = closure[..index].iter().find(|other| {
+                other.kind == pin.kind && other.name == pin.name && other.tag == pin.tag
+            }) && other.sha256 != pin.sha256
+            {
+                return Err(format!(
+                    "{} is pinned at two different contents in one closure (`{}` and `{}`)",
+                    pin.label(),
+                    other.sha256,
+                    pin.sha256
+                ));
+            }
+        }
         Ok(Self { root, closure })
     }
 

--- a/crates/daemon-config-internal/src/repository/pins.rs
+++ b/crates/daemon-config-internal/src/repository/pins.rs
@@ -1,0 +1,294 @@
+//! The pin model a launch coordinator ships to every daemon in a launch.
+//!
+//! A pin states which bytes to run and where they can be read: the
+//! fingerprint of the declaring file, plus the [`EntryOrigin`] the
+//! coordinator resolved it from. A daemon holding content with the same
+//! fingerprint reuses its own copy whatever repository it arrived from; one
+//! that does not fetches the pinned commit. Nothing on the receiving side
+//! resolves a name, so a machine's own cache freshness, repository
+//! priorities and exclusions never influence a launch it participates in.
+//!
+//! A git origin is a fact about a shared repository that any machine can
+//! fetch. A filesystem origin names a tree on the machine that minted the
+//! pin, so it is valid only for that machine's own in-process adds; a pin
+//! that crosses a machine boundary must carry a git origin, and the
+//! receiving side refuses one that does not.
+//!
+//! Every field is a validating newtype, so serde-decoding a pin that crossed
+//! a machine boundary IS the receiving side's structural validation: a
+//! traversal path, a truncated commit or a malformed fingerprint fails at
+//! decode, before any filesystem or network is touched.
+
+use super::origin::EntryOrigin;
+use super::types::{ItemName, ItemTag, ManifestFingerprint};
+use serde::{Deserialize, Serialize, de};
+use std::fmt;
+
+/// Which section of a repository index a pinned identity lives in.
+///
+/// Launchers are absent on purpose: a launcher document is read once, by the
+/// coordinator, and never crosses a machine boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PinKind {
+    Node,
+    Contract,
+    Pairing,
+}
+
+impl fmt::Display for PinKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Node => "node",
+            Self::Contract => "contract",
+            Self::Pairing => "pairing",
+        })
+    }
+}
+
+/// One pinned identity: what it is called, which bytes it is, and where to
+/// read them.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PinnedItem {
+    pub kind: PinKind,
+    pub name: ItemName,
+    pub tag: ItemTag,
+    /// Fingerprint of the declaring file's bytes. Content is what authorises
+    /// reuse: a daemon holding these bytes under any identity or repository
+    /// uses its own copy and never fetches.
+    pub sha256: ManifestFingerprint,
+    /// Where the coordinator read the bytes, in the same vocabulary the
+    /// repo caches record: the remote, the exact commit, and the path the
+    /// repository's index declares for the identity.
+    pub origin: EntryOrigin,
+}
+
+impl PinnedItem {
+    /// How refusals name a pin: `node camera:v1`.
+    pub fn label(&self) -> String {
+        format!("{} `{}:{}`", self.kind, self.name, self.tag)
+    }
+}
+
+/// Everything one deployment runs: the root node the launcher names and the
+/// closure the coordinator resolved underneath it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DeploymentPins {
+    /// The node the deployment names. Always [`PinKind::Node`], enforced at
+    /// decode: a document whose root is a contract describes no deployment,
+    /// and refusing it at the boundary beats tripping over it mid-add.
+    pub root: PinnedItem,
+    /// Every transitive node dependency of the root, and every contract and
+    /// pairing document any manifest in the deployment names. A daemon adds
+    /// from this list alone; an identity missing from it is a refusal, not a
+    /// lookup.
+    pub closure: Vec<PinnedItem>,
+}
+
+impl DeploymentPins {
+    pub fn new(root: PinnedItem, closure: Vec<PinnedItem>) -> Result<Self, String> {
+        if root.kind != PinKind::Node {
+            return Err(format!(
+                "a deployment's root pin must be a node, got {}",
+                root.label()
+            ));
+        }
+        Ok(Self { root, closure })
+    }
+
+    /// The root and its closure, root first.
+    pub fn items(&self) -> impl Iterator<Item = &PinnedItem> {
+        std::iter::once(&self.root).chain(self.closure.iter())
+    }
+}
+
+impl<'de> Deserialize<'de> for DeploymentPins {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        /// The same shape without the root-kind rule, so the rule lives in
+        /// [`DeploymentPins::new`] and decoding cannot bypass it.
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct Raw {
+            root: PinnedItem,
+            #[serde(default)]
+            closure: Vec<PinnedItem>,
+        }
+
+        let raw = Raw::deserialize(deserializer)?;
+        Self::new(raw.root, raw.closure).map_err(de::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::internal::repository::types::GitCommit;
+    use crate::internal::repository::types::RepoRelativePath;
+
+    fn pin(kind: PinKind, name: &str, tag: &str) -> PinnedItem {
+        PinnedItem {
+            kind,
+            name: ItemName::parse(name).expect("valid name"),
+            tag: ItemTag::parse(tag).expect("valid tag"),
+            sha256: ManifestFingerprint::parse(&"a".repeat(64)).expect("valid sha"),
+            origin: EntryOrigin::Git {
+                repo_url: "https://github.com/acme/nodes-hub".to_owned(),
+                repo_ref: Some("main".to_owned()),
+                commit: GitCommit::parse(&"b".repeat(40)).expect("valid commit"),
+                path: RepoRelativePath::parse("camera/peppy.json5").expect("valid path"),
+            },
+        }
+    }
+
+    #[test]
+    fn deployment_pins_round_trip_through_json5() {
+        let pins = DeploymentPins::new(
+            pin(PinKind::Node, "camera", "v1"),
+            vec![
+                pin(PinKind::Node, "driver", "v2"),
+                pin(PinKind::Contract, "frames", "v1"),
+                pin(PinKind::Pairing, "joint_link", "v1"),
+            ],
+        )
+        .expect("a node root");
+        let encoded = serde_json5::to_string(&pins).expect("serialize");
+        let decoded: DeploymentPins = serde_json5::from_str(&encoded).expect("deserialize");
+        assert_eq!(decoded, pins);
+    }
+
+    /// A root pin as raw JSON5, with the identity fields filled in. The hex
+    /// widths are generated rather than typed so the tests exercise the
+    /// rules, not the author's counting.
+    fn raw_root(kind: &str, path: &str, commit: &str, sha: &str, url: &str) -> String {
+        format!(
+            r#"{{ root: {{ kind: "{kind}", name: "camera", tag: "v1", sha256: "{sha}",
+                      origin: {{ source_type: "git", repo_url: "{url}", commit: "{commit}",
+                                 path: "{path}" }} }} }}"#
+        )
+    }
+
+    #[test]
+    fn an_absent_closure_decodes_as_empty() {
+        let raw = raw_root(
+            "node",
+            "camera/peppy.json5",
+            &"d".repeat(40),
+            &"c".repeat(64),
+            "https://example.com/hub",
+        );
+        let decoded: DeploymentPins = serde_json5::from_str(&raw).expect("decodes");
+        assert!(decoded.closure.is_empty());
+        assert!(matches!(
+            &decoded.root.origin,
+            EntryOrigin::Git { repo_ref: None, .. }
+        ));
+    }
+
+    /// Decoding is the receiving side's structural validation, so a
+    /// malformed pin from a hostile or buggy sender must fail here, before
+    /// any filesystem or network is touched.
+    #[test]
+    fn decoding_refuses_a_pin_that_does_not_validate() {
+        let good_sha = "c".repeat(64);
+        let good_commit = "d".repeat(40);
+        let cases = [
+            (
+                "a traversal path",
+                raw_root(
+                    "node",
+                    "../../etc/passwd",
+                    &good_commit,
+                    &good_sha,
+                    "https://x",
+                ),
+            ),
+            (
+                "an absolute path",
+                raw_root("node", "/etc/passwd", &good_commit, &good_sha, "https://x"),
+            ),
+            (
+                "an abbreviated commit",
+                raw_root(
+                    "node",
+                    "camera/peppy.json5",
+                    "dddddd",
+                    &good_sha,
+                    "https://x",
+                ),
+            ),
+            (
+                "a malformed fingerprint",
+                raw_root(
+                    "node",
+                    "camera/peppy.json5",
+                    &good_commit,
+                    "not-a-sha",
+                    "https://x",
+                ),
+            ),
+        ];
+        for (label, raw) in cases {
+            assert!(
+                serde_json5::from_str::<DeploymentPins>(&raw).is_err(),
+                "{label} must be refused"
+            );
+        }
+    }
+
+    #[test]
+    fn decoding_refuses_a_root_that_is_not_a_node() {
+        let raw = raw_root(
+            "contract",
+            "frames.json5",
+            &"d".repeat(40),
+            &"c".repeat(64),
+            "https://example.com/hub",
+        );
+        let err = serde_json5::from_str::<DeploymentPins>(&raw).expect_err("must be refused");
+        assert!(err.to_string().contains("must be a node"), "{err}");
+    }
+
+    #[test]
+    fn decoding_refuses_an_unknown_field() {
+        let raw = raw_root(
+            "node",
+            "camera/peppy.json5",
+            &"d".repeat(40),
+            &"c".repeat(64),
+            "https://example.com/hub",
+        )
+        .replacen('{', "{ extra: true,", 1);
+        let err = serde_json5::from_str::<DeploymentPins>(&raw).expect_err("must be refused");
+        assert!(err.to_string().contains("extra"), "{err}");
+    }
+
+    /// A filesystem origin decodes: it is how a machine pins its own
+    /// in-process adds. What refuses it for a pin that crossed a machine
+    /// boundary is the receiving daemon's reserve validation, not the codec.
+    #[test]
+    fn a_filesystem_origin_decodes() {
+        let raw = format!(
+            r#"{{ root: {{ kind: "node", name: "camera", tag: "v1", sha256: "{}",
+                      origin: {{ source_type: "fs", path: "/nodes/camera/peppy.json5" }} }} }}"#,
+            "c".repeat(64)
+        );
+        let decoded: DeploymentPins = serde_json5::from_str(&raw).expect("decodes");
+        assert!(matches!(&decoded.root.origin, EntryOrigin::Fs { .. }));
+    }
+
+    #[test]
+    fn items_yields_the_root_first() {
+        let pins = DeploymentPins::new(
+            pin(PinKind::Node, "camera", "v1"),
+            vec![pin(PinKind::Contract, "frames", "v1")],
+        )
+        .expect("a node root");
+        let labels: Vec<String> = pins.items().map(PinnedItem::label).collect();
+        assert_eq!(labels, vec!["node `camera:v1`", "contract `frames:v1`"]);
+    }
+}

--- a/crates/peppy/src/commands/node/add.rs
+++ b/crates/peppy/src/commands/node/add.rs
@@ -147,7 +147,9 @@ async fn add_node_async(ctx: &Arc<AppContext>, params: AddNodeParams) -> Result<
     //
     // `Git`/`Http` root sources still skip the preflight since we'd need to
     // fetch them to read the manifest; the daemon's add action stops
-    // existing instances transparently in that path.
+    // existing instances transparently in that path. `Pinned` skips it for a
+    // different reason: `parse_node_source` never produces one, so the arm
+    // exists only for exhaustiveness.
     if !force {
         let active_instances = match &node_source {
             NodeSource::Fs(path) => {

--- a/crates/peppy/src/commands/node/add.rs
+++ b/crates/peppy/src/commands/node/add.rs
@@ -141,9 +141,9 @@ async fn add_node_async(ctx: &Arc<AppContext>, params: AddNodeParams) -> Result<
     // is already in the stack with active instances.
     //
     // - `NodeSource::Fs`: read `(name, tag)` from the local `peppy.json5`.
-    // - `NodeSource::RepoNode`: use the user-supplied `(name, tag)`
+    // - `NodeSource::ResolveRef`: use the user-supplied `(name, tag)`
     //   directly; no parsing needed. (Validated at parse time by
-    //   `NodeSource::repo_node`.)
+    //   `NodeSource::resolve_ref`.)
     //
     // `Git`/`Http` root sources still skip the preflight since we'd need to
     // fetch them to read the manifest; the daemon's add action stops
@@ -158,7 +158,7 @@ async fn add_node_async(ctx: &Arc<AppContext>, params: AddNodeParams) -> Result<
                 )
                 .await?
             }
-            NodeSource::RepoNode { name, tag } => {
+            NodeSource::ResolveRef { name, tag } => {
                 fetch_active_instances_for_name_tag(
                     &conn,
                     name.clone(),
@@ -167,7 +167,7 @@ async fn add_node_async(ctx: &Arc<AppContext>, params: AddNodeParams) -> Result<
                 )
                 .await?
             }
-            NodeSource::Git { .. } | NodeSource::Http { .. } => None,
+            NodeSource::Git { .. } | NodeSource::Http { .. } | NodeSource::Pinned { .. } => None,
         };
 
         if let Some((node_name, node_tag, instance_ids)) = active_instances {

--- a/crates/peppy/src/commands/node/source.rs
+++ b/crates/peppy/src/commands/node/source.rs
@@ -81,7 +81,11 @@ pub fn parse_node_source(source: &str, git_ref: Option<String>) -> Result<NodeSo
         let (name, tag) = source
             .split_once(':')
             .expect("looks_like_repo_node_ref guarantees a ':'");
-        return NodeSource::repo_node(name, tag).map_err(|e| Error::ExecutionFailed(e.to_string()));
+        // The receiving daemon resolves the reference against its own repo
+        // cache and continues by pin, so `peppy node add camera:v1` against
+        // a remote target keeps resolving on that target's machine.
+        return NodeSource::resolve_ref(name, tag)
+            .map_err(|e| Error::ExecutionFailed(e.to_string()));
     }
 
     if git_ref.is_some() {
@@ -241,8 +245,8 @@ mod tests {
     #[test]
     fn parse_node_source_recognizes_name_tag() {
         let src = parse_node_source("some_node:v123", None).unwrap();
-        let NodeSource::RepoNode { name, tag } = &src else {
-            panic!("expected RepoNode, got {:?}", src);
+        let NodeSource::ResolveRef { name, tag } = &src else {
+            panic!("expected ResolveRef, got {:?}", src);
         };
         assert_eq!(name, "some_node");
         assert_eq!(tag, "v123");

--- a/crates/peppy/tests/multi_daemon_e2e.rs
+++ b/crates/peppy/tests/multi_daemon_e2e.rs
@@ -982,14 +982,14 @@ async fn start_federation(prefix: &str) -> Federation {
     )
     .await;
 
-    // Each daemon resolves the deployments placed on it against its OWN cache,
-    // so both halves need one. A coordinator-only refresh leaves the peer
-    // refusing the launch in preflight, which is exactly the failure this
-    // fixture used to produce.
-    for daemon in [&robot, &cloud] {
-        daemon.wait_until_serving().await;
-        daemon.refresh_repos().await;
-    }
+    // Only the coordinator's cache decides what a launch runs: it resolves
+    // every deployment once and ships pinned content to the peer, which
+    // fetches whatever it does not already hold. The robot submits every
+    // launch in this suite, so the cloud daemon deliberately gets NO
+    // refresh: its empty cache is what proves the pins carry the launch.
+    robot.wait_until_serving().await;
+    robot.refresh_repos().await;
+    cloud.wait_until_serving().await;
 
     Federation {
         robot,

--- a/docs/src/content/docs/advanced_guides/federation.mdx
+++ b/docs/src/content/docs/advanced_guides/federation.mdx
@@ -63,6 +63,16 @@ login`](/advanced_guides/platform/).
 liveness is checked against the live federation at launch time, because what
 matters is whether the coordinator can *talk to* a machine right now.
 
+Every daemon in a federation runs the same Peppy version. A mixed-version
+federation is refused during preflight, with a message naming both versions and
+the machine to upgrade; versions are never negotiated.
+
+Only the coordinator's repositories matter to a launch. The daemon you submit
+to resolves every deployment from its own caches and ships the result to the
+others as pinned content, so `peppy repo refresh` is the submitting machine's
+business and the other machines' caches can be stale, differently prioritized,
+or empty.
+
 ## Core node links
 
 A launcher does not name machines. It declares **core node links**, which are
@@ -140,11 +150,11 @@ peppy stack launch --place robot_onboard@self \
 This launch will REPLACE the node stack on 1 remote daemon(s): cn-atlas-h100
 Parsing launcher configuration
 Resolving 5 deployment(s)
-Using the manifest cn-atlas-h100 resolved for repo:deliberative_planner:v1
+Retrieving node config for repo:deliberative_planner:v1
 Validating dependencies
 Adding uvc_camera_python_mock:v1 on `cn-robot-7`
 Adding deliberative_planner:v1 on `cn-atlas-h100`
-[cn-atlas-h100] Fetching deliberative_planner:v1
+[cn-atlas-h100] Materializing 1 pinned node(s) for node `deliberative_planner:v1`
 ...
 Starting uvc_camera_python_mock:v1 instance wrist_cam_inst on `cn-robot-7`
 Starting my_python_robot_arm:v1 instance arm_inst on `cn-robot-7`
@@ -246,9 +256,22 @@ its own. The launch works out which machines are watching each instance and
 tells that instance's daemon, which is what makes a source restart drop and
 redeclare a remote observer's subscription exactly as it does a local one.
 
+**The bytes themselves.** The coordinator resolves every node in the launch,
+the ones placed elsewhere included: the named node, every transitive
+dependency, and every contract and pairing document any of their manifests
+reference. What crosses the boundary is that decision, pinned: the exact
+content it read, identified by fingerprint, plus the repository, commit, and
+published path it came from. A machine holding content with the same
+fingerprint reuses its own copy, whichever repository it arrived from; one
+that does not fetches the pinned commit. No machine but the coordinator
+resolves a name, so a peer's cache freshness, repository priorities, and
+exclusions never decide what a launch runs. Here `cn-atlas-h100` runs the
+planner the robot's caches describe, even if its own were refreshed a week
+apart.
+
 The thing to notice is that none of this looks different from the
 single-machine case. Federation changes where instances run, not how they are
-wired.
+wired, and every machine runs the same bytes the submitting machine resolved.
 
 ## Ordering, degradation, and failure
 
@@ -273,6 +296,15 @@ freshness therefore owns a staleness watchdog. In the example that is
 `subgoal_ttl_ms`: a subgoal is authoritative for two seconds after the policy
 adopts it, and then the policy falls back to its own local behavior. The uplink
 is an *enhancement path*, not a dependency.
+
+**A pin that cannot be honored is a refusal, never a fallback.** A peer that
+does not hold a pinned content and cannot reach the pinned repository refuses
+its part of the launch and names the location it could not reach. One that
+fetches the pinned commit and reads different bytes than the pin's fingerprint
+refuses naming both fingerprints, because that means the remote moved under
+the pin or the location resolved to something else. In neither case does the
+peer fall back to resolving the name against its own cache: that would
+reintroduce per-machine resolution at exactly the moment nobody is watching.
 
 **On failure, the launch stops and clears every slice it started.** There is no
 rollback, because a launch REPLACES the previous stack: by the time anything can
@@ -305,8 +337,17 @@ participants keep running.
   refused during preflight, before any stack is touched.
 - **`local:` sources cannot cross machines.** The path names a tree on the
   coordinator's filesystem. A `local:` deployment must keep all of its instances
-  on one core node; publish the node to a repo or url source to split it. That
-  is why the proprietary planner in the example is a registry source.
+  on one core node; publish the node to a repo or git-backed source to split it.
+  That is why the proprietary planner in the example is a registry source.
+- **A filesystem repository cannot back a deployment placed on another
+  machine.** A `repo:` deployment is pinned to wherever the coordinator's cache
+  resolved it, and a filesystem repository entry is a path only the coordinator
+  can read, the same rule as `local:` one level down. Two things still work:
+  keep that deployment's instances on one core node, or serve the node from a
+  git repository, which every machine can fetch.
+- **The unit of byte coherence is one launch.** Two launches submitted while a
+  repository moves between them may run different revisions of it; each launch
+  is internally coherent, and nothing synchronizes one launch with the next.
 - **A launcher file path cannot target a remote daemon.** `peppy stack launch
   ./my_launcher.json5 --core-node cn-atlas-h100` is refused for the same reason.
   Use a repository launcher, or run the command from the machine holding the

--- a/docs/src/content/docs/advanced_guides/lockfiles.mdx
+++ b/docs/src/content/docs/advanced_guides/lockfiles.mdx
@@ -1,10 +1,52 @@
 ---
-title: Lockfiles
-description: Validate dependency interfaces with hashes to prevent consuming from a wrong node
+title: Content pins
+description: How a manifest pins the exact contract or pairing document it was written against, and how that composes with launch-time pinning
 sidebar:
   order: 7
 ---
 
-## Introduction
+Two mechanisms fix which bytes a node's interfaces are generated from, and
+they answer different questions: what an author requires, and what a launch
+decides.
 
-Coming soon!
+## Author pins: what a manifest may state
+
+Every place a manifest references a contract or pairing document by
+`name:tag` accepts an optional `sha256`, the fingerprint of the exact
+document file the author wrote the node against:
+
+```json5
+depends_on: {
+  contracts: [
+    { link_id: "cam", name: "rgb_camera", tag: "v1",
+      sha256: "3f9c0e21ab7e5f6d8a4b1c0d9e8f7a6b5c4d3e2f1a0b9c8d7e6f5a4b3c2d1e0f" }
+  ],
+}
+```
+
+An unpinned reference resolves to whatever the repository caches hold for
+that `name:tag`; a pinned one resolves to exactly the stated content, and
+anything else is refused naming both fingerprints. Pin when a node's
+correctness depends on a specific revision of a document that a tag alone
+does not identify; leave unpinned to follow the document as its repository
+evolves.
+
+An author pin is a statement about authorship: it travels with the manifest,
+so every machine that ever adds the node enforces it.
+
+## Launch pins: what a launch decides
+
+A launch pins everything, whether the manifests do or not. The machine the
+launch is submitted to resolves every node, every transitive dependency, and
+every contract and pairing document once, and every machine in the launch
+runs exactly the content it resolved; see
+[Federation](/advanced_guides/federation/#what-crosses-a-daemon-boundary).
+A launch pin exists for the duration of one launch and is minted from
+whatever the submitting machine's caches held at that moment.
+
+The two compose rather than compete. Where a manifest carries an author pin,
+the launch resolves the reference through it, so the launch pin and the
+author pin name the same bytes. A launch whose closure would need one
+document at two different contents is refused up front, naming both
+fingerprints, because a single launch runs a single answer for each
+identity.

--- a/docs/src/content/docs/guides/launch_files.mdx
+++ b/docs/src/content/docs/guides/launch_files.mdx
@@ -47,7 +47,7 @@ The `source` attribute supports four formats:
  - **Repository**: Reference a node that is already registered in your user repositories. Specify `name` and `tag`, or use the combined `name: "<name>:<tag>"` shorthand. The node is resolved against your local nodes cache at `~/.peppy/cache/nodes.json5`.
 
 :::note
-The repository source resolves nodes from a locally cached index. Run `peppy repo refresh` before launching to ensure the cache is up to date.
+The repository source resolves nodes from the locally cached index of the machine the launch is submitted to. Run `peppy repo refresh` on that machine before launching to ensure its cache is up to date. In a federated launch it is the only machine whose cache matters: it resolves every deployment and its dependencies once and ships the result to the other machines as pinned content, so their caches need no refresh and cannot change what the launch runs.
 
 If a node or tag is missing from the cache, the launch fails with a "not found" error. If the cache instead contains the same `name:tag` **twice from one repository**, the launch fails with a distinct ambiguity error naming both manifests — never "not found", since the node is present rather than absent. The refusal happens while sources are being resolved, before anything is added, built, or run, and it covers transitive dependencies too: an ambiguity two levels down is exactly as fatal as one at the top. See [Using a repository-indexed node](/advanced_guides/repositories/#using-a-repository-indexed-node).
 :::
@@ -105,7 +105,7 @@ Launchers discovered by `peppy repo refresh` (see [Repositories](/advanced_guide
 peppy stack launch openarm01_sim_teleop
 ```
 
-An argument that contains a path separator or ends in `.json5` is always resolved as a filesystem path. A bare name (no separator, no extension) is first tried on disk as `<name>.json5` next to your current directory, and only falls back to the repository cache at `~/.peppy/cache/launchers.json5` when no such file exists. Run `peppy repo refresh` first to ensure the launcher cache is populated.
+An argument that contains a path separator or ends in `.json5` is always resolved as a filesystem path. A bare name (no separator, no extension) is first tried on disk as `<name>.json5` next to your current directory, and only falls back to the repository cache at `~/.peppy/cache/launchers.json5` when no such file exists. Run `peppy repo refresh` first on the machine you submit the launch to; the launcher document, like every repository source, resolves on that machine alone.
 
 If the name resolves neither to a file nor to a cached launcher, the launch fails with an explicit "not found" error. If one repository provides two launcher files with that name, the launch fails with a distinct ambiguity error naming both — launchers are keyed by filename, so two identically named `.json5` files anywhere in one repository contest the same name even in different directories.
 

--- a/docs/src/content/docs/quickstart.mdx
+++ b/docs/src/content/docs/quickstart.mdx
@@ -107,7 +107,7 @@ It prints the instance's state and health plus the path to its run log, which is
 
 **A build fails on Linux.** Apptainer needs unprivileged user namespaces, which the installer normally configures. Check with `peppy container status`, and repair it with `peppy container setup` (see [Containers](/advanced_guides/containers/)).
 
-**The launch fails with `repo-node ... not found` or `nodes.json5 not found or empty`.** The local index is stale or was never populated. Run `peppy repo refresh` and launch again.
+**The launch fails with `Dependencies missing from nodes cache` or `nodes.json5 not found or empty`.** The local index is stale or was never populated. Run `peppy repo refresh` and launch again.
 
 </details>
 

--- a/docs/src/content/docs/reference/faq.mdx
+++ b/docs/src/content/docs/reference/faq.mdx
@@ -50,11 +50,9 @@ This dashboard will also allow you to "vibecode" robot environements.
 <details>
 <summary>My launch failed with an error that looks unrelated to what I changed. Where do I start?</summary>
 
-Check `peppy repo list` first, before reading the error too literally.
+Check `peppy repo list` on the machine you submitted the launch to, before reading the error too literally.
 
-Peppy's default repositories track a moving branch, so a change merged upstream reaches your machine on the next `peppy repo refresh` without a Peppy release. If a repository ends up declaring the same `name:tag` twice, that identity has no defensible answer, and the symptom can surface far from the cause: two machines in one federated launch may each have resolved a different node, and the launch then fails much later with something like a pairing-slot mismatch between two nodes that were never meant to be in the same graph.
-
-Peppy refuses such an identity up front rather than picking one, naming both manifests. `peppy repo list` marks the offending entries `(conflict: claimed twice here)`, and `peppy repo refresh` reports the exact files. See [When a repository fails](/advanced_guides/repositories/#when-a-repository-fails).
+Peppy's default repositories track a moving branch, so a change merged upstream reaches your machine on the next `peppy repo refresh` without a Peppy release. Only the submitting machine's repositories decide what a launch runs: it resolves every deployment once and every other machine in the launch runs those exact bytes, so a stale or differently-configured cache on another machine is never the cause. If a repository declares the same `name:tag` twice, that identity has no defensible answer and Peppy refuses it up front rather than picking one, naming both manifests. See [When a repository fails](/advanced_guides/repositories/#when-a-repository-fails).
 
 </details>
 


### PR DESCRIPTION
## Summary

One launch, one set of bytes: the daemon a launch is submitted to now decides which bytes every machine in the launch runs, instead of each peer resolving names against its own cache.

Previously a `repo:` deployment crossed to a peer as a bare `name:tag`, and the peer resolved it, plus every transitive dependency, contract, and pairing document underneath it, against its own repositories. Two machines refreshed a week apart ran different revisions under one launcher entry, and nothing caught it unless a deployment straddled both machines. The motivating incident was a pairing-slot mismatch forty seconds into a launch, between nodes that were never meant to share a graph.

Now the coordinator resolves each deployment's full closure once and ships **pins**: the manifest file's content fingerprint plus the origin it was read from (repository remote, exact commit, published path — the same `EntryOrigin` the repo caches record). A receiving daemon reuses its own content on a fingerprint match, whatever repository it arrived from; fetches the pinned commit otherwise; and refuses on an unreachable location or a post-fetch mismatch, naming both fingerprints. No code path resolves a name on the receiving side. `git:` deployments pin the commit their ref resolved to, so a moving branch cannot split a launch either. `peppy node add name:tag` runs the same resolve-then-pin pipeline with the receiving daemon as its own coordinator, so name resolution exists in exactly one place.

Notable structure:

- New `daemon_config::repository::pins` model (`PinnedItem`, `DeploymentPins`); serde decoding is the peer's structural validation (traversal paths, truncated commits, malformed fingerprints all fail at decode). `EntryOrigin` moves into `daemon-config-internal` so pins and cache entries share one location vocabulary.
- `add_batch` becomes the pinned executor: materialize exactly the pin set (content match or fetch, with symlink containment on fetched paths), refuse an incomplete closure, then the existing topo order, identical-manifest skip, and rollback guard. Contract/pairing doc pins ride each sub-goal, with an author `sha256` pin that contradicts the launch pin refused.
- Launch pipeline order: resolve deployments → graph validation (its refusals keep first say) → doc-pin minting → federated preflight, whose reservations carry each participant's pins for offline validation. Every refusal lands before any machine is reserved or torn down.
- Deleted with no shim: `NodeSource::RepoNode`, `portable_node_source`, the delegated-manifest machinery, and the straddle cross-check (with one resolution there is nothing to compare). Every remote start is pinned by the coordinator's config fingerprint, straddles included.
- New refusal: a `repo:` deployment resolving to a filesystem repository entry cannot be placed on another machine (the same rule as `local:`, one level down).
- Docs rewritten (federation, launch files, FAQ, content pins); only the coordinator's `peppy repo refresh` matters to a launch now.

**Breaking wire change**, gated by the existing exact-version reservation handshake: every daemon in a federation upgrades together, then runs `peppy repo update`. The release-notes entry should land with the release flow. Consumes Peppy-bot/public-peppy-libs#79 (merged); `Cargo.lock` advances to it, `Cargo.toml` stays on the default branch.

## Test plan

- `cargo test --locked --workspace` against the merged libs revision: 65 suites, 1846 tests, 0 failures.
- `cargo test --locked -p peppy --features multi_daemon_e2e --test multi_daemon_e2e` (Docker + Apptainer): 8/8, with the harness inverted to refresh **only the coordinator** — the peer daemon starts with an empty repo cache and materializes the whole launch from pins, which is the feature's decisive end-to-end proof.
- New unit coverage: cross-repo content reuse with an unreachable pinned remote (proves no fetch on match), drifted local copy falling through to the pin's origin, post-fetch fingerprint mismatch refusal naming both fingerprints, absent pinned path refusal, fs-pin refusals at the coordinator and at the peer's reserve, incomplete-closure refusal, doc-pin lookup (gaps and author-pin conflicts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Federated launches now resolve deployments and dependencies centrally, then distribute exact pinned content across nodes.
  * Added support for pinned node and document content, including Git-backed sources.
  * Added validation for content integrity, portability, dependency completeness, and duplicate identities.
* **Bug Fixes**
  * Prevented launches from using mismatched or unavailable content across nodes.
  * Improved handling and reporting of missing dependencies and invalid pins.
* **Documentation**
  * Updated federation, launch, troubleshooting, FAQ, and content-pin guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->