### PR TITLE
List every machine's node log files in the launch summary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,7 +573,7 @@ dependencies = [
 [[package]]
 name = "build-helpers"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#960c8c8eb08cf149805c68ac60f402a72e447563"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#4f740e2cfabcbbf319d38bb7a7991f6d045f353a"
 dependencies = [
  "sha2",
 ]
@@ -765,7 +765,7 @@ dependencies = [
 [[package]]
 name = "config-test-support"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#960c8c8eb08cf149805c68ac60f402a72e447563"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#4f740e2cfabcbbf319d38bb7a7991f6d045f353a"
 dependencies = [
  "askama",
  "git2",
@@ -909,7 +909,7 @@ dependencies = [
 [[package]]
 name = "core-node-api"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#960c8c8eb08cf149805c68ac60f402a72e447563"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#4f740e2cfabcbbf319d38bb7a7991f6d045f353a"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -1248,7 +1248,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1396,7 +1396,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2581,7 +2581,7 @@ dependencies = [
 [[package]]
 name = "json5-pretty"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#960c8c8eb08cf149805c68ac60f402a72e447563"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#4f740e2cfabcbbf319d38bb7a7991f6d045f353a"
 dependencies = [
  "serde",
  "serde_json",
@@ -2985,7 +2985,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3371,7 +3371,7 @@ dependencies = [
 [[package]]
 name = "peppy-config-model"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#960c8c8eb08cf149805c68ac60f402a72e447563"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#4f740e2cfabcbbf319d38bb7a7991f6d045f353a"
 dependencies = [
  "capnp",
  "clap",
@@ -3394,7 +3394,7 @@ version = "0.0.1"
 [[package]]
 name = "peppylib-rs"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#960c8c8eb08cf149805c68ac60f402a72e447563"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#4f740e2cfabcbbf319d38bb7a7991f6d045f353a"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -3589,7 +3589,7 @@ dependencies = [
 [[package]]
 name = "pmi"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#960c8c8eb08cf149805c68ac60f402a72e447563"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#4f740e2cfabcbbf319d38bb7a7991f6d045f353a"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -3807,7 +3807,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.5",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4057,7 +4057,7 @@ dependencies = [
  "pin-project-lite",
  "rustls",
  "rustls-pki-types",
- "rustls-platform-verifier 0.6.2",
+ "rustls-platform-verifier 0.7.0",
  "serde",
  "serde_json",
  "sync_wrapper",
@@ -4243,7 +4243,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4311,7 +4311,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4332,7 +4332,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4708,7 +4708,7 @@ version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
 dependencies = [
- "dirs 4.0.0",
+ "dirs 6.0.0",
 ]
 
 [[package]]
@@ -5044,7 +5044,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5947,7 +5947,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/core-node-internal/src/services/stack/launch.rs
+++ b/crates/core-node-internal/src/services/stack/launch.rs
@@ -371,7 +371,9 @@ async fn add_and_build_group(
         .await;
 
         if core_node != local {
-            if let Err(reason) = add_and_build_remotely(ctx, goal, core_node, item).await {
+            if let Err(reason) =
+                add_and_build_remotely(ctx, goal, core_node, key, item, &mut outcome).await
+            {
                 outcome.failure = Some(reason);
                 return outcome;
             }
@@ -403,6 +405,7 @@ async fn add_and_build_group(
                 node_label: key.label(),
                 log_path: path,
                 failed,
+                core_node: local.to_owned(),
             });
         }
 
@@ -440,6 +443,7 @@ async fn add_and_build_group(
                 node_label: key.label(),
                 log_path: path,
                 failed: build_failed,
+                core_node: local.to_owned(),
             });
         }
 
@@ -459,10 +463,10 @@ async fn add_and_build_group(
 /// content on a fingerprint match and fetching the pinned commit otherwise,
 /// and never resolves a name against its own cache.
 ///
-/// The peer's own log paths are not folded into this launch's log lists: they
-/// name files on that machine, and a path the operator cannot open is worse
-/// than no path. What the operator gets instead is the peer's output, relayed
-/// live into this launch's feedback stream and attributed to its core node.
+/// Each accepted goal's log entry lands in this launch's log lists exactly as
+/// a local one does, stamped with the peer's core node because the path names
+/// a file on that machine's filesystem. The peer's output is also relayed
+/// live into this launch's feedback stream, attributed to its core node.
 ///
 /// Neither goal carries the caller's forwarded environment. Those values
 /// (PATH first among them) describe the coordinator's machine, and a build
@@ -473,7 +477,9 @@ async fn add_and_build_remotely(
     ctx: &ProcessLaunchContext,
     goal: &LaunchGoal,
     core_node: &str,
+    key: &NodeKey,
     item: &PlannedDeployment,
+    outcome: &mut GroupOutcome,
 ) -> std::result::Result<(), String> {
     // A real budget, unlike the in-process path's zero: this goal passes
     // through the peer's own concurrency gate, which reports the remaining time
@@ -487,9 +493,21 @@ async fn add_and_build_remotely(
     .with_pins(crate::services::node::pins::encode_pins(
         &item.closure_pins,
     )?);
-    let added = federated::run_remote_goal(ctx, core_node, &add_goal, ctx.idle_timeouts.add)
+    let added = match federated::run_remote_goal(ctx, core_node, &add_goal, ctx.idle_timeouts.add)
         .await
-        .map_err(|reason| format!("failed to add node {}: {reason}", item.node_name))?;
+    {
+        Ok(run) => {
+            outcome.add_logs.push(NodeAddLogEntry {
+                node_label: key.label(),
+                log_path: run.log_path,
+                failed: run.outcome.is_err(),
+                core_node: core_node.to_owned(),
+            });
+            run.outcome
+        }
+        Err(reason) => Err(reason),
+    }
+    .map_err(|reason| format!("failed to add node {}: {reason}", item.node_name))?;
 
     let build_goal = NodeBuildGoal::new(
         added.node_name.unwrap_or_else(|| item.node_name.clone()),
@@ -497,9 +515,19 @@ async fn add_and_build_remotely(
         ctx.idle_timeouts.build.as_secs(),
     )
     .with_launch_id(&goal.launch_id);
-    federated::run_remote_goal(ctx, core_node, &build_goal, ctx.idle_timeouts.build)
-        .await
-        .map_err(|reason| format!("failed to build node {}: {reason}", item.node_name))
+    match federated::run_remote_goal(ctx, core_node, &build_goal, ctx.idle_timeouts.build).await {
+        Ok(run) => {
+            outcome.build_logs.push(NodeBuildLogEntry {
+                node_label: key.label(),
+                log_path: run.log_path,
+                failed: run.outcome.is_err(),
+                core_node: core_node.to_owned(),
+            });
+            run.outcome
+        }
+        Err(reason) => Err(reason),
+    }
+    .map_err(|reason| format!("failed to build node {}: {reason}", item.node_name))
 }
 
 /// Step 7: Prepare the host paths that containers on THIS machine will bind.
@@ -1001,7 +1029,17 @@ async fn start_node_instances(
             let outcome = if local {
                 start_locally(ctx, key, instance_id, node_run_goal, run_log_paths).await
             } else {
-                start_remotely(ctx, goal, &core_node, node_run_goal, &item.config_sha256).await
+                start_remotely(
+                    ctx,
+                    goal,
+                    &core_node,
+                    key,
+                    instance_id,
+                    node_run_goal,
+                    &item.config_sha256,
+                    run_log_paths,
+                )
+                .await
             };
 
             if let Err(reason) = outcome {
@@ -1038,6 +1076,7 @@ async fn start_locally(
             node_label: key.label(),
             log_path: path,
             failed,
+            core_node: ctx.bound_core_node.clone(),
         });
     }
 
@@ -1051,7 +1090,8 @@ async fn start_locally(
 }
 
 /// Starts one instance on a peer, pinning the manifest this coordinator
-/// resolved for its deployment.
+/// resolved for its deployment, and recording its log entry stamped with the
+/// peer's core node.
 ///
 /// The hash closes the window between add and start: the peer compares it
 /// against the entity now in its stack and refuses if the two no longer
@@ -1059,17 +1099,33 @@ async fn start_locally(
 /// loudly instead of starting a node the plan was never checked against.
 /// Every remote instance carries it, straddling deployments included,
 /// because the coordinator resolved every deployment itself.
+#[allow(clippy::too_many_arguments)] // Distinct inputs; bundling them would only move the list.
 async fn start_remotely(
     ctx: &ProcessLaunchContext,
     goal: &LaunchGoal,
     core_node: &str,
+    key: &NodeKey,
+    instance_id: &str,
     node_run_goal: NodeRunGoal,
     config_sha256: &str,
+    run_log_paths: &mut Vec<NodeRunLogEntry>,
 ) -> std::result::Result<(), String> {
     let node_run_goal = node_run_goal
         .with_launch_id(&goal.launch_id)
         .with_manifest_sha256(config_sha256);
-    federated::run_remote_goal(ctx, core_node, &node_run_goal, ctx.idle_timeouts.run).await
+    match federated::run_remote_goal(ctx, core_node, &node_run_goal, ctx.idle_timeouts.run).await {
+        Ok(run) => {
+            run_log_paths.push(NodeRunLogEntry {
+                instance_id: instance_id.to_string(),
+                node_label: key.label(),
+                log_path: run.log_path,
+                failed: run.outcome.is_err(),
+                core_node: core_node.to_owned(),
+            });
+            run.outcome
+        }
+        Err(reason) => Err(reason),
+    }
 }
 
 async fn handle_goal_request(

--- a/crates/core-node-internal/src/services/stack/launch/federated/dispatch.rs
+++ b/crates/core-node-internal/src/services/stack/launch/federated/dispatch.rs
@@ -23,6 +23,7 @@
 //! command, so they get one stream; the prefix is what keeps it readable when
 //! two machines are building at once.
 
+use std::path::PathBuf;
 use std::time::Duration;
 
 use core_node_api::ActionGoal;
@@ -59,7 +60,10 @@ pub(in crate::services::stack) trait RemoteGoal: ActionGoal {
     type Outcome;
 
     fn label() -> &'static str;
-    fn decode_acceptance(payload: &[u8]) -> std::result::Result<(), String>;
+    /// Decodes the peer's goal response: the log file the peer created for
+    /// this goal, on its own filesystem, when it accepted, and the rejection
+    /// reason when it refused.
+    fn decode_acceptance(payload: &[u8]) -> std::result::Result<PathBuf, String>;
     fn decode_feedback_line(payload: &[u8]) -> Option<String>;
     fn decode_outcome(payload: &[u8]) -> std::result::Result<Self::Outcome, String>;
 }
@@ -74,11 +78,11 @@ macro_rules! impl_remote_goal {
                 $label
             }
 
-            fn decode_acceptance(payload: &[u8]) -> std::result::Result<(), String> {
+            fn decode_acceptance(payload: &[u8]) -> std::result::Result<PathBuf, String> {
                 let response = <$response>::decode(payload)
                     .map_err(|e| format!("undecodable {} goal response: {e}", $label))?;
                 if response.accepted {
-                    return Ok(());
+                    return Ok(response.log_path);
                 }
                 Err(response
                     .rejection_reason
@@ -134,8 +138,22 @@ impl_remote_goal!(
     drop
 );
 
+/// What one accepted goal produced, as the coordinator records it.
+///
+/// `log_path` names the log file the peer created for the goal, on its own
+/// filesystem, known from the moment the peer accepted. It is carried
+/// separately from `outcome` so a failed phase still names the file that
+/// explains it.
+pub(in crate::services::stack) struct RemoteGoalRun<T> {
+    pub(in crate::services::stack) log_path: PathBuf,
+    pub(in crate::services::stack) outcome: std::result::Result<T, String>,
+}
+
 /// Sends one goal to `core_node` and drives it to completion, relaying its
 /// feedback into this launch's stream.
+///
+/// Returns `Err` only when the peer never accepted the goal (the send failed
+/// or the peer refused), which is the one case with no log file to name.
 ///
 /// `idle_timeout` is the same per-phase budget the in-process path uses, but
 /// measured against RELAYED feedback rather than local subprocess output: a
@@ -148,7 +166,7 @@ pub(in crate::services::stack) async fn run_remote_goal<G: RemoteGoal>(
     core_node: &str,
     goal: &G,
     idle_timeout: Duration,
-) -> std::result::Result<G::Outcome, String> {
+) -> std::result::Result<RemoteGoalRun<G::Outcome>, String> {
     let mut handle = send_goal(
         goal,
         &ctx.messenger,
@@ -160,63 +178,68 @@ pub(in crate::services::stack) async fn run_remote_goal<G: RemoteGoal>(
     .await
     .map_err(|e| format!("`{core_node}` did not accept the {} goal: {e}", G::label()))?;
 
-    G::decode_acceptance(handle.goal_reply().body.as_ref())
+    let log_path = G::decode_acceptance(handle.goal_reply().body.as_ref())
         .map_err(|reason| format!("`{core_node}` refused the {}: {reason}", G::label()))?;
 
-    let mut last_activity = tokio::time::Instant::now();
-    loop {
-        let now = tokio::time::Instant::now();
-        if ctx.launch_deadline.is_some_and(|deadline| now >= deadline) {
-            return Err(format!(
-                "max launch timeout exceeded while `{core_node}` was running {}",
-                G::label()
-            ));
-        }
-        if now.duration_since(last_activity) >= idle_timeout {
-            return Err(format!(
-                "`{core_node}` produced no {} output for {}s",
-                G::label(),
-                idle_timeout.as_secs()
-            ));
-        }
-
-        // Wait exactly until the nearer of the two budgets would be blown,
-        // rather than ticking. A remote build can be silent for minutes, and
-        // both budgets are re-checked at the top of the loop anyway, so waking
-        // any earlier than the deadline that would end the wait is pure spin —
-        // multiplied by every peer running a goal concurrently.
-        let idle_expiry = last_activity + idle_timeout;
-        let wake_at = match ctx.launch_deadline {
-            Some(deadline) => idle_expiry.min(deadline),
-            None => idle_expiry,
-        };
-        match tokio::time::timeout_at(wake_at, handle.on_next_feedback()).await {
-            Ok(Ok(message)) => {
-                last_activity = tokio::time::Instant::now();
-                if let Some(line) = G::decode_feedback_line(message.payload().as_ref()) {
-                    publish_stdout(ctx, format!("[{core_node}] {line}"), G::STEP).await;
-                }
+    let outcome = async {
+        let mut last_activity = tokio::time::Instant::now();
+        loop {
+            let now = tokio::time::Instant::now();
+            if ctx.launch_deadline.is_some_and(|deadline| now >= deadline) {
+                return Err(format!(
+                    "max launch timeout exceeded while `{core_node}` was running {}",
+                    G::label()
+                ));
             }
-            // End of stream: the peer completed the goal.
-            Ok(Err(_)) => break,
-            // A budget elapsed with nothing to read; the checks above name it.
-            Err(_) => {}
+            if now.duration_since(last_activity) >= idle_timeout {
+                return Err(format!(
+                    "`{core_node}` produced no {} output for {}s",
+                    G::label(),
+                    idle_timeout.as_secs()
+                ));
+            }
+
+            // Wait exactly until the nearer of the two budgets would be blown,
+            // rather than ticking. A remote build can be silent for minutes, and
+            // both budgets are re-checked at the top of the loop anyway, so waking
+            // any earlier than the deadline that would end the wait is pure spin,
+            // multiplied by every peer running a goal concurrently.
+            let idle_expiry = last_activity + idle_timeout;
+            let wake_at = match ctx.launch_deadline {
+                Some(deadline) => idle_expiry.min(deadline),
+                None => idle_expiry,
+            };
+            match tokio::time::timeout_at(wake_at, handle.on_next_feedback()).await {
+                Ok(Ok(message)) => {
+                    last_activity = tokio::time::Instant::now();
+                    if let Some(line) = G::decode_feedback_line(message.payload().as_ref()) {
+                        publish_stdout(ctx, format!("[{core_node}] {line}"), G::STEP).await;
+                    }
+                }
+                // End of stream: the peer completed the goal.
+                Ok(Err(_)) => break,
+                // A budget elapsed with nothing to read; the checks above name it.
+                Err(_) => {}
+            }
         }
+
+        let result_timeout = ctx
+            .launch_deadline
+            .map(|deadline| {
+                deadline
+                    .saturating_duration_since(tokio::time::Instant::now())
+                    .max(Duration::from_secs(1))
+            })
+            .unwrap_or(GOAL_ACCEPT_TIMEOUT);
+        let payload = ActionMessenger::request_result_body(&ctx.messenger, &handle, result_timeout)
+            .await
+            .map_err(|reason| format!("`{core_node}` {}: {reason}", G::label()))?;
+
+        G::decode_outcome(payload.as_ref()).map_err(|reason| format!("`{core_node}`: {reason}"))
     }
+    .await;
 
-    let result_timeout = ctx
-        .launch_deadline
-        .map(|deadline| {
-            deadline
-                .saturating_duration_since(tokio::time::Instant::now())
-                .max(Duration::from_secs(1))
-        })
-        .unwrap_or(GOAL_ACCEPT_TIMEOUT);
-    let payload = ActionMessenger::request_result_body(&ctx.messenger, &handle, result_timeout)
-        .await
-        .map_err(|reason| format!("`{core_node}` {}: {reason}", G::label()))?;
-
-    G::decode_outcome(payload.as_ref()).map_err(|reason| format!("`{core_node}`: {reason}"))
+    Ok(RemoteGoalRun { log_path, outcome })
 }
 
 /// Tells every participant to replace its stack slice, in parallel.

--- a/crates/core-node-internal/tests/listen_for_launch.rs
+++ b/crates/core-node-internal/tests/listen_for_launch.rs
@@ -876,6 +876,25 @@ async fn listen_for_launch_configuration_succeed() {
             .map(|e| &e.instance_id)
             .collect::<Vec<_>>()
     );
+
+    // Every log entry names the machine whose filesystem holds the file. This
+    // launch places everything on the coordinator, so every entry carries its
+    // core node.
+    let expected_core_node = &started_core_node.core_node_name;
+    let all_core_nodes: Vec<&str> = result
+        .node_add_logs
+        .iter()
+        .map(|e| e.core_node.as_str())
+        .chain(result.node_build_logs.iter().map(|e| e.core_node.as_str()))
+        .chain(result.node_run_logs.iter().map(|e| e.core_node.as_str()))
+        .collect();
+    assert!(
+        all_core_nodes
+            .iter()
+            .all(|core_node| core_node == expected_core_node),
+        "every log entry should carry the coordinator's core node `{expected_core_node}`, got: \
+         {all_core_nodes:?}"
+    );
 }
 
 /// Launch file references nodes by `{ name, tag }` (long form) and
@@ -1744,6 +1763,10 @@ async fn listen_for_launch_configuration_fails_when_run_cmd_exits_with_error() {
     assert!(
         !result.node_run_logs[0].log_path.as_os_str().is_empty(),
         "start log path should be non-empty"
+    );
+    assert_eq!(
+        result.node_run_logs[0].core_node, started_core_node.core_node_name,
+        "a failed start's log entry still names the machine holding the file"
     );
 }
 

--- a/crates/peppy/src/commands/stack/launch.rs
+++ b/crates/peppy/src/commands/stack/launch.rs
@@ -51,6 +51,15 @@ fn compute_cli_max_timeout(max_timeout_secs: Option<u64>) -> Option<Duration> {
     })
 }
 
+/// One line of the "Node log files" listing:
+/// `node_name:tag@core-node: /path/to/log`, with a ` [FAILED]` marker before
+/// the colon when the phase failed. The core node names the machine whose
+/// filesystem holds the log file.
+fn node_log_line(node_label: &str, core_node: &str, failed: bool, log_path: &Path) -> String {
+    let marker = if failed { " [FAILED]" } else { "" };
+    format!("{node_label}@{core_node}{marker}: {}", log_path.display())
+}
+
 fn display_node_log_files(
     add_logs: &[NodeAddLogEntry],
     build_logs: &[NodeBuildLogEntry],
@@ -59,43 +68,43 @@ fn display_node_log_files(
     if add_logs.is_empty() && build_logs.is_empty() && run_logs.is_empty() {
         return;
     }
+    let line = |node_label: &str, core_node: &str, failed: bool, log_path: &Path| {
+        (node_log_line(node_label, core_node, failed, log_path), failed)
+    };
+    let sections = [
+        (
+            "Add",
+            add_logs
+                .iter()
+                .map(|e| line(&e.node_label, &e.core_node, e.failed, &e.log_path))
+                .collect::<Vec<_>>(),
+        ),
+        (
+            "Build",
+            build_logs
+                .iter()
+                .map(|e| line(&e.node_label, &e.core_node, e.failed, &e.log_path))
+                .collect(),
+        ),
+        (
+            "Run",
+            run_logs
+                .iter()
+                .map(|e| line(&e.node_label, &e.core_node, e.failed, &e.log_path))
+                .collect(),
+        ),
+    ];
     info!("Node log files:");
-    if !add_logs.is_empty() {
-        info!("  Add:");
-        for e in add_logs {
-            info!("    `{}`: {}", e.node_label, e.log_path.display());
+    for (title, lines) in sections {
+        if lines.is_empty() {
+            continue;
         }
-    }
-    if !build_logs.is_empty() {
-        info!("  Build:");
-        for e in build_logs {
-            let marker = if e.failed { " [FAILED]" } else { "" };
-            if e.failed {
-                tracing::error!("    `{}`{}: {}", e.node_label, marker, e.log_path.display());
+        info!("  {title}:");
+        for (text, failed) in lines {
+            if failed {
+                tracing::error!("    {text}");
             } else {
-                info!("    `{}`: {}", e.node_label, e.log_path.display());
-            }
-        }
-    }
-    if !run_logs.is_empty() {
-        info!("  Run:");
-        for e in run_logs {
-            let marker = if e.failed { " [FAILED]" } else { "" };
-            if e.failed {
-                tracing::error!(
-                    "    {} (`{}`){}: {}",
-                    e.instance_id,
-                    e.node_label,
-                    marker,
-                    e.log_path.display()
-                );
-            } else {
-                info!(
-                    "    {} (`{}`): {}",
-                    e.instance_id,
-                    e.node_label,
-                    e.log_path.display()
-                );
+                info!("    {text}");
             }
         }
     }
@@ -772,5 +781,34 @@ mod tests {
     fn launch_ids_are_distinct_per_launch() {
         assert_ne!(new_launch_id(), new_launch_id());
         assert!(new_launch_id().starts_with("launch-"));
+    }
+
+    #[test]
+    fn node_log_line_names_the_core_node_holding_the_file() {
+        let line = node_log_line(
+            "deliberative_planner:v1",
+            "cn-vibrant-chaplygin",
+            false,
+            Path::new("/tmp/.peppy/logs/add/deliberative_planner_v1.log"),
+        );
+        assert_eq!(
+            line,
+            "deliberative_planner:v1@cn-vibrant-chaplygin: \
+             /tmp/.peppy/logs/add/deliberative_planner_v1.log"
+        );
+    }
+
+    #[test]
+    fn node_log_line_marks_a_failed_phase_before_the_colon() {
+        let line = node_log_line(
+            "reactive_policy:v1",
+            "cn-robot-7",
+            true,
+            Path::new("/tmp/.peppy/logs/build/reactive_policy_v1.log"),
+        );
+        assert_eq!(
+            line,
+            "reactive_policy:v1@cn-robot-7 [FAILED]: /tmp/.peppy/logs/build/reactive_policy_v1.log"
+        );
     }
 }

--- a/crates/peppy/tests/multi_daemon_e2e.rs
+++ b/crates/peppy/tests/multi_daemon_e2e.rs
@@ -1193,6 +1193,26 @@ async fn a_federated_launch_places_each_instance_on_its_wired_core_node() {
         launch.text
     );
 
+    // The final log listing names every machine's files, each entry stamped
+    // with the core node whose filesystem holds the path. The planner lives
+    // only on the peer, so its label@core-node prefix appears exactly three
+    // times: once each under Add, Build and Run.
+    assert!(
+        launch.text.contains(&format!(
+            "uvc_camera_python_mock:v1@{}: ",
+            federation.robot_core_node
+        )),
+        "the log listing must name the coordinator's own entries:\n{}",
+        launch.text
+    );
+    let planner_entry = format!("deliberative_planner:v1@{}: ", federation.cloud_core_node);
+    assert_eq!(
+        launch.text.matches(&planner_entry).count(),
+        3,
+        "Add, Build and Run must each list the peer-held planner log:\n{}",
+        launch.text
+    );
+
     // An untargeted `stack list` fans out over the whole federation and prints
     // every machine's section, so proving an instance is NOT on a daemon takes
     // that daemon's own slice. Wait for the fan-out to settle, then ask each


### PR DESCRIPTION
## Summary
- A federated launch's `LaunchResult` now carries the add, build and run log entries of every participant, not only the coordinator's. The coordinator harvests each dispatched goal's log path from the peer's acceptance response (`NodeAdd/Build/RunGoalResponse.log_path`), so a failed remote phase still names the file that explains it.
- Every entry is stamped with the core node whose filesystem holds the path, locally executed phases included.
- The CLI's `Node log files` listing prints each entry as `node_name:tag@core-node: path` (backticks dropped), with a ` [FAILED]` marker before the colon on failed phases, uniformly across Add/Build/Run.

## Merge order
Blocked on Peppy-bot/public-peppy-libs#81, which adds the `coreNode` wire field. CI here stays red until that merges to `main` and this branch's `Cargo.lock` is refreshed (`cargo update core-node-api`); I'll push the lock bump once #81 lands.

## Test plan
- `cargo test -p peppy stack::launch`: 25 tests pass, including new unit tests for the `label@core-node` line format and the `[FAILED]` marker.
- `cargo test -p core-node --test listen_for_launch`: 15 tests pass, with new assertions that every entry carries the coordinator's core node and that a failed start's entry still names its machine.
- `cargo check -p peppy --features multi_daemon_e2e --tests` compiles; the federated e2e (`a_federated_launch_places_each_instance_on_its_wired_core_node`) now asserts the listing names both machines and that the peer-held planner log appears under Add, Build and Run. Docker is unavailable in this environment, so that e2e runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Launch logs now identify the core node hosting each log file.
  * Remote Add, Build, and Run operations retain per-node log paths and outcomes, including failed phases.
  * Failed launch entries are clearly marked and continue to provide diagnostic log locations.
  * Launch feedback now groups Add, Build, and Run logs with consistent formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->