### PR TITLE
Produce the Linux container bindings in every release build

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -36,10 +36,10 @@ steps:
     command: .buildkite/scripts/tests.sh
     env:
       # CI does the full cross-platform peppylib build: cross-compile the .so
-      # for every Linux arch. A plain `cargo build` leaves this unset and, like
-      # a Linux build, produces only the host dynamic lib, so local dev builds
-      # stay fast; the release path and CI turn it on. On a warm build cache
-      # this is a no-op (present, fresh artifacts are reused); it only pays the
+      # for every Linux arch. Test builds are debug, which skips the cross
+      # build unless this opts in (release builds always run it); leaving it
+      # unset is what keeps local dev builds fast. On a warm build cache this
+      # is a no-op (present, fresh artifacts are reused); it only pays the
       # cross-build cost when the cache is cold. Cross-arch apptainer is
       # separate, gated by PEPPY_CROSS_ARCH.
       PEPPY_CROSS_BUILD: "1"

--- a/crates/generator-internal/Cargo.toml
+++ b/crates/generator-internal/Cargo.toml
@@ -50,9 +50,6 @@ json5-pretty = { workspace = true }
 pmi = { workspace = true, features = ["zenoh", "build_zenoh"] }
 serde_json5 = "0.2.1"
 tempfile = "3.10"
-# Lets the scaffold test gate itself on the same PEPPY_CROSS_BUILD predicate the
-# build script uses, so the two never drift.
-peppylib-build-policy = { workspace = true }
 peppylib = { workspace = true }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
 rstest = { workspace = true }

