### PR TITLE
Let a coordinator's next launch take over its stale reservation

### DIFF
--- a/crates/core-node-internal/src/services/federation.rs
+++ b/crates/core-node-internal/src/services/federation.rs
@@ -32,6 +32,15 @@
 //! the reservation, and [`SliceOwnership::release_because_coordinator_gone`]
 //! drops it the moment that token disappears.
 //!
+//! The lease covers a coordinator that LEFT; a lost release from one that
+//! stayed is covered by takeover. The release at the end of a launch is
+//! best-effort, so a coordinator whose messaging failed mid-launch ends its
+//! launch still holding this daemon while remaining present on the
+//! federation. A coordinator drives one launch at a time, which makes the
+//! recovery safe: reserving for a NEW launch id from the coordinator already
+//! holding this daemon proves the held launch is over, and
+//! [`SliceOwnership::try_reserve`] hands the reservation to the new launch.
+//!
 //! The registry here is deliberately pure: it owns the state machine and
 //! nothing else, so every transition (including the coordinator-gone one) is
 //! unit-testable without a messenger, a timer, or a sleep. Wiring the presence
@@ -78,6 +87,15 @@ pub enum ReserveOutcome {
     /// coordinator-presence watch either, since the one the first attempt
     /// spawned is still supervising this same reservation.
     AlreadyHeld,
+    /// The requesting coordinator already held this daemon, but for a launch
+    /// it is no longer driving, so the reservation now belongs to the
+    /// requesting launch. A coordinator drives one launch at a time, which is
+    /// what makes the handover safe: a new launch id from the holding
+    /// coordinator proves the held launch ended and its release never landed.
+    /// Like [`Self::AlreadyHeld`], no new presence watch is owed: the watch is
+    /// scoped to the coordinator, and the one supervising the stale
+    /// reservation supervises this one.
+    TookOverFromSameCoordinator { stale_launch_id: String },
     /// Another launch holds it. The coordinator that receives this releases
     /// every reservation it did obtain and fails the launch, so no machine is
     /// left half-replaced.
@@ -105,10 +123,28 @@ impl SliceOwnership {
     /// [`ReserveOutcome::AlreadyHeld`]): the exchange is a network round trip,
     /// so a coordinator whose reply was lost must be able to retry without
     /// deadlocking against its own reservation.
+    ///
+    /// Reserving for a NEW launch from the coordinator already holding this
+    /// daemon also succeeds (as
+    /// [`ReserveOutcome::TookOverFromSameCoordinator`]). The release at the
+    /// end of a launch is best-effort, and the presence lease only clears a
+    /// reservation whose coordinator LEFT the federation: a coordinator whose
+    /// messaging failed mid-launch stays present, so a lost release would
+    /// otherwise hold this daemon against every retry until a `stack reset`.
+    /// A coordinator drives one launch at a time, so a new launch id from the
+    /// holding coordinator proves the held launch is over.
     pub fn try_reserve(&self, launch_id: &str, coordinator: &str) -> ReserveOutcome {
         let mut state = self.state.lock();
         match &state.reservation {
             Some(held) if held.launch_id == launch_id => ReserveOutcome::AlreadyHeld,
+            Some(held) if held.coordinator_core_node == coordinator => {
+                let stale_launch_id = held.launch_id.clone();
+                state.reservation = Some(HeldReservation {
+                    launch_id: launch_id.to_owned(),
+                    coordinator_core_node: coordinator.to_owned(),
+                });
+                ReserveOutcome::TookOverFromSameCoordinator { stale_launch_id }
+            }
             Some(held) => ReserveOutcome::HeldByAnotherLaunch {
                 launch_id: held.launch_id.clone(),
                 coordinator_core_node: held.coordinator_core_node.clone(),
@@ -301,6 +337,46 @@ mod tests {
             ownership.try_reserve("launch-a", "cn-robot-7"),
             ReserveOutcome::AlreadyHeld
         );
+    }
+
+    /// The lost-release wedge: a launch whose release never landed (the
+    /// coordinator's messaging failed mid-launch while the coordinator stayed
+    /// present, so the lease never fired) must not hold this daemon against
+    /// every retry until a `stack reset`. A coordinator drives one launch at
+    /// a time, so a new launch id from the holding coordinator proves the
+    /// held launch is over, and the reservation moves to it.
+    #[test]
+    fn the_same_coordinators_next_launch_takes_over_a_stale_reservation() {
+        let ownership = SliceOwnership::new();
+        ownership.try_reserve("launch-a", "cn-robot-7");
+
+        assert_eq!(
+            ownership.try_reserve("launch-b", "cn-robot-7"),
+            ReserveOutcome::TookOverFromSameCoordinator {
+                stale_launch_id: "launch-a".to_owned(),
+            }
+        );
+        assert_eq!(
+            ownership.held_reservation(),
+            Some(("launch-b".to_owned(), "cn-robot-7".to_owned())),
+            "the reservation must now belong to the launch the coordinator is driving"
+        );
+    }
+
+    /// The takeover keeps the lease intact: the presence watch is scoped to
+    /// the coordinator, not the launch, so the coordinator vanishing still
+    /// frees the machine after its reservation changed hands.
+    #[test]
+    fn a_taken_over_reservation_still_releases_when_the_coordinator_vanishes() {
+        let ownership = SliceOwnership::new();
+        ownership.try_reserve("launch-a", "cn-robot-7");
+        ownership.try_reserve("launch-b", "cn-robot-7");
+
+        assert_eq!(
+            ownership.release_because_coordinator_gone("cn-robot-7"),
+            Some("launch-b".to_owned())
+        );
+        assert_eq!(ownership.held_reservation(), None);
     }
 
     #[test]

--- a/crates/core-node-internal/src/services/federation.rs
+++ b/crates/core-node-internal/src/services/federation.rs
@@ -58,12 +58,51 @@ use core_node_api::LaunchScoped;
 use core_node_api::encoding::LaunchIdentity;
 use parking_lot::Mutex;
 use std::sync::Arc;
+use tokio_util::sync::CancellationToken;
+
+/// The lifetime of one reservation, handed to the presence watch supervising
+/// it.
+///
+/// A lease ends exactly when its reservation does, whichever way that happens:
+/// the coordinator releasing it, `stack reset` clearing it, or the watch
+/// dropping it because the coordinator left. Ending it is what stops the watch,
+/// so a daemon that serves launch after launch holds one presence subscription
+/// per HELD reservation rather than one per launch it has ever taken part in.
+///
+/// It is also the watch's identity, which is why
+/// [`SliceOwnership::release_because_coordinator_gone`] takes a lease rather
+/// than a coordinator name: a coordinator reserves this daemon again for every
+/// launch it drives, and a watch left over from an earlier reservation of that
+/// same coordinator must not be able to drop the current one.
+#[derive(Debug, Clone)]
+pub struct Lease(CancellationToken);
+
+impl Lease {
+    fn new() -> Self {
+        Self(CancellationToken::new())
+    }
+
+    fn end(&self) {
+        self.0.cancel();
+    }
+
+    fn has_ended(&self) -> bool {
+        self.0.is_cancelled()
+    }
+
+    /// Resolves when the reservation this lease covers ends.
+    pub async fn ended(&self) {
+        self.0.cancelled().await;
+    }
+}
 
 /// A reservation currently held by this daemon.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug)]
 struct HeldReservation {
     launch_id: String,
     coordinator_core_node: String,
+    /// Ends when this reservation does; see [`Lease`].
+    lease: Lease,
 }
 
 #[derive(Debug, Default)]
@@ -77,10 +116,13 @@ struct OwnershipState {
 }
 
 /// Outcome of [`SliceOwnership::try_reserve`].
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub enum ReserveOutcome {
-    /// The reservation was just taken for the requesting launch.
-    Reserved,
+    /// The reservation was just taken for the requesting launch, and owes that
+    /// reservation the one presence watch supervising it. Carrying the lease
+    /// is what pairs the two: a watch can only be spawned for a reservation
+    /// this call created, and it can only ever act on that one.
+    Reserved { lease: Lease },
     /// The requesting launch already held it. Distinct from [`Self::Reserved`]
     /// because the two owe the caller different work: a coordinator retrying a
     /// dropped reply must not refuse itself, but it must not get a second
@@ -92,9 +134,9 @@ pub enum ReserveOutcome {
     /// requesting launch. A coordinator drives one launch at a time, which is
     /// what makes the handover safe: a new launch id from the holding
     /// coordinator proves the held launch ended and its release never landed.
-    /// Like [`Self::AlreadyHeld`], no new presence watch is owed: the watch is
-    /// scoped to the coordinator, and the one supervising the stale
-    /// reservation supervises this one.
+    /// Like [`Self::AlreadyHeld`], no new presence watch is owed: the launch id
+    /// changes inside the reservation that is already held, so its lease, and
+    /// the watch holding that lease, carry over.
     TookOverFromSameCoordinator { stale_launch_id: String },
     /// Another launch holds it. The coordinator that receives this releases
     /// every reservation it did obtain and fails the launch, so no machine is
@@ -135,14 +177,13 @@ impl SliceOwnership {
     /// holding coordinator proves the held launch is over.
     pub fn try_reserve(&self, launch_id: &str, coordinator: &str) -> ReserveOutcome {
         let mut state = self.state.lock();
-        match &state.reservation {
+        match state.reservation.as_mut() {
             Some(held) if held.launch_id == launch_id => ReserveOutcome::AlreadyHeld,
             Some(held) if held.coordinator_core_node == coordinator => {
-                let stale_launch_id = held.launch_id.clone();
-                state.reservation = Some(HeldReservation {
-                    launch_id: launch_id.to_owned(),
-                    coordinator_core_node: coordinator.to_owned(),
-                });
+                // The launch id changes inside the reservation that is already
+                // held, rather than the reservation being replaced, so the
+                // lease the watch is holding stays the live one.
+                let stale_launch_id = std::mem::replace(&mut held.launch_id, launch_id.to_owned());
                 ReserveOutcome::TookOverFromSameCoordinator { stale_launch_id }
             }
             Some(held) => ReserveOutcome::HeldByAnotherLaunch {
@@ -150,11 +191,13 @@ impl SliceOwnership {
                 coordinator_core_node: held.coordinator_core_node.clone(),
             },
             None => {
+                let lease = Lease::new();
                 state.reservation = Some(HeldReservation {
                     launch_id: launch_id.to_owned(),
                     coordinator_core_node: coordinator.to_owned(),
+                    lease: lease.clone(),
                 });
-                ReserveOutcome::Reserved
+                ReserveOutcome::Reserved { lease }
             }
         }
     }
@@ -167,33 +210,34 @@ impl SliceOwnership {
     /// participants actually acked, so the release has to be idempotent.
     pub fn release(&self, launch_id: &str) -> bool {
         let mut state = self.state.lock();
-        match &state.reservation {
+        match state.reservation.as_ref() {
             Some(held) if held.launch_id != launch_id => false,
             Some(_) => {
-                state.reservation = None;
+                end_held_reservation(&mut state);
                 true
             }
             None => true,
         }
     }
 
-    /// Drops the reservation because the coordinator holding it vanished from
-    /// the federation. This is what keeps a dead coordinator from wedging a
-    /// machine until its next daemon restart.
+    /// Drops the reservation `lease` covers, because the coordinator holding it
+    /// vanished from the federation. This is what keeps a dead coordinator from
+    /// wedging a machine until its next daemon restart.
     ///
-    /// Scoped to the named coordinator so a stale watch (one belonging to an
-    /// earlier, already-released reservation) cannot free a reservation that a
-    /// different coordinator has since taken.
+    /// Takes the lease rather than a coordinator name so a watch that outlived
+    /// its reservation frees nothing. A lease ends with the reservation it
+    /// covers, and only one is ever live, so a watch whose lease has ended
+    /// cannot drop the reservation a later launch took, not even one driven by
+    /// the same coordinator it was watching.
     ///
     /// Returns the launch that was released, if any.
-    pub fn release_because_coordinator_gone(&self, coordinator: &str) -> Option<String> {
+    pub fn release_because_coordinator_gone(&self, lease: &Lease) -> Option<String> {
         let mut state = self.state.lock();
-        let held = state.reservation.as_ref()?;
-        if held.coordinator_core_node != coordinator {
+        if lease.has_ended() {
             return None;
         }
-        let launch_id = held.launch_id.clone();
-        state.reservation = None;
+        let launch_id = state.reservation.as_ref()?.launch_id.clone();
+        end_held_reservation(&mut state);
         Some(launch_id)
     }
 
@@ -265,8 +309,18 @@ impl SliceOwnership {
     /// releases whatever launch was mid-flight over this machine.
     pub fn clear(&self) {
         let mut state = self.state.lock();
-        state.reservation = None;
+        end_held_reservation(&mut state);
         state.slice = None;
+    }
+}
+
+/// Drops the held reservation and ends its lease, which is what stops the
+/// presence watch supervising it. Every way out of a reservation goes through
+/// here, so none of them can leave a watch running over a reservation that is
+/// no longer held.
+fn end_held_reservation(state: &mut OwnershipState) {
+    if let Some(held) = state.reservation.take() {
+        held.lease.end();
     }
 }
 
@@ -288,13 +342,27 @@ mod tests {
     /// excludes it.
     const LOCAL: Goal = Goal(None);
 
+    /// Reserves and returns the lease the presence watch would be given.
+    ///
+    /// Every test that later acts as that watch needs it, and a reservation
+    /// that is not fresh has none, so the panic states which outcome a test
+    /// expected rather than leaving it as an unwrapped `None`.
+    fn reserve_expecting_a_fresh_lease(
+        ownership: &SliceOwnership,
+        launch_id: &str,
+        coordinator: &str,
+    ) -> Lease {
+        let ReserveOutcome::Reserved { lease } = ownership.try_reserve(launch_id, coordinator)
+        else {
+            panic!("`{launch_id}` should have taken a fresh reservation on `{coordinator}`");
+        };
+        lease
+    }
+
     #[test]
     fn a_free_daemon_accepts_a_reservation() {
         let ownership = SliceOwnership::new();
-        assert_eq!(
-            ownership.try_reserve("launch-a", "cn-robot-7"),
-            ReserveOutcome::Reserved
-        );
+        reserve_expecting_a_fresh_lease(&ownership, "launch-a", "cn-robot-7");
         assert_eq!(
             ownership.held_reservation(),
             Some(("launch-a".to_owned(), "cn-robot-7".to_owned()))
@@ -308,12 +376,17 @@ mod tests {
         let ownership = SliceOwnership::new();
         ownership.try_reserve("launch-a", "cn-robot-7");
 
+        let ReserveOutcome::HeldByAnotherLaunch {
+            launch_id,
+            coordinator_core_node,
+        } = ownership.try_reserve("launch-b", "cn-robot-9")
+        else {
+            panic!("a second coordinator must be refused while `launch-a` holds the daemon");
+        };
         assert_eq!(
-            ownership.try_reserve("launch-b", "cn-robot-9"),
-            ReserveOutcome::HeldByAnotherLaunch {
-                launch_id: "launch-a".to_owned(),
-                coordinator_core_node: "cn-robot-7".to_owned(),
-            }
+            (launch_id.as_str(), coordinator_core_node.as_str()),
+            ("launch-a", "cn-robot-7"),
+            "the refusal must name the launch holding the daemon and who drives it"
         );
         assert_eq!(
             ownership.held_reservation(),
@@ -329,13 +402,13 @@ mod tests {
     #[test]
     fn re_reserving_the_same_launch_reports_the_reservation_as_already_held() {
         let ownership = SliceOwnership::new();
-        assert_eq!(
-            ownership.try_reserve("launch-a", "cn-robot-7"),
-            ReserveOutcome::Reserved
-        );
-        assert_eq!(
-            ownership.try_reserve("launch-a", "cn-robot-7"),
-            ReserveOutcome::AlreadyHeld
+        reserve_expecting_a_fresh_lease(&ownership, "launch-a", "cn-robot-7");
+        assert!(
+            matches!(
+                ownership.try_reserve("launch-a", "cn-robot-7"),
+                ReserveOutcome::AlreadyHeld
+            ),
+            "a retry of the same launch owes no second presence watch"
         );
     }
 
@@ -350,12 +423,12 @@ mod tests {
         let ownership = SliceOwnership::new();
         ownership.try_reserve("launch-a", "cn-robot-7");
 
-        assert_eq!(
-            ownership.try_reserve("launch-b", "cn-robot-7"),
-            ReserveOutcome::TookOverFromSameCoordinator {
-                stale_launch_id: "launch-a".to_owned(),
-            }
-        );
+        let ReserveOutcome::TookOverFromSameCoordinator { stale_launch_id } =
+            ownership.try_reserve("launch-b", "cn-robot-7")
+        else {
+            panic!("the holding coordinator's next launch must take over its stale reservation");
+        };
+        assert_eq!(stale_launch_id, "launch-a");
         assert_eq!(
             ownership.held_reservation(),
             Some(("launch-b".to_owned(), "cn-robot-7".to_owned())),
@@ -363,17 +436,21 @@ mod tests {
         );
     }
 
-    /// The takeover keeps the lease intact: the presence watch is scoped to
-    /// the coordinator, not the launch, so the coordinator vanishing still
-    /// frees the machine after its reservation changed hands.
+    /// The takeover keeps the lease intact: the reservation the watch is
+    /// supervising changes launch, it is not replaced, so the coordinator
+    /// vanishing still frees the machine after the handover.
     #[test]
     fn a_taken_over_reservation_still_releases_when_the_coordinator_vanishes() {
         let ownership = SliceOwnership::new();
-        ownership.try_reserve("launch-a", "cn-robot-7");
+        let lease = reserve_expecting_a_fresh_lease(&ownership, "launch-a", "cn-robot-7");
         ownership.try_reserve("launch-b", "cn-robot-7");
 
+        assert!(
+            !lease.has_ended(),
+            "a takeover must not end the lease the watch is holding"
+        );
         assert_eq!(
-            ownership.release_because_coordinator_gone("cn-robot-7"),
+            ownership.release_because_coordinator_gone(&lease),
             Some("launch-b".to_owned())
         );
         assert_eq!(ownership.held_reservation(), None);
@@ -385,9 +462,46 @@ mod tests {
         ownership.try_reserve("launch-a", "cn-robot-7");
         assert!(ownership.release("launch-a"));
         assert_eq!(ownership.held_reservation(), None);
+        reserve_expecting_a_fresh_lease(&ownership, "launch-b", "cn-robot-9");
+    }
+
+    /// The watch is a subscription, so a reservation that ends any other way
+    /// has to stop it. Otherwise a daemon serving launch after launch keeps one
+    /// presence watch per launch it ever took part in, all of them supervising
+    /// a reservation that is long gone.
+    #[test]
+    fn every_way_out_of_a_reservation_ends_its_lease() {
+        let ownership = SliceOwnership::new();
+
+        let released = reserve_expecting_a_fresh_lease(&ownership, "launch-a", "cn-robot-7");
+        ownership.release("launch-a");
+        assert!(released.has_ended(), "a release must stop the watch");
+
+        let reset = reserve_expecting_a_fresh_lease(&ownership, "launch-b", "cn-robot-7");
+        ownership.clear();
+        assert!(reset.has_ended(), "a `stack reset` must stop the watch");
+
+        let vanished = reserve_expecting_a_fresh_lease(&ownership, "launch-c", "cn-robot-7");
+        ownership.release_because_coordinator_gone(&vanished);
+        assert!(
+            vanished.has_ended(),
+            "a watch that released its own reservation has nothing left to watch"
+        );
+    }
+
+    /// A launch refused because another one holds the daemon leaves the holder
+    /// supervised: the refusal changes nothing, so the watch must keep running.
+    #[test]
+    fn a_refused_reservation_leaves_the_holders_lease_alone() {
+        let ownership = SliceOwnership::new();
+        let lease = reserve_expecting_a_fresh_lease(&ownership, "launch-a", "cn-robot-7");
+
+        ownership.try_reserve("launch-b", "cn-robot-9");
+
+        assert!(!lease.has_ended());
         assert_eq!(
-            ownership.try_reserve("launch-b", "cn-robot-9"),
-            ReserveOutcome::Reserved
+            ownership.release_because_coordinator_gone(&lease),
+            Some("launch-a".to_owned())
         );
     }
 
@@ -415,18 +529,14 @@ mod tests {
     #[test]
     fn a_vanished_coordinator_releases_its_reservation() {
         let ownership = SliceOwnership::new();
-        ownership.try_reserve("launch-a", "cn-robot-7");
+        let lease = reserve_expecting_a_fresh_lease(&ownership, "launch-a", "cn-robot-7");
 
         assert_eq!(
-            ownership.release_because_coordinator_gone("cn-robot-7"),
+            ownership.release_because_coordinator_gone(&lease),
             Some("launch-a".to_owned())
         );
         assert_eq!(ownership.held_reservation(), None);
-        assert_eq!(
-            ownership.try_reserve("launch-b", "cn-robot-9"),
-            ReserveOutcome::Reserved,
-            "the machine must be usable again once its coordinator is gone"
-        );
+        reserve_expecting_a_fresh_lease(&ownership, "launch-b", "cn-robot-9");
     }
 
     /// A watch belonging to an already-released reservation must not free a
@@ -434,26 +544,41 @@ mod tests {
     #[test]
     fn a_stale_coordinator_watch_does_not_release_someone_elses_reservation() {
         let ownership = SliceOwnership::new();
-        ownership.try_reserve("launch-a", "cn-robot-7");
+        let stale = reserve_expecting_a_fresh_lease(&ownership, "launch-a", "cn-robot-7");
         ownership.release("launch-a");
         ownership.try_reserve("launch-b", "cn-robot-9");
 
-        assert_eq!(
-            ownership.release_because_coordinator_gone("cn-robot-7"),
-            None
-        );
+        assert_eq!(ownership.release_because_coordinator_gone(&stale), None);
         assert_eq!(
             ownership.held_reservation(),
             Some(("launch-b".to_owned(), "cn-robot-9".to_owned()))
         );
     }
 
+    /// The same trap, sprung by the coordinator a stale watch is actually
+    /// watching. A coordinator reserves this daemon once per launch it drives,
+    /// so between one launch's release and the next launch's reservation there
+    /// is a window where a watch left over from the first is still live. It
+    /// must not drop the second launch's reservation, whatever it sees in that
+    /// window: the coordinator is present, and the launch it is driving is not
+    /// the one that watch was supervising.
     #[test]
-    fn a_vanished_coordinator_with_no_reservation_releases_nothing() {
+    fn a_stale_watch_does_not_release_the_same_coordinators_next_reservation() {
         let ownership = SliceOwnership::new();
+        let stale = reserve_expecting_a_fresh_lease(&ownership, "launch-a", "cn-robot-7");
+        ownership.release("launch-a");
+        let live = reserve_expecting_a_fresh_lease(&ownership, "launch-b", "cn-robot-7");
+
+        assert_eq!(ownership.release_because_coordinator_gone(&stale), None);
         assert_eq!(
-            ownership.release_because_coordinator_gone("cn-robot-7"),
-            None
+            ownership.held_reservation(),
+            Some(("launch-b".to_owned(), "cn-robot-7".to_owned())),
+            "the launch the coordinator is driving must keep the daemon it reserved"
+        );
+        assert_eq!(
+            ownership.release_because_coordinator_gone(&live),
+            Some("launch-b".to_owned()),
+            "the live watch must still be the one that can free the machine"
         );
     }
 

--- a/crates/core-node-internal/src/services/federation/service.rs
+++ b/crates/core-node-internal/src/services/federation/service.rs
@@ -13,7 +13,7 @@
 //! coordinator leaves the federation. The state machine itself lives in the
 //! parent module and is tested there without any of this plumbing.
 
-use super::{ReserveOutcome, SliceOwnership};
+use super::{Lease, ReserveOutcome, SliceOwnership};
 use crate::Result;
 use crate::services::node::RelationshipCoordinators;
 use crate::services::response::into_service_response;
@@ -165,14 +165,14 @@ async fn reserve_inner(
             .encode()
             .map_err(Into::into);
         }
-        // Only a FRESH reservation needs a watch. A coordinator retrying a
-        // dropped reply re-reserves what it already holds, and the watch its
-        // first attempt spawned is still supervising that same reservation, so
-        // watching again would leave a presence subscription per retry. The
-        // takeover keeps the same coordinator, and the watch is scoped to the
-        // coordinator, so the stale reservation's watch supervises the new one.
-        ReserveOutcome::Reserved => {
-            watch_coordinator_presence(context, &decoded.coordinator_core_node)
+        // Only a FRESH reservation needs a watch, and the lease it hands back
+        // is what that watch supervises. A coordinator retrying a dropped reply
+        // re-reserves what it already holds, and a takeover moves the launch id
+        // inside the reservation already held: in both cases the live lease is
+        // the one the existing watch is holding, so watching again would leave
+        // a presence subscription per retry.
+        ReserveOutcome::Reserved { lease } => {
+            watch_coordinator_presence(context, &decoded.coordinator_core_node, lease)
         }
         ReserveOutcome::TookOverFromSameCoordinator { stale_launch_id } => {
             warn!(
@@ -216,20 +216,23 @@ fn validate_deployment_pins(pins_json5: &[String]) -> std::result::Result<(), St
     Ok(())
 }
 
-/// Turns the reservation into a LEASE: while this daemon holds a reservation
-/// for `coordinator`, it watches that core node's presence and releases the
-/// moment the token disappears.
+/// Turns the reservation into a LEASE: while `lease` covers this daemon's
+/// reservation for `coordinator`, it watches that core node's presence and
+/// releases the moment the token disappears.
 ///
 /// Without this, a coordinator that died mid-launch would wedge every machine
 /// it had reserved until each daemon restarted, with nothing in the UI to
 /// explain the refusals. That is the exact failure mode this plan refuses to
 /// accept for cross-daemon pairing, so it must not be introduced one level up.
 ///
-/// The task is scoped to the coordinator it watches:
-/// `release_because_coordinator_gone` is a no-op unless that same coordinator
-/// still holds the reservation, so a watch outliving its reservation cannot
-/// free a later one.
-fn watch_coordinator_presence(context: &FederationServiceContext, coordinator: &str) {
+/// The task lives exactly as long as the reservation it supervises. Ending the
+/// lease (a release, a `stack reset`, or this task's own) stops the watch, so a
+/// daemon that serves launch after launch holds one presence subscription
+/// rather than one per launch it has ever taken part in. The lease is also what
+/// `release_because_coordinator_gone` is scoped to, so a watch that did outlive
+/// its reservation frees nothing: not a later coordinator's reservation, and
+/// not the next one taken by the coordinator it was watching.
+fn watch_coordinator_presence(context: &FederationServiceContext, coordinator: &str, lease: Lease) {
     let messenger = context.messenger.clone();
     let coordinator = coordinator.to_owned();
     let ownership = Arc::clone(&context.ownership);
@@ -247,7 +250,7 @@ fn watch_coordinator_presence(context: &FederationServiceContext, coordinator: &
                      releasing its reservation rather than holding one this daemon \
                      cannot supervise"
                 );
-                ownership.release_because_coordinator_gone(&coordinator);
+                ownership.release_because_coordinator_gone(&lease);
                 return;
             }
         };
@@ -256,6 +259,9 @@ fn watch_coordinator_presence(context: &FederationServiceContext, coordinator: &
             let event = tokio::select! {
                 biased;
                 _ = shutdown.cancelled() => return,
+                // The reservation ended some other way, so there is nothing
+                // left to supervise and the subscription can go.
+                _ = lease.ended() => return,
                 event = watch.rx.recv_async() => match event {
                     Ok(event) => event,
                     // The presence stream ended, so this reservation has lost
@@ -268,7 +274,7 @@ fn watch_coordinator_presence(context: &FederationServiceContext, coordinator: &
                              its reservation rather than holding one this daemon can no longer \
                              supervise"
                         );
-                        ownership.release_because_coordinator_gone(&coordinator);
+                        ownership.release_because_coordinator_gone(&lease);
                         return;
                     }
                 },
@@ -279,7 +285,7 @@ fn watch_coordinator_presence(context: &FederationServiceContext, coordinator: &
             };
             // Stop watching as soon as the reservation is no longer ours to
             // supervise, whether we released it here or it had already gone.
-            match ownership.release_because_coordinator_gone(&coordinator) {
+            match ownership.release_because_coordinator_gone(&lease) {
                 Some(launch_id) => {
                     warn!(
                         "coordinator `{coordinator}` left the federation; released its \

--- a/crates/core-node-internal/src/services/federation/service.rs
+++ b/crates/core-node-internal/src/services/federation/service.rs
@@ -168,9 +168,19 @@ async fn reserve_inner(
         // Only a FRESH reservation needs a watch. A coordinator retrying a
         // dropped reply re-reserves what it already holds, and the watch its
         // first attempt spawned is still supervising that same reservation, so
-        // watching again would leave a presence subscription per retry.
+        // watching again would leave a presence subscription per retry. The
+        // takeover keeps the same coordinator, and the watch is scoped to the
+        // coordinator, so the stale reservation's watch supervises the new one.
         ReserveOutcome::Reserved => {
             watch_coordinator_presence(context, &decoded.coordinator_core_node)
+        }
+        ReserveOutcome::TookOverFromSameCoordinator { stale_launch_id } => {
+            warn!(
+                "launch `{stale_launch_id}` still held this daemon's reservation when its \
+                 coordinator `{}` reserved for launch `{}`; that launch is over and its \
+                 release never landed, so the reservation moves to the new launch",
+                decoded.coordinator_core_node, decoded.launch_id
+            );
         }
         ReserveOutcome::AlreadyHeld => {}
     }

--- a/crates/core-node-internal/src/services/stack/launch.rs
+++ b/crates/core-node-internal/src/services/stack/launch.rs
@@ -493,21 +493,20 @@ async fn add_and_build_remotely(
     .with_pins(crate::services::node::pins::encode_pins(
         &item.closure_pins,
     )?);
-    let added = match federated::run_remote_goal(ctx, core_node, &add_goal, ctx.idle_timeouts.add)
-        .await
-    {
-        Ok(run) => {
-            outcome.add_logs.push(NodeAddLogEntry {
-                node_label: key.label(),
-                log_path: run.log_path,
-                failed: run.outcome.is_err(),
-                core_node: core_node.to_owned(),
-            });
-            run.outcome
+    let added =
+        match federated::run_remote_goal(ctx, core_node, &add_goal, ctx.idle_timeouts.add).await {
+            Ok(run) => {
+                outcome.add_logs.push(NodeAddLogEntry {
+                    node_label: key.label(),
+                    log_path: run.log_path,
+                    failed: run.outcome.is_err(),
+                    core_node: core_node.to_owned(),
+                });
+                run.outcome
+            }
+            Err(reason) => Err(reason),
         }
-        Err(reason) => Err(reason),
-    }
-    .map_err(|reason| format!("failed to add node {}: {reason}", item.node_name))?;
+        .map_err(|reason| format!("failed to add node {}: {reason}", item.node_name))?;
 
     let build_goal = NodeBuildGoal::new(
         added.node_name.unwrap_or_else(|| item.node_name.clone()),

--- a/crates/core-node-internal/src/services/stack/launch.rs
+++ b/crates/core-node-internal/src/services/stack/launch.rs
@@ -531,11 +531,10 @@ async fn add_and_build_remotely(
 
 /// Step 7: Prepare the host paths that containers on THIS machine will bind.
 ///
-/// Scoped to the coordinator's own instances. A peer's bind sources live on the
-/// peer's filesystem, so creating them here would make directories on the wrong
-/// machine and still leave the peer's missing. See the Federation guide's
-/// Limits section: a container node placed on a peer needs its bind sources to
-/// already exist there.
+/// Scoped to the coordinator's own instances. A peer's bind sources name paths
+/// on the peer's filesystem, so creating them here would make directories on
+/// the wrong machine; the peer prepares them itself when it starts the
+/// instance, which is where every machine prepares the sources it binds.
 ///
 /// Its CLEANUP is not so scoped. This step runs after step 6, by which point
 /// every participant has had its stack replaced and its nodes added and built,

--- a/crates/core-node-internal/src/services/stack/launch/federated/mod.rs
+++ b/crates/core-node-internal/src/services/stack/launch/federated/mod.rs
@@ -186,13 +186,13 @@ async fn reserve_participants(
     .await;
 
     let mut slices: Vec<ParticipantSlice> = Vec::new();
-    let mut reserved: Vec<String> = Vec::new();
+    let mut to_release: Vec<String> = Vec::new();
     let mut refusals: Vec<String> = Vec::new();
 
     for (core_node, outcome) in acks {
         match outcome {
             Ok(response) if response.accepted => {
-                reserved.push(core_node.clone());
+                to_release.push(core_node.clone());
                 // The reservation is already recorded above, so a version
                 // refusal here still releases it.
                 match check_version(&core_node, &response, own_version) {
@@ -203,13 +203,22 @@ async fn reserve_participants(
                     Err(reason) => refusals.push(reason),
                 }
             }
+            // An answered refusal reserved nothing, so the peer owes no
+            // release.
             Ok(response) => refusals.push(format!(
                 "`{core_node}` refused: {}",
                 response
                     .rejection_reason
                     .unwrap_or_else(|| "no reason given".to_owned())
             )),
-            Err(reason) => refusals.push(reason),
+            // An unanswered reservation is not a refusal: the request may have
+            // landed and reserved the peer with only the ack lost, so it is
+            // released with the ones that acked. Releasing a peer that never
+            // reserved succeeds as a no-op.
+            Err(reason) => {
+                to_release.push(core_node.clone());
+                refusals.push(reason);
+            }
         }
     }
 
@@ -225,7 +234,7 @@ async fn reserve_participants(
         coordinator,
         caller_instance_id,
         launch_id,
-        &reserved,
+        &to_release,
     )
     .await;
 
@@ -288,7 +297,8 @@ pub(crate) async fn release_participants(
             ),
             Err(e) => tracing::warn!(
                 "could not release `{core_node}` from launch `{launch_id}` ({e}); its \
-                 reservation drops on its own when this coordinator leaves the federation"
+                 reservation drops on its own when this coordinator reserves it for its \
+                 next launch or leaves the federation"
             ),
         }
     }))

--- a/crates/peppy/src/commands/stack/launch.rs
+++ b/crates/peppy/src/commands/stack/launch.rs
@@ -69,7 +69,10 @@ fn display_node_log_files(
         return;
     }
     let line = |node_label: &str, core_node: &str, failed: bool, log_path: &Path| {
-        (node_log_line(node_label, core_node, failed, log_path), failed)
+        (
+            node_log_line(node_label, core_node, failed, log_path),
+            failed,
+        )
     };
     let sections = [
         (

--- a/crates/peppy/tests/multi_daemon_e2e.rs
+++ b/crates/peppy/tests/multi_daemon_e2e.rs
@@ -758,7 +758,7 @@ async fn federated_router_peer_topology_daemons_are_enumerated_and_collisions_ar
 
 // ── Federated launch ──────────────────────────────────────────────────────
 //
-// Four tests rather than one long one. The fixtures genuinely differ (a
+// Separate tests rather than one long one. The fixtures genuinely differ (a
 // coordinator restart, a killed peer, and `--local` with no peer at all are
 // three different worlds), and a single sequential test would hide every
 // assertion after the first failure behind one stage number.
@@ -782,6 +782,7 @@ const CONTAINER_LAUNCHER_DIR: &str = "/etc/peppy/launchers";
 const SPLIT_COMPUTE_LAUNCHER_FILE: &str = "split_compute_manipulation.json5";
 const HUB_NODE_PROBE_LAUNCHER_FILE: &str = "hub_node_probe.json5";
 const CALLER_ENV_PROBE_LAUNCHER_FILE: &str = "caller_env_probe.json5";
+const UNBINDABLE_PEER_LAUNCHER_FILE: &str = "unbindable_peer.json5";
 
 fn container_launcher(file_name: &str) -> String {
     format!("{CONTAINER_LAUNCHER_DIR}/{file_name}")
@@ -818,6 +819,39 @@ const CALLER_ENV_PROBE_LAUNCHER: &str = r#"{
     {
       source: { name: "my_python_robot_arm", tag: "v1" },
       instances: [{ instance_id: "env_probe_arm_inst", core_node: "remote_worker" }],
+    },
+  ],
+}
+"#;
+
+/// A launch that gets as far as the peer's RUN and fails there.
+///
+/// `uvc_camera_video_reconstruction_python` is a container node whose node
+/// definition binds `/tmp/video_reconstruction`, and that directory exists on
+/// neither daemon: the coordinator creates missing bind sources only for the
+/// instances it runs itself, and a peer creates none at all. So the peer adds
+/// the node, builds it, accepts the run goal, opens its log file, and fails
+/// starting the container. The camera stays on the coordinator, which is what
+/// makes the marked entry evidence of attribution rather than of every entry
+/// belonging to one machine.
+const UNBINDABLE_PEER_LAUNCHER: &str = r#"{
+  peppy_schema: "launcher/v1",
+  core_nodes: ["remote_worker"],
+  deployments: [
+    {
+      source: { name: "uvc_camera_python_mock", tag: "v1" },
+      instances: [{ instance_id: "unbindable_cam_inst" }],
+    },
+    {
+      source: { name: "uvc_camera_video_reconstruction_python", tag: "v1" },
+      instances: [
+        {
+          instance_id: "unbindable_recon_inst",
+          core_node: "remote_worker",
+          arguments: { video_duration_seconds: 5 },
+          links: { camera: "unbindable_cam_inst" },
+        },
+      ],
     },
   ],
 }
@@ -998,6 +1032,11 @@ async fn start_federation(prefix: &str) -> Federation {
         CALLER_ENV_PROBE_LAUNCHER,
     )
     .expect("writing the caller-env probe launcher into the launcher mount");
+    std::fs::write(
+        launcher_dir.path().join(UNBINDABLE_PEER_LAUNCHER_FILE),
+        UNBINDABLE_PEER_LAUNCHER,
+    )
+    .expect("writing the unbindable-peer launcher into the launcher mount");
 
     let robot = start_daemon(
         &launch,
@@ -1408,6 +1447,67 @@ async fn an_unreachable_peer_fails_the_launch_and_is_named() {
             .all(|id| !holds_instance(&robot_stack.text, id)),
         "a refused preflight must not have started anything:\n{}",
         robot_stack.text
+    );
+}
+
+/// A phase that fails on a machine the operator cannot see must still name the
+/// file that explains it, on the machine whose filesystem holds it.
+///
+/// The peer accepts the run goal and fails it, which is the only shape that
+/// produces a failed remote log entry: a goal the peer never accepts has no log
+/// file to name, and `an_unreachable_peer_fails_the_launch_and_is_named` covers
+/// that one. Everything asserted here is read from the launch's own listing,
+/// because that listing is the operator's whole route to a log file sitting on
+/// another machine.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_peer_phase_that_fails_still_names_the_peers_log_file() {
+    let federation = start_federation("peppy-fed-peer-fail").await;
+
+    let launch = federation
+        .robot
+        .peppy(&[
+            "stack",
+            "launch",
+            "--place",
+            &format!("remote_worker@{}", federation.cloud_core_node),
+            &container_launcher(UNBINDABLE_PEER_LAUNCHER_FILE),
+        ])
+        .await;
+    assert!(
+        !launch.success(),
+        "a peer that cannot start its container must fail the launch:\n{}",
+        launch.text
+    );
+
+    // One phase failed on one machine, so exactly one entry carries the marker,
+    // and it is the peer's.
+    assert_eq!(
+        launch.text.matches("[FAILED]").count(),
+        1,
+        "only the phase that failed may be marked:\n{}",
+        launch.text
+    );
+    let peer_node = "uvc_camera_video_reconstruction_python:v1";
+    assert!(
+        launch.text.contains(&format!(
+            "{peer_node}@{} [FAILED]: ",
+            federation.cloud_core_node
+        )),
+        "the failed run must be listed against the peer holding its log file:\n{}",
+        launch.text
+    );
+
+    // The phases that DID succeed on that same peer keep their entries. A run
+    // that failed is not the whole story of the machine it failed on, and the
+    // add and build logs are where an operator looks next.
+    assert_eq!(
+        launch
+            .text
+            .matches(&format!("{peer_node}@{}: ", federation.cloud_core_node))
+            .count(),
+        2,
+        "the peer's successful Add and Build must still be listed:\n{}",
+        launch.text
     );
 }
 

--- a/crates/peppy/tests/multi_daemon_e2e.rs
+++ b/crates/peppy/tests/multi_daemon_e2e.rs
@@ -824,14 +824,17 @@ const CALLER_ENV_PROBE_LAUNCHER: &str = r#"{
 }
 "#;
 
+/// The host path `uvc_camera_video_reconstruction_python:v1` bind-mounts, taken
+/// verbatim from its node definition in `nodes-hub`.
+const PEER_BIND_SOURCE: &str = "/tmp/video_reconstruction";
+
 /// A launch that gets as far as the peer's RUN and fails there.
 ///
-/// `uvc_camera_video_reconstruction_python` is a container node whose node
-/// definition binds `/tmp/video_reconstruction`, and that directory exists on
-/// neither daemon: the coordinator creates missing bind sources only for the
-/// instances it runs itself, and a peer creates none at all. So the peer adds
-/// the node, builds it, accepts the run goal, opens its log file, and fails
-/// starting the container. The camera stays on the coordinator, which is what
+/// `uvc_camera_video_reconstruction_python` is a container node that binds
+/// [`PEER_BIND_SOURCE`], and the test makes that source unusable on the peer
+/// alone (see `a_peer_phase_that_fails_still_names_the_peers_log_file`). So the
+/// peer adds the node, builds it, accepts the run goal, opens its log file, and
+/// fails preparing the bind. The camera stays on the coordinator, which is what
 /// makes the marked entry evidence of attribution rather than of every entry
 /// belonging to one machine.
 const UNBINDABLE_PEER_LAUNCHER: &str = r#"{
@@ -1462,6 +1465,21 @@ async fn an_unreachable_peer_fails_the_launch_and_is_named() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn a_peer_phase_that_fails_still_names_the_peers_log_file() {
     let federation = start_federation("peppy-fed-peer-fail").await;
+
+    // Make the peer's bind source unusable. A daemon creates a missing bind
+    // source itself right before it starts the container, on whichever machine
+    // runs the instance, so a merely absent path would be created and the run
+    // would succeed. A dangling symlink is the shape that cannot be: it does
+    // not exist, so the daemon tries to create it, and `mkdir` refuses because
+    // the symlink already occupies the name. Planted on the peer only, so the
+    // coordinator's own instance still gets through every phase.
+    require_success(
+        federation
+            .cloud
+            .exec(vec!["ln", "-s", "/no_such_bind_target", PEER_BIND_SOURCE])
+            .await,
+        &format!("planting an uncreatable {PEER_BIND_SOURCE} on the peer"),
+    );
 
     let launch = federation
         .robot

--- a/docs/src/content/docs/advanced_guides/federation.mdx
+++ b/docs/src/content/docs/advanced_guides/federation.mdx
@@ -136,9 +136,8 @@ thing that changes is what `self` binds to: from the robot that is
 a planning role, not a privileged one, so the topology does not depend on where
 the command was typed.
 
-Two things do follow the coordinator, and both argue for the robot here: an
-instance that omits `core_node` runs there, and container bind sources are
-created only for the instances that machine runs itself (see [Limits](#limits)).
+One thing does follow the coordinator, and it argues for the robot here: an
+instance that omits `core_node` runs on the coordinating daemon.
 
 ```bash
 peppy stack launch --place robot_onboard@self \
@@ -364,7 +363,3 @@ participants keep running.
   file.
 - **No re-placement of a running instance.** Moving an instance to another
   machine means launching again.
-- **A peer prepares no container bind mounts.** The coordinator creates missing
-  bind sources for the instances it runs itself, but a path on another machine
-  is that machine's to provide. A container node placed on a peer needs its bind
-  sources to already exist there.


### PR DESCRIPTION
## Problem

A federated `stack launch` retry is refused with:

```
`cn-vibrant-chaplygin` refused: already reserved for launch `launch-sharp-hugle-2467` driven by core node `cn-xenodochial-newton`
```

even though no other launch is running. Sequence that wedges the participant:

1. A launch reserves its participants, tears down, and starts dispatching.
2. The coordinator's messaging session fails mid-launch (`MessagingSessionError("Session not initialized")`), so the slice clear **and the best-effort reservation release** to the participant both fail.
3. The presence lease never fires because it only covers a coordinator that *left the federation*; this coordinator daemon stayed up (only its outbound messaging failed transiently).
4. Every retry mints a fresh launch id, so `try_reserve` refuses it forever until a manual `peppy stack reset` or a participant daemon restart.

## Fix

A coordinator drives one launch at a time (its goal gate refuses concurrent `stack_launch` goals), so a reserve request carrying a **new** launch id from the **same coordinator that already holds the daemon** proves the held launch is over and its release was lost:

- **Participant** (`SliceOwnership::try_reserve`): hands the reservation to the new launch (`ReserveOutcome::TookOverFromSameCoordinator`) instead of refusing. No new presence watch is spawned: the watch is scoped to the coordinator, so the existing one keeps supervising the taken-over reservation. A *different* coordinator is still refused, preserving the anti-race guarantee the reservation exists for.
- **Coordinator** (`reserve_participants`): a failed preflight now also releases peers whose reserve call went *unanswered*, since the request may have landed with only the ack lost. Releasing a peer that never reserved is already an idempotent no-op.

## Test plan

- New unit tests: same-coordinator takeover hands the reservation over; a taken-over reservation is still freed when the coordinator vanishes.
- `cargo test -p core-node --lib`: 351 passed.
- `cargo clippy -p core-node --lib` clean; touched files are rustfmt-clean (the `launch.rs:493` fmt drift is pre-existing on `dev`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Federated launch logs now identify the core node associated with each Add, Build, and Run stage.
  * Failed remote stages retain links to their diagnostic logs.
  * Same-coordinator launches can take over stale reservations safely.

* **Bug Fixes**
  * Improved reservation cleanup when acknowledgements are lost or coordinators disconnect.
  * Standardized launch log formatting and failure indicators across local and remote operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->