### PR TITLE
Keep the caller's environment on the caller's machine in federated launches

### DIFF
--- a/crates/core-node-internal/src/services/stack/launch.rs
+++ b/crates/core-node-internal/src/services/stack/launch.rs
@@ -168,6 +168,9 @@ struct ProcessLaunchContext {
     feedback_publisher: ActionFeedbackPublisher,
     log_file: Arc<StdMutex<File>>,
     log_path: PathBuf,
+    /// The caller's forwarded environment. It describes the machine the launch
+    /// was typed on, so it reaches goals executed on this daemon and stays off
+    /// every goal dispatched to a peer.
     env_vars: Vec<(String, String)>,
     timeouts: StackLaunchTimeouts,
     /// Whole-launch deadline. `None` means the user did not opt into a max; only idle timeouts
@@ -377,7 +380,9 @@ async fn add_and_build_group(
 
         // The identical source and pins a peer would receive: a launch adds
         // one set of bytes wherever a deployment lands, so the local arm
-        // must not get to differ from the dispatched one.
+        // must not get to differ from the dispatched one. The environment is
+        // the one deliberate difference: the caller's env vars describe this
+        // machine, so they apply here and stay off the goals a peer receives.
         let node_add_goal = match crate::services::node::pins::encode_pins(&item.closure_pins) {
             Ok(pins) => {
                 NodeAddGoal::for_internal_execution(item.source.clone(), STACK_LAUNCH_GIT_HASH)
@@ -458,6 +463,12 @@ async fn add_and_build_group(
 /// name files on that machine, and a path the operator cannot open is worse
 /// than no path. What the operator gets instead is the peer's output, relayed
 /// live into this launch's feedback stream and attributed to its core node.
+///
+/// Neither goal carries the caller's forwarded environment. Those values
+/// (PATH first among them) describe the coordinator's machine, and a build
+/// that resolves its tools through another machine's PATH fails on hosts
+/// that have the toolchain installed. The peer's daemon supplies its own
+/// environment to whatever these goals spawn.
 async fn add_and_build_remotely(
     ctx: &ProcessLaunchContext,
     goal: &LaunchGoal,
@@ -472,7 +483,6 @@ async fn add_and_build_remotely(
         STACK_LAUNCH_GIT_HASH,
         ctx.idle_timeouts.add.as_secs(),
     )
-    .with_env_vars(ctx.env_vars.clone())
     .with_launch_id(&goal.launch_id)
     .with_pins(crate::services::node::pins::encode_pins(
         &item.closure_pins,
@@ -486,7 +496,6 @@ async fn add_and_build_remotely(
         added.node_tag.unwrap_or_else(|| item.node_tag.clone()),
         ctx.idle_timeouts.build.as_secs(),
     )
-    .with_env_vars(ctx.env_vars.clone())
     .with_launch_id(&goal.launch_id);
     federated::run_remote_goal(ctx, core_node, &build_goal, ctx.idle_timeouts.build)
         .await
@@ -709,10 +718,13 @@ fn mount_source(mount: &str) -> &str {
     mount.split(':').next().unwrap_or(mount)
 }
 
-/// The environment one launched instance is started with: the caller
-/// environment the launch goal forwards to every node, with the instance's own
-/// `env_vars` layered on top so a deployment can pin what differs per instance
-/// (a device path, a board id) without depending on whoever ran the launch.
+/// The environment one launched instance is started with: the forwarded
+/// caller environment, when the instance runs on the coordinator's own
+/// machine, with the instance's own `env_vars` layered on top so a deployment
+/// can pin what differs per instance (a device path, a board id) without
+/// depending on whoever ran the launch. An instance placed on a peer starts
+/// from an empty forwarded set, because the caller's environment describes
+/// the caller's machine and no other.
 ///
 /// A key declared by the instance replaces the forwarded one rather than
 /// appearing twice: the spawn paths differ on duplicates (a process node's
@@ -951,6 +963,10 @@ async fn start_node_instances(
             };
 
             let local = core_node == ctx.bound_core_node;
+            // The caller's forwarded environment applies to instances started
+            // on this machine, which it describes. An instance on a peer gets
+            // only the env_vars its launcher file declares for it.
+            let forwarded_env: &[(String, String)] = if local { &ctx.env_vars } else { &[] };
             let node_run_goal = if local {
                 NodeRunGoal::for_internal_execution(
                     instance_plan,
@@ -967,7 +983,7 @@ async fn start_node_instances(
                     ctx.idle_timeouts.run.as_secs(),
                 )
             }
-            .with_env_vars(instance_environment(&ctx.env_vars, &instance.env_vars))
+            .with_env_vars(instance_environment(forwarded_env, &instance.env_vars))
             .with_requested_pairs(
                 requested_by_instance
                     .remove(instance_id)
@@ -1657,6 +1673,20 @@ mod tests {
                 ("BOARD_ID".to_string(), "3".to_string()),
                 ("ESP32_DEVICE".to_string(), "/dev/ttyUSB0".to_string()),
             ]
+        );
+    }
+
+    /// An instance on a peer starts from no forwarded environment, so the
+    /// env_vars its launcher file declares are the whole environment its run
+    /// goal carries.
+    #[test]
+    fn a_peer_instance_carries_only_its_declared_env_vars() {
+        let mut instance_env = BTreeMap::new();
+        instance_env.insert("ESP32_DEVICE".to_string(), "/dev/ttyUSB0".to_string());
+
+        assert_eq!(
+            instance_environment(&[], &instance_env),
+            vec![("ESP32_DEVICE".to_string(), "/dev/ttyUSB0".to_string())]
         );
     }
 

--- a/crates/node-stack-internal/src/node_stack/build_steps.rs
+++ b/crates/node-stack-internal/src/node_stack/build_steps.rs
@@ -359,7 +359,7 @@ pub(super) async fn run_build_cmd(
         command.env(key, value);
     }
     let child = spawn_in_process_group(command)
-        .map_err(|e| format!("failed to execute build_cmd `{}`: {}", full_cmd_display, e))?;
+        .map_err(|e| spawn_failure_message(&full_cmd_display, &program, working_dir, &e))?;
 
     let (status, _) =
         stream_child_output(child, feedback_tx, log_file, false, cancel_token).await?;
@@ -373,6 +373,33 @@ pub(super) async fn run_build_cmd(
 
     debug!("build_cmd completed successfully");
     Ok(())
+}
+
+/// Explains a failed `build_cmd` spawn. The raw OS error for the common
+/// failure, ENOENT, names no path at all, and it covers two very different
+/// repairs: the program is not on the PATH the daemon runs build commands
+/// with (a host missing a toolchain), or the node's working directory
+/// vanished. The error an operator sees for a launch that failed on another
+/// machine has to say which one it is.
+fn spawn_failure_message(
+    full_cmd_display: &str,
+    program: &str,
+    working_dir: &Path,
+    error: &std::io::Error,
+) -> String {
+    if error.kind() == std::io::ErrorKind::NotFound {
+        if !working_dir.exists() {
+            return format!(
+                "failed to execute build_cmd `{full_cmd_display}`: \
+                 working directory {working_dir:?} does not exist"
+            );
+        }
+        return format!(
+            "failed to execute build_cmd `{full_cmd_display}`: program `{program}` \
+             not found on the PATH the daemon runs build commands with"
+        );
+    }
+    format!("failed to execute build_cmd `{full_cmd_display}`: {error}")
 }
 
 #[cfg(test)]
@@ -438,6 +465,87 @@ mod tests {
                 tag
             );
         }
+    }
+
+    fn test_log_file() -> Arc<StdMutex<File>> {
+        Arc::new(StdMutex::new(
+            tempfile::tempfile().expect("tempfile should succeed"),
+        ))
+    }
+
+    #[tokio::test]
+    async fn run_build_cmd_names_a_missing_program() {
+        let working_dir = tempfile::tempdir().expect("tempdir should succeed");
+        let (feedback_tx, _feedback_rx) = mpsc::unbounded_channel();
+        let cmd = vec!["peppy-test-no-such-tool".to_string(), "sync".to_string()];
+        let err = run_build_cmd(
+            Some(&cmd),
+            working_dir.path(),
+            &[],
+            &feedback_tx,
+            test_log_file(),
+            &CancellationToken::new(),
+        )
+        .await
+        .expect_err("a nonexistent program must fail to spawn");
+        assert!(
+            err.contains("program `peppy-test-no-such-tool` not found on the PATH"),
+            "the error must name the missing program, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_build_cmd_names_a_missing_working_dir() {
+        let working_dir = std::path::Path::new("/nonexistent-peppy-build-cwd");
+        let (feedback_tx, _feedback_rx) = mpsc::unbounded_channel();
+        let cmd = vec!["true".to_string()];
+        let err = run_build_cmd(
+            Some(&cmd),
+            working_dir,
+            &[],
+            &feedback_tx,
+            test_log_file(),
+            &CancellationToken::new(),
+        )
+        .await
+        .expect_err("a missing working directory must fail the spawn");
+        assert!(
+            err.contains("working directory \"/nonexistent-peppy-build-cwd\" does not exist"),
+            "the error must name the missing working directory, got: {err}"
+        );
+    }
+
+    /// A PATH handed to the child through `env_vars` is what the spawned
+    /// program is looked up against. This is what makes the environment a
+    /// build goal carries decisive: a goal with no PATH of its own resolves
+    /// programs against the daemon's environment, and one that carries a
+    /// PATH resolves against that PATH alone.
+    #[tokio::test]
+    async fn run_build_cmd_resolves_the_program_via_the_child_path() {
+        let tool_dir = tempfile::tempdir().expect("tempdir should succeed");
+        let tool = tool_dir.path().join("peppy-test-stub-tool");
+        std::fs::write(&tool, "#!/bin/sh\nexit 0\n").expect("write stub tool");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&tool, std::fs::Permissions::from_mode(0o755))
+                .expect("chmod stub tool");
+        }
+
+        let working_dir = tempfile::tempdir().expect("tempdir should succeed");
+        let (feedback_tx, _feedback_rx) = mpsc::unbounded_channel();
+        let cmd = vec!["peppy-test-stub-tool".to_string(), "sync".to_string()];
+        let env_vars = vec![("PATH".to_string(), tool_dir.path().display().to_string())];
+        run_build_cmd(
+            Some(&cmd),
+            working_dir.path(),
+            &env_vars,
+            &feedback_tx,
+            test_log_file(),
+            &CancellationToken::new(),
+        )
+        .await
+        .expect("the stub tool must resolve through the env_vars PATH alone");
     }
 
     #[test]

--- a/crates/peppy/src/commands/node/env.rs
+++ b/crates/peppy/src/commands/node/env.rs
@@ -41,6 +41,10 @@ fn should_forward_env(key: &str, value: &str) -> bool {
 /// caller-only vars that would be incorrect in the node's working directory,
 /// and vars whose name or value a node could not receive intact (see
 /// [`should_forward_env`]).
+///
+/// What is collected here reaches the daemon this process talks to and no
+/// further: these values describe this machine, so a launch that places an
+/// instance on a peer daemon dispatches its goals without them.
 pub fn caller_env_overrides() -> Vec<(String, String)> {
     std::env::vars()
         .filter(|(key, value)| should_forward_env(key, value))

--- a/crates/peppy/tests/multi_daemon_e2e.rs
+++ b/crates/peppy/tests/multi_daemon_e2e.rs
@@ -280,25 +280,39 @@ struct Daemon {
 impl Daemon {
     /// Runs `peppy` inside this container and returns its combined output.
     async fn peppy(&self, args: &[&str]) -> ExecOutput {
-        let mut cmd = vec![CONTAINER_PEPPY_BINARY];
+        self.peppy_with_env(&[], args).await
+    }
+
+    /// Runs `peppy` with `KEY=value` entries layered over the container's own
+    /// environment via `env(1)`: what an operator's shell does to the CLI's
+    /// environment, done to this exec.
+    async fn peppy_with_env(&self, env: &[&str], args: &[&str]) -> ExecOutput {
+        let mut cmd = vec!["/usr/bin/env"];
+        cmd.extend_from_slice(env);
+        cmd.push(CONTAINER_PEPPY_BINARY);
         cmd.extend_from_slice(args);
+        self.exec(cmd).await
+    }
+
+    /// Runs one command inside this container and returns its combined output.
+    async fn exec(&self, cmd: Vec<&str>) -> ExecOutput {
         let mut result = self
             .container
             .exec(ExecCommand::new(cmd).with_cmd_ready_condition(CmdWaitFor::exit()))
             .await
-            .unwrap_or_else(|error| panic!("failed to exec peppy in {}: {error}", self.name));
+            .unwrap_or_else(|error| panic!("failed to exec in {}: {error}", self.name));
         let exit_code = result
             .exit_code()
             .await
-            .unwrap_or_else(|error| panic!("peppy exit code in {}: {error}", self.name));
+            .unwrap_or_else(|error| panic!("exec exit code in {}: {error}", self.name));
         let stdout = result
             .stdout_to_vec()
             .await
-            .unwrap_or_else(|error| panic!("peppy stdout in {}: {error}", self.name));
+            .unwrap_or_else(|error| panic!("exec stdout in {}: {error}", self.name));
         let stderr = result
             .stderr_to_vec()
             .await
-            .unwrap_or_else(|error| panic!("peppy stderr in {}: {error}", self.name));
+            .unwrap_or_else(|error| panic!("exec stderr in {}: {error}", self.name));
         ExecOutput {
             exit_code,
             text: format!(
@@ -767,6 +781,7 @@ const SPLIT_COMPUTE_LAUNCHER: &str =
 const CONTAINER_LAUNCHER_DIR: &str = "/etc/peppy/launchers";
 const SPLIT_COMPUTE_LAUNCHER_FILE: &str = "split_compute_manipulation.json5";
 const HUB_NODE_PROBE_LAUNCHER_FILE: &str = "hub_node_probe.json5";
+const CALLER_ENV_PROBE_LAUNCHER_FILE: &str = "caller_env_probe.json5";
 
 fn container_launcher(file_name: &str) -> String {
     format!("{CONTAINER_LAUNCHER_DIR}/{file_name}")
@@ -787,6 +802,22 @@ const HUB_NODE_PROBE_LAUNCHER: &str = r#"{
     {
       source: { name: "my_python_robot_arm", tag: "v1" },
       instances: [{ instance_id: "probe_arm_inst" }],
+    },
+  ],
+}
+"#;
+
+/// One native Python node placed wholly on the peer. The launcher driven when
+/// what matters is WHERE a build resolves its tools, not the topology: the
+/// peer must build `my_python_robot_arm` with its own environment, whatever
+/// the caller's looks like.
+const CALLER_ENV_PROBE_LAUNCHER: &str = r#"{
+  peppy_schema: "launcher/v1",
+  core_nodes: ["remote_worker"],
+  deployments: [
+    {
+      source: { name: "my_python_robot_arm", tag: "v1" },
+      instances: [{ instance_id: "env_probe_arm_inst", core_node: "remote_worker" }],
     },
   ],
 }
@@ -962,6 +993,11 @@ async fn start_federation(prefix: &str) -> Federation {
         HUB_NODE_PROBE_LAUNCHER,
     )
     .expect("writing the probe launcher into the launcher mount");
+    std::fs::write(
+        launcher_dir.path().join(CALLER_ENV_PROBE_LAUNCHER_FILE),
+        CALLER_ENV_PROBE_LAUNCHER,
+    )
+    .expect("writing the caller-env probe launcher into the launcher mount");
 
     let robot = start_daemon(
         &launch,
@@ -1058,6 +1094,64 @@ async fn hub_nodes_build_and_run_inside_a_daemon_container() {
         .robot
         .wait_for_node_log("probe_arm_inst", "[arm] published joint_states")
         .await;
+}
+
+/// The caller's environment stays on the caller's machine.
+///
+/// The scenario is a field failure: an operator launches from a machine whose
+/// `PATH` does not name the directory the peer keeps its tools in, and the
+/// peer's `uv sync` dies with `No such file or directory` on a host that has
+/// `uv` installed, because the build resolves programs through the caller's
+/// forwarded `PATH` instead of the peer's own. So this launch runs under a
+/// `PATH` of directories that exist on every machine here but hold no `uv`,
+/// and the peer must still build and start the node. The canary closes the
+/// other half: no variable from the operator's shell appears in any process
+/// on the peer, so what a node sees is decided by its launcher file and the
+/// machine it runs on, not by whoever typed the launch.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_peer_builds_with_its_own_environment_not_the_callers() {
+    let federation = start_federation("peppy-caller-env").await;
+
+    let launch = federation
+        .robot
+        .peppy_with_env(
+            &[
+                "PATH=/usr/sbin:/usr/bin:/sbin:/bin",
+                "CALLER_CANARY=from_the_operators_shell",
+            ],
+            &[
+                "stack",
+                "launch",
+                "--place",
+                &format!("remote_worker@{}", federation.cloud_core_node),
+                &container_launcher(CALLER_ENV_PROBE_LAUNCHER_FILE),
+            ],
+        )
+        .await;
+    assert!(
+        launch.success(),
+        "a peer must resolve build tools on its own machine, not through the caller's PATH:\n{}",
+        launch.text
+    );
+
+    federation
+        .cloud
+        .wait_for_node_log("env_probe_arm_inst", "[arm] published joint_states")
+        .await;
+
+    let leaked = federation
+        .cloud
+        .exec(vec![
+            "/bin/sh",
+            "-c",
+            "cat /proc/[0-9]*/environ 2>/dev/null | tr '\\0' '\\n' | grep ^CALLER_CANARY= || true",
+        ])
+        .await;
+    assert!(
+        !leaked.text.contains("CALLER_CANARY"),
+        "the caller's environment must not reach any process on the peer:\n{}",
+        leaked.text
+    );
 }
 
 /// The whole thing, end to end: one command on the robot, two machines running

--- a/docs/src/content/docs/advanced_guides/federation.mdx
+++ b/docs/src/content/docs/advanced_guides/federation.mdx
@@ -171,6 +171,16 @@ replaces them. And the `[cn-atlas-h100]` prefix: the peer's own output is
 relayed into this one stream and attributed, because a launch that ran half its
 work somewhere you cannot see is not one you can debug.
 
+Each machine builds and runs its slice with its own environment. Nothing from
+the machine the launch was typed on crosses over: not its `PATH`, not its
+shell environment. A node's `build_cmd` names its toolchain (`uv` for the
+default Python template, or whatever the node declares), and every machine a
+launch places that node on must have that toolchain installed where its daemon
+can find it; a machine that lacks it fails the launch with an error naming the
+missing program. The one way to hand a value to a remote instance is the
+`env_vars` of that instance in the launcher file, which apply wherever the
+instance is placed.
+
 ## Verifying placement
 
 `peppy stack list` from either machine shows both slices, each attributed to the


### PR DESCRIPTION
## Problem

A federated `stack launch` forwards the CLI's filtered caller environment, `PATH` and `HOME` included, into the add, build, and run goals it dispatches to peer daemons. A peer's build then resolves its `build_cmd` through the coordinator machine's `PATH` string, evaluated against the peer's filesystem. Field failure:

```
failed to build node deliberative_planner: 'cn-vibrant-chaplygin': ... failed to execute build_cmd `uv sync --no-editable`: No such file or directory (os error 2)
```

This fails even on peers that have the toolchain installed, whenever the caller's `PATH` does not name the directory the peer keeps it in. And when a peer genuinely lacks the toolchain, the raw ENOENT names neither the program nor what is missing.

## Replication first

Commit 1 (7396db5) adds a multi-daemon e2e test that drives exactly the field scenario: a launch from the robot container under a `PATH` of directories that exist on every machine but hold no `uv`, placing one native Python node on the cloud peer, plus a canary variable that must never appear in any process on the peer. The peer has `uv` installed; the build still dies with the field error, because it resolves through the caller's forwarded `PATH`.

Red run on commit 1 alone: https://github.com/Peppy-bot/peppy/actions/runs/30750976562 — fails only on the new test, with `failed to build node my_python_robot_arm: `cn-cloud`: ... failed to execute build_cmd `uv sync --no-editable`: No such file or directory (os error 2)`.

## Fix

Commit 2 (8907e05) keeps the caller's environment on the caller's machine:

- Goals dispatched to peers carry no forwarded caller environment. Peer add/build goals carry none at all; peer run goals carry exactly the `env_vars` the launcher file declares for the instance. Instances on the coordinator's own machine keep receiving the forwarded environment, which does describe that machine.
- A `build_cmd` spawn failing with ENOENT reports something actionable: the missing program by name (any toolchain: `uv`, `pixi`, `poetry`, ...), or the missing working directory. No toolchain is vendored or special-cased; a machine that lacks a tool fails loudly and clearly.
- The Federation guide states the contract: each machine builds and runs its slice with its own environment, and instance `env_vars` in the launcher file are the one way to hand a value to a remote instance.

## Test plan

- Multi-daemon e2e: red on commit 1 alone (link above), green on commit 1+2: https://github.com/Peppy-bot/peppy/actions/runs/30752017757
- Unit: spawn-failure messages name the program / working directory; child-PATH resolution mechanism locked (`node-stack`); `instance_environment` composition including the peer-instance case (`core-node`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
