### PR TITLE
Open the CLI control session as a pure Zenoh client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,7 +573,7 @@ dependencies = [
 [[package]]
 name = "build-helpers"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#78a9b4d3ad5b284da5b01552aeac8596d4ee3d0f"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#960c8c8eb08cf149805c68ac60f402a72e447563"
 dependencies = [
  "sha2",
 ]
@@ -765,7 +765,7 @@ dependencies = [
 [[package]]
 name = "config-test-support"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#78a9b4d3ad5b284da5b01552aeac8596d4ee3d0f"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#960c8c8eb08cf149805c68ac60f402a72e447563"
 dependencies = [
  "askama",
  "git2",
@@ -909,7 +909,7 @@ dependencies = [
 [[package]]
 name = "core-node-api"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#78a9b4d3ad5b284da5b01552aeac8596d4ee3d0f"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#960c8c8eb08cf149805c68ac60f402a72e447563"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -1248,7 +1248,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1396,7 +1396,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2581,7 +2581,7 @@ dependencies = [
 [[package]]
 name = "json5-pretty"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#78a9b4d3ad5b284da5b01552aeac8596d4ee3d0f"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#960c8c8eb08cf149805c68ac60f402a72e447563"
 dependencies = [
  "serde",
  "serde_json",
@@ -2985,7 +2985,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3371,7 +3371,7 @@ dependencies = [
 [[package]]
 name = "peppy-config-model"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#78a9b4d3ad5b284da5b01552aeac8596d4ee3d0f"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#960c8c8eb08cf149805c68ac60f402a72e447563"
 dependencies = [
  "capnp",
  "clap",
@@ -3394,7 +3394,7 @@ version = "0.0.1"
 [[package]]
 name = "peppylib-rs"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#78a9b4d3ad5b284da5b01552aeac8596d4ee3d0f"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#960c8c8eb08cf149805c68ac60f402a72e447563"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -3589,7 +3589,7 @@ dependencies = [
 [[package]]
 name = "pmi"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#78a9b4d3ad5b284da5b01552aeac8596d4ee3d0f"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#960c8c8eb08cf149805c68ac60f402a72e447563"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -3807,7 +3807,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.5",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4057,7 +4057,7 @@ dependencies = [
  "pin-project-lite",
  "rustls",
  "rustls-pki-types",
- "rustls-platform-verifier 0.7.0",
+ "rustls-platform-verifier 0.6.2",
  "serde",
  "serde_json",
  "sync_wrapper",
@@ -4243,7 +4243,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4311,7 +4311,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4332,7 +4332,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4708,7 +4708,7 @@ version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
 dependencies = [
- "dirs 6.0.0",
+ "dirs 4.0.0",
 ]
 
 [[package]]
@@ -5044,7 +5044,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5947,7 +5947,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/peppy/src/context.rs
+++ b/crates/peppy/src/context.rs
@@ -101,8 +101,10 @@ impl AppContext {
         messaging_port: u16,
         namespace: config::namespace::Namespace,
     ) -> crate::error::Result<()> {
-        // Open the control session under the typed namespace recorded by the
-        // daemon generation so the CLI reaches its daemon and node services.
+        // Open the control session as a pure Zenoh client under the typed
+        // namespace recorded by the daemon generation: no loopback listener,
+        // no gossip discovery, every request relayed through the daemon's
+        // router.
         self.messenger_handle
             .get_or_try_init(|| async {
                 MessengerHandle::connect(messaging_host, messaging_port)


### PR DESCRIPTION
## Summary

Bumps the seven `public-peppy-libs` packages `78a9b4d3 -> 960c8c8e` (Peppy-bot/public-peppy-libs#80) and updates the `connect_with_endpoint` comment to match. With that revision, the CLI's `SessionScope::Namespace` control session opens in Zenoh **client** mode:

- no ephemeral loopback listener bound per CLI invocation, no gossip discovery; every request relays through the daemon's router,
- a dead daemon fails promptly at session open instead of hanging into per-request timeouts,
- the session-open log line reads `Zenoh {peer|client} session connected to <endpoint>` (the connect target), so it can no longer be mistaken for a second zenohd router starting.

The daemon (`service serve`) and spawned nodes keep their behavior: the daemon still spawns the zenohd router and opens its own peer session via `ZenohAdapter::with_router`, and nodes still connect through `SessionScope::Discovery`.

## Test plan

- `cargo fmt --all -- --check` and full `cargo test --locked` pass against the bumped revision.
- Live e2e against a running daemon on current code: `peppy repo update` logs `Zenoh client session connected to tcp://127.0.0.1:7448`, owns zero listening sockets for the entire run (sampled via `ss -tlnp` 56 times), and streams the refresh feedback to completion, confirming wire interop between a client-mode CLI and a peer-mode daemon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)