--- a/crates/generator-internal/build.rs
+++ b/crates/generator-internal/build.rs
@@ -641,9 +641,10 @@ mod peppylib_build {
     /// `current_hash` (per the recorded build state; no state = unknown
     /// provenance) and therefore must not be embedded — see
     /// [`peppylib_build_policy::should_embed_so`]. In practice these are the
-    /// Linux container bindings after a shared-crate change: a plain build
-    /// rebuilds only the host `.so` and skips the cross-compile, so the cache
-    /// keeps Linux bindings from older sources. The files are left in place
+    /// Linux container bindings after a shared-crate change: a debug build
+    /// without PEPPY_CROSS_BUILD rebuilds only the host `.so` and skips the
+    /// cross-compile, so the cache keeps Linux bindings from older sources.
+    /// The files are left in place
     /// (another checkout at their revision may still embed them; the next
     /// cross build overwrites them) — they are only excluded from this build's
     /// embed.
@@ -840,6 +841,21 @@ mod peppylib_build {
 
         let current_hash = compute_source_hash(&peppylib_py_dir);
 
+        let profile = peppylib_build_policy::BuildProfile::from_env();
+        // The single cross-build decision for this compilation: every release
+        // build produces the Linux container bindings, a debug build only under
+        // PEPPY_CROSS_BUILD. Emitted as PEPPYLIB_CROSS_BUILD so the scaffold
+        // test gates on the decision this script actually took and the two can
+        // never drift.
+        let cross_build = peppylib_build_policy::cross_build_enabled(
+            profile,
+            peppylib_build_policy::cross_build_requested(),
+        );
+        println!(
+            "cargo:rustc-env=PEPPYLIB_CROSS_BUILD={}",
+            u8::from(cross_build)
+        );
+
         // Release cross-builds run inside the Lima VM, which has no pixi and must
         // not touch the cargo checkout. They consume the host-built `.so` from an
         // explicit directory (mounted from the host) instead of building.
@@ -861,7 +877,6 @@ mod peppylib_build {
         std::fs::create_dir_all(&so_dir)
             .unwrap_or_else(|e| panic!("failed to create peppylib .so dir {so_dir:?}: {e}"));
 
-        let profile = peppylib_build_policy::BuildProfile::from_env();
         let host = host_platform_suffix();
 
         // Every platform this machine produces: the host always, plus the Linux
@@ -967,15 +982,15 @@ mod peppylib_build {
         }
 
         // Linux container bindings (macOS only). The build host is macOS, so
-        // every Linux `.so` is a cross-compile, and all are release-only: like a
-        // Linux `cargo build` (which builds only its own native host `.so`), a
-        // regular build here produces only the host dynamic lib. The Linux
-        // bindings are built solely under PEPPY_CROSS_BUILD (set by
-        // scripts/build_release.sh and CI), so a plain `cargo build` never pays
-        // the slow zig cross-compile and the two platforms stay consistent.
+        // every Linux `.so` is a cross-compile, and all are built in release
+        // mode: like a Linux `cargo build` (which builds only its own native
+        // host `.so`), a plain debug build here produces only the host dynamic
+        // lib. The Linux bindings are built solely when the cross build is
+        // enabled (every release build, plus debug builds that opt in via
+        // PEPPY_CROSS_BUILD), so a plain debug `cargo build` never pays the
+        // slow zig cross-compile and the two platforms stay consistent.
         #[cfg(target_os = "macos")]
         {
-            let cross_build = peppylib_build_policy::cross_build_requested();
             for target in LINUX_CROSS_TARGETS {
                 let suffix = target.platform_suffix;
                 let target_so = so_dir.join(format!("_peppylib.abi3.{suffix}.so"));
@@ -1003,7 +1018,7 @@ mod peppylib_build {
         }
 
         // Cached bindings this build chose not to rebuild (the Linux
-        // cross-compiles, without PEPPY_CROSS_BUILD) may date from other
+        // cross-compiles, when the cross build is disabled) may date from other
         // sources; embedding one ships a model mismatch inside container
         // images that only surfaces when the node crashes at startup. Exclude
         // them so container builds for those platforms fail up front with the
@@ -1014,7 +1029,7 @@ mod peppylib_build {
                 "cargo:warning=Excluding {name} from the embedded peppylib set: it was \
                  built from different sources. Container Python nodes for that platform \
                  will fail to build until a cross build refreshes it \
-                 (PEPPY_CROSS_BUILD=1 cargo build, or scripts/build_release.sh)."
+                 (cargo build --release, or PEPPY_CROSS_BUILD=1 for a debug build)."
             );
         }
         generate_embedded_peppylib_so(&so_dir, &stale);

--- a/crates/generator-internal/src/generator/python/scaffold.rs
+++ b/crates/generator-internal/src/generator/python/scaffold.rs
@@ -129,9 +129,10 @@ pub fn add_peppylib_dependencies(
                              '{target_suffix}' (expected '{expected_so_name}'). \
                              Linux container bindings are only produced (or, \
                              after a shared-crate change, refreshed) by a cross \
-                             build: rebuild peppy with PEPPY_CROSS_BUILD=1 \
-                             (scripts/build_release.sh does this) and restart \
-                             the daemon."
+                             build: every release build runs one, a debug build \
+                             only with PEPPY_CROSS_BUILD=1. Rebuild peppy \
+                             (`cargo build --release`, or PEPPY_CROSS_BUILD=1 \
+                             `cargo build`) and restart the daemon."
                         ),
                     )
                 })?;
@@ -396,15 +397,16 @@ mod tests {
     /// all release builds (including cross-compilation) originate.
     ///
     /// The Linux container bindings (linux-aarch64 and linux-x86_64) are produced
-    /// only in a cross build (PEPPY_CROSS_BUILD, set by scripts/build_release.sh
-    /// and the CI workflow); a regular build produces only the host dynamic lib,
-    /// so the embedded set lacks every Linux platform and this test has nothing to
-    /// assert and skips. The gate uses the same predicate the build script does,
-    /// so the two never disagree.
+    /// only when the cross build is enabled: every release build, plus debug
+    /// builds that opt in via PEPPY_CROSS_BUILD (the CI workflows do). Otherwise
+    /// the embedded set lacks every Linux platform and this test has nothing to
+    /// assert and skips. The gate reads PEPPYLIB_CROSS_BUILD, the decision the
+    /// build script actually took for this compilation, so the two can never
+    /// disagree.
     #[test]
     #[cfg(target_os = "macos")]
     fn embedded_peppylib_contains_all_release_platform_dynamic_lib() {
-        if !peppylib_build_policy::cross_build_requested() {
+        if env!("PEPPYLIB_CROSS_BUILD") != "1" {
             return;
         }
 

--- a/crates/peppylib-build-policy/src/lib.rs
+++ b/crates/peppylib-build-policy/src/lib.rs
@@ -11,5 +11,6 @@
 mod so_build;
 
 pub use so_build::{
-    BuildProfile, cross_build_requested, should_build_host, should_cross_compile, should_embed_so,
+    BuildProfile, cross_build_enabled, cross_build_requested, should_build_host,
+    should_cross_compile, should_embed_so,
 };

--- a/crates/peppylib-build-policy/src/so_build.rs
+++ b/crates/peppylib-build-policy/src/so_build.rs
@@ -45,11 +45,10 @@ pub fn should_build_host(present: bool, current: bool, force: bool) -> bool {
     force || !present || !current
 }
 
-/// Whether the caller requested a cross-platform build by setting
-/// `PEPPY_CROSS_BUILD` (scripts/build_release.sh and the CI workflow do). Only a
-/// cross build produces the Linux container bindings; a plain `cargo build`
-/// builds only the host dynamic lib and skips the slow zig cross-compile, so
-/// local dev builds stay fast.
+/// Whether the caller explicitly requested a cross-platform build by setting
+/// `PEPPY_CROSS_BUILD` (the CI test workflows do, and a developer iterating on
+/// container bindings can). Release builds need no request: they always run
+/// the cross build (see [`cross_build_enabled`]).
 ///
 /// Any non-empty value other than "0" counts as set, matching the
 /// `PEPPYLIB_REBUILD` convention.
@@ -57,18 +56,31 @@ pub fn cross_build_requested() -> bool {
     std::env::var("PEPPY_CROSS_BUILD").is_ok_and(|v| !v.is_empty() && v != "0")
 }
 
+/// Whether this build produces the Linux container bindings.
+///
+/// Every release build does: a release binary is a deployment artifact, and a
+/// daemon without the Linux bindings embedded fails every container Python
+/// node build on its machine, so `cargo build --release` must never ship
+/// without them. A debug build skips the slow zig cross-compile to keep local
+/// iteration fast, unless the caller opts in via `PEPPY_CROSS_BUILD`
+/// ([`cross_build_requested`]).
+pub fn cross_build_enabled(profile: BuildProfile, requested: bool) -> bool {
+    profile == BuildProfile::Release || requested
+}
+
 /// Whether a Linux `.so` cross-compile must run for a target.
 ///
 /// The build host is macOS, so every Linux target is a cross-compile, and all of
-/// them are release-only. A regular `cargo build` therefore produces only the
-/// host dynamic lib, exactly like a Linux build (which likewise builds only its
-/// own native host `.so`); this keeps the two platforms consistent and a plain
-/// build fast. The Linux bindings are built solely in a cross build
-/// (`cross_build`, from [`cross_build_requested`], set by
-/// `scripts/build_release.sh` and CI), where a target is (re)built when a rebuild
-/// is forced, the `.so` is missing, or its recorded state is stale. `force`
+/// them are built in release mode regardless of the cargo profile. A plain debug
+/// `cargo build` therefore produces only the host dynamic lib, exactly like a
+/// Linux build (which likewise builds only its own native host `.so`); this
+/// keeps the two platforms consistent and a plain build fast. The Linux bindings
+/// are built solely when the cross build is enabled (`cross_build`, from
+/// [`cross_build_enabled`]: every release build, plus debug builds that opt in
+/// via `PEPPY_CROSS_BUILD`), where a target is (re)built when a rebuild is
+/// forced, the `.so` is missing, or its recorded state is stale. `force`
 /// (`PEPPYLIB_REBUILD`) alone never triggers a Linux build: it refreshes the host
-/// artifact, while the Linux bindings stay gated on the cross-build flag.
+/// artifact, while the Linux bindings stay gated on the cross-build decision.
 pub fn should_cross_compile(cross_build: bool, present: bool, stale: bool, force: bool) -> bool {
     cross_build && (force || !present || stale)
 }
@@ -78,9 +90,10 @@ pub fn should_cross_compile(cross_build: bool, present: bool, stale: bool, force
 /// Only a binding whose recorded source hash matches the sources of the build
 /// that embeds it may ship: the daemon serializes node configs with the model
 /// it was compiled against, and a binding compiled from a different revision
-/// of the shared crates deserializes them with a different model. A plain
-/// `cargo build` never rebuilds the Linux container bindings (see
-/// [`should_cross_compile`]), so after a shared-crate change the cache can
+/// of the shared crates deserializes them with a different model. A debug
+/// build without `PEPPY_CROSS_BUILD` never rebuilds the Linux container
+/// bindings (see [`should_cross_compile`]), so after a shared-crate change
+/// the cache can
 /// hold Linux `.so` from older sources — embedding one puts the schema
 /// mismatch inside the container image, where it only surfaces as a baffling
 /// parse error when the node starts (e.g. `unknown field \`implements\``).
@@ -118,9 +131,21 @@ mod tests {
     }
 
     #[test]
-    fn linux_so_is_release_only() {
-        // Without a cross build a Linux .so is never produced, regardless of
-        // whether it is missing or stale, and not even under `force` (which
+    fn release_builds_always_enable_the_cross_build() {
+        assert!(cross_build_enabled(BuildProfile::Release, false));
+        assert!(cross_build_enabled(BuildProfile::Release, true));
+    }
+
+    #[test]
+    fn debug_builds_enable_the_cross_build_only_on_request() {
+        assert!(!cross_build_enabled(BuildProfile::Debug, false));
+        assert!(cross_build_enabled(BuildProfile::Debug, true));
+    }
+
+    #[test]
+    fn linux_so_requires_an_enabled_cross_build() {
+        // With the cross build disabled a Linux .so is never produced, regardless
+        // of whether it is missing or stale, and not even under `force` (which
         // refreshes the host build, not a Linux cross-compile). This matches a
         // Linux `cargo build`, which likewise builds only its own host .so.
         for present in [false, true] {

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -7,14 +7,10 @@ set -eu
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 command -v pixi >/dev/null 2>&1 || { echo "error: 'pixi' is required (https://pixi.sh)" >&2; exit 1; }
 
-# Enable the release-only Linux container bindings: cross-compile the peppylib
-# .so for every Linux arch (linux-aarch64 and linux-x86_64) from this macOS host.
-# A plain `cargo build` leaves this unset and, like a Linux build, produces only
-# the host dynamic lib, so local dev builds stay fast; only this script and CI
-# set it. Native apptainer is always built regardless of this flag; cross-arch
-# apptainer is a separate axis, gated by PEPPY_CROSS_ARCH (set in
-# scripts/functions/build.py).
-export PEPPY_CROSS_BUILD=1
+# The Linux container bindings (the peppylib .so for linux-aarch64 and
+# linux-x86_64) need no flag here: every release build cross-compiles them, and
+# this script builds everything in release. Cross-arch apptainer is a separate
+# axis, gated by PEPPY_CROSS_ARCH (set in scripts/functions/build.py).
 
 # Force a fresh peppylib native-extension build (including the Linux cross-compile)
 # so release artifacts never embed a stale .so left over from a debug build.


### PR DESCRIPTION
## Why

Field failure (2026-08-02): a federated `stack launch` placing container Python nodes on the Mac daemon failed with `no embedded native extension found for platform 'linux-aarch64'`. The daemon had been rebuilt with a plain `cargo build` after a peppy-shared change (public-peppy-libs dfd811e touches `peppylib-rs`/`peppylib-py` messaging, both `.so` hash inputs), so the cached linux-aarch64 binding was excluded from the embed as stale and the daemon shipped without any Linux container binding.

A binary that serves container nodes is a deployment artifact and must never ship without the Linux bindings, so the release profile now implies the peppylib cross build: `cargo build --release` needs no flag. `PEPPY_CROSS_BUILD` remains the opt-in for debug builds (CI test workflows set it; plain debug builds stay fast without it).

## What

- `peppylib-build-policy`: new pure `cross_build_enabled(profile, requested)` = release || requested, with unit tests; docs reworded around the new rule.
- `generator-internal/build.rs`: computes the single cross-build decision up front and emits it as `PEPPYLIB_CROSS_BUILD`; the macOS cross-compile block consumes it.
- Scaffold test gate now reads `PEPPYLIB_CROSS_BUILD` (the decision the build script actually took) instead of re-evaluating the env var at test time, so gate and build can never drift; drops the `peppylib-build-policy` dev-dependency that existed only for that gate.
- Scaffolder error message and build warning now name both remedies (`cargo build --release`, or `PEPPY_CROSS_BUILD=1` for a debug build).
- `scripts/build_release.sh` drops its now-redundant `PEPPY_CROSS_BUILD=1` export (every cargo invocation in the release pipeline is `--release`; the Lima VM path consumes prebuilt `.so` and is unaffected).

Not included: the matching comment reword in `.github/workflows/tests.yml` (push rejected: token lacks `workflow` scope). The env var there is still needed and still correct; only its comment's "the release path and CI turn it on" phrasing is stale.

## Test plan

- `cargo test -p peppylib-build-policy`: 13 passed locally (covers the new policy plus the existing cross-compile/embed matrix).
- `cargo check -p generator`: the modified build script compiles and runs its full decision path (native build itself can't finish in the agent container; CI covers it).
- CI Tests workflow exercises the debug+`PEPPY_CROSS_BUILD` path; the macOS scaffold test `embedded_peppylib_contains_all_release_platform_dynamic_lib` asserts all three platform bindings are embedded whenever the cross build is enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)