### PR TITLE
Participant mount sources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,7 +573,7 @@ dependencies = [
 [[package]]
 name = "build-helpers"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#4f740e2cfabcbbf319d38bb7a7991f6d045f353a"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#bef114e6699d889ea36bd24aa3cd198b84d4ee5c"
 dependencies = [
  "sha2",
 ]
@@ -765,7 +765,7 @@ dependencies = [
 [[package]]
 name = "config-test-support"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#4f740e2cfabcbbf319d38bb7a7991f6d045f353a"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#bef114e6699d889ea36bd24aa3cd198b84d4ee5c"
 dependencies = [
  "askama",
  "git2",
@@ -909,7 +909,7 @@ dependencies = [
 [[package]]
 name = "core-node-api"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#4f740e2cfabcbbf319d38bb7a7991f6d045f353a"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#bef114e6699d889ea36bd24aa3cd198b84d4ee5c"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -2419,9 +2419,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "ipnetwork"
@@ -2581,7 +2581,7 @@ dependencies = [
 [[package]]
 name = "json5-pretty"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#4f740e2cfabcbbf319d38bb7a7991f6d045f353a"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#bef114e6699d889ea36bd24aa3cd198b84d4ee5c"
 dependencies = [
  "serde",
  "serde_json",
@@ -2589,9 +2589,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.49.2"
+version = "0.49.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a77951c56b6a0af03c22af6953d6ffcfba9403c765578921f3f1089b999db6"
+checksum = "508004a5500f2e1f68af048f70feea2de86d35ab115d85716530860822aef397"
 dependencies = [
  "ahash",
  "bytecount",
@@ -2620,18 +2620,18 @@ dependencies = [
 
 [[package]]
 name = "jsonschema-regex"
-version = "0.49.2"
+version = "0.49.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c2e64f341a1d6a15d2daa3c967e48921cf15b9c7f23a9899e8b63c7f7c4199"
+checksum = "5a8b30cafa78358ae6cd1494a7d6410b89530e28bf567f862c869c667e900d9f"
 dependencies = [
  "regex-syntax",
 ]
 
 [[package]]
 name = "jsonschema-value"
-version = "0.49.2"
+version = "0.49.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e097778f3e9c6a33862077dbf07aca0360d0b18d2a7abc323da132df49ee83"
+checksum = "5526bd381d230af94908d07e6835a33fd82a465e12f5f1e9c81f5c2aa23b3c21"
 dependencies = [
  "ahash",
  "bytecount",
@@ -2724,9 +2724,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
+checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
 dependencies = [
  "libc",
 ]
@@ -3371,7 +3371,7 @@ dependencies = [
 [[package]]
 name = "peppy-config-model"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#4f740e2cfabcbbf319d38bb7a7991f6d045f353a"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#bef114e6699d889ea36bd24aa3cd198b84d4ee5c"
 dependencies = [
  "capnp",
  "clap",
@@ -3394,7 +3394,7 @@ version = "0.0.1"
 [[package]]
 name = "peppylib-rs"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#4f740e2cfabcbbf319d38bb7a7991f6d045f353a"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#bef114e6699d889ea36bd24aa3cd198b84d4ee5c"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -3589,7 +3589,7 @@ dependencies = [
 [[package]]
 name = "pmi"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#4f740e2cfabcbbf319d38bb7a7991f6d045f353a"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#bef114e6699d889ea36bd24aa3cd198b84d4ee5c"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -3983,9 +3983,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.49.2"
+version = "0.49.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b772e96f8eb6badd4eb10fbc08b8a98244c09b4af37e72e8fa612c854604b870"
+checksum = "7af3eb523cce0df0af3c30d624b829b2dabd233172b5bc2615fcd03ceae8f746"
 dependencies = [
  "ahash",
  "fluent-uri",

--- a/crates/containers-internal/src/apptainer/facade.rs
+++ b/crates/containers-internal/src/apptainer/facade.rs
@@ -566,28 +566,7 @@ impl Apptainer {
                 lima_home,
                 ..
             } => {
-                let home = std::env::var("HOME").map_err(|_| {
-                    Error::ConfigurationError("HOME environment variable not set".into())
-                })?;
-
-                // Host runtime trees are never Lima's to carry. Registering
-                // `/run/user` here would write it into the Lima YAML — restarting
-                // the VM to mount the Mac's copy (which does not exist) over the
-                // guest's own runtime tmpfs — and would then whitelist it in
-                // `extra_mounts`, so `translate_path` would wave it through. The
-                // filter lives here rather than at the call sites because all
-                // three of them (stack preflight, node run, node build) funnel
-                // through this one method.
-                let external_paths: Vec<&str> = mount_src_paths
-                    .iter()
-                    .filter(|p| {
-                        let absolute = resolve_absolute(p);
-                        !absolute.starts_with(&home)
-                            && !crate::is_host_provided_mount_source(&absolute)
-                    })
-                    .copied()
-                    .collect();
-
+                let external_paths = paths_lima_must_mount(mount_src_paths)?;
                 if external_paths.is_empty() {
                     return Ok(());
                 }
@@ -628,6 +607,27 @@ impl Apptainer {
                 }
 
                 Ok(())
+            }
+        }
+    }
+
+    /// Whether [`Self::ensure_host_mounts`] would restart the execution
+    /// environment for these paths, asked without doing it.
+    ///
+    /// Always `false` on `Backend::Native`: there is no VM, so nothing a mount
+    /// registration does can disturb a running container. On `Backend::Lima` a
+    /// restart is what makes a new mount visible, and it takes every container
+    /// in the guest with it, so callers with something running ask first.
+    pub fn host_mounts_need_restart(&self, mount_src_paths: &[&str]) -> Result<bool> {
+        match &self.backend {
+            Backend::Native { .. } => Ok(false),
+            Backend::Lima { lima_home, .. } => {
+                let external_paths = paths_lima_must_mount(mount_src_paths)?;
+                if external_paths.is_empty() {
+                    return Ok(false);
+                }
+                let config_path = lima_home.join(lima::LIMA_INSTANCE).join("lima.yaml");
+                lima::extra_mounts_would_change(&config_path, &external_paths)
             }
         }
     }
@@ -1094,6 +1094,30 @@ fn to_absolute(path: &Path) -> std::io::Result<PathBuf> {
     } else {
         Ok(path.to_path_buf())
     }
+}
+
+/// The subset of `mount_src_paths` that has to be written into the Lima config
+/// for the guest to see it.
+///
+/// `$HOME` is already auto-mounted, so paths under it need nothing. Host
+/// runtime trees are never Lima's to carry: registering `/run/user` would write
+/// it into the Lima YAML, restarting the VM to mount the Mac's copy (which does
+/// not exist) over the guest's own runtime tmpfs, and would then whitelist it in
+/// `extra_mounts` so `translate_path` waved it through. The filter lives here
+/// rather than at the call sites because all of them (stack preflight, node
+/// run, node build) funnel through the two methods that use it, which must
+/// agree on what counts.
+fn paths_lima_must_mount<'a>(mount_src_paths: &[&'a str]) -> Result<Vec<&'a str>> {
+    let home = std::env::var("HOME")
+        .map_err(|_| Error::ConfigurationError("HOME environment variable not set".into()))?;
+    Ok(mount_src_paths
+        .iter()
+        .filter(|p| {
+            let absolute = resolve_absolute(p);
+            !absolute.starts_with(&home) && !crate::is_host_provided_mount_source(&absolute)
+        })
+        .copied()
+        .collect())
 }
 
 /// Resolve a potentially relative path to an absolute one.

--- a/crates/containers-internal/src/apptainer/lima.rs
+++ b/crates/containers-internal/src/apptainer/lima.rs
@@ -832,6 +832,16 @@ where
     }
 }
 
+/// Whether [`ensure_extra_mounts`] would rewrite the config for these paths,
+/// asked without rewriting it.
+///
+/// The answer is "would the VM be restarted", which callers need before they
+/// take an action that a restart would ruin: every container running in the
+/// guest dies with it.
+pub(crate) fn extra_mounts_would_change(config_path: &Path, paths: &[&str]) -> Result<bool> {
+    Ok(plan_extra_mounts(config_path, paths)?.changes_config())
+}
+
 /// Ensure that the given host paths are listed as mounts in the Lima config.
 ///
 /// Reads the Lima YAML config, checks existing mount locations, and appends
@@ -841,6 +851,52 @@ where
 /// Also performs cleanup: removes existing mount entries for paths that no longer
 /// exist on the host or that are blocked system paths (which Lima would reject).
 pub(crate) fn ensure_extra_mounts(config_path: &Path, paths: &[&str]) -> Result<bool> {
+    let plan = plan_extra_mounts(config_path, paths)?;
+    if !plan.changes_config() {
+        return Ok(false);
+    }
+
+    for location in &plan.removed {
+        tracing::info!("Removing Lima mount (stale or system path): {}", location);
+    }
+    for location in &plan.added {
+        tracing::info!("Adding Lima mount: {}", location);
+    }
+
+    let yaml_str = serde_yaml::to_string(&plan.config)
+        .map_err(|e| Error::LimaInstanceError(format!("failed to serialize Lima config: {e}")))?;
+    std::fs::write(config_path, yaml_str).map_err(|e| {
+        Error::LimaInstanceError(format!(
+            "failed to write Lima config {}: {e}",
+            config_path.display()
+        ))
+    })?;
+    Ok(true)
+}
+
+/// The mount list as it should be, and what getting there costs.
+///
+/// Planning is separated from writing so that asking "would this restart the
+/// VM" reads the same file through the same rules as the call that acts on the
+/// answer, without touching the config or announcing changes it is not making.
+struct MountPlan {
+    config: serde_yaml::Value,
+    /// Locations dropped because they are gone from the host or are system
+    /// paths Lima would reject.
+    removed: Vec<String>,
+    /// Requested locations that were not registered yet.
+    added: Vec<String>,
+}
+
+impl MountPlan {
+    /// Whether applying this plan rewrites the config, which is the same
+    /// question as whether it restarts the VM.
+    fn changes_config(&self) -> bool {
+        !self.removed.is_empty() || !self.added.is_empty()
+    }
+}
+
+fn plan_extra_mounts(config_path: &Path, paths: &[&str]) -> Result<MountPlan> {
     let content = std::fs::read_to_string(config_path).map_err(|e| {
         Error::LimaInstanceError(format!(
             "failed to read Lima config {}: {e}",
@@ -866,10 +922,10 @@ pub(crate) fn ensure_extra_mounts(config_path: &Path, paths: &[&str]) -> Result<
         .as_sequence_mut()
         .ok_or_else(|| Error::LimaInstanceError("Lima config 'mounts' is not a sequence".into()))?;
 
-    let mut modified = false;
+    let mut removed = Vec::new();
+    let mut added = Vec::new();
 
     // Phase 1: Clean up stale or invalid existing mounts.
-    let original_len = mounts_seq.len();
     mounts_seq.retain(|entry| {
         let Some(location) = entry.get("location").and_then(|v| v.as_str()) else {
             return true; // Keep entries without a location field
@@ -878,22 +934,12 @@ pub(crate) fn ensure_extra_mounts(config_path: &Path, paths: &[&str]) -> Result<
         if location == "~" || location == "null" {
             return true;
         }
-        if is_blocked_mount_source(location) {
-            tracing::info!("Removing invalid Lima mount (system path): {}", location);
-            return false;
-        }
-        if !Path::new(location).exists() {
-            tracing::info!(
-                "Removing stale Lima mount (path does not exist): {}",
-                location
-            );
+        if is_blocked_mount_source(location) || !Path::new(location).exists() {
+            removed.push(location.to_string());
             return false;
         }
         true
     });
-    if mounts_seq.len() != original_len {
-        modified = true;
-    }
 
     // Phase 2: Add new mounts (skip blocked system paths).
     let existing: Vec<String> = mounts_seq
@@ -925,24 +971,15 @@ pub(crate) fn ensure_extra_mounts(config_path: &Path, paths: &[&str]) -> Result<
                 serde_yaml::Value::Bool(true),
             );
             mounts_seq.push(serde_yaml::Value::Mapping(mount_entry));
-            tracing::info!("Adding Lima mount: {}", path);
-            modified = true;
+            added.push((*path).to_string());
         }
     }
 
-    if modified {
-        let yaml_str = serde_yaml::to_string(&config).map_err(|e| {
-            Error::LimaInstanceError(format!("failed to serialize Lima config: {e}"))
-        })?;
-        std::fs::write(config_path, yaml_str).map_err(|e| {
-            Error::LimaInstanceError(format!(
-                "failed to write Lima config {}: {e}",
-                config_path.display()
-            ))
-        })?;
-    }
-
-    Ok(modified)
+    Ok(MountPlan {
+        config,
+        removed,
+        added,
+    })
 }
 
 #[cfg(test)]
@@ -1012,6 +1049,42 @@ mod tests {
 
         let modified = ensure_extra_mounts(&config_path, &[existing_path]).expect("should succeed");
         assert!(!modified, "config should not have been modified");
+    }
+
+    /// The dry run answers the same question as the write, and leaves the
+    /// config exactly as it found it. Callers ask it before doing something a
+    /// VM restart would ruin, so a false "no" costs them running containers and
+    /// a write here would restart the VM they were protecting.
+    #[test]
+    fn extra_mounts_would_change_matches_the_write_without_performing_it() {
+        let dir = tempdir().expect("create temp dir");
+        let config_path = dir.path().join("lima.yaml");
+        let registered = dir.path().join("registered_mount");
+        fs::create_dir_all(&registered).expect("create registered mount dir");
+        let registered = registered.to_str().expect("utf-8 path");
+        let initial = format!(
+            "mounts:\n  - location: \"~\"\n    writable: true\n  - location: {registered}\n    writable: true\n"
+        );
+        fs::write(&config_path, &initial).expect("write initial config");
+
+        assert!(
+            !extra_mounts_would_change(&config_path, &[registered]).expect("should succeed"),
+            "an already-registered path changes nothing"
+        );
+        assert!(
+            extra_mounts_would_change(&config_path, &["/data/new_mount"]).expect("should succeed"),
+            "a path the guest cannot see yet has to be written in"
+        );
+        assert_eq!(
+            fs::read_to_string(&config_path).expect("read config"),
+            initial,
+            "asking must not rewrite the config"
+        );
+
+        assert!(
+            ensure_extra_mounts(&config_path, &["/data/new_mount"]).expect("should succeed"),
+            "the write must agree with the answer the dry run gave"
+        );
     }
 
     #[test]

--- a/crates/containers-internal/src/lib.rs
+++ b/crates/containers-internal/src/lib.rs
@@ -12,7 +12,9 @@ pub use apptainer::Apptainer;
 #[cfg(target_os = "linux")]
 pub use apptainer::{SetupStatus, check_setup_status};
 pub use error::{Error, Result};
-pub use mount_source::is_host_provided_mount_source;
+pub use mount_source::{
+    auto_created_warning, ensure_bind_source, is_host_provided_mount_source, mount_spec_source,
+};
 
 /// Pinned Apptainer version bundled at build time.
 pub const APPTAINER_VERSION: &str = env!("APPTAINER_VERSION");

--- a/crates/containers-internal/src/mount_source.rs
+++ b/crates/containers-internal/src/mount_source.rs
@@ -32,6 +32,51 @@ pub fn is_host_provided_mount_source(path: &Path) -> bool {
         || path.starts_with("/sys")
 }
 
+/// Makes one bind mount source usable by the container runtime, reporting
+/// whether it had to create it.
+///
+/// An existing path is left untouched whatever it is (file, socket, device,
+/// directory); a [host-provided](is_host_provided_mount_source) one is accepted
+/// as-is; anything else missing is created with `mkdir -p`.
+///
+/// `true` means the caller owes the operator a warning. Auto-creating is what
+/// makes node-owned scratch and output directories work without ceremony, and
+/// it is also what silently turns a typo'd file bind into an empty directory,
+/// so every caller announces it in whatever stream it owns. The warning text
+/// itself is [`auto_created_warning`], so the three streams say the same thing.
+pub fn ensure_bind_source(src: &Path) -> std::io::Result<bool> {
+    if src.exists() || is_host_provided_mount_source(src) {
+        return Ok(false);
+    }
+    std::fs::create_dir_all(src).map_err(|e| {
+        std::io::Error::new(
+            e.kind(),
+            format!(
+                "bind mount source does not exist: {} (auto-create failed: {e})",
+                src.display()
+            ),
+        )
+    })?;
+    Ok(true)
+}
+
+/// The host path out of a `host_path[:container_path[:options]]` mount spec.
+///
+/// The source is the only part of a spec that exists outside the container, so
+/// it is the only part that gets created, registered with the execution
+/// environment, or named in a failure about the host.
+pub fn mount_spec_source(spec: &str) -> &str {
+    spec.split(':').next().unwrap_or(spec)
+}
+
+/// What every caller of [`ensure_bind_source`] says when it returns `true`.
+pub fn auto_created_warning(src: &str) -> String {
+    format!(
+        "auto-created missing bind mount source: {src} \
+         (if you intended to bind an existing file, this is a typo)"
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -67,5 +112,82 @@ mod tests {
                 "{path} is an ordinary bind source and must keep auto-create + warning"
             );
         }
+    }
+
+    #[test]
+    fn ensure_bind_source_creates_a_missing_path_and_reports_it() {
+        let parent = tempfile::tempdir().expect("tempdir");
+        let target = parent.path().join("scratch").join("nested");
+
+        assert!(
+            ensure_bind_source(&target).expect("missing dir should be auto-created"),
+            "creating the path must be reported so the caller can warn"
+        );
+        assert!(target.is_dir(), "the whole missing chain must be created");
+    }
+
+    /// An existing path is whatever the operator made it. Reporting `false`
+    /// keeps the warning for the case it was written for: a path that was not
+    /// there at all.
+    #[test]
+    fn ensure_bind_source_leaves_an_existing_path_alone() {
+        let existing = tempfile::tempdir().expect("tempdir");
+        assert!(
+            !ensure_bind_source(existing.path()).expect("existing dir should be accepted"),
+            "an existing path is not an auto-create"
+        );
+    }
+
+    /// The host owns these trees, so a missing one is accepted rather than
+    /// conjured, and there is nothing to warn about.
+    #[test]
+    fn ensure_bind_source_accepts_host_provided_paths_without_creating() {
+        for path in [
+            "/dev/does-not-exist-xyz",
+            "/proc/missing",
+            "/sys/missing",
+            // The runtime tmpfs. Sim nodes bind `/run/user` to back
+            // `XDG_RUNTIME_DIR`; on a macOS daemon there is no `/run` and `/`
+            // is read-only, so any attempt to create it fails with `EROFS`.
+            "/run/user",
+        ] {
+            assert!(
+                !ensure_bind_source(Path::new(path)).unwrap_or_else(|error| panic!(
+                    "{path} is host-provided and must be accepted: {error}"
+                )),
+                "{path} must not be reported as created"
+            );
+        }
+        assert!(
+            !Path::new("/dev/does-not-exist-xyz").exists(),
+            "a host-provided path must be left missing, not created"
+        );
+    }
+
+    /// The failure names the path and stays recognisable: callers surface this
+    /// string to an operator who has to work out which bind is wrong.
+    ///
+    /// A dangling symlink is the deterministic way to make the create fail: the
+    /// path does not exist, so the auto-create is attempted, and `mkdir` then
+    /// refuses because the name is already taken. Unlike a read-only parent, no
+    /// uid bypasses it, so the test means the same thing wherever it runs.
+    #[cfg(unix)]
+    #[test]
+    fn ensure_bind_source_reports_a_failed_auto_create() {
+        let parent = tempfile::tempdir().expect("tempdir");
+        let target = parent.path().join("bind_source");
+        std::os::unix::fs::symlink(parent.path().join("no_such_target"), &target)
+            .expect("plant a dangling symlink");
+
+        let error = ensure_bind_source(&target).expect_err("an uncreatable path must fail");
+        let message = error.to_string();
+        assert!(
+            message.contains("bind mount source does not exist"),
+            "error must keep the canonical phrase, got: {message}"
+        );
+        assert!(
+            message.contains(target.to_string_lossy().as_ref()),
+            "error must name the offending path, got: {message}"
+        );
     }
 }

--- a/crates/core-node-internal/src/services/federation/service.rs
+++ b/crates/core-node-internal/src/services/federation/service.rs
@@ -21,7 +21,8 @@ use core_node_api::ServiceId;
 use core_node_api::encoding::{
     FederationVerdict, LaunchIdentity, PairCommitRequest, ParticipantReleaseRequest,
     ParticipantReserveRequest, ParticipantReserveResponse, ParticipantSliceBeginRequest,
-    RelationshipEvent, RelationshipNotification, RelationshipNotificationAck,
+    ParticipantSliceBeginResponse, RelationshipEvent, RelationshipNotification,
+    RelationshipNotificationAck,
 };
 use core_node_api::names;
 use daemon_config::repository::DeploymentPins;
@@ -301,12 +302,20 @@ fn watch_coordinator_presence(context: &FederationServiceContext, coordinator: &
 }
 
 /// The commit point of a federated launch on this machine: the coordinator has
-/// every participant reserved, so this daemon's slice is now replaced.
+/// every participant reserved, so this daemon's slice is now replaced and the
+/// host paths its containers will bind are prepared.
 ///
 /// Destructive, and gated on the reservation. A request naming a launch this
 /// daemon is not reserved for is refused, which is what stops a stale
 /// coordinator, or one whose lease already lapsed, from wiping a machine out
 /// from under the launch that legitimately owns it.
+///
+/// The bind sources are prepared HERE, in the window between clearing the slice
+/// and running the first node of the new one, because that is the only moment
+/// this machine has no container running: registering a host path the container
+/// VM has not seen restarts it, and a restart takes every container in it. The
+/// coordinator resolved the paths, since a mount path can name an instance
+/// parameter and this daemon is handed one instance at a time.
 async fn slice_begin_inner(
     request: &ServiceRequestContext,
     context: &FederationServiceContext,
@@ -314,7 +323,7 @@ async fn slice_begin_inner(
     let decoded = ParticipantSliceBeginRequest::decode(request.message().payload().as_ref())?;
 
     let Some((held_launch, coordinator)) = context.ownership.held_reservation() else {
-        return FederationVerdict::refused(format!(
+        return ParticipantSliceBeginResponse::refused(format!(
             "this daemon holds no reservation, so it will not replace its stack for launch \
              `{}`. The reservation is a lease on the coordinator's presence; if the coordinator \
              dropped off the federation it was released, and the launch has to start over.",
@@ -324,7 +333,7 @@ async fn slice_begin_inner(
         .map_err(Into::into);
     };
     if held_launch != decoded.launch_id {
-        return FederationVerdict::refused(format!(
+        return ParticipantSliceBeginResponse::refused(format!(
             "this daemon is reserved for launch `{held_launch}` driven by core node \
              `{coordinator}`, not `{}`",
             decoded.launch_id
@@ -356,7 +365,18 @@ async fn slice_begin_inner(
         .ownership
         .record_slice(LaunchIdentity::new(decoded.launch_id.clone(), coordinator));
 
-    FederationVerdict::ok().encode().map_err(Into::into)
+    // Recorded first, prepared second: the slice is already this launch's, so a
+    // machine that cannot provide a bind source is a refusal the coordinator
+    // acts on, not wreckage nobody can find.
+    match crate::services::stack::prepare_container_mounts(&decoded.mount_sources).await {
+        Ok(auto_created) => ParticipantSliceBeginResponse::ok(auto_created),
+        Err(reason) => ParticipantSliceBeginResponse::refused(format!(
+            "this daemon cannot prepare the container bind sources for launch `{}`: {reason}",
+            decoded.launch_id
+        )),
+    }
+    .encode()
+    .map_err(Into::into)
 }
 
 /// Records this daemon's half of a cross-daemon pair, on behalf of the daemon

--- a/crates/core-node-internal/src/services/node/run.rs
+++ b/crates/core-node-internal/src/services/node/run.rs
@@ -1007,10 +1007,38 @@ async fn process_node_run(
     //    so `127.0.0.1` already reaches the host router and the node follows the
     //    daemon's messaging topology exactly like a process node.
     let container_gateway = if is_container {
-        let apptainer = match tokio::task::spawn_blocking(containers::Apptainer::new).await {
-            Ok(Ok(a)) => a,
-            Ok(Err(e)) => {
-                let msg = format!("Failed to initialize Apptainer: {}", e);
+        // Both halves are blocking work — building the facade probes the host
+        // runtime, and the refusal below reads the execution environment's
+        // config off disk — so they share one trip to the blocking pool rather
+        // than doing file I/O on an async worker.
+        //
+        // The refusal is there because starting this container may have to make
+        // a host path visible to the execution environment, and on a VM backend
+        // that means restarting it, which kills every container already in it.
+        // A stack launch prepares a machine's mounts while its slice is empty
+        // precisely so this never bites; anything else reaching here (a `peppy
+        // node run` against a live stack, say) is refused rather than paid for
+        // by the nodes already running.
+        let mount_paths = resolved_mount_paths.clone();
+        let peppy_dirs = ctx.action.peppy_dirs.clone();
+        let node_stack = ctx.action.node_stack.clone();
+        let starting_instance_id = instance_id_str.to_owned();
+        let apptainer = match tokio::task::spawn_blocking(move || {
+            let apptainer = containers::Apptainer::new()
+                .map_err(|e| format!("Failed to initialize Apptainer: {}", e))?;
+            refuse_restart_over_running_containers(
+                &apptainer,
+                &mount_paths,
+                &peppy_dirs,
+                &node_stack,
+                &starting_instance_id,
+            )?;
+            Ok::<_, String>(apptainer)
+        })
+        .await
+        {
+            Ok(Ok(apptainer)) => apptainer,
+            Ok(Err(msg)) => {
                 write_error_to_log(&ctx.log_file, &msg);
                 return NodeRunResult::failure(msg);
             }
@@ -1020,24 +1048,6 @@ async fn process_node_run(
                 return NodeRunResult::failure(msg);
             }
         };
-
-        // Starting this container may have to make a host path visible to the
-        // execution environment, and on a VM backend that means restarting it,
-        // which kills every container already in it. A stack launch prepares a
-        // machine's mounts while its slice is empty precisely so this never
-        // bites; anything else reaching here (a `peppy node run` against a live
-        // stack, say) is refused rather than paid for by the nodes already
-        // running.
-        if let Err(msg) = refuse_restart_over_running_containers(
-            &apptainer,
-            &resolved_mount_paths,
-            &ctx.action.peppy_dirs,
-            &ctx.action.node_stack,
-            instance_id_str,
-        ) {
-            write_error_to_log(&ctx.log_file, &msg);
-            return NodeRunResult::failure(msg);
-        }
 
         apptainer.host_gateway()
     } else {

--- a/crates/core-node-internal/src/services/node/run.rs
+++ b/crates/core-node-internal/src/services/node/run.rs
@@ -729,6 +729,63 @@ fn refuse_stale_manifest(
     ))
 }
 
+/// Refuses a container start whose host mounts cannot be registered without
+/// restarting the execution environment underneath containers already running
+/// in it.
+///
+/// The instance being started is not in the stack yet, so it cannot be in
+/// `running`; every id there belongs to a node this start would kill.
+fn refuse_restart_over_running_containers(
+    apptainer: &containers::Apptainer,
+    resolved_mount_paths: &[String],
+    peppy_dirs: &PeppyDirs,
+    node_stack: &NodeStack,
+    instance_id: &str,
+) -> std::result::Result<(), String> {
+    // The same set the start is about to register: what the node binds, plus
+    // the peppy root that holds its image, working dir and runtime config.
+    let root = peppy_dirs
+        .root()
+        .to_str()
+        .ok_or_else(|| "peppy root path is not valid UTF-8".to_string())?;
+    let mut sources: Vec<&str> = resolved_mount_paths
+        .iter()
+        .map(|mount| containers::mount_spec_source(mount))
+        .collect();
+    sources.push(root);
+
+    let needs_restart = apptainer
+        .host_mounts_need_restart(&sources)
+        .map_err(|e| format!("Failed to check the container host mounts: {e}"))?;
+    if !needs_restart {
+        return Ok(());
+    }
+
+    match restart_refusal(instance_id, &node_stack.live_container_instance_ids()) {
+        Some(refusal) => Err(refusal),
+        None => Ok(()),
+    }
+}
+
+/// What to tell an operator whose start would cost them running containers,
+/// and nothing when it costs them nothing.
+///
+/// Separated from the runtime query so the wording and the "only when something
+/// would die" rule are checkable on any platform, including the Linux hosts
+/// where no execution environment can restart in the first place.
+fn restart_refusal(instance_id: &str, running: &[String]) -> Option<String> {
+    if running.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "cannot start `{instance_id}`: its bind mounts are not visible to the container \
+         execution environment yet, and making them visible restarts it, which would stop the \
+         container node(s) already running here ({}). Stop them first, or start everything in \
+         one `peppy stack launch`, which prepares a machine's mounts before it runs anything.",
+        running.join(", ")
+    ))
+}
+
 async fn process_node_run(
     goal: NodeRunGoal,
     mut runtime_config: RuntimeConfig,
@@ -963,6 +1020,25 @@ async fn process_node_run(
                 return NodeRunResult::failure(msg);
             }
         };
+
+        // Starting this container may have to make a host path visible to the
+        // execution environment, and on a VM backend that means restarting it,
+        // which kills every container already in it. A stack launch prepares a
+        // machine's mounts while its slice is empty precisely so this never
+        // bites; anything else reaching here (a `peppy node run` against a live
+        // stack, say) is refused rather than paid for by the nodes already
+        // running.
+        if let Err(msg) = refuse_restart_over_running_containers(
+            &apptainer,
+            &resolved_mount_paths,
+            &ctx.action.peppy_dirs,
+            &ctx.action.node_stack,
+            instance_id_str,
+        ) {
+            write_error_to_log(&ctx.log_file, &msg);
+            return NodeRunResult::failure(msg);
+        }
+
         apptainer.host_gateway()
     } else {
         None
@@ -1995,6 +2071,32 @@ mod tests {
             "the operator needs both fingerprints to see what moved; got: {refusal}"
         );
         assert!(refusal.contains("Re-run the launch"), "got: {refusal}");
+    }
+
+    /// A restart with nothing in the execution environment costs nothing, so
+    /// the start goes ahead. This is the ordinary case: the first container of
+    /// a stack, or any container on a machine whose slice was just cleared.
+    #[test]
+    fn a_restart_that_would_stop_nothing_is_not_refused() {
+        assert!(restart_refusal("recon_inst", &[]).is_none());
+    }
+
+    /// The refusal has to name what would be lost and what to do instead:
+    /// its whole job is to turn a silent kill of the running stack into a
+    /// decision the operator gets to make.
+    #[test]
+    fn a_restart_that_would_stop_running_containers_is_refused_and_names_them() {
+        let refusal = restart_refusal(
+            "recon_inst",
+            &["cam_inst".to_owned(), "arm_inst".to_owned()],
+        )
+        .expect("running containers must stop the start");
+        assert!(refusal.contains("recon_inst"), "got: {refusal}");
+        assert!(
+            refusal.contains("cam_inst") && refusal.contains("arm_inst"),
+            "every instance that would be stopped must be named; got: {refusal}"
+        );
+        assert!(refusal.contains("peppy stack launch"), "got: {refusal}");
     }
 
     #[test]

--- a/crates/core-node-internal/src/services/stack.rs
+++ b/crates/core-node-internal/src/services/stack.rs
@@ -1,9 +1,11 @@
 mod benchmark;
+mod container_mounts;
 mod launch;
 mod list;
 mod reset;
 
 pub use benchmark::listen_for_stack_benchmark;
+pub(crate) use container_mounts::prepare_container_mounts;
 pub use launch::STACK_LAUNCH_GIT_HASH;
 pub use launch::listen_for_stack_launch;
 pub use launch::{StackLaunchDefaults, StackLaunchTimeouts};

--- a/crates/core-node-internal/src/services/stack/container_mounts.rs
+++ b/crates/core-node-internal/src/services/stack/container_mounts.rs
@@ -61,12 +61,17 @@ pub(crate) async fn prepare_container_mounts(
     Ok(auto_created)
 }
 
-/// The subset of `mount_sources` a Lima guest cannot already see.
+/// The subset of `mount_sources` a Lima guest cannot already see, absolute.
 ///
 /// Only macOS runs containers in a VM. Home-relative paths arrive through
 /// Lima's default `~` mount and host-provided trees are the guest's own, so
 /// neither is ours to register; what is left is the paths that need an explicit
 /// mount, which is what costs a VM restart.
+///
+/// Absolute because a registration ends up as a `location:` in the Lima config,
+/// which the VM resolves with no notion of the daemon's working directory: a
+/// relative source has to be anchored the same way the create above anchored
+/// it, or the guest would mount something else, or nothing.
 fn external_lima_mount_sources(mount_sources: &[String]) -> Vec<String> {
     if !cfg!(target_os = "macos") {
         return Vec::new();
@@ -75,14 +80,14 @@ fn external_lima_mount_sources(mount_sources: &[String]) -> Vec<String> {
     let home = std::env::var_os("HOME").map(PathBuf::from);
     mount_sources
         .iter()
-        .filter(|src| {
+        .filter_map(|src| {
             let src_path = absolute_mount_source(src);
-            !is_host_provided_mount_source(&src_path)
-                && home
+            let guest_already_sees = is_host_provided_mount_source(&src_path)
+                || home
                     .as_ref()
-                    .is_none_or(|home_path| !src_path.starts_with(home_path))
+                    .is_some_and(|home_path| src_path.starts_with(home_path));
+            (!guest_already_sees).then(|| src_path.to_string_lossy().into_owned())
         })
-        .cloned()
         .collect()
 }
 
@@ -197,5 +202,33 @@ mod tests {
             vec!["/opt/robot_assets".to_string()],
             "a non-home path the guest cannot otherwise see must be registered",
         );
+    }
+
+    /// A relative source is decided against its absolute form, so it must be
+    /// registered in that form too: a `location:` in the Lima config is
+    /// resolved by the VM, which has no working directory to relate it to.
+    ///
+    /// Which branch applies depends on where the test binary runs: a checkout
+    /// under `$HOME` makes the path one Lima already mounts, and dropping it is
+    /// the same anchoring decision seen from the other side.
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn relative_sources_are_forwarded_to_lima_absolute() {
+        let cwd = std::env::current_dir().expect("a working directory");
+        let home = std::env::var("HOME").expect("HOME is set on a macOS test host");
+        let forwarded = external_lima_mount_sources(&["robot_assets".to_string()]);
+
+        if cwd.starts_with(&home) {
+            assert!(
+                forwarded.is_empty(),
+                "a relative source under $HOME resolves into Lima's own mount, got: {forwarded:?}"
+            );
+        } else {
+            assert_eq!(
+                forwarded,
+                vec![cwd.join("robot_assets").to_string_lossy().into_owned()],
+                "a relative source must reach Lima anchored, not verbatim",
+            );
+        }
     }
 }

--- a/crates/core-node-internal/src/services/stack/container_mounts.rs
+++ b/crates/core-node-internal/src/services/stack/container_mounts.rs
@@ -1,0 +1,201 @@
+//! Preparing the host paths a machine's containers will bind.
+//!
+//! Every daemon that runs a slice of a launch does this once, while its stack
+//! is empty: the coordinator as a launch step, a participant when it is told to
+//! replace its slice. The reason it cannot be left to the instance starts that
+//! need the paths is [`Apptainer::ensure_host_mounts`]: registering a host path
+//! the container VM has not seen restarts that VM, and a restart takes every
+//! container already running in it. Doing the whole machine's registration
+//! before the first instance starts is what keeps that restart free.
+//!
+//! On Linux there is no VM and `ensure_host_mounts` is a no-op, so what remains
+//! is the auto-create of missing sources, which every machine owes its own
+//! instances.
+
+use std::path::{Path, PathBuf};
+
+use containers::{Apptainer, is_host_provided_mount_source};
+
+/// Makes this machine's bind sources usable, and reports the ones it created.
+///
+/// Creation comes first and registration second, on purpose: Lima drops a
+/// mount whose host path does not exist, so registering an absent source would
+/// buy a VM restart now and another one later when the path appears.
+///
+/// The returned paths are the ones that did not exist. Each is an operator
+/// warning its caller must surface in whatever stream it owns, because an
+/// auto-created source is also what a bind meant to name an existing file looks
+/// like when the name is misspelled.
+pub(crate) async fn prepare_container_mounts(
+    mount_sources: &[String],
+) -> std::result::Result<Vec<String>, String> {
+    let mut auto_created = Vec::new();
+    for src in mount_sources {
+        if containers::ensure_bind_source(Path::new(src)).map_err(|e| e.to_string())? {
+            auto_created.push(src.clone());
+        }
+    }
+
+    let lima_mount_sources = external_lima_mount_sources(mount_sources);
+    if lima_mount_sources.is_empty() {
+        return Ok(auto_created);
+    }
+
+    // A first-time mount registration restarts the Lima VM, so this runs on the
+    // blocking pool rather than holding the async worker for the restart.
+    tokio::task::spawn_blocking(move || {
+        let mut apptainer =
+            Apptainer::new().map_err(|e| format!("Failed to initialize Apptainer: {e}"))?;
+        let refs = lima_mount_sources
+            .iter()
+            .map(String::as_str)
+            .collect::<Vec<_>>();
+        apptainer
+            .ensure_host_mounts(&refs)
+            .map_err(|e| format!("Failed to prepare container host mounts: {e}"))
+    })
+    .await
+    .map_err(|e| format!("Failed to prepare container host mounts: {e}"))
+    .and_then(|result| result)?;
+
+    Ok(auto_created)
+}
+
+/// The subset of `mount_sources` a Lima guest cannot already see.
+///
+/// Only macOS runs containers in a VM. Home-relative paths arrive through
+/// Lima's default `~` mount and host-provided trees are the guest's own, so
+/// neither is ours to register; what is left is the paths that need an explicit
+/// mount, which is what costs a VM restart.
+fn external_lima_mount_sources(mount_sources: &[String]) -> Vec<String> {
+    if !cfg!(target_os = "macos") {
+        return Vec::new();
+    }
+
+    let home = std::env::var_os("HOME").map(PathBuf::from);
+    mount_sources
+        .iter()
+        .filter(|src| {
+            let src_path = absolute_mount_source(src);
+            !is_host_provided_mount_source(&src_path)
+                && home
+                    .as_ref()
+                    .is_none_or(|home_path| !src_path.starts_with(home_path))
+        })
+        .cloned()
+        .collect()
+}
+
+fn absolute_mount_source(src: &str) -> PathBuf {
+    let path = Path::new(src);
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .map(|cwd| cwd.join(path))
+            .unwrap_or_else(|_| path.to_path_buf())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn prepare_reports_only_the_sources_it_created() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let existing = root.path().join("already_there");
+        std::fs::create_dir(&existing).expect("mkdir");
+        let missing = root.path().join("scratch").join("output");
+
+        let auto_created = prepare_container_mounts(&[
+            existing.to_string_lossy().into_owned(),
+            missing.to_string_lossy().into_owned(),
+        ])
+        .await
+        .expect("both sources are preparable");
+
+        assert_eq!(
+            auto_created,
+            vec![missing.to_string_lossy().into_owned()],
+            "only the missing source is an operator warning"
+        );
+        assert!(
+            missing.is_dir(),
+            "the missing source must have been created"
+        );
+    }
+
+    /// The whole preparation fails rather than half-registering a machine: a
+    /// source that cannot be created is a bind that cannot work, and the launch
+    /// that needs it is better stopped here than at the instance start.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn prepare_fails_when_a_source_cannot_be_created() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let target = root.path().join("bind_source");
+        std::os::unix::fs::symlink(root.path().join("no_such_target"), &target)
+            .expect("plant a dangling symlink");
+
+        let error = prepare_container_mounts(&[target.to_string_lossy().into_owned()])
+            .await
+            .expect_err("an uncreatable source must fail");
+        assert!(
+            error.contains(target.to_string_lossy().as_ref()),
+            "the failure must name the offending path, got: {error}"
+        );
+    }
+
+    /// A host-provided source must never be handed to Lima as an extra mount.
+    /// Registering `/run/user` would mount the macOS side (which does not even
+    /// exist) over the guest's own runtime tmpfs, and would restart the VM to
+    /// do it. The guest resolves these paths itself.
+    ///
+    /// macOS-gated like its companions below: off macOS
+    /// `external_lima_mount_sources` returns empty before consulting the
+    /// filter at all, so an ungated assertion would hold with the filter
+    /// deleted and prove nothing. The predicate itself is platform-independent
+    /// and covered in `containers::mount_source`.
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn host_provided_sources_are_not_forwarded_to_lima() {
+        let forwarded = external_lima_mount_sources(&[
+            "/run/user".to_string(),
+            "/dev/ttyUSB0".to_string(),
+            "/proc/self".to_string(),
+            "/sys/class".to_string(),
+        ]);
+        assert!(
+            forwarded.is_empty(),
+            "host-provided trees must stay out of the Lima mount list, got: {forwarded:?}"
+        );
+    }
+
+    /// Lima mounts `$HOME` itself, so a path under it is already visible to the
+    /// guest and registering it would buy a VM restart for nothing.
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn home_relative_sources_are_not_forwarded_to_lima() {
+        let home = std::env::var("HOME").expect("HOME is set on a macOS test host");
+        let forwarded = external_lima_mount_sources(&[format!("{home}/.peppy/built_nodes")]);
+        assert!(
+            forwarded.is_empty(),
+            "a path Lima already mounts must not be registered again, got: {forwarded:?}"
+        );
+    }
+
+    /// The complement of the tests above: the filter is a carve-out, not a
+    /// blanket opt-out. An ordinary path outside `$HOME` still has to reach
+    /// Lima or the guest could not see it. Only meaningful on macOS, where
+    /// `external_lima_mount_sources` does its work.
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn ordinary_external_sources_are_still_forwarded_to_lima() {
+        let forwarded = external_lima_mount_sources(&["/opt/robot_assets".to_string()]);
+        assert_eq!(
+            forwarded,
+            vec!["/opt/robot_assets".to_string()],
+            "a non-home path the guest cannot otherwise see must be registered",
+        );
+    }
+}

--- a/crates/core-node-internal/src/services/stack/launch.rs
+++ b/crates/core-node-internal/src/services/stack/launch.rs
@@ -19,7 +19,6 @@ use crate::services::node::{
 };
 use chrono::Local;
 use config::apply_parameter_defaults;
-use containers::is_host_provided_mount_source;
 use core_node_api::ActionId;
 use core_node_api::encoding::LaunchIdentity;
 use core_node_api::encoding::{
@@ -40,7 +39,7 @@ use peppylib::{MessengerHandle, PeppyResult};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs::File;
 use std::panic::AssertUnwindSafe;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::task::JoinHandle;
@@ -531,10 +530,10 @@ async fn add_and_build_remotely(
 
 /// Step 7: Prepare the host paths that containers on THIS machine will bind.
 ///
-/// Scoped to the coordinator's own instances. A peer's bind sources name paths
-/// on the peer's filesystem, so creating them here would make directories on
-/// the wrong machine; the peer prepares them itself when it starts the
-/// instance, which is where every machine prepares the sources it binds.
+/// Scoped to the coordinator's own instances: every machine prepares what its
+/// own containers bind, and a participant was handed its share when it was told
+/// to replace its slice. Creating a peer's paths here would make directories on
+/// the wrong machine.
 ///
 /// Its CLEANUP is not so scoped. This step runs after step 6, by which point
 /// every participant has had its stack replaced and its nodes added and built,
@@ -544,32 +543,16 @@ async fn prepare_container_host_mounts(
     ctx: &ProcessLaunchContext,
     ordered: &[NodeKey],
     planned_by_key: &HashMap<NodeKey, PlannedDeployment>,
-    placements: &daemon_config::launcher::Placements,
+    mut mount_sources: Vec<String>,
     participants: &[String],
 ) -> std::result::Result<(), LaunchResult> {
-    let mut mount_sources = match collect_container_mount_sources(
-        ordered,
-        planned_by_key,
-        placements,
-        ctx.bound_core_node.as_str(),
-    ) {
-        Ok(paths) => paths,
-        Err(reason) => return Err(fail_and_clear_stack(ctx, reason, participants).await),
-    };
-
-    if let Err(reason) = ensure_launch_bind_sources(ctx, &mount_sources).await {
-        return Err(fail_and_clear_stack(ctx, reason, participants).await);
-    }
-
     // The peppy data root hosts the container build working dirs (`tmp/`),
     // built images (`built_nodes/`), and instance dirs. When it sits outside
     // `$HOME` (dev roots at `$TMPDIR/.peppy`) the Lima guest cannot see it,
-    // so register it here whenever the stack has container nodes. Doing it in
-    // this step front-loads the one-time VM restart a new mount triggers,
-    // instead of paying it mid-build. Added after `ensure_launch_bind_sources`
-    // on purpose: the root always exists and must not hit the auto-create
-    // warning path. `external_lima_mount_sources` filters it out on Linux and
-    // for home-relative roots (prod).
+    // so register it here whenever the stack has container nodes. It always
+    // exists, so it never reaches the auto-create warning path, and
+    // `external_lima_mount_sources` filters it out on Linux and for
+    // home-relative roots (prod).
     if stack_has_container_nodes(ordered, planned_by_key) {
         match ctx.peppy_dirs.root().to_str() {
             Some(root) => mount_sources.push(root.to_owned()),
@@ -580,8 +563,7 @@ async fn prepare_container_host_mounts(
         }
     }
 
-    let lima_mount_sources = external_lima_mount_sources(&mount_sources);
-    if lima_mount_sources.is_empty() {
+    if mount_sources.is_empty() {
         return Ok(());
     }
 
@@ -592,26 +574,20 @@ async fn prepare_container_host_mounts(
     )
     .await;
 
-    let result = tokio::task::spawn_blocking(move || {
-        let mut apptainer = containers::Apptainer::new()
-            .map_err(|e| format!("Failed to initialize Apptainer: {e}"))?;
-        let refs = lima_mount_sources
-            .iter()
-            .map(String::as_str)
-            .collect::<Vec<_>>();
-        apptainer
-            .ensure_host_mounts(&refs)
-            .map_err(|e| format!("Failed to prepare container host mounts: {e}"))
-    })
-    .await
-    .map_err(|e| format!("Failed to prepare container host mounts: {e}"))
-    .and_then(|result| result);
-
-    if let Err(reason) = result {
-        return Err(fail_and_clear_stack(ctx, reason, participants).await);
+    match super::container_mounts::prepare_container_mounts(&mount_sources).await {
+        Ok(auto_created) => {
+            for src in auto_created {
+                publish_stderr(
+                    ctx,
+                    containers::auto_created_warning(&src),
+                    LaunchFeedbackStep::LauncherStep,
+                )
+                .await;
+            }
+            Ok(())
+        }
+        Err(reason) => Err(fail_and_clear_stack(ctx, reason, participants).await),
     }
-
-    Ok(())
 }
 
 fn stack_has_container_nodes(
@@ -625,19 +601,24 @@ fn stack_has_container_nodes(
     })
 }
 
-fn collect_container_mount_sources(
-    ordered: &[NodeKey],
-    planned_by_key: &HashMap<NodeKey, PlannedDeployment>,
+/// The host paths each machine's container instances bind, keyed by core node.
+///
+/// Resolved here, on the coordinator, because only the coordinator holds the
+/// whole plan: a mount path may name an instance parameter, and a machine is
+/// handed one instance at a time. Machines with nothing to bind are absent
+/// rather than present-and-empty, so a caller iterating this map is iterating
+/// the machines that have work to do.
+///
+/// Called before the launch turns destructive, which is what makes an
+/// unresolvable mount path (a parameter with no value) cost nobody their stack.
+fn container_mount_sources_by_machine(
+    planned: &[PlannedDeployment],
     placements: &daemon_config::launcher::Placements,
-    coordinator: &str,
-) -> std::result::Result<Vec<String>, String> {
-    let mut seen = HashSet::new();
-    let mut mount_sources = Vec::new();
+) -> std::result::Result<HashMap<String, Vec<String>>, String> {
+    let mut by_machine: HashMap<String, Vec<String>> = HashMap::new();
+    let mut seen: HashSet<(String, String)> = HashSet::new();
 
-    for key in ordered {
-        let Some(item) = planned_by_key.get(key) else {
-            continue;
-        };
+    for item in planned {
         let Some(container) = item.config.execution.container.as_ref() else {
             continue;
         };
@@ -645,103 +626,38 @@ fn collect_container_mount_sources(
         if raw_mount_paths.is_empty() {
             continue;
         }
+        let label = NodeKey::new(&item.node_name, &item.node_tag).label();
 
         for instance in &item.deployment.instances {
-            if placements.of(instance.instance_id.as_str()) != coordinator {
-                continue;
-            }
+            let machine = placements.of(instance.instance_id.as_str());
             let mut arguments = instance.arguments.clone();
             let missing =
                 apply_parameter_defaults(&mut arguments, &item.config.execution.parameters);
             if !missing.is_empty() {
                 return Err(format!(
-                    "failed to prepare container mounts for {} instance {}: Missing required parameters: {}",
-                    key.label(),
+                    "failed to prepare container mounts for {label} instance {}: Missing required parameters: {}",
                     instance.instance_id,
                     missing.join(", ")
                 ));
             }
 
-            let resolved_mount_paths =
-                match resolve_mount_path_parameters(raw_mount_paths, &arguments) {
-                    Ok(paths) => paths,
-                    Err(msg) => {
-                        return Err(format!(
-                            "failed to prepare container mounts for {} instance {}: {msg}",
-                            key.label(),
-                            instance.instance_id,
-                        ));
-                    }
-                };
+            let resolved_mount_paths = resolve_mount_path_parameters(raw_mount_paths, &arguments)
+                .map_err(|msg| {
+                format!(
+                    "failed to prepare container mounts for {label} instance {}: {msg}",
+                    instance.instance_id,
+                )
+            })?;
             for mount in resolved_mount_paths {
-                let src = mount_source(&mount).to_string();
-                if seen.insert(src.clone()) {
-                    mount_sources.push(src);
+                let src = containers::mount_spec_source(&mount).to_string();
+                if seen.insert((machine.to_owned(), src.clone())) {
+                    by_machine.entry(machine.to_owned()).or_default().push(src);
                 }
             }
         }
     }
 
-    Ok(mount_sources)
-}
-
-async fn ensure_launch_bind_sources(
-    ctx: &ProcessLaunchContext,
-    mount_sources: &[String],
-) -> std::result::Result<(), String> {
-    for src in mount_sources {
-        let src_path = Path::new(src);
-        if src_path.exists() || is_host_provided_mount_source(src_path) {
-            continue;
-        }
-
-        std::fs::create_dir_all(src_path)
-            .map_err(|e| format!("failed to create bind mount source {src}: {e}"))?;
-        publish_stderr(
-            ctx,
-            format!(
-                "auto-created missing bind mount source: {src} (if you intended to bind an existing file, this is a typo)"
-            ),
-            LaunchFeedbackStep::LauncherStep,
-        )
-        .await;
-    }
-
-    Ok(())
-}
-
-fn external_lima_mount_sources(mount_sources: &[String]) -> Vec<String> {
-    if !cfg!(target_os = "macos") {
-        return Vec::new();
-    }
-
-    let home = std::env::var_os("HOME").map(PathBuf::from);
-    mount_sources
-        .iter()
-        .filter(|src| {
-            let src_path = absolute_mount_source(src);
-            !is_host_provided_mount_source(&src_path)
-                && home
-                    .as_ref()
-                    .is_none_or(|home_path| !src_path.starts_with(home_path))
-        })
-        .cloned()
-        .collect()
-}
-
-fn absolute_mount_source(src: &str) -> PathBuf {
-    let path = Path::new(src);
-    if path.is_absolute() {
-        path.to_path_buf()
-    } else {
-        std::env::current_dir()
-            .map(|cwd| cwd.join(path))
-            .unwrap_or_else(|_| path.to_path_buf())
-    }
-}
-
-fn mount_source(mount: &str) -> &str {
-    mount.split(':').next().unwrap_or(mount)
+    Ok(by_machine)
 }
 
 /// The environment one launched instance is started with: the forwarded
@@ -1365,11 +1281,35 @@ async fn process_launch(goal: LaunchGoal, ctx: ProcessLaunchContext) -> LaunchRe
         .await;
     }
 
+    // Step 4c: Work out what each machine's containers will bind, while a
+    // failure is still free. A mount path that names a parameter with no value
+    // fails here, before any stack is replaced, rather than on the machine that
+    // would have had to bind it.
+    let mount_sources_by_machine = match container_mount_sources_by_machine(&planned, &placements) {
+        Ok(by_machine) => by_machine,
+        Err(reason) => {
+            publish_stderr(&ctx, reason.clone(), LaunchFeedbackStep::LauncherStep).await;
+            return release_and_fail(
+                &ctx,
+                &goal,
+                &participants,
+                LaunchResult::failure(&ctx.log_path, reason),
+            )
+            .await;
+        }
+    };
+
     // Step 5: The commit point. Every participant is reserved and the whole
     // plan is validated, so now, and only now, do stacks get replaced. Peers
-    // first: if one refuses, this daemon still has its own stack.
-    if let Err(reason) =
-        federated::begin_participant_slices(&ctx, &goal.launch_id, &participants).await
+    // first: if one refuses, this daemon still has its own stack. Each one is
+    // handed the bind sources its slice needs, to prepare while it is empty.
+    if let Err(reason) = federated::begin_participant_slices(
+        &ctx,
+        &goal.launch_id,
+        &participants,
+        &mount_sources_by_machine,
+    )
+    .await
     {
         publish_stderr(&ctx, reason.clone(), LaunchFeedbackStep::LauncherStep).await;
         federated::clear_participant_slices(&ctx, &participants).await;
@@ -1427,8 +1367,17 @@ async fn process_launch(goal: LaunchGoal, ctx: ProcessLaunchContext) -> LaunchRe
         // starts. Updating Lima's mount table can restart the VM; doing it
         // lazily during a later instance start would kill containers already
         // launched by this stack operation.
-        prepare_container_host_mounts(&ctx, &ordered, &planned_by_key, &placements, &participants)
-            .await?;
+        prepare_container_host_mounts(
+            &ctx,
+            &ordered,
+            &planned_by_key,
+            mount_sources_by_machine
+                .get(ctx.bound_core_node.as_str())
+                .cloned()
+                .unwrap_or_default(),
+            &participants,
+        )
+        .await?;
 
         // Step 8: Start instances in dependency order.
         start_node_instances(
@@ -1511,46 +1460,6 @@ mod tests {
     use std::collections::BTreeMap;
     use std::sync::atomic::{AtomicBool, Ordering};
     use tokio::sync::Notify;
-
-    /// A host-provided source must never be handed to Lima as an extra mount.
-    /// Registering `/run/user` would mount the macOS side (which does not even
-    /// exist) over the guest's own runtime tmpfs, and would restart the VM to
-    /// do it. The guest resolves these paths itself.
-    ///
-    /// macOS-gated like its companion below: off macOS
-    /// `external_lima_mount_sources` returns empty before consulting the
-    /// filter at all, so an ungated assertion would hold with the filter
-    /// deleted and prove nothing. The predicate itself is platform-independent
-    /// and covered in `containers::mount_source`.
-    #[test]
-    #[cfg(target_os = "macos")]
-    fn host_provided_sources_are_not_forwarded_to_lima() {
-        let forwarded = external_lima_mount_sources(&[
-            "/run/user".to_string(),
-            "/dev/ttyUSB0".to_string(),
-            "/proc/self".to_string(),
-            "/sys/class".to_string(),
-        ]);
-        assert!(
-            forwarded.is_empty(),
-            "host-provided trees must stay out of the Lima mount list, got: {forwarded:?}"
-        );
-    }
-
-    /// The complement of the test above: the filter is a carve-out, not a
-    /// blanket opt-out. An ordinary path outside `$HOME` still has to reach
-    /// Lima or the guest could not see it. Only meaningful on macOS, where
-    /// `external_lima_mount_sources` does its work.
-    #[test]
-    #[cfg(target_os = "macos")]
-    fn ordinary_external_sources_are_still_forwarded_to_lima() {
-        let forwarded = external_lima_mount_sources(&["/opt/robot_assets".to_string()]);
-        assert_eq!(
-            forwarded,
-            vec!["/opt/robot_assets".to_string()],
-            "a non-home path the guest cannot otherwise see must be registered",
-        );
-    }
 
     /// Builds a phase future that signals `cleanup_ran` if it observes the
     /// cancel token, simulating `run_node_run`'s `abort_started` branch.
@@ -1655,6 +1564,217 @@ mod tests {
         );
     }
 
+    /// A parameter a mount path can reference and an instance can leave out.
+    const DEFAULTED_OUTPUT_DIR: &str =
+        r#"output_dir: { $type: "string", $default: "/var/lib/peppy_default" }"#;
+    /// The same parameter with nothing to fall back to, so an instance that
+    /// omits it cannot resolve its mount path.
+    const REQUIRED_OUTPUT_DIR: &str = r#"output_dir: "string""#;
+
+    /// A planned deployment of one container node, with the parameter schema,
+    /// mount paths and instances a test cares about and defaults everywhere
+    /// else.
+    fn planned_container_deployment(
+        node_name: &str,
+        parameters: &str,
+        mount_paths: &[&str],
+        instances: &[(&str, Option<&str>, BTreeMap<String, AnyType>)],
+    ) -> PlannedDeployment {
+        let mounts = mount_paths
+            .iter()
+            .map(|path| format!("\"{path}\""))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let config = config::node::NodeConfigParser::from_content(&format!(
+            r#"{{
+                peppy_schema: "node/v1",
+                manifest: {{ name: "{node_name}", tag: "v1" }},
+                execution: {{
+                    language: "python",
+                    container: {{ def_file: "apptainer.def", mount_paths: [{mounts}] }},
+                    parameters: {{ {parameters} }},
+                }},
+                interfaces: {{}},
+            }}"#
+        ))
+        .expect("parse node config");
+
+        PlannedDeployment {
+            deployment: Deployment {
+                source: daemon_config::launcher::DeploymentSource::Repo(
+                    daemon_config::launcher::DeploymentRepoSource {
+                        name: node_name.to_owned(),
+                        tag: "v1".to_owned(),
+                    },
+                ),
+                instances: instances
+                    .iter()
+                    .map(|(instance_id, core_node, arguments)| {
+                        let mut instance = daemon_config::launcher::DeploymentInstance::empty(
+                            config::runtime::Name::new(*instance_id).expect("valid instance id"),
+                        );
+                        instance.arguments = arguments.clone();
+                        instance.core_node = core_node.map(str::to_owned);
+                        instance
+                    })
+                    .collect(),
+            },
+            source: NodeSource::resolve_ref(node_name, "v1").expect("valid node ref"),
+            node_name: node_name.to_owned(),
+            node_tag: "v1".to_owned(),
+            config,
+            config_sha256: String::new(),
+            root_pin: None,
+            closure_pins: Vec::new(),
+            pin_manifests: Vec::new(),
+        }
+    }
+
+    fn placements_with(
+        coordinator: &str,
+        by_instance: &[(&str, &str)],
+    ) -> daemon_config::launcher::Placements {
+        daemon_config::launcher::Placements::new(
+            daemon_config::core_node_name::CoreNodeName::new(coordinator).expect("valid name"),
+            by_instance
+                .iter()
+                .map(|(instance, core_node)| {
+                    (
+                        (*instance).to_owned(),
+                        daemon_config::core_node_name::CoreNodeName::new(*core_node)
+                            .expect("valid name"),
+                    )
+                })
+                .collect(),
+        )
+    }
+
+    /// Each machine gets its own instances' sources and nobody else's. This is
+    /// what a participant is handed to prepare, so a source landing on the
+    /// wrong machine would make a directory there and still leave the binding
+    /// machine without one.
+    #[test]
+    fn mount_sources_are_grouped_by_the_machine_that_binds_them() {
+        let planned = vec![planned_container_deployment(
+            "recorder",
+            DEFAULTED_OUTPUT_DIR,
+            &["/data/episodes:/episodes:rw"],
+            &[
+                ("robot_inst", None, BTreeMap::new()),
+                ("cloud_inst", Some("cn-cloud"), BTreeMap::new()),
+            ],
+        )];
+        let placements = placements_with("cn-robot", &[("cloud_inst", "cn-cloud")]);
+
+        let by_machine = container_mount_sources_by_machine(&planned, &placements)
+            .expect("every mount path resolves");
+
+        assert_eq!(
+            by_machine.get("cn-robot").map(Vec::as_slice),
+            Some(["/data/episodes".to_owned()].as_slice())
+        );
+        assert_eq!(
+            by_machine.get("cn-cloud").map(Vec::as_slice),
+            Some(["/data/episodes".to_owned()].as_slice())
+        );
+    }
+
+    /// A machine with nothing to bind is absent, not present-and-empty: the
+    /// caller iterates this map to decide who has preparation to do.
+    #[test]
+    fn a_machine_running_no_container_bind_is_absent_from_the_grouping() {
+        let planned = vec![
+            planned_container_deployment(
+                "recorder",
+                DEFAULTED_OUTPUT_DIR,
+                &["/data/episodes"],
+                &[("cloud_inst", Some("cn-cloud"), BTreeMap::new())],
+            ),
+            planned_container_deployment(
+                "camera",
+                DEFAULTED_OUTPUT_DIR,
+                &[],
+                &[("robot_inst", None, BTreeMap::new())],
+            ),
+        ];
+        let placements = placements_with("cn-robot", &[("cloud_inst", "cn-cloud")]);
+
+        let by_machine = container_mount_sources_by_machine(&planned, &placements)
+            .expect("every mount path resolves");
+
+        assert_eq!(by_machine.len(), 1);
+        assert!(by_machine.contains_key("cn-cloud"));
+    }
+
+    /// Two instances of one node on one machine binding the same path is one
+    /// source, and the same path on two machines is one source each: the map
+    /// dedupes per machine, not globally.
+    #[test]
+    fn a_repeated_source_is_listed_once_per_machine() {
+        let mut arguments = BTreeMap::new();
+        arguments.insert(
+            "output_dir".to_owned(),
+            AnyType::String("/data/shared".to_owned()),
+        );
+        let planned = vec![planned_container_deployment(
+            "recorder",
+            DEFAULTED_OUTPUT_DIR,
+            &["${parameters:output_dir}:/out:rw"],
+            &[
+                ("first_inst", None, arguments.clone()),
+                ("second_inst", None, arguments),
+            ],
+        )];
+
+        let by_machine =
+            container_mount_sources_by_machine(&planned, &placements_with("cn-robot", &[]))
+                .expect("every mount path resolves");
+
+        assert_eq!(
+            by_machine.get("cn-robot").map(Vec::as_slice),
+            Some(["/data/shared".to_owned()].as_slice())
+        );
+    }
+
+    /// A parameter the instance never supplies falls back to the node's
+    /// default, so the machine that runs it still knows what to prepare.
+    #[test]
+    fn a_defaulted_mount_parameter_resolves_to_the_nodes_default() {
+        let planned = vec![planned_container_deployment(
+            "recorder",
+            DEFAULTED_OUTPUT_DIR,
+            &["${parameters:output_dir}:/out:rw"],
+            &[("robot_inst", None, BTreeMap::new())],
+        )];
+
+        let by_machine =
+            container_mount_sources_by_machine(&planned, &placements_with("cn-robot", &[]))
+                .expect("the parameter default resolves");
+
+        assert_eq!(
+            by_machine.get("cn-robot").map(Vec::as_slice),
+            Some(["/var/lib/peppy_default".to_owned()].as_slice())
+        );
+    }
+
+    /// An unresolvable mount path names the instance it belongs to. This runs
+    /// before the launch turns destructive, so it is the operator's whole
+    /// description of what went wrong.
+    #[test]
+    fn an_unresolvable_mount_path_names_its_instance() {
+        let planned = vec![planned_container_deployment(
+            "recorder",
+            REQUIRED_OUTPUT_DIR,
+            &["${parameters:output_dir}:/out:rw"],
+            &[("robot_inst", None, BTreeMap::new())],
+        )];
+
+        let error = container_mount_sources_by_machine(&planned, &placements_with("cn-robot", &[]))
+            .expect_err("an unknown parameter cannot resolve");
+        assert!(error.contains("recorder:v1"), "got: {error}");
+        assert!(error.contains("robot_inst"), "got: {error}");
+    }
+
     fn plan_with(use_sim_time: Option<bool>) -> config::runtime::NodeInstancePlan {
         config::runtime::NodeInstancePlan {
             use_sim_time,
@@ -1702,7 +1822,10 @@ mod tests {
         .expect("parameterized mount should resolve");
 
         assert_eq!(resolved, vec!["/tmp/video_reconstruction:/frames:rw"]);
-        assert_eq!(mount_source(&resolved[0]), "/tmp/video_reconstruction");
+        assert_eq!(
+            containers::mount_spec_source(&resolved[0]),
+            "/tmp/video_reconstruction"
+        );
     }
 
     /// An instance's `env_vars` are added to the forwarded caller environment

--- a/crates/core-node-internal/src/services/stack/launch/federated/dispatch.rs
+++ b/crates/core-node-internal/src/services/stack/launch/federated/dispatch.rs
@@ -23,6 +23,7 @@
 //! command, so they get one stream; the prefix is what keeps it readable when
 //! two machines are building at once.
 
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -242,24 +243,36 @@ pub(in crate::services::stack) async fn run_remote_goal<G: RemoteGoal>(
     Ok(RemoteGoalRun { log_path, outcome })
 }
 
-/// Tells every participant to replace its stack slice, in parallel.
+/// Tells every participant to replace its stack slice, in parallel, handing
+/// each the bind sources its slice needs.
 ///
 /// This is the first destructive step of a federated launch on any machine, and
 /// it happens only once every participant is reserved. A refusal here is
 /// returned rather than retried: the reservation makes it nearly impossible
 /// (this coordinator holds each machine), so a refusal means the peer's lease
 /// lapsed or the network dropped, and continuing would build half a topology.
+///
+/// A participant that had to create one of those sources says so, and the line
+/// is relayed here attributed to its machine: an auto-created bind source is
+/// how a misspelled file bind looks, and the operator watching this launch is
+/// the one who can tell the two apart.
 pub(in crate::services::stack) async fn begin_participant_slices(
     ctx: &ProcessLaunchContext,
     launch_id: &str,
     participants: &[String],
+    mount_sources_by_machine: &HashMap<String, Vec<String>>,
 ) -> std::result::Result<(), String> {
-    let request = ParticipantSliceBeginRequest::new(launch_id);
     let outcomes = futures::future::join_all(participants.iter().map(|core_node| {
-        let request = &request;
+        let request = ParticipantSliceBeginRequest::new(
+            launch_id,
+            mount_sources_by_machine
+                .get(core_node)
+                .cloned()
+                .unwrap_or_default(),
+        );
         async move {
             let outcome = poll(
-                request,
+                &request,
                 &ctx.messenger,
                 ctx.bound_core_node.as_str(),
                 ctx.core_instance_id.as_str(),
@@ -275,7 +288,16 @@ pub(in crate::services::stack) async fn begin_participant_slices(
     let mut refusals = Vec::new();
     for (core_node, outcome) in outcomes {
         match outcome {
-            Ok(response) if response.ok => {}
+            Ok(response) if response.ok => {
+                for src in response.auto_created_mount_sources {
+                    publish_stderr(
+                        ctx,
+                        format!("[{core_node}] {}", containers::auto_created_warning(&src)),
+                        LaunchFeedbackStep::LauncherStep,
+                    )
+                    .await;
+                }
+            }
             Ok(response) => refusals.push(format!(
                 "`{core_node}` refused: {}",
                 response

--- a/crates/node-stack-internal/src/node_stack.rs
+++ b/crates/node-stack-internal/src/node_stack.rs
@@ -1394,6 +1394,25 @@ impl NodeStack {
         guard.live_instance_ids_for_pairing()
     }
 
+    /// The instance ids that a container-runtime restart would take with it:
+    /// the live instances of container nodes, in start order.
+    ///
+    /// Process nodes are excluded because they run on the host, outside any
+    /// runtime the daemon can restart, and so does the root entity. `Starting`
+    /// counts alongside `Running`: an instance whose container is up but whose
+    /// handshake has not landed dies just as thoroughly.
+    pub fn live_container_instance_ids(&self) -> Vec<String> {
+        let guard = self.shared.read();
+        guard
+            .entities_snapshot()
+            .iter()
+            .flat_map(|handle| {
+                let entity = handle.read();
+                live_container_instances_of(entity.config(), entity.instances())
+            })
+            .collect()
+    }
+
     /// Snapshot for plan-phase pairing validation: every non-root entity
     /// with at least one live-for-pairing (non-terminal) instance, in one
     /// read-locked pass. Nodes without pairing slots are included so a
@@ -1435,6 +1454,24 @@ impl NodeStack {
             })
             .collect()
     }
+}
+
+/// One entity's contribution to [`NodeStack::live_container_instance_ids`].
+///
+/// A process node contributes nothing however many instances it has: its
+/// children run on the host, where no container-runtime restart reaches them.
+fn live_container_instances_of(
+    config: &NodeConfig,
+    instances: &[TrackedNodeInstance],
+) -> Vec<String> {
+    if config.execution.container.is_none() {
+        return Vec::new();
+    }
+    instances
+        .iter()
+        .filter(|instance| !instance.state().is_terminal())
+        .map(|instance| instance.instance_id().as_str().to_string())
+        .collect()
 }
 
 /// One node's contribution to the plan-phase pairing snapshot: its live
@@ -1484,4 +1521,78 @@ pub fn pairing_slot_view(
         );
     }
     out
+}
+
+/// Which instances a container-runtime restart would take with it, decided per
+/// entity. The graph walk around it ([`NodeStack::live_container_instance_ids`])
+/// is a `flat_map`; the rule is here, where it can be stated on hand-built
+/// entities rather than on a stack with real children in it.
+#[cfg(test)]
+mod live_container_instances_tests {
+    use super::*;
+    use config::node::NodeConfigParser;
+
+    fn config_of(execution: &str) -> NodeConfig {
+        NodeConfigParser::from_content(&format!(
+            r#"{{
+                peppy_schema: "node/v1",
+                manifest: {{ name: "recon", tag: "v1" }},
+                execution: {execution},
+                interfaces: {{}},
+            }}"#
+        ))
+        .expect("valid test node config")
+    }
+
+    fn container_config() -> NodeConfig {
+        config_of(r#"{ language: "python", container: { def_file: "apptainer.def" } }"#)
+    }
+
+    fn instance(id: &str, state: InstanceState) -> TrackedNodeInstance {
+        TrackedNodeInstance::new(
+            Name::new(id).expect("valid instance id"),
+            None,
+            state,
+            std::collections::BTreeMap::new(),
+        )
+    }
+
+    /// `Starting` counts alongside `Running`: its container is already up in
+    /// the runtime even though the handshake has not landed, so a restart kills
+    /// it just as thoroughly.
+    #[test]
+    fn a_container_nodes_non_terminal_instances_are_all_at_risk() {
+        let instances = [
+            instance("running_inst", InstanceState::Running),
+            instance("starting_inst", InstanceState::Starting),
+        ];
+        assert_eq!(
+            live_container_instances_of(&container_config(), &instances),
+            vec!["running_inst".to_string(), "starting_inst".to_string()]
+        );
+    }
+
+    /// An instance that has already exited cannot be stopped again, so naming
+    /// it in a refusal would be telling the operator to save something dead.
+    #[test]
+    fn a_container_nodes_finished_instances_are_not_at_risk() {
+        let instances = [
+            instance("finished_inst", InstanceState::Finished),
+            instance("failed_inst", InstanceState::Failed),
+        ];
+        assert!(
+            live_container_instances_of(&container_config(), &instances).is_empty(),
+            "a terminal instance has nothing left to lose"
+        );
+    }
+
+    /// A process node's children run on the host. Counting them would refuse
+    /// starts that cost nothing, including on the root entity, which is always
+    /// running and is never a container.
+    #[test]
+    fn a_process_nodes_instances_are_never_at_risk() {
+        let process = config_of(r#"{ language: "rust", run_cmd: ["recon"] }"#);
+        let instances = [instance("running_inst", InstanceState::Running)];
+        assert!(live_container_instances_of(&process, &instances).is_empty());
+    }
 }

--- a/crates/node-stack-internal/src/node_stack/run_steps.rs
+++ b/crates/node-stack-internal/src/node_stack/run_steps.rs
@@ -21,8 +21,6 @@ use tracing::{debug, warn};
 
 use tokio::sync::mpsc;
 
-use containers::is_host_provided_mount_source;
-
 use crate::archive::extract_tar_zst;
 use crate::build_io::{FeedbackLine, FeedbackStream, write_feedback_log_line};
 
@@ -477,46 +475,28 @@ pub(super) async fn build_container_command(
     })
 }
 
-/// Ensures every bind mount source path is usable by the container runtime.
+/// Makes every bind mount source usable by the container runtime, announcing
+/// the ones it had to create.
 ///
-/// For each entry:
-///   - existing paths are left untouched (they may be files, sockets, devices,
-///     or directories; we must not modify them);
-///   - paths the host provides ([`is_host_provided_mount_source`]) are
-///     accepted as-is, since the daemon's host may legitimately not have the
-///     device node or runtime dir;
-///   - any other missing path is auto-created with `mkdir -p`, and a warning
-///     line is emitted both to the daemon `tracing` log and to the
-///     per-instance start log via `feedback_sink`. The warning is the only
-///     line of defence against a typo'd file bind being silently turned into
-///     an empty directory, so callers MUST pass the per-instance log sink.
+/// [`containers::ensure_bind_source`] decides what to touch; this adds the
+/// reporting. An auto-create goes to the daemon `tracing` log, to the
+/// per-instance start log via `feedback_sink`, and onto `feedback_tx` as a
+/// Warning-stream line, because it is the only line of defence against a typo'd
+/// file bind being silently turned into an empty directory. Callers MUST
+/// therefore pass the per-instance log sink.
 ///
 /// Returns the underlying `io::Error` (with the offending path embedded in
-/// the message) if `create_dir_all` fails.
+/// the message) if a source is missing and cannot be created.
 pub(super) fn ensure_bind_sources(
     binds: &[ContainerBind],
     feedback_sink: &Arc<StdMutex<File>>,
     feedback_tx: &mpsc::UnboundedSender<FeedbackLine>,
 ) -> std::io::Result<()> {
     for bind in binds {
-        let src_path = Path::new(&bind.src);
-        if src_path.exists() || is_host_provided_mount_source(src_path) {
+        if !containers::ensure_bind_source(Path::new(&bind.src))? {
             continue;
         }
-        std::fs::create_dir_all(src_path).map_err(|e| {
-            std::io::Error::new(
-                e.kind(),
-                format!(
-                    "bind mount source does not exist: {} (auto-create failed: {})",
-                    bind.src, e
-                ),
-            )
-        })?;
-        let warning = format!(
-            "auto-created missing bind mount source: {} \
-             (if you intended to bind an existing file, this is a typo)",
-            bind.src
-        );
+        let warning = containers::auto_created_warning(&bind.src);
         warn!("{}", warning);
         write_feedback_log_line(feedback_sink, FeedbackStream::Warning, &warning);
         let _ = feedback_tx.send(FeedbackLine {
@@ -697,42 +677,6 @@ mod tests {
     }
 
     #[test]
-    fn ensure_bind_sources_accepts_host_provided_paths_without_creating() {
-        let (sink, log_file) = make_log_sink();
-        let binds = vec![
-            ContainerBind {
-                src: "/dev/does-not-exist-xyz".to_string(),
-                dest: None,
-                opts: None,
-            },
-            ContainerBind {
-                src: "/proc/missing".to_string(),
-                dest: None,
-                opts: None,
-            },
-            ContainerBind {
-                src: "/sys/missing".to_string(),
-                dest: None,
-                opts: None,
-            },
-            // The runtime tmpfs. Sim nodes bind `/run/user` to back
-            // `XDG_RUNTIME_DIR`; on a macOS daemon there is no `/run` and `/`
-            // is read-only, so any attempt to create it fails with `EROFS`.
-            ContainerBind {
-                src: "/run/user".to_string(),
-                dest: None,
-                opts: None,
-            },
-        ];
-        let (tx, mut rx) = make_feedback_channel();
-        ensure_bind_sources(&binds, &sink, &tx).expect("host-provided paths should be accepted");
-        assert!(rx.try_recv().is_err(), "no warning should be sent");
-        assert!(!Path::new("/dev/does-not-exist-xyz").exists());
-        let log_contents = std::fs::read_to_string(log_file.path()).unwrap_or_default();
-        assert!(!log_contents.contains("auto-created"));
-    }
-
-    #[test]
     fn ensure_bind_sources_creates_missing_dir_and_warns() {
         let parent = tempfile::tempdir().expect("tempdir");
         let target = parent.path().join("scratch").join("nested");
@@ -775,27 +719,17 @@ mod tests {
         assert!(rx.try_recv().is_err(), "exactly one warning expected");
     }
 
+    /// A source that cannot be created stops the start rather than being
+    /// warned about: there is nothing to bind. What the failure says is
+    /// [`containers::ensure_bind_source`]'s to define; what matters here is
+    /// that it reaches the caller instead of being swallowed into a warning.
+    #[cfg(unix)]
     #[test]
-    fn ensure_bind_sources_propagates_create_dir_failures() {
-        // /proc/1/<x> is a kernel-managed path that mkdir cannot create. We
-        // bypass the /proc shortcut by using /proc/1 as the parent (the
-        // shortcut only applies to paths whose top-level component is
-        // /dev|/proc|/sys, and ours starts with /proc, so we use a sibling
-        // path under a non-special root that we make non-writable instead).
+    fn ensure_bind_sources_propagates_a_failed_auto_create() {
         let parent = tempfile::tempdir().expect("tempdir");
-        let ro_parent = parent.path().join("ro");
-        std::fs::create_dir(&ro_parent).expect("mkdir ro");
-        // Make the parent read-only so create_dir_all fails on the child.
-        let mut perms = std::fs::metadata(&ro_parent)
-            .expect("metadata")
-            .permissions();
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            perms.set_mode(0o500);
-        }
-        std::fs::set_permissions(&ro_parent, perms).expect("set perms");
-        let target = ro_parent.join("child");
+        let target = parent.path().join("bind_source");
+        std::os::unix::fs::symlink(parent.path().join("no_such_target"), &target)
+            .expect("plant a dangling symlink");
 
         let (sink, _log) = make_log_sink();
         let binds = vec![ContainerBind {
@@ -804,29 +738,19 @@ mod tests {
             opts: None,
         }];
 
-        let (tx, _rx) = make_feedback_channel();
-        let err = ensure_bind_sources(&binds, &sink, &tx)
-            .expect_err("read-only parent should make auto-create fail");
-        let msg = err.to_string();
+        let (tx, mut rx) = make_feedback_channel();
+        let error = ensure_bind_sources(&binds, &sink, &tx)
+            .expect_err("an uncreatable source must fail the start");
         assert!(
-            msg.contains("bind mount source does not exist"),
-            "error must preserve the canonical phrase, got: {msg}"
+            error
+                .to_string()
+                .contains(target.to_string_lossy().as_ref()),
+            "error must name the offending path, got: {error}"
         );
         assert!(
-            msg.contains(target.to_string_lossy().as_ref()),
-            "error must mention the offending path, got: {msg}"
+            rx.try_recv().is_err(),
+            "a source that was never created must not be announced as one"
         );
-
-        // Restore permissions so the tempdir can be cleaned up.
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let mut perms = std::fs::metadata(&ro_parent)
-                .expect("metadata")
-                .permissions();
-            perms.set_mode(0o700);
-            std::fs::set_permissions(&ro_parent, perms).expect("restore perms");
-        }
     }
 
     #[test]

--- a/crates/peppy/tests/multi_daemon_e2e.rs
+++ b/crates/peppy/tests/multi_daemon_e2e.rs
@@ -782,7 +782,7 @@ const CONTAINER_LAUNCHER_DIR: &str = "/etc/peppy/launchers";
 const SPLIT_COMPUTE_LAUNCHER_FILE: &str = "split_compute_manipulation.json5";
 const HUB_NODE_PROBE_LAUNCHER_FILE: &str = "hub_node_probe.json5";
 const CALLER_ENV_PROBE_LAUNCHER_FILE: &str = "caller_env_probe.json5";
-const UNBINDABLE_PEER_LAUNCHER_FILE: &str = "unbindable_peer.json5";
+const PEER_RUN_FAILURE_LAUNCHER_FILE: &str = "peer_run_failure.json5";
 
 fn container_launcher(file_name: &str) -> String {
     format!("{CONTAINER_LAUNCHER_DIR}/{file_name}")
@@ -824,35 +824,34 @@ const CALLER_ENV_PROBE_LAUNCHER: &str = r#"{
 }
 "#;
 
-/// The host path `uvc_camera_video_reconstruction_python:v1` bind-mounts, taken
-/// verbatim from its node definition in `nodes-hub`.
-const PEER_BIND_SOURCE: &str = "/tmp/video_reconstruction";
+/// The instance the launcher places on the peer, and whose working directory
+/// the test makes unusable there.
+const PEER_RUN_FAILURE_INSTANCE: &str = "peer_fail_recon_inst";
 
 /// A launch that gets as far as the peer's RUN and fails there.
 ///
-/// `uvc_camera_video_reconstruction_python` is a container node that binds
-/// [`PEER_BIND_SOURCE`], and the test makes that source unusable on the peer
-/// alone (see `a_peer_phase_that_fails_still_names_the_peers_log_file`). So the
-/// peer adds the node, builds it, accepts the run goal, opens its log file, and
-/// fails preparing the bind. The camera stays on the coordinator, which is what
-/// makes the marked entry evidence of attribution rather than of every entry
-/// belonging to one machine.
-const UNBINDABLE_PEER_LAUNCHER: &str = r#"{
+/// The peer adds its node, builds it, accepts the run goal, opens its log file,
+/// and then cannot materialize [`PEER_RUN_FAILURE_INSTANCE`]'s working
+/// directory, which the test has made uncreatable on the peer alone (see
+/// `a_peer_phase_that_fails_still_names_the_peers_log_file`). The camera stays
+/// on the coordinator, which is what makes the marked entry evidence of
+/// attribution rather than of every entry belonging to one machine.
+const PEER_RUN_FAILURE_LAUNCHER: &str = r#"{
   peppy_schema: "launcher/v1",
   core_nodes: ["remote_worker"],
   deployments: [
     {
       source: { name: "uvc_camera_python_mock", tag: "v1" },
-      instances: [{ instance_id: "unbindable_cam_inst" }],
+      instances: [{ instance_id: "peer_fail_cam_inst" }],
     },
     {
       source: { name: "uvc_camera_video_reconstruction_python", tag: "v1" },
       instances: [
         {
-          instance_id: "unbindable_recon_inst",
+          instance_id: "peer_fail_recon_inst",
           core_node: "remote_worker",
           arguments: { video_duration_seconds: 5 },
-          links: { camera: "unbindable_cam_inst" },
+          links: { camera: "peer_fail_cam_inst" },
         },
       ],
     },
@@ -1036,10 +1035,10 @@ async fn start_federation(prefix: &str) -> Federation {
     )
     .expect("writing the caller-env probe launcher into the launcher mount");
     std::fs::write(
-        launcher_dir.path().join(UNBINDABLE_PEER_LAUNCHER_FILE),
-        UNBINDABLE_PEER_LAUNCHER,
+        launcher_dir.path().join(PEER_RUN_FAILURE_LAUNCHER_FILE),
+        PEER_RUN_FAILURE_LAUNCHER,
     )
-    .expect("writing the unbindable-peer launcher into the launcher mount");
+    .expect("writing the peer-run-failure launcher into the launcher mount");
 
     let robot = start_daemon(
         &launch,
@@ -1466,19 +1465,29 @@ async fn an_unreachable_peer_fails_the_launch_and_is_named() {
 async fn a_peer_phase_that_fails_still_names_the_peers_log_file() {
     let federation = start_federation("peppy-fed-peer-fail").await;
 
-    // Make the peer's bind source unusable. A daemon creates a missing bind
-    // source itself right before it starts the container, on whichever machine
-    // runs the instance, so a merely absent path would be created and the run
-    // would succeed. A dangling symlink is the shape that cannot be: it does
-    // not exist, so the daemon tries to create it, and `mkdir` refuses because
-    // the symlink already occupies the name. Planted on the peer only, so the
-    // coordinator's own instance still gets through every phase.
+    // Make the peer unable to materialize the instance it will be asked to run.
+    // A dangling symlink is the shape that cannot be created: it does not
+    // exist, so the daemon goes to create the working directory, and `mkdir`
+    // refuses because the symlink already occupies the name. It is planted on
+    // the working directory rather than on a bind source because bind sources
+    // are prepared when the peer takes over its slice, before the phases this
+    // test is about; nothing prepares this one ahead of the start. Planted on
+    // the peer only, so the coordinator's own instance gets through every
+    // phase.
+    let instance_dir = format!("{CONTAINER_PEPPY_HOME}/instances/{PEER_RUN_FAILURE_INSTANCE}");
     require_success(
         federation
             .cloud
-            .exec(vec!["ln", "-s", "/no_such_bind_target", PEER_BIND_SOURCE])
+            .exec(vec![
+                "sh",
+                "-c",
+                &format!(
+                    "mkdir -p {CONTAINER_PEPPY_HOME}/instances \
+                     && ln -s /no_such_instance_dir_target {instance_dir}"
+                ),
+            ])
             .await,
-        &format!("planting an uncreatable {PEER_BIND_SOURCE} on the peer"),
+        &format!("planting an uncreatable {instance_dir} on the peer"),
     );
 
     let launch = federation
@@ -1488,7 +1497,7 @@ async fn a_peer_phase_that_fails_still_names_the_peers_log_file() {
             "launch",
             "--place",
             &format!("remote_worker@{}", federation.cloud_core_node),
-            &container_launcher(UNBINDABLE_PEER_LAUNCHER_FILE),
+            &container_launcher(PEER_RUN_FAILURE_LAUNCHER_FILE),
         ])
         .await;
     assert!(

--- a/crates/peppy/tests/multi_daemon_e2e.rs
+++ b/crates/peppy/tests/multi_daemon_e2e.rs
@@ -1466,14 +1466,15 @@ async fn a_peer_phase_that_fails_still_names_the_peers_log_file() {
     let federation = start_federation("peppy-fed-peer-fail").await;
 
     // Make the peer unable to materialize the instance it will be asked to run.
-    // A dangling symlink is the shape that cannot be created: it does not
-    // exist, so the daemon goes to create the working directory, and `mkdir`
-    // refuses because the symlink already occupies the name. It is planted on
-    // the working directory rather than on a bind source because bind sources
-    // are prepared when the peer takes over its slice, before the phases this
-    // test is about; nothing prepares this one ahead of the start. Planted on
-    // the peer only, so the coordinator's own instance gets through every
-    // phase.
+    // A plain file is the shape that survives the daemon's own cleanup: the
+    // start first clears any leftover working directory of that name, and that
+    // clear refuses on a non-directory, so the name stays occupied and the
+    // directory can never be created. A symlink would not do — clearing a
+    // leftover unlinks it, and the start would sail on. It is planted on the
+    // working directory rather than on a bind source because bind sources are
+    // prepared when the peer takes over its slice, before the phases this test
+    // is about; nothing prepares this one ahead of the start. Planted on the
+    // peer only, so the coordinator's own instance gets through every phase.
     let instance_dir = format!("{CONTAINER_PEPPY_HOME}/instances/{PEER_RUN_FAILURE_INSTANCE}");
     require_success(
         federation
@@ -1483,7 +1484,7 @@ async fn a_peer_phase_that_fails_still_names_the_peers_log_file() {
                 "-c",
                 &format!(
                     "mkdir -p {CONTAINER_PEPPY_HOME}/instances \
-                     && ln -s /no_such_instance_dir_target {instance_dir}"
+                     && printf '' > {instance_dir}"
                 ),
             ])
             .await,

--- a/docs/src/content/docs/advanced_guides/containers.mdx
+++ b/docs/src/content/docs/advanced_guides/containers.mdx
@@ -304,6 +304,8 @@ Top-level system directories such as `/`, `/tmp`, `/var`, `/etc`, `/dev`, `/usr`
 
 :::note
 On macOS, Peppy automatically configures the Lima VM to make mounted paths accessible inside the guest. No extra setup is needed; paths outside your home directory are handled transparently.
+
+Registering a new path with the VM restarts it, which stops every container node running on that machine. `peppy stack launch` prepares a machine's mount paths before it starts anything, so a launch never pays that cost. A `peppy node run` that would introduce a new path while container nodes are already running is refused instead, naming the instances it would have stopped: stop them first, or launch them together.
 :::
 
 ### Using parameters in mount paths

--- a/docs/src/content/docs/advanced_guides/federation.mdx
+++ b/docs/src/content/docs/advanced_guides/federation.mdx
@@ -278,6 +278,16 @@ exclusions never decide what a launch runs. Here `cn-atlas-h100` runs the
 planner the robot's caches describe, even if its own were refreshed a week
 apart.
 
+**Container bind sources.** A [container node](/advanced_guides/containers/)
+declares the host paths it mounts, and a mount path may name an instance
+parameter, so what a given instance binds is known only to the coordinator that
+resolved the whole plan. Each machine is handed the paths its own instances
+bind, once, at the moment it is told to replace its slice: it creates the
+missing ones and makes them visible to its container runtime while it is
+running nothing. A path it had to create is reported back and shown in the
+launch output against that machine, the same warning you would get had the
+instance run on your own.
+
 The thing to notice is that none of this looks different from the
 single-machine case. Federation changes where instances run, not how they are
 wired, and every machine runs the same bytes the submitting machine resolved.

--- a/docs/src/content/docs/advanced_guides/federation.mdx
+++ b/docs/src/content/docs/advanced_guides/federation.mdx
@@ -281,12 +281,17 @@ apart.
 **Container bind sources.** A [container node](/advanced_guides/containers/)
 declares the host paths it mounts, and a mount path may name an instance
 parameter, so what a given instance binds is known only to the coordinator that
-resolved the whole plan. Each machine is handed the paths its own instances
-bind, once, at the moment it is told to replace its slice: it creates the
-missing ones and makes them visible to its container runtime while it is
-running nothing. A path it had to create is reported back and shown in the
-launch output against that machine, the same warning you would get had the
-instance run on your own.
+resolved the whole plan. Every machine prepares the paths its own instances
+bind, and does it while running nothing: a participant is handed its share and
+prepares it the moment it is told to replace its slice, and the coordinator
+prepares its own once every machine's nodes are added and built, before the
+first instance starts anywhere. Preparing creates a missing path as a
+directory and makes it visible to that machine's container runtime; a missing
+`/dev`, `/proc`, `/run`, or `/sys` path is the host's to provide and is left
+alone. A path a machine had to create is reported back and shown in the launch
+output against that machine, the same warning you would get had the instance
+run on your own — and the same reason it is worth reading, since a bind meant
+to name a file looks exactly like this when the name is misspelled.
 
 The thing to notice is that none of this looks different from the
 single-machine case. Federation changes where instances run, not how they are


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Container launches now prepare missing bind-source paths automatically and report created paths.
  * Federated launches resolve and prepare machine-specific container mounts.
  * Reservation handling is safer when coordinators disconnect or take over stale reservations.
* **Bug Fixes**
  * Prevented node runs from restarting active container environments unexpectedly.
  * Improved cleanup of reservations after incomplete or failed launches.
* **Documentation**
  * Added guidance on macOS mount registration, VM restarts, and federated bind paths.
* **Tests**
  * Expanded coverage for mount preparation, reservation recovery, and federated launch failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->