### PR TITLE
Remove filesystem launcher origins and path/git/url deployment sources

### DIFF
--- a/crates/core-node-internal/src/services/stack/launch.rs
+++ b/crates/core-node-internal/src/services/stack/launch.rs
@@ -1295,8 +1295,7 @@ async fn handle_goal_request(
 /// 8. Start instances in dependency order
 async fn process_launch(goal: LaunchGoal, ctx: ProcessLaunchContext) -> LaunchResult {
     // Step 1: Parse the launcher and bind its core node links to machines.
-    let (deployments, nodes_directory, placements) = match parse_launcher_config(&ctx, &goal).await
-    {
+    let (deployments, placements) = match parse_launcher_config(&ctx, &goal).await {
         Ok(result) => result,
         Err(launch_result) => return launch_result,
     };
@@ -1305,11 +1304,10 @@ async fn process_launch(goal: LaunchGoal, ctx: ProcessLaunchContext) -> LaunchRe
     // node pins the whole launch runs. Resolution touches no other machine
     // and tears nothing down, so refusing here is free, and the
     // reservations below need the pins to carry.
-    let mut planned =
-        match resolve_deployments(&ctx, deployments, &nodes_directory, &placements).await {
-            Ok(result) => result,
-            Err(launch_result) => return launch_result,
-        };
+    let mut planned = match resolve_deployments(&ctx, deployments, &placements).await {
+        Ok(result) => result,
+        Err(launch_result) => return launch_result,
+    };
 
     // Step 3: Validate dependencies and compute one global topological order,
     // across every machine. There is exactly one planner. Runs before the

--- a/crates/core-node-internal/src/services/stack/launch/resolve.rs
+++ b/crates/core-node-internal/src/services/stack/launch/resolve.rs
@@ -1,52 +1,29 @@
 use super::feedback::{publish_stderr, publish_stdout};
 use super::{NodeKey, PlannedDeployment, ProcessLaunchContext};
 use crate::services::node::pins;
-use crate::services::node::resolve_node_config;
 use crate::services::repo::cache as repo_cache;
 use core_node_api::encoding::{
-    LaunchFeedbackStep, LaunchGoal, LaunchResult, LauncherOrigin, NodeSource, PlacementSpec,
+    LaunchFeedbackStep, LaunchGoal, LaunchResult, NodeSource, PlacementSpec,
 };
 use daemon_config::core_node_name::CoreNodeName;
 use daemon_config::format_quoted_list;
-use daemon_config::launcher::{Deployment, DeploymentSource, PeppyLauncherParser, Placements};
+use daemon_config::launcher::{Deployment, PeppyLauncherParser, Placements};
 use daemon_config::repository::PinnedItem;
 use parking_lot::Mutex as StdMutex;
 use std::collections::{BTreeMap, BTreeSet, HashSet};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::Arc;
 
-/// Why a `local:` source cannot cross a machine boundary.
-///
-/// Reads as one rule with [`pins::portable_pin_refusal`]: whether the tree a
-/// deployment resolves to sits behind a `local:` path or a filesystem
-/// repository entry, it lives on the coordinator's disk and no other machine
-/// can read it.
-pub(crate) fn local_source_refusal(
-    spec: &daemon_config::launcher::DeploymentLocalSource,
-) -> String {
-    format!(
-        "`local:{}` cannot be placed on another core node: the path names a tree on the \
-         coordinator's filesystem. A `local:` deployment must keep all of its instances on \
-         one core node; publish the node to a repo or git-backed source to split it across \
-         machines.",
-        spec.local.display()
-    )
-}
-
 fn deployment_label(deployment: &Deployment) -> String {
-    match &deployment.source {
-        DeploymentSource::Local(spec) => format!("local:{}", spec.local.display()),
-        DeploymentSource::Git(spec) => format!("git:{}@{}:{}", spec.repo, spec.ref_, spec.path),
-        DeploymentSource::Url(spec) => format!("url:{}", spec.url),
-        DeploymentSource::Repo(spec) => format!("repo:{}:{}", spec.name, spec.tag),
-    }
+    format!("{}:{}", deployment.source.name, deployment.source.tag)
 }
 
-/// Step 1: Parse launcher configuration from file path.
+/// Step 1: Resolve the launcher name through the repository cache and parse
+/// the launcher file it points at.
 pub(super) async fn parse_launcher_config(
     ctx: &ProcessLaunchContext,
     goal: &LaunchGoal,
-) -> std::result::Result<(Vec<Deployment>, PathBuf, Placements), LaunchResult> {
+) -> std::result::Result<(Vec<Deployment>, Placements), LaunchResult> {
     publish_stdout(
         ctx,
         "Parsing launcher configuration",
@@ -54,7 +31,7 @@ pub(super) async fn parse_launcher_config(
     )
     .await;
 
-    let launch_file = match resolve_launcher_origin(ctx, &goal.launcher_origin).await {
+    let launch_file = match resolve_launcher_name(ctx, &goal.launcher_name).await {
         Ok(path) => path,
         Err(msg) => {
             publish_stderr(ctx, &msg, LaunchFeedbackStep::LauncherStep).await;
@@ -90,12 +67,6 @@ pub(super) async fn parse_launcher_config(
         }
     };
 
-    // Use the parent directory of the launch file as the nodes_directory.
-    let nodes_directory = launch_file
-        .parent()
-        .map(|p| p.to_path_buf())
-        .unwrap_or_else(|| PathBuf::from("."));
-
     let placements = match resolve_placements(&peppy_launcher, goal, ctx.bound_core_node.as_str()) {
         Ok(placements) => placements,
         Err(msg) => {
@@ -104,8 +75,7 @@ pub(super) async fn parse_launcher_config(
         }
     };
 
-    let deployments = peppy_launcher.deployments.clone();
-    Ok((deployments, nodes_directory, placements))
+    Ok((peppy_launcher.deployments, placements))
 }
 
 /// Binds the launcher's declared core node links to the machines the caller
@@ -243,43 +213,38 @@ fn wire_core_node_links<'a>(
         .collect()
 }
 
-/// Translate a `LauncherOrigin` into a concrete on-disk path.
+/// Translate a launcher name into a concrete on-disk path.
 ///
-/// `Fs` is a no-op; `Repository` looks up the launcher in the cache and, for git-sourced
-/// entries, materializes the checkout via `ensure_checkout`. Progress lines emitted by the
-/// (blocking) checkout are buffered into a `Vec` and flushed to the launch feedback topic
-/// after the resolver returns: quiet for cached/Fs entries, a few lines for fresh clones.
-async fn resolve_launcher_origin(
+/// Looks up the launcher in the cache and, for git-sourced entries, materializes the
+/// checkout via `ensure_checkout`. Progress lines emitted by the (blocking) checkout are
+/// buffered into a `Vec` and flushed to the launch feedback topic after the resolver
+/// returns: quiet for cached entries, a few lines for fresh clones.
+async fn resolve_launcher_name(
     ctx: &ProcessLaunchContext,
-    origin: &LauncherOrigin,
+    name: &str,
 ) -> std::result::Result<PathBuf, String> {
-    match origin {
-        LauncherOrigin::Fs(path) => Ok(path.clone()),
-        LauncherOrigin::Repository { name } => {
-            let peppy_dirs = ctx.peppy_dirs.clone();
-            let name_for_blocking = name.clone();
-            let collected = Arc::new(StdMutex::new(Vec::<String>::new()));
-            let collected_for_cb = Arc::clone(&collected);
+    let peppy_dirs = ctx.peppy_dirs.clone();
+    let name_for_blocking = name.to_owned();
+    let collected = Arc::new(StdMutex::new(Vec::<String>::new()));
+    let collected_for_cb = Arc::clone(&collected);
 
-            let result = tokio::task::spawn_blocking(move || {
-                crate::services::repo::cache::resolve_repo_launcher_path(
-                    &name_for_blocking,
-                    &peppy_dirs,
-                    &|line| {
-                        collected_for_cb.lock().push(line.to_owned());
-                    },
-                )
-            })
-            .await
-            .map_err(|e| format!("launcher resolver join error: {e}"))?;
+    let result = tokio::task::spawn_blocking(move || {
+        crate::services::repo::cache::resolve_repo_launcher_path(
+            &name_for_blocking,
+            &peppy_dirs,
+            &|line| {
+                collected_for_cb.lock().push(line.to_owned());
+            },
+        )
+    })
+    .await
+    .map_err(|e| format!("launcher resolver join error: {e}"))?;
 
-            let captured: Vec<String> = std::mem::take(&mut *collected.lock());
-            for line in captured {
-                publish_stdout(ctx, line, LaunchFeedbackStep::LauncherStep).await;
-            }
-            result
-        }
+    let captured: Vec<String> = std::mem::take(&mut *collected.lock());
+    for line in captured {
+        publish_stdout(ctx, line, LaunchFeedbackStep::LauncherStep).await;
     }
+    result
 }
 
 /// Step 2: Resolve every deployment, once, on this daemon.
@@ -298,7 +263,6 @@ async fn resolve_launcher_origin(
 pub(super) async fn resolve_deployments(
     ctx: &ProcessLaunchContext,
     deployments: Vec<Deployment>,
-    nodes_directory: &Path,
     placements: &Placements,
 ) -> std::result::Result<Vec<PlannedDeployment>, LaunchResult> {
     publish_stdout(
@@ -308,16 +272,13 @@ pub(super) async fn resolve_deployments(
     )
     .await;
 
-    // The node index, loaded ONCE for the whole launch. Every `repo:`
-    // deployment resolves against the same one, and every materialization
-    // shares it rather than copying it, so a launch pays one read of a file
-    // that lists every node this machine's repositories publish. Loaded
-    // lazily: a launcher with no `repo:` deployment never touches it.
+    // The node index, loaded ONCE for the whole launch. Every deployment
+    // resolves against the same one, and every materialization shares it
+    // rather than copying it, so a launch pays one read of a file that lists
+    // every node this machine's repositories publish. Loaded lazily: an empty
+    // launcher never touches it.
     let mut node_entries: Option<Arc<Vec<repo_cache::NodeCacheEntry>>> = None;
-    if deployments
-        .iter()
-        .any(|deployment| matches!(deployment.source, DeploymentSource::Repo(_)))
-    {
+    if !deployments.is_empty() {
         match repo_cache::load_node_cache(&ctx.peppy_dirs) {
             Ok(entries) => node_entries = Some(Arc::new(entries)),
             Err(e) => {
@@ -343,13 +304,12 @@ pub(super) async fn resolve_deployments(
 
         // Resolution runs partly on blocking threads, so progress lines are
         // buffered through a shared Vec and flushed here, the same shape
-        // `resolve_launcher_origin` uses: quiet for cached entries, a few
+        // `resolve_launcher_name` uses: quiet for cached entries, a few
         // clone lines for fresh fetches, published in order either way.
         let collected = Arc::new(StdMutex::new(Vec::<String>::new()));
         let resolved = resolve_one(
             ctx,
             &deployment,
-            nodes_directory,
             placements,
             node_entries.as_ref(),
             &collected,
@@ -470,7 +430,6 @@ fn refuse_unportable_pins<'a>(
 async fn resolve_one(
     ctx: &ProcessLaunchContext,
     deployment: &Deployment,
-    nodes_directory: &Path,
     placements: &Placements,
     node_entries: Option<&Arc<Vec<repo_cache::NodeCacheEntry>>>,
     collected: &Arc<StdMutex<Vec<String>>>,
@@ -488,104 +447,34 @@ async fn resolve_one(
         Arc::new(move |line: &str| sink.lock().push(line.to_owned()))
     };
 
-    match &deployment.source {
-        DeploymentSource::Local(spec) => {
-            if remote {
-                return Err(local_source_refusal(spec));
-            }
-            let source = NodeSource::Fs(if spec.local.is_absolute() {
-                spec.local.clone()
-            } else {
-                nodes_directory.join(&spec.local)
-            });
-            let config = resolve_node_config(source.clone(), &ctx.peppy_dirs)
-                .await
-                .map_err(|e| {
-                    format!("failed to retrieve node config for deployment {label}: {e}")
-                })?;
-            let manifests = vec![config.manifest.clone()];
-            Ok(ResolvedDeployment {
-                source,
-                config,
-                root_pin: None,
-                closure_pins: Vec::new(),
-                pin_manifests: manifests,
-            })
-        }
-        DeploymentSource::Repo(spec) => {
-            let entries = node_entries
-                .expect("a repo: deployment always resolves against a loaded node index");
-            let closure = pins::resolve_pinned_closure(
-                &ctx.peppy_dirs,
-                entries,
-                &spec.name,
-                &spec.tag,
-                shared_feedback(),
-            )
-            .await
-            .map_err(|e| format!("deployment {label}: {e}"))?;
-            if remote {
-                refuse_unportable_pins(&label, closure.nodes.iter().map(|node| &node.pin))?;
-            }
-            let dep_pins = closure.dep_pins();
-            let manifests = closure.manifests();
-            // The closure is owned here, so the root comes out by move: its
-            // config and pin are the two largest things in it.
-            let mut nodes = closure.nodes;
-            let root = nodes.remove(0);
-            let source = pinned_source(&label, &root.pin)?;
-            Ok(ResolvedDeployment {
-                source,
-                config: root.config,
-                root_pin: Some(root.pin),
-                closure_pins: dep_pins,
-                pin_manifests: manifests,
-            })
-        }
-        DeploymentSource::Git(spec) => {
-            let root = pins::resolve_git_deployment(
-                &ctx.peppy_dirs,
-                &spec.repo,
-                &spec.path,
-                Some(spec.ref_.as_str()),
-                shared_feedback(),
-            )
-            .await
-            .map_err(|e| format!("deployment {label}: {e}"))?;
-            if remote {
-                refuse_unportable_pins(&label, std::iter::once(&root.pin))?;
-            }
-            let source = pinned_source(&label, &root.pin)?;
-            let manifests = vec![root.config.manifest.clone()];
-            Ok(ResolvedDeployment {
-                source,
-                config: root.config,
-                root_pin: Some(root.pin),
-                closure_pins: Vec::new(),
-                pin_manifests: manifests,
-            })
-        }
-        DeploymentSource::Url(spec) => {
-            let source = NodeSource::Http {
-                url: url::Url::parse(&spec.url)
-                    .map_err(|e| format!("invalid HTTP URL `{}`: {e}", spec.url))?,
-                sha256: Some(spec.sha256.clone()),
-            };
-            let config = resolve_node_config(source.clone(), &ctx.peppy_dirs)
-                .await
-                .map_err(|e| {
-                    format!("failed to retrieve node config for deployment {label}: {e}")
-                })?;
-            let manifests = vec![config.manifest.clone()];
-            Ok(ResolvedDeployment {
-                source,
-                config,
-                root_pin: None,
-                closure_pins: Vec::new(),
-                pin_manifests: manifests,
-            })
-        }
+    let entries =
+        node_entries.expect("a deployment always resolves against a loaded node index");
+    let closure = pins::resolve_pinned_closure(
+        &ctx.peppy_dirs,
+        entries,
+        &deployment.source.name,
+        &deployment.source.tag,
+        shared_feedback(),
+    )
+    .await
+    .map_err(|e| format!("deployment {label}: {e}"))?;
+    if remote {
+        refuse_unportable_pins(&label, closure.nodes.iter().map(|node| &node.pin))?;
     }
+    let dep_pins = closure.dep_pins();
+    let manifests = closure.manifests();
+    // The closure is owned here, so the root comes out by move: its
+    // config and pin are the two largest things in it.
+    let mut nodes = closure.nodes;
+    let root = nodes.remove(0);
+    let source = pinned_source(&label, &root.pin)?;
+    Ok(ResolvedDeployment {
+        source,
+        config: root.config,
+        root_pin: Some(root.pin),
+        closure_pins: dep_pins,
+        pin_manifests: manifests,
+    })
 }
 
 /// The add source a pinned deployment dispatches with. Shared by the `repo:`
@@ -669,7 +558,7 @@ pub(super) async fn mint_doc_pins(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use daemon_config::launcher::DeploymentInstance;
+    use daemon_config::launcher::{DeploymentInstance, DeploymentSource};
     use daemon_config::repository::{
         EntryOrigin, GitCommit, ItemName, ItemTag, ManifestFingerprint, PinKind, RepoRelativePath,
     };
@@ -728,7 +617,7 @@ mod tests {
 
     /// The refusal the portability rule produces: a filesystem repository
     /// entry behind an off-coordinator placement names a tree only this
-    /// machine can read, exactly like a `local:` source, and the message
+    /// machine can read, and the message
     /// says what still works.
     #[test]
     fn a_filesystem_backed_pin_is_refused_for_a_remote_placement() {
@@ -747,18 +636,6 @@ mod tests {
             path: RepoRelativePath::parse("planner/peppy.json5").expect("valid path"),
         });
         assert!(refuse_unportable_pins("repo:planner:v1", std::iter::once(&git_pin)).is_ok());
-    }
-
-    /// A path names a tree on the coordinator's disk, so a peer resolving it
-    /// would read a different tree or nothing at all.
-    #[test]
-    fn the_local_source_refusal_names_the_tree_and_the_way_out() {
-        let DeploymentSource::Local(spec) = source(r#"{ local: "./nodes/planner" }"#) else {
-            panic!("expected a local source");
-        };
-        let error = local_source_refusal(&spec);
-        assert!(error.contains("names a tree on"), "got: {error}");
-        assert!(error.contains("repo or git-backed source"), "got: {error}");
     }
 
     // --- Placement: binding a launcher's declared links to real machines ---

--- a/crates/core-node-internal/tests/common/fixtures.rs
+++ b/crates/core-node-internal/tests/common/fixtures.rs
@@ -76,13 +76,15 @@ pub fn create_tar_zst_from_dir(source_dir: &Path, archive_path: &Path, archive_r
     encoder.finish().expect("failed to finalize zstd stream");
 }
 
-/// Builder for `nodes.json5` and `contracts.json5` cache fixtures. Tests call
-/// [`TestPackagesCache::fs_entry`] / `git_entry` / `contract_git_entry` to
-/// declare discovered items, then [`TestPackagesCache::write`] to serialize
-/// the files under `peppy_dirs.cache_dir()`.
+/// Builder for `nodes.json5`, `launchers.json5`, and `contracts.json5` cache
+/// fixtures. Tests call [`TestPackagesCache::fs_entry`] / `git_entry` /
+/// `launcher_fs_entry` / `contract_git_entry` to declare discovered items,
+/// then [`TestPackagesCache::write`] to serialize the files under
+/// `peppy_dirs.cache_dir()`.
 #[derive(Default)]
 pub struct TestPackagesCache {
     entries: Vec<serde_json::Value>,
+    launchers: Vec<serde_json::Value>,
     contracts: Vec<serde_json::Value>,
 }
 
@@ -170,6 +172,11 @@ impl TestPackagesCache {
     /// `path_in_repo` is the directory containing `peppy.json5` within
     /// the checked-out repo. We join `NODE_CONFIG_FILE` so the cache
     /// records the manifest file path.
+    ///
+    /// The fingerprint is computed from the repository's worktree copy of
+    /// the manifest when `repo_url` is a path on this machine (a pinned add
+    /// verifies the materialized bytes against it); a fixture whose repo is
+    /// remote or lookup-only records a seeded one instead.
     pub fn git_entry(
         mut self,
         name: &str,
@@ -179,16 +186,38 @@ impl TestPackagesCache {
         path_in_repo: &str,
     ) -> Self {
         let manifest_path = Path::new(path_in_repo).join(NODE_CONFIG_FILE);
+        let local_repo = repo_url.strip_prefix("file://").unwrap_or(repo_url);
+        let sha256 = std::fs::read(Path::new(local_repo).join(&manifest_path))
+            .map(|bytes| config::fingerprint::fingerprint_for_bytes(&bytes))
+            .unwrap_or_else(|_| seeded_sha(&format!("{name}:{tag}")));
         self.entries.push(serde_json::json!({
             "node_name": name,
             "node_tag": tag,
-            "sha256": seeded_sha(&format!("{name}:{tag}")),
+            "sha256": sha256,
             "origin": git_origin(
                 repo_url,
                 resolved_ref,
                 &manifest_path.to_string_lossy(),
                 &format!("{name}:{tag}"),
             ),
+        }));
+        self
+    }
+
+    /// Adds a `launchers.json5` entry for a filesystem-sourced launcher.
+    /// `absolute_path` points at the launcher `.json5` file itself. The
+    /// fingerprint is computed from the file when it exists; a fixture whose
+    /// file is written later records a seeded one instead (launcher
+    /// resolution materializes the origin's path without a drift check).
+    pub fn launcher_fs_entry(mut self, name: &str, absolute_path: impl AsRef<Path>) -> Self {
+        let path = absolute_path.as_ref();
+        let sha256 = std::fs::read(path)
+            .map(|bytes| config::fingerprint::fingerprint_for_bytes(&bytes))
+            .unwrap_or_else(|_| seeded_sha(name));
+        self.launchers.push(serde_json::json!({
+            "launcher_name": name,
+            "sha256": sha256,
+            "origin": fs_origin(path),
         }));
         self
     }
@@ -242,6 +271,19 @@ impl TestPackagesCache {
             serde_json::to_string_pretty(&self.entries).expect("failed to serialize cache entries");
         std::fs::write(nodes_repo_cache_path(peppy_dirs), content)
             .expect("failed to write nodes.json5 fixture");
+        let launchers_path = core_node::launchers_repo_cache_path(peppy_dirs);
+        if self.launchers.is_empty() {
+            match std::fs::remove_file(&launchers_path) {
+                Ok(()) => {}
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => panic!("failed to remove stale launchers.json5 fixture: {e}"),
+            }
+        } else {
+            let launchers_content = serde_json::to_string_pretty(&self.launchers)
+                .expect("failed to serialize launcher cache entries");
+            std::fs::write(launchers_path, launchers_content)
+                .expect("failed to write launchers.json5 fixture");
+        }
         let contracts_path = core_node::contracts_repo_cache_path(peppy_dirs);
         if self.contracts.is_empty() {
             match std::fs::remove_file(&contracts_path) {

--- a/crates/core-node-internal/tests/launch_assets/peppy_launcher.json5
+++ b/crates/core-node-internal/tests/launch_assets/peppy_launcher.json5
@@ -3,7 +3,7 @@
   deployments: [
     {
       source: {
-        local: "./fake_robot_brain"
+        name: "fake_robot_brain:v1"
       },
       instances: [
         {
@@ -18,7 +18,7 @@
     },
     {
       source: {
-        local: "./fake_openarm01_controller",
+        name: "fake_openarm01_controller:v1",
       },
       instances: [
         {
@@ -29,7 +29,7 @@
     },
     {
       source: {
-        local: "./fake_uvc_camera",
+        name: "fake_uvc_camera:v1",
       },
       instances: [
         {

--- a/crates/core-node-internal/tests/listen_for_launch.rs
+++ b/crates/core-node-internal/tests/listen_for_launch.rs
@@ -6,7 +6,7 @@ use config::node::NodeConfigParser;
 use config::runtime::Name;
 use core_node_api::ActionId;
 use core_node_api::encoding::{
-    LaunchFeedback, LaunchGoal, LaunchGoalResponse, LaunchResult, LauncherOrigin,
+    LaunchFeedback, LaunchGoal, LaunchGoalResponse, LaunchResult,
 };
 use daemon_config::consts::PEPPY_OUTPUT_DIR;
 use git2::{Repository, Signature};
@@ -97,9 +97,7 @@ const LAUNCHER_EXAMPLE1: &str = r#"
   deployments: [
     {
       source: {
-        repo: "${UVC_CAMERA_REPO}",
-        path: "uvc_camera",
-        ref: "v1"
+        name: "uvc_camera:v1"
       },
       instances: [
         {
@@ -141,7 +139,7 @@ const LAUNCHER_EXAMPLE1: &str = r#"
       ]
     },
     {
-      source: { local: "./robot_brain" },
+      source: { name: "robot_brain:v1" },
       instances: [
         {
           instance_id: "main_robot_brain",
@@ -354,14 +352,14 @@ fn create_uvc_camera_repo(to_path: &Path, node_tag: &str) -> PathBuf {
 async fn send_node_launch_and_wait(
     messenger: &MessengerHandle,
     core_node_name: &str,
-    peppy_launch_file_path: &Path,
+    launcher_name: &str,
     goal_timeout: Duration,
     result_timeout: Duration,
 ) -> Result<(LaunchGoalResponse, LaunchResult), String> {
-    send_launch_origin_and_wait(
+    send_launch_and_wait(
         messenger,
         core_node_name,
-        LauncherOrigin::Fs(peppy_launch_file_path.to_path_buf()),
+        launcher_name,
         goal_timeout,
         result_timeout,
         vec![],
@@ -369,35 +367,16 @@ async fn send_node_launch_and_wait(
     .await
 }
 
-async fn send_node_launch_and_wait_with_env(
+async fn send_launch_and_wait(
     messenger: &MessengerHandle,
     core_node_name: &str,
-    peppy_launch_file_path: &Path,
-    goal_timeout: Duration,
-    result_timeout: Duration,
-    env_vars: Vec<(String, String)>,
-) -> Result<(LaunchGoalResponse, LaunchResult), String> {
-    send_launch_origin_and_wait(
-        messenger,
-        core_node_name,
-        LauncherOrigin::Fs(peppy_launch_file_path.to_path_buf()),
-        goal_timeout,
-        result_timeout,
-        env_vars,
-    )
-    .await
-}
-
-async fn send_launch_origin_and_wait(
-    messenger: &MessengerHandle,
-    core_node_name: &str,
-    launcher_origin: LauncherOrigin,
+    launcher_name: &str,
     goal_timeout: Duration,
     result_timeout: Duration,
     env_vars: Vec<(String, String)>,
 ) -> Result<(LaunchGoalResponse, LaunchResult), String> {
     let goal = LaunchGoal::new(
-        launcher_origin,
+        launcher_name,
         "launch-test-fixture",
         300,
         300,
@@ -483,6 +462,7 @@ async fn listen_for_launch_configuration_succeed_with_complex_dependencies() {
 
     let started_core_node = start_core_node_with_mock_messenger().await;
     let node_stack = started_core_node.node_stack.clone();
+    let peppy_dirs = started_core_node.peppy_dirs.clone();
     let node_messenger =
         MessengerHandle::from_shared(Arc::clone(&started_core_node.shared_messenger));
 
@@ -490,6 +470,7 @@ async fn listen_for_launch_configuration_succeed_with_complex_dependencies() {
     // peppygen files (including git.hash) automatically using the "stack-launch" marker.
     let temp_dir = tempdir().expect("failed to create temp directory");
     let source_assets_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/launch_assets");
+    let mut cache = TestPackagesCache::new();
     for node_name in [FAKE_UVC_CAMERA, FAKE_ROBOT_BRAIN, FAKE_OPENARM01_CONTROLLER] {
         let source_node_dir = source_assets_dir.join(node_name);
         let dest_node_dir = temp_dir.path().join(node_name);
@@ -497,6 +478,7 @@ async fn listen_for_launch_configuration_succeed_with_complex_dependencies() {
         let dest_config_path = dest_node_dir.join(NODE_CONFIG_FILE);
         fs::copy(source_node_dir.join(NODE_CONFIG_FILE), &dest_config_path)
             .expect("failed to copy node config");
+        cache = cache.fs_entry(node_name, NODE_TAG, &dest_node_dir);
     }
     let launch_file_path = temp_dir.path().join("peppy_launcher.json5");
     fs::copy(
@@ -504,6 +486,9 @@ async fn listen_for_launch_configuration_succeed_with_complex_dependencies() {
         &launch_file_path,
     )
     .expect("failed to copy launcher file");
+    cache
+        .launcher_fs_entry("peppy_launcher", &launch_file_path)
+        .write(&peppy_dirs);
 
     // Set up ready/health responders for all instances in the launcher config.
     let _ready_camera_front = AbortOnDrop(
@@ -593,7 +578,7 @@ async fn listen_for_launch_configuration_succeed_with_complex_dependencies() {
     let (_goal_response, result) = send_node_launch_and_wait(
         &started_core_node.caller_handle,
         &started_core_node.core_node_name,
-        &launch_file_path,
+        "peppy_launcher",
         GOAL_TIMEOUT,
         RESULT_TIMEOUT,
     )
@@ -647,10 +632,11 @@ async fn listen_for_launch_configuration_succeed() {
 
     let started_core_node = start_core_node_with_mock_messenger().await;
     let node_stack = started_core_node.node_stack.clone();
+    let peppy_dirs = started_core_node.peppy_dirs.clone();
 
     let nodes_dir = tempdir().expect("failed to create temp nodes directory");
     let uvc_repo_path = create_uvc_camera_repo(nodes_dir.path(), NODE_TAG);
-    let _robot_brain_path = write_node_config(
+    let robot_brain_path = write_node_config(
         nodes_dir.path(),
         ROBOT_NODE_NAME,
         NODE_TAG,
@@ -727,15 +713,27 @@ async fn listen_for_launch_configuration_succeed() {
     // Allow listeners to establish.
     tokio::time::sleep(Duration::from_millis(50)).await;
 
-    let launcher_json5 =
-        LAUNCHER_EXAMPLE1.replace("${UVC_CAMERA_REPO}", &uvc_repo_path.display().to_string());
     let launch_file_path = nodes_dir.path().join("peppy_launcher.json5");
-    fs::write(&launch_file_path, &launcher_json5).expect("failed to write launch file");
+    fs::write(&launch_file_path, LAUNCHER_EXAMPLE1).expect("failed to write launch file");
+
+    // uvc_camera resolves through a git-backed cache entry (exercising the
+    // clone-at-launch path), robot_brain through a plain fs entry.
+    TestPackagesCache::new()
+        .git_entry(
+            UVC_NODE_NAME,
+            NODE_TAG,
+            &uvc_repo_path.display().to_string(),
+            NODE_TAG,
+            "uvc_camera",
+        )
+        .fs_entry(ROBOT_NODE_NAME, NODE_TAG, &robot_brain_path)
+        .launcher_fs_entry("peppy_launcher", &launch_file_path)
+        .write(&peppy_dirs);
 
     let (_goal_response, result) = send_node_launch_and_wait(
         &started_core_node.caller_handle,
         &started_core_node.core_node_name,
-        &launch_file_path,
+        "peppy_launcher",
         GOAL_TIMEOUT,
         RESULT_TIMEOUT,
     )
@@ -936,9 +934,11 @@ async fn listen_for_launch_configuration_succeeds_with_repo_sources() {
 
     // Map both nodes into the user-repo cache. This is what the
     // `{ name, tag }` launcher shape resolves against.
+    let launch_file_path = nodes_dir.path().join("peppy_launcher.json5");
     TestPackagesCache::new()
         .fs_entry(BRAIN_NODE, NODE_TAG, &brain_dir)
         .fs_entry(ARM_NODE, NODE_TAG, &arm_dir)
+        .launcher_fs_entry("peppy_launcher", &launch_file_path)
         .write(&peppy_dirs);
 
     let _ready_brain = AbortOnDrop(
@@ -1004,13 +1004,12 @@ async fn listen_for_launch_configuration_succeeds_with_repo_sources() {
   ]
 }}"#
     );
-    let launch_file_path = nodes_dir.path().join("peppy_launcher.json5");
     fs::write(&launch_file_path, &launcher_json5).expect("failed to write launch file");
 
     let (_goal_response, result) = send_node_launch_and_wait(
         &started_core_node.caller_handle,
         &started_core_node.core_node_name,
-        &launch_file_path,
+        "peppy_launcher",
         GOAL_TIMEOUT,
         RESULT_TIMEOUT,
     )
@@ -1072,11 +1071,14 @@ async fn listen_for_launch_configuration_launch_config_invalid_json5_returns_err
     let bad_launcher_json5 = r#"{ peppy_schema: "launcher/v1", deployments: [ }"#;
     let launch_file_path = nodes_dir.path().join("peppy_launcher.json5");
     fs::write(&launch_file_path, bad_launcher_json5).expect("failed to write launch file");
+    TestPackagesCache::new()
+        .launcher_fs_entry("peppy_launcher", &launch_file_path)
+        .write(&started_core_node.peppy_dirs);
 
     let (_goal_response, result) = send_node_launch_and_wait(
         &started_core_node.caller_handle,
         &started_core_node.core_node_name,
-        &launch_file_path,
+        "peppy_launcher",
         GOAL_TIMEOUT,
         RESULT_TIMEOUT,
     )
@@ -1114,14 +1116,17 @@ async fn listen_for_launch_configuration_launch_file_path_must_be_a_file() {
         .push_config(existing_config, false, &existing_path)
         .expect("should seed stack");
 
-    // Create a file (not a directory) to use as the "launch file"
+    // Register a launcher cache entry whose path is a directory, not a file.
     let bad_launch_file = nodes_dir.path().join("not_a_file_dir");
     fs::create_dir_all(&bad_launch_file).expect("failed to create directory");
-    // Point to a path that is a directory, not a file
+    TestPackagesCache::new()
+        .launcher_fs_entry("peppy_launcher", &bad_launch_file)
+        .write(&started_core_node.peppy_dirs);
+
     let (_goal_response, result) = send_node_launch_and_wait(
         &started_core_node.caller_handle,
         &started_core_node.core_node_name,
-        &bad_launch_file,
+        "peppy_launcher",
         GOAL_TIMEOUT,
         RESULT_TIMEOUT,
     )
@@ -1130,11 +1135,11 @@ async fn listen_for_launch_configuration_launch_file_path_must_be_a_file() {
 
     assert!(
         !result.success,
-        "launch should fail when launch file path is a directory"
+        "launch should fail when the launcher cache entry points at a directory"
     );
     assert!(
         node_stack.contains(EXISTING_NODE, NODE_TAG),
-        "stack should not be mutated on invalid launch file path"
+        "stack should not be mutated on an invalid launcher path"
     );
 }
 
@@ -1162,23 +1167,27 @@ async fn listen_for_launch_config_missing_required_deployment_does_not_apply_par
         .push_config(existing_config, false, &existing_path)
         .expect("should seed stack");
 
-    // One deployment exists, the other is missing and required.
+    // One deployment resolves through the cache, the other is missing from it.
     let launcher_json5 = r#"
     {
       peppy_schema: "launcher/v1",
       deployments: [
-        { source: { local: "./existing_node" }, instances: [ { instance_id: "ok" } ] },
-        { source: { local: "./missing_node" }, instances: [ { instance_id: "nope" } ] }
+        { source: { name: "existing_node:v1" }, instances: [ { instance_id: "ok" } ] },
+        { source: { name: "missing_node:v1" }, instances: [ { instance_id: "nope" } ] }
       ]
     }
     "#;
     let launch_file_path = nodes_dir.path().join("peppy_launcher.json5");
     fs::write(&launch_file_path, launcher_json5).expect("failed to write launch file");
+    TestPackagesCache::new()
+        .fs_entry(EXISTING_NODE, NODE_TAG, &existing_path)
+        .launcher_fs_entry("peppy_launcher", &launch_file_path)
+        .write(&started_core_node.peppy_dirs);
 
     let (_goal_response, result) = send_node_launch_and_wait(
         &started_core_node.caller_handle,
         &started_core_node.core_node_name,
-        &launch_file_path,
+        "peppy_launcher",
         GOAL_TIMEOUT,
         RESULT_TIMEOUT,
     )
@@ -1205,7 +1214,7 @@ async fn listen_for_launch_configuration_launch_config_dependency_errors_are_rej
     let node_stack = started_core_node.node_stack.clone();
 
     let nodes_dir = tempdir().expect("failed to create nodes dir");
-    let _uvc_path = write_node_config(
+    let uvc_path = write_node_config(
         nodes_dir.path(),
         UVC_NODE_NAME,
         NODE_TAG,
@@ -1215,7 +1224,7 @@ async fn listen_for_launch_configuration_launch_config_dependency_errors_are_rej
         // Intentionally do NOT emit camera_stream so dependency validation fails.
         false,
     );
-    let _brain_path = write_node_config(
+    let brain_path = write_node_config(
         nodes_dir.path(),
         ROBOT_NODE_NAME,
         NODE_TAG,
@@ -1245,18 +1254,23 @@ async fn listen_for_launch_configuration_launch_config_dependency_errors_are_rej
     {
       peppy_schema: "launcher/v1",
       deployments: [
-        { source: { local: "./uvc_camera" }, instances: [ { instance_id: "camera_front" } ] },
-        { source: { local: "./robot_brain" }, instances: [ { instance_id: "main_robot_brain" } ] }
+        { source: { name: "uvc_camera:v1" }, instances: [ { instance_id: "camera_front" } ] },
+        { source: { name: "robot_brain:v1" }, instances: [ { instance_id: "main_robot_brain" } ] }
       ]
     }
     "#;
     let launch_file_path = nodes_dir.path().join("peppy_launcher.json5");
     fs::write(&launch_file_path, launcher_json5).expect("failed to write launch file");
+    TestPackagesCache::new()
+        .fs_entry(UVC_NODE_NAME, NODE_TAG, &uvc_path)
+        .fs_entry(ROBOT_NODE_NAME, NODE_TAG, &brain_path)
+        .launcher_fs_entry("peppy_launcher", &launch_file_path)
+        .write(&started_core_node.peppy_dirs);
 
     let (_goal_response, result) = send_node_launch_and_wait(
         &started_core_node.caller_handle,
         &started_core_node.core_node_name,
-        &launch_file_path,
+        "peppy_launcher",
         GOAL_TIMEOUT,
         RESULT_TIMEOUT,
     )
@@ -1281,7 +1295,7 @@ async fn listen_for_launch_configuration_launch_config_second_request_replaces_e
     let node_stack = started_core_node.node_stack.clone();
     let nodes_dir = tempdir().expect("failed to create nodes dir");
 
-    let _node_a_path = write_node_config(
+    let node_a_path = write_node_config(
         nodes_dir.path(),
         "node_a",
         NODE_TAG,
@@ -1290,7 +1304,7 @@ async fn listen_for_launch_configuration_launch_config_second_request_replaces_e
         false,
         false,
     );
-    let _node_b_path = write_node_config(
+    let node_b_path = write_node_config(
         nodes_dir.path(),
         "node_b",
         NODE_TAG,
@@ -1345,14 +1359,26 @@ async fn listen_for_launch_configuration_launch_config_second_request_replaces_e
     tokio::time::sleep(Duration::from_millis(50)).await;
 
     let launch_a = r#"
-    { peppy_schema: "launcher/v1", deployments: [ { source: { local: "./node_a" }, instances: [ { instance_id: "a1" } ] } ] }
+    { peppy_schema: "launcher/v1", deployments: [ { source: { name: "node_a:v1" }, instances: [ { instance_id: "a1" } ] } ] }
     "#;
-    let launch_file_path_a = nodes_dir.path().join("peppy_launcher.json5");
+    let launch_file_path_a = nodes_dir.path().join("launch_a.json5");
     fs::write(&launch_file_path_a, launch_a).expect("failed to write launch file");
+    let launch_b = r#"
+    { peppy_schema: "launcher/v1", deployments: [ { source: { name: "node_b:v1" }, instances: [ { instance_id: "b1" } ] } ] }
+    "#;
+    let launch_file_path_b = nodes_dir.path().join("launch_b.json5");
+    fs::write(&launch_file_path_b, launch_b).expect("failed to write launch file");
+    TestPackagesCache::new()
+        .fs_entry("node_a", NODE_TAG, &node_a_path)
+        .fs_entry("node_b", NODE_TAG, &node_b_path)
+        .launcher_fs_entry("launch_a", &launch_file_path_a)
+        .launcher_fs_entry("launch_b", &launch_file_path_b)
+        .write(&started_core_node.peppy_dirs);
+
     let (_goal_a, result_a) = send_node_launch_and_wait(
         &started_core_node.caller_handle,
         &started_core_node.core_node_name,
-        &launch_file_path_a,
+        "launch_a",
         GOAL_TIMEOUT,
         RESULT_TIMEOUT,
     )
@@ -1377,15 +1403,10 @@ async fn listen_for_launch_configuration_launch_config_second_request_replaces_e
         "node_a process {pid_a} should be running after the first launch"
     );
 
-    let launch_b = r#"
-    { peppy_schema: "launcher/v1", deployments: [ { source: { local: "./node_b" }, instances: [ { instance_id: "b1" } ] } ] }
-    "#;
-    let launch_file_path_b = nodes_dir.path().join("peppy_launcher.json5");
-    fs::write(&launch_file_path_b, launch_b).expect("failed to write launch file");
     let (_goal_b, result_b) = send_node_launch_and_wait(
         &started_core_node.caller_handle,
         &started_core_node.core_node_name,
-        &launch_file_path_b,
+        "launch_b",
         GOAL_TIMEOUT,
         RESULT_TIMEOUT,
     )
@@ -1435,7 +1456,7 @@ async fn listen_for_launch_configuration_fails_when_one_node_never_becomes_healt
     .await;
 
     // Node to be launched: starts a real process but never reports healthy.
-    let _node_b_path = write_node_config(
+    let node_b_path = write_node_config(
         nodes_dir.path(),
         "node_b",
         NODE_TAG,
@@ -1460,22 +1481,25 @@ async fn listen_for_launch_configuration_fails_when_one_node_never_becomes_healt
     );
 
     let launch_b = r#"
-    { peppy_schema: "launcher/v1", deployments: [ { source: { local: "./node_b" }, instances: [ { instance_id: "b1" } ] } ] }
+    { peppy_schema: "launcher/v1", deployments: [ { source: { name: "node_b:v1" }, instances: [ { instance_id: "b1" } ] } ] }
     "#;
     let launch_file_path = nodes_dir.path().join("peppy_launcher.json5");
     fs::write(&launch_file_path, launch_b).expect("failed to write launch file");
+    TestPackagesCache::new()
+        .fs_entry("node_b", NODE_TAG, &node_b_path)
+        .launcher_fs_entry("peppy_launcher", &launch_file_path)
+        .write(&started_core_node.peppy_dirs);
 
     // Drive the launch concurrently so we can capture node_b's started pid
     // before the health-timeout failure tears the stack down. Without the fix,
     // that partially-started instance would be orphaned by the failure path.
     let caller = started_core_node.caller_handle.clone();
     let core_name = started_core_node.core_node_name.clone();
-    let path = launch_file_path.clone();
     let launch_task = tokio::spawn(async move {
         send_node_launch_and_wait(
             &caller,
             &core_name,
-            &path,
+            "peppy_launcher",
             GOAL_TIMEOUT,
             Duration::from_secs(30),
         )
@@ -1558,7 +1582,7 @@ async fn listen_for_launch_configuration_fails_when_build_cmd_fails_and_clears_s
     .await;
 
     // Node with a failing build_cmd.
-    let _failing_node_path = write_node_config_with_options(
+    let failing_node_path = write_node_config_with_options(
         nodes_dir.path(),
         "failing_node",
         NODE_TAG,
@@ -1571,15 +1595,19 @@ async fn listen_for_launch_configuration_fails_when_build_cmd_fails_and_clears_s
     );
 
     let launcher_json5 = r#"
-    { peppy_schema: "launcher/v1", deployments: [ { source: { local: "./failing_node" }, instances: [ { instance_id: "f1" } ] } ] }
+    { peppy_schema: "launcher/v1", deployments: [ { source: { name: "failing_node:v1" }, instances: [ { instance_id: "f1" } ] } ] }
     "#;
     let launch_file_path = nodes_dir.path().join("peppy_launcher.json5");
     fs::write(&launch_file_path, launcher_json5).expect("failed to write launch file");
+    TestPackagesCache::new()
+        .fs_entry("failing_node", NODE_TAG, &failing_node_path)
+        .launcher_fs_entry("peppy_launcher", &launch_file_path)
+        .write(&started_core_node.peppy_dirs);
 
     let (_goal_response, result) = send_node_launch_and_wait(
         &started_core_node.caller_handle,
         &started_core_node.core_node_name,
-        &launch_file_path,
+        "peppy_launcher",
         GOAL_TIMEOUT,
         RESULT_TIMEOUT,
     )
@@ -1646,7 +1674,7 @@ async fn listen_for_launch_configuration_fails_when_run_cmd_exits_with_error() {
     .await;
 
     // Node whose run_cmd exits immediately with a non-zero status.
-    let _failing_node_path = write_node_config_with_options(
+    let failing_node_path = write_node_config_with_options(
         nodes_dir.path(),
         NODE_NAME,
         NODE_TAG,
@@ -1659,15 +1687,19 @@ async fn listen_for_launch_configuration_fails_when_run_cmd_exits_with_error() {
     );
 
     let launcher_json5 = format!(
-        r#"{{ peppy_schema: "launcher/v1", deployments: [ {{ source: {{ local: "./{NODE_NAME}" }}, instances: [ {{ instance_id: "{INSTANCE_ID}" }} ] }} ] }}"#
+        r#"{{ peppy_schema: "launcher/v1", deployments: [ {{ source: {{ name: "{NODE_NAME}:{NODE_TAG}" }}, instances: [ {{ instance_id: "{INSTANCE_ID}" }} ] }} ] }}"#
     );
     let launch_file_path = nodes_dir.path().join("peppy_launcher.json5");
     fs::write(&launch_file_path, &launcher_json5).expect("failed to write launch file");
+    TestPackagesCache::new()
+        .fs_entry(NODE_NAME, NODE_TAG, &failing_node_path)
+        .launcher_fs_entry("peppy_launcher", &launch_file_path)
+        .write(&started_core_node.peppy_dirs);
 
     let (_goal_response, result) = send_node_launch_and_wait(
         &started_core_node.caller_handle,
         &started_core_node.core_node_name,
-        &launch_file_path,
+        "peppy_launcher",
         GOAL_TIMEOUT,
         RESULT_TIMEOUT,
     )
@@ -1783,7 +1815,7 @@ async fn listen_for_node_launch_uses_env_overrides_for_path() {
     let started_core_node = start_core_node_with_mock_messenger().await;
 
     let nodes_dir = tempdir().expect("failed to create nodes dir");
-    let _node_path = write_node_config(
+    let node_path = write_node_config(
         nodes_dir.path(),
         NODE_NAME,
         NODE_TAG,
@@ -1793,16 +1825,20 @@ async fn listen_for_node_launch_uses_env_overrides_for_path() {
         false,
     );
     let launch_json5 = format!(
-        r#"{{ peppy_schema: "launcher/v1", deployments: [ {{ source: {{ local: "./{NODE_NAME}" }}, instances: [ {{ instance_id: "{INSTANCE_ID}" }} ] }} ] }}"#
+        r#"{{ peppy_schema: "launcher/v1", deployments: [ {{ source: {{ name: "{NODE_NAME}:{NODE_TAG}" }}, instances: [ {{ instance_id: "{INSTANCE_ID}" }} ] }} ] }}"#
     );
     let launch_file_path = nodes_dir.path().join("peppy_launcher.json5");
     fs::write(&launch_file_path, &launch_json5).expect("failed to write launch file");
+    TestPackagesCache::new()
+        .fs_entry(NODE_NAME, NODE_TAG, &node_path)
+        .launcher_fs_entry("peppy_launcher", &launch_file_path)
+        .write(&started_core_node.peppy_dirs);
 
     // `printout` does not exist in the system when this is run
     let (_, launch_result) = send_node_launch_and_wait(
         &started_core_node.caller_handle,
         &started_core_node.core_node_name,
-        &launch_file_path,
+        "peppy_launcher",
         GOAL_TIMEOUT,
         RESULT_TIMEOUT,
     )
@@ -1871,10 +1907,10 @@ sleep \"${1:-60}\"
     let new_path = format!("{}:{}", bin_dir.path().display(), current_path);
     let env_vars = vec![("PATH".to_string(), new_path)];
 
-    let (_, launch_result) = send_node_launch_and_wait_with_env(
+    let (_, launch_result) = send_launch_and_wait(
         &started_core_node.caller_handle,
         &started_core_node.core_node_name,
-        &launch_file_path,
+        "peppy_launcher",
         GOAL_TIMEOUT,
         RESULT_TIMEOUT,
         env_vars,
@@ -1912,7 +1948,7 @@ async fn listen_for_launch_applies_per_instance_env_vars() {
         "printf '%s' \"$ESP32_DEVICE\" > {}; exec sleep 60",
         probe_path.display()
     );
-    let _node_path = write_node_config(
+    let node_path = write_node_config(
         nodes_dir.path(),
         NODE_NAME,
         NODE_TAG,
@@ -1923,10 +1959,14 @@ async fn listen_for_launch_applies_per_instance_env_vars() {
     );
 
     let launcher_json5 = format!(
-        r#"{{ peppy_schema: "launcher/v1", deployments: [ {{ source: {{ local: "./{NODE_NAME}" }}, instances: [ {{ instance_id: "{INSTANCE_ID}", env_vars: {{ ESP32_DEVICE: "{INSTANCE_DEVICE}" }} }} ] }} ] }}"#
+        r#"{{ peppy_schema: "launcher/v1", deployments: [ {{ source: {{ name: "{NODE_NAME}:{NODE_TAG}" }}, instances: [ {{ instance_id: "{INSTANCE_ID}", env_vars: {{ ESP32_DEVICE: "{INSTANCE_DEVICE}" }} }} ] }} ] }}"#
     );
     let launch_file_path = nodes_dir.path().join("peppy_launcher.json5");
     fs::write(&launch_file_path, &launcher_json5).expect("failed to write launch file");
+    TestPackagesCache::new()
+        .fs_entry(NODE_NAME, NODE_TAG, &node_path)
+        .launcher_fs_entry("peppy_launcher", &launch_file_path)
+        .write(&started_core_node.peppy_dirs);
 
     let node_messenger =
         MessengerHandle::from_shared(Arc::clone(&started_core_node.shared_messenger));
@@ -1956,10 +1996,10 @@ async fn listen_for_launch_applies_per_instance_env_vars() {
 
     // The caller environment carries the same key with a different value, so a
     // matching probe can only come from the instance's own declaration.
-    let (_goal_response, result) = send_node_launch_and_wait_with_env(
+    let (_goal_response, result) = send_launch_and_wait(
         &started_core_node.caller_handle,
         &started_core_node.core_node_name,
-        &launch_file_path,
+        "peppy_launcher",
         GOAL_TIMEOUT,
         RESULT_TIMEOUT,
         vec![("ESP32_DEVICE".to_string(), CALLER_DEVICE.to_string())],
@@ -1986,9 +2026,9 @@ async fn listen_for_launch_applies_per_instance_env_vars() {
     );
 }
 
-/// `LauncherOrigin::Repository` resolves the launcher name through `launchers.json5`
-/// (the launcher repo cache) and uses the on-disk path it points at. The deployment
-/// itself uses a local source so we don't need to spin up a fake git repo.
+/// A launcher name resolves through `launchers.json5` (the launcher repo
+/// cache) and uses the on-disk path it points at. The deployment resolves
+/// through an fs entry in the nodes cache.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn listen_for_launch_resolves_launcher_from_repository_cache() {
     const ROBOT_NODE_NAME: &str = "robot_brain_repo";
@@ -2002,7 +2042,7 @@ async fn listen_for_launch_resolves_launcher_from_repository_cache() {
         MessengerHandle::from_shared(Arc::clone(&started_core_node.shared_messenger));
 
     let nodes_dir = tempdir().expect("failed to create temp nodes directory");
-    let _brain_path = write_node_config(
+    let brain_path = write_node_config(
         nodes_dir.path(),
         ROBOT_NODE_NAME,
         NODE_TAG,
@@ -2034,14 +2074,13 @@ async fn listen_for_launch_resolves_launcher_from_repository_cache() {
     );
     tokio::time::sleep(Duration::from_millis(50)).await;
 
-    // Launcher file references the node by its directory name (`local: "./robot_brain_repo"`),
-    // resolved relative to the launcher file's parent dir.
+    // Launcher file references the node by its `name:tag` in the nodes cache.
     let launcher_json5 = format!(
         r#"{{
   peppy_schema: "launcher/v1",
   deployments: [
     {{
-      source: {{ local: "./{ROBOT_NODE_NAME}" }},
+      source: {{ name: "{ROBOT_NODE_NAME}:{NODE_TAG}" }},
       instances: [
         {{ instance_id: "main_robot_brain" }}
       ]
@@ -2052,31 +2091,17 @@ async fn listen_for_launch_resolves_launcher_from_repository_cache() {
     let launcher_file_path = nodes_dir.path().join(format!("{LAUNCHER_NAME}.json5"));
     fs::write(&launcher_file_path, &launcher_json5).expect("failed to write launcher file");
 
-    // Hand-write the launcher cache so the daemon can map the bare name back to the file.
-    let cache_entries = serde_json::json!([
-        {
-            "launcher_name": LAUNCHER_NAME,
-            "sha256": config::fingerprint::fingerprint_for_bytes(launcher_json5.as_bytes()),
-            "origin": common::fs_origin(&launcher_file_path),
-        }
-    ]);
-    let cache_dir = peppy_dirs.cache_dir();
-    fs::create_dir_all(&cache_dir).expect("failed to create cache dir");
-    fs::write(
-        cache_dir.join("launchers.json5"),
-        serde_json::to_string_pretty(&cache_entries).expect("serialize cache"),
-    )
-    .expect("failed to write launchers.json5");
+    TestPackagesCache::new()
+        .fs_entry(ROBOT_NODE_NAME, NODE_TAG, &brain_path)
+        .launcher_fs_entry(LAUNCHER_NAME, &launcher_file_path)
+        .write(&peppy_dirs);
 
-    let (_goal_response, result) = send_launch_origin_and_wait(
+    let (_goal_response, result) = send_node_launch_and_wait(
         &started_core_node.caller_handle,
         &started_core_node.core_node_name,
-        LauncherOrigin::Repository {
-            name: LAUNCHER_NAME.to_string(),
-        },
+        LAUNCHER_NAME,
         GOAL_TIMEOUT,
         RESULT_TIMEOUT,
-        vec![],
     )
     .await
     .expect("launch should complete");
@@ -2092,7 +2117,7 @@ async fn listen_for_launch_resolves_launcher_from_repository_cache() {
     );
 }
 
-/// When the `Repository` origin names a launcher that is not in the cache, the daemon
+/// When the goal names a launcher that is not in the cache, the daemon
 /// surfaces an explicit error pointing at `launchers.json5` and does not fall back to
 /// any filesystem lookup.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -2109,15 +2134,12 @@ async fn listen_for_launch_repository_miss_returns_explicit_error() {
     )
     .expect("failed to write launchers.json5");
 
-    let (_goal_response, result) = send_launch_origin_and_wait(
+    let (_goal_response, result) = send_node_launch_and_wait(
         &started_core_node.caller_handle,
         &started_core_node.core_node_name,
-        LauncherOrigin::Repository {
-            name: "definitely_missing_launcher".to_string(),
-        },
+        "definitely_missing_launcher",
         GOAL_TIMEOUT,
         RESULT_TIMEOUT,
-        vec![],
     )
     .await
     .expect("launch should return a result");

--- a/crates/daemon-config-internal/src/launcher.rs
+++ b/crates/daemon-config-internal/src/launcher.rs
@@ -18,7 +18,6 @@ pub use pairings::{
 };
 pub use parse::PeppyLauncherParser;
 pub use types::{
-    Deployment, DeploymentGitSource, DeploymentInstance, DeploymentLocalSource,
-    DeploymentRepoSource, DeploymentSource, DeploymentUrlSource, DuplicateLinkTarget,
-    FrameworkOverrides, LinkTargets, LinkValue, PeppyLauncher, Placements, split_link_target,
+    Deployment, DeploymentInstance, DeploymentSource, DuplicateLinkTarget, FrameworkOverrides,
+    LinkTargets, LinkValue, PeppyLauncher, Placements, split_link_target,
 };

--- a/crates/daemon-config-internal/src/launcher/parse.rs
+++ b/crates/daemon-config-internal/src/launcher/parse.rs
@@ -41,10 +41,7 @@ mod tests {
             peppy_schema: "launcher/v1",
             deployments: [
                 {
-                    source: {
-                        url: "https://example.com/fake_robot_brain.tar.zst",
-                        sha256: "33e83da60a54e3bb487a9a3b67705918602143b30f158143b6909acaf017a36a"
-                    },
+                    source: { name: "fake_robot_brain", tag: "v1" },
                     instances: [
                         {
                             instance_id: "the_brain",
@@ -53,11 +50,7 @@ mod tests {
                     ]
                 },
                 {
-                    source: {
-                        repo: "https://github.com/Peppy-bot/nodes-hub.git",
-                        path: "fake_openarm01_controller",
-                        ref: "0.1.0"
-                    },
+                    source: { name: "fake_openarm01_controller:v1" },
                     instances: [
                         {
                             instance_id: "the_nervous_system",
@@ -66,7 +59,7 @@ mod tests {
                     ]
                 },
                 {
-                    source: { local: "./esp32_board" },
+                    source: { name: "esp32_board:v1" },
                     instances: [
                         {
                             instance_id: "esp32_1",
@@ -83,19 +76,17 @@ mod tests {
         let deployments = cfg.deployments;
         assert_eq!(deployments.len(), 3);
 
-        // Check first deployment
-        let DeploymentSource::Url(url) = &deployments[0].source else {
-            panic!("expected url source");
-        };
-        assert_eq!(url.url, "https://example.com/fake_robot_brain.tar.zst");
+        // Check first deployment (long form)
+        let DeploymentSource { name, tag } = &deployments[0].source;
+        assert_eq!(name, "fake_robot_brain");
+        assert_eq!(tag, "v1");
         assert_eq!(deployments[0].instances[0].instance_id, "the_brain");
         assert!(deployments[0].instances[0].arguments.is_empty());
 
-        // Check second deployment
-        let DeploymentSource::Git(git) = &deployments[1].source else {
-            panic!("expected git source");
-        };
-        assert_eq!(git.ref_, "0.1.0");
+        // Check second deployment (combined `name:tag` shorthand)
+        let DeploymentSource { name, tag } = &deployments[1].source;
+        assert_eq!(name, "fake_openarm01_controller");
+        assert_eq!(tag, "v1");
         assert_eq!(
             deployments[1].instances[0].instance_id,
             "the_nervous_system"
@@ -103,10 +94,7 @@ mod tests {
         assert!(deployments[1].instances[0].arguments.is_empty());
 
         // Check third deployment
-        let DeploymentSource::Local(local) = &deployments[2].source else {
-            panic!("expected local source");
-        };
-        assert_eq!(local.local, std::path::PathBuf::from("esp32_board"));
+        assert_eq!(deployments[2].source.name, "esp32_board");
         assert_eq!(deployments[2].instances.len(), 1);
         assert_eq!(deployments[2].instances[0].instance_id, "esp32_1");
         assert!(deployments[2].instances[0].arguments.is_empty());
@@ -185,7 +173,7 @@ mod tests {
             peppy_schema: "launcher/v1",
             deployments: [
                 {
-                    source: { local: "" },
+                    source: { name: "" },
                     instances: []
                 }
             ]
@@ -195,7 +183,7 @@ mod tests {
         let Error::Parsing(ParsingError::InvalidDeploymentSource(msg)) = result.unwrap_err() else {
             panic!("expected InvalidDeploymentSource error");
         };
-        assert_eq!(msg, "local path cannot be empty");
+        assert_eq!(msg, "deployment source name cannot be empty");
     }
 
     #[test]

--- a/crates/daemon-config-internal/src/launcher/types.rs
+++ b/crates/daemon-config-internal/src/launcher/types.rs
@@ -8,10 +8,7 @@ use serde::{
 };
 use std::collections::{BTreeMap, HashSet};
 
-pub use crate::source::{
-    DeploymentGitSource, DeploymentLocalSource, DeploymentRepoSource, DeploymentSource,
-    DeploymentUrlSource,
-};
+pub use crate::source::DeploymentSource;
 
 #[derive(Debug, Clone, Serialize)]
 pub struct PeppyLauncher {
@@ -613,7 +610,7 @@ mod tests {
     #[test]
     fn duplicate_instance_ids_are_rejected() {
         let duplicate_instances = r#"{
-            source: { local: "./uvc_camera" },
+            source: { name: "uvc_camera:v1" },
             instances: [
                 { instance_id: "camera_front" },
                 { instance_id: "camera_front" }
@@ -712,19 +709,19 @@ mod tests {
             peppy_schema: "launcher/v1",
             deployments: [
                 {
-                    source: { local: "./left" },
+                    source: { name: "left_camera:v1" },
                     instances: [{ instance_id: "cam_wrist_left", arguments: {} }]
                 },
                 {
-                    source: { local: "./right" },
+                    source: { name: "right_camera:v1" },
                     instances: [{ instance_id: "cam_wrist_right", arguments: {} }]
                 },
                 {
-                    source: { local: "./torso" },
+                    source: { name: "torso_camera:v1" },
                     instances: [{ instance_id: "cam_torso", arguments: {} }]
                 },
                 {
-                    source: { local: "./backbone" },
+                    source: { name: "backbone:v1" },
                     instances: [{
                         instance_id: "backbone",
                         links: {
@@ -825,7 +822,7 @@ mod tests {
             peppy_schema: "launcher/v1",
             deployments: [
                 {
-                    source: { local: "./backbone" },
+                    source: { name: "backbone:v1" },
                     instances: [{
                         instance_id: "backbone",
                         links: {
@@ -922,7 +919,7 @@ mod tests {
             peppy_schema: "launcher/v1",
             deployments: [
                 {
-                    source: { local: "./backbone" },
+                    source: { name: "backbone:v1" },
                     instances: [{
                         instance_id: "backbone",
                         links: { "_": "backbone" }

--- a/crates/daemon-config-internal/src/lib.rs
+++ b/crates/daemon-config-internal/src/lib.rs
@@ -89,9 +89,8 @@ pub mod peppy_config {
 // -- launcher --
 pub mod launcher {
     pub use crate::internal::launcher::{
-        AlreadyPairedSlots, BindingValidationItem, Deployment, DeploymentGitSource,
-        DeploymentInstance, DeploymentLocalSource, DeploymentRepoSource, DeploymentSource,
-        DeploymentUrlSource, DuplicateLinkTarget, FrameworkOverrides, LinkTargets, LinkValue,
+        AlreadyPairedSlots, BindingValidationItem, Deployment, DeploymentInstance,
+        DeploymentSource, DuplicateLinkTarget, FrameworkOverrides, LinkTargets, LinkValue,
         PairingValidationItem, PeppyLauncher, PeppyLauncherParser, Placements, PlannedObservation,
         PlannedPairEndpoint, PlannedPairing, ValidatedBindings, ValidatedLinkPlan,
         ValidatedObservations, ValidatedPairings, split_link_target, validate_bindings,
@@ -121,8 +120,5 @@ pub mod repository {
 
 // -- source --
 pub mod source {
-    pub use crate::internal::source::{
-        DeploymentGitSource, DeploymentLocalSource, DeploymentRepoSource, DeploymentSource,
-        DeploymentUrlSource,
-    };
+    pub use crate::internal::source::DeploymentSource;
 }

--- a/crates/daemon-config-internal/src/source.rs
+++ b/crates/daemon-config-internal/src/source.rs
@@ -2,41 +2,14 @@ use serde::{
     Deserialize, Serialize,
     de::{self, Deserializer},
 };
-use std::path::{Component, Path, PathBuf};
 
+/// Deployment source: a node reference resolved through the user's repo
+/// cache (`~/.peppy/cache/nodes.json5`). Accepts `{ name, tag }` or the
+/// combined `{ name: "<name>:<tag>" }` shorthand. Nodes that live outside
+/// a configured repository are made resolvable by registering their
+/// directory in `repositories.json5` (`peppy repo add <path>`).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-#[serde(untagged)]
-pub enum DeploymentSource {
-    Local(DeploymentLocalSource),
-    Git(DeploymentGitSource),
-    Url(DeploymentUrlSource),
-    Repo(DeploymentRepoSource),
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub struct DeploymentLocalSource {
-    pub local: PathBuf,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub struct DeploymentGitSource {
-    pub repo: String,
-    pub path: String,
-    #[serde(rename = "ref")]
-    pub ref_: String,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub struct DeploymentUrlSource {
-    pub url: String,
-    pub sha256: String,
-}
-
-/// Deployment source that resolves a node through the user's repo cache
-/// (`~/.peppy/cache/nodes.json5`). Accepts `{ name, tag }` or the
-/// combined `{ name: "<name>:<tag>" }` shorthand.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub struct DeploymentRepoSource {
+pub struct DeploymentSource {
     pub name: String,
     pub tag: String,
 }
@@ -49,102 +22,6 @@ where
     de::Error::custom(err.json5_message())
 }
 
-fn trim_non_empty<E>(value: String, empty_error: &'static str) -> Result<String, E>
-where
-    E: de::Error,
-{
-    let trimmed = value.trim();
-    if trimmed.is_empty() {
-        return Err(invalid_deployment_source::<E>(empty_error));
-    }
-    Ok(trimmed.to_owned())
-}
-
-fn normalize_git_path<E>(value: String) -> Result<String, E>
-where
-    E: de::Error,
-{
-    let pre_trim = value.trim();
-    // Reject absolute paths (including leading-slash form) and parent-dir
-    // components *before* stripping leading slashes; otherwise `/foo/bar`
-    // would be silently coerced to a valid relative path.
-    let original_path = Path::new(pre_trim);
-    if original_path.is_absolute()
-        || original_path
-            .components()
-            .any(|c| matches!(c, Component::ParentDir | Component::Prefix(_)))
-    {
-        return Err(invalid_deployment_source::<E>(
-            "git path cannot be absolute or contain parent-dir components",
-        ));
-    }
-    let trimmed = pre_trim.trim_start_matches('/');
-    if trimmed.is_empty() {
-        return Err(invalid_deployment_source::<E>("git path cannot be empty"));
-    }
-    Ok(trimmed.to_owned())
-}
-
-fn normalize_http_url<E>(value: String) -> Result<String, E>
-where
-    E: de::Error,
-{
-    let trimmed = trim_non_empty::<E>(value, "url cannot be empty")?;
-
-    if trimmed.contains(' ') {
-        return Err(invalid_deployment_source::<E>(
-            "url must not contain spaces",
-        ));
-    }
-
-    let (scheme, rest) = if let Some(rest) = trimmed.strip_prefix("https://") {
-        ("https", rest)
-    } else if let Some(rest) = trimmed.strip_prefix("http://") {
-        ("http", rest)
-    } else {
-        return Err(invalid_deployment_source::<E>(
-            "url must start with http:// or https://",
-        ));
-    };
-    _ = scheme;
-
-    // rest must have a non-empty host followed by a non-empty path
-    let (host_part, path_part) = match rest.find('/') {
-        Some(idx) => (&rest[..idx], &rest[idx..]),
-        None => {
-            return Err(invalid_deployment_source::<E>(
-                "url must have a non-empty path",
-            ));
-        }
-    };
-
-    if host_part.is_empty() {
-        return Err(invalid_deployment_source::<E>("url must have a host"));
-    }
-
-    // path_part starts with '/', so a path of just "/" means no meaningful path
-    if path_part == "/" || path_part.is_empty() {
-        return Err(invalid_deployment_source::<E>(
-            "url must have a non-empty path",
-        ));
-    }
-
-    Ok(trimmed)
-}
-
-fn normalize_sha256_hex<E>(value: String) -> Result<String, E>
-where
-    E: de::Error,
-{
-    let trimmed = trim_non_empty::<E>(value, "sha256 cannot be empty")?;
-    if trimmed.len() != 64 || !trimmed.chars().all(|c| c.is_ascii_hexdigit()) {
-        return Err(invalid_deployment_source::<E>(
-            "sha256 must be a 64-character hexadecimal string",
-        ));
-    }
-    Ok(trimmed.to_ascii_lowercase())
-}
-
 fn split_repo_name_and_tag<E>(
     raw_name: String,
     raw_tag: Option<&str>,
@@ -155,19 +32,19 @@ where
     let name_trimmed = raw_name.trim();
     if name_trimmed.is_empty() {
         return Err(invalid_deployment_source::<E>(
-            "repo source name cannot be empty",
+            "deployment source name cannot be empty",
         ));
     }
 
     let (name, tag) = if let Some((n, t)) = name_trimmed.split_once(':') {
         if raw_tag.is_some() {
             return Err(invalid_deployment_source::<E>(
-                "repo source cannot combine `name: \"<name>:<tag>\"` with a separate `tag` field",
+                "deployment source cannot combine `name: \"<name>:<tag>\"` with a separate `tag` field",
             ));
         }
         if t.contains(':') {
             return Err(invalid_deployment_source::<E>(
-                "repo source `name` must contain at most one ':' separating name and tag",
+                "deployment source `name` must contain at most one ':' separating name and tag",
             ));
         }
         (n.trim().to_owned(), t.trim().to_owned())
@@ -175,15 +52,15 @@ where
         let tag = raw_tag.map(str::trim).unwrap_or("");
         if tag.is_empty() {
             return Err(invalid_deployment_source::<E>(
-                "repo source requires a non-empty `tag` (or the combined `name: \"<name>:<tag>\"` form)",
+                "deployment source requires a non-empty `tag` (or the combined `name: \"<name>:<tag>\"` form)",
             ));
         }
         (name_trimmed.to_owned(), tag.to_owned())
     };
 
-    config::repo_node_id::validate_repo_node_name(&name, "repo source name")
+    config::repo_node_id::validate_repo_node_name(&name, "deployment source name")
         .map_err(invalid_deployment_source::<E>)?;
-    config::repo_node_id::validate_repo_node_tag(&tag, "repo source tag")
+    config::repo_node_id::validate_repo_node_tag(&tag, "deployment source tag")
         .map_err(invalid_deployment_source::<E>)?;
 
     Ok((name, tag))
@@ -198,95 +75,19 @@ impl<'de> Deserialize<'de> for DeploymentSource {
         #[serde(deny_unknown_fields)]
         struct RawDeploymentSource {
             #[serde(default)]
-            local: Option<String>,
-            #[serde(default)]
-            repo: Option<String>,
-            #[serde(default)]
-            path: Option<String>,
-            #[serde(rename = "ref", default)]
-            ref_: Option<String>,
-            #[serde(default)]
-            url: Option<String>,
-            #[serde(default)]
-            sha256: Option<String>,
-            #[serde(default)]
             name: Option<String>,
             #[serde(default)]
             tag: Option<String>,
         }
 
         let raw = RawDeploymentSource::deserialize(deserializer)?;
-        let has_local = raw.local.is_some();
-        let has_git = raw.repo.is_some() || raw.path.is_some() || raw.ref_.is_some();
-        let has_url = raw.url.is_some() || raw.sha256.is_some();
-        let has_repo = raw.name.is_some() || raw.tag.is_some();
-
-        match (has_local, has_git, has_url, has_repo) {
-            (false, false, false, true) => {
-                let name_raw = raw.name.ok_or_else(|| {
-                    invalid_deployment_source::<D::Error>("repo source requires `name`")
-                })?;
-                let (name, tag) =
-                    split_repo_name_and_tag::<D::Error>(name_raw, raw.tag.as_deref())?;
-                Ok(DeploymentSource::Repo(DeploymentRepoSource { name, tag }))
-            }
-            (true, false, false, false) => {
-                let local = trim_non_empty::<D::Error>(
-                    raw.local.expect("local is present"),
-                    "local path cannot be empty",
-                )?;
-                let local: PathBuf = Path::new(&local)
-                    .components()
-                    .filter(|c| !matches!(c, Component::CurDir))
-                    .collect();
-                Ok(DeploymentSource::Local(DeploymentLocalSource { local }))
-            }
-            (false, true, false, false) => {
-                let repo = raw.repo.ok_or_else(|| {
-                    invalid_deployment_source::<D::Error>("git source requires `repo`")
-                })?;
-                let path = raw.path.ok_or_else(|| {
-                    invalid_deployment_source::<D::Error>("git source requires `path`")
-                })?;
-                let ref_ = raw.ref_.ok_or_else(|| {
-                    invalid_deployment_source::<D::Error>("git source requires `ref`")
-                })?;
-
-                let repo = trim_non_empty::<D::Error>(repo, "git repo cannot be empty")?;
-                let path = normalize_git_path::<D::Error>(path)?;
-                let ref_ = trim_non_empty::<D::Error>(ref_, "git ref cannot be empty")?;
-
-                Ok(DeploymentSource::Git(DeploymentGitSource {
-                    repo,
-                    path,
-                    ref_,
-                }))
-            }
-            (false, false, true, false) => {
-                let url = raw.url.ok_or_else(|| {
-                    invalid_deployment_source::<D::Error>("url source requires `url`")
-                })?;
-                let sha256 = raw.sha256.ok_or_else(|| {
-                    invalid_deployment_source::<D::Error>("url source requires `sha256`")
-                })?;
-
-                let url = normalize_http_url::<D::Error>(url)?;
-                let sha256 = normalize_sha256_hex::<D::Error>(sha256)?;
-
-                Ok(DeploymentSource::Url(DeploymentUrlSource { url, sha256 }))
-            }
-            _ => {
-                if has_git && has_repo {
-                    Err(invalid_deployment_source::<D::Error>(
-                        "cannot mix git fields (`repo`, `path`, `ref`) with repo-source fields (`name`, `tag`); use one source type per deployment",
-                    ))
-                } else {
-                    Err(invalid_deployment_source::<D::Error>(
-                        "source must be one of: { local }, { repo, path, ref }, { url, sha256 }, { name, tag }",
-                    ))
-                }
-            }
-        }
+        let name_raw = raw.name.ok_or_else(|| {
+            invalid_deployment_source::<D::Error>(
+                "deployment source requires `name` (`{ name, tag }` or `{ name: \"<name>:<tag>\" }`)",
+            )
+        })?;
+        let (name, tag) = split_repo_name_and_tag::<D::Error>(name_raw, raw.tag.as_deref())?;
+        Ok(DeploymentSource { name, tag })
     }
 }
 
@@ -296,124 +97,22 @@ mod tests {
     use crate::error::ParsingError;
 
     #[test]
-    fn deployment_source_parses_all_variants() {
-        let local: DeploymentSource = serde_json5::from_str("{ local: \"./uvc_camera\" }").unwrap();
-        let DeploymentSource::Local(local) = local else {
-            panic!("expected local source");
-        };
-        assert_eq!(local.local, PathBuf::from("uvc_camera"));
-
-        let git: DeploymentSource = serde_json5::from_str(
-            "{ repo: \"https://github.com/Peppy-bot/nodes-hub.git\", path: \"fake_openarm01_controller\", ref: \"0.1.0\" }",
-        )
-        .unwrap();
-        let DeploymentSource::Git(git) = git else {
-            panic!("expected git source");
-        };
-        assert_eq!(git.repo, "https://github.com/Peppy-bot/nodes-hub.git");
-        assert_eq!(git.path, "fake_openarm01_controller");
-        assert_eq!(git.ref_, "0.1.0");
-
-        let url: DeploymentSource = serde_json5::from_str(
-            "{ url: \"https://example.com/fake_robot_brain.tar.zst\", sha256: \"33e83da60a54e3bb487a9a3b67705918602143b30f158143b6909acaf017a36a\" }",
-        )
-        .unwrap();
-        let DeploymentSource::Url(url) = url else {
-            panic!("expected url source");
-        };
-        assert_eq!(url.url, "https://example.com/fake_robot_brain.tar.zst");
-        assert_eq!(
-            url.sha256,
-            "33e83da60a54e3bb487a9a3b67705918602143b30f158143b6909acaf017a36a"
-        );
-    }
-
-    #[test]
-    fn deployment_source_validation_errors_are_structured() {
-        let empty_local: Result<DeploymentSource, _> = serde_json5::from_str("{ local: \"\" }");
-        let err = empty_local.expect_err("empty local should fail");
-        let ParsingError::InvalidDeploymentSource(msg) = err.into() else {
-            panic!("expected invalid deployment source error");
-        };
-        assert_eq!(msg, "local path cannot be empty");
-
-        let bad_url: Result<DeploymentSource, _> = serde_json5::from_str(
-            "{ url: \"ftp://example.com/node.tar.zst\", sha256: \"33e83da60a54e3bb487a9a3b67705918602143b30f158143b6909acaf017a36a\" }",
-        );
-        let err = bad_url.expect_err("non-http url should fail");
-        let ParsingError::InvalidDeploymentSource(msg) = err.into() else {
-            panic!("expected invalid deployment source error");
-        };
-        assert_eq!(msg, "url must start with http:// or https://");
-
-        let bad_sha: Result<DeploymentSource, _> = serde_json5::from_str(
-            "{ url: \"https://example.com/node.tar.zst\", sha256: \"not-a-sha\" }",
-        );
-        let err = bad_sha.expect_err("bad sha256 should fail");
-        let ParsingError::InvalidDeploymentSource(msg) = err.into() else {
-            panic!("expected invalid deployment source error");
-        };
-        assert_eq!(msg, "sha256 must be a 64-character hexadecimal string");
-    }
-
-    #[test]
-    fn deployment_source_rejects_malformed_urls() {
-        let valid_sha = "33e83da60a54e3bb487a9a3b67705918602143b30f158143b6909acaf017a36a";
-
-        let cases = [
-            (
-                format!("{{ url: \"https://\", sha256: \"{valid_sha}\" }}"),
-                "url must have a non-empty path",
-            ),
-            (
-                format!("{{ url: \"https:// /node.tar.zst\", sha256: \"{valid_sha}\" }}"),
-                "url must not contain spaces",
-            ),
-            (
-                format!("{{ url: \"https://example.com\", sha256: \"{valid_sha}\" }}"),
-                "url must have a non-empty path",
-            ),
-            (
-                format!("{{ url: \"https://example.com/\", sha256: \"{valid_sha}\" }}"),
-                "url must have a non-empty path",
-            ),
-        ];
-
-        for (input, expected_msg) in cases {
-            let result: Result<DeploymentSource, _> = serde_json5::from_str(&input);
-            let err = result.expect_err(&format!("expected failure for: {input}"));
-            let ParsingError::InvalidDeploymentSource(msg) = err.into() else {
-                panic!("expected InvalidDeploymentSource for: {input}");
-            };
-            assert_eq!(msg, expected_msg, "wrong message for: {input}");
-        }
-    }
-
-    // -- DeploymentRepoSource tests --
-
-    #[test]
-    fn repo_source_parses_name_and_tag_fields() {
+    fn deployment_source_parses_name_and_tag_fields() {
         let src: DeploymentSource =
             serde_json5::from_str("{ name: \"robot_brain\", tag: \"v1\" }").unwrap();
-        let DeploymentSource::Repo(repo) = src else {
-            panic!("expected repo source");
-        };
-        assert_eq!(repo.name, "robot_brain");
-        assert_eq!(repo.tag, "v1");
+        assert_eq!(src.name, "robot_brain");
+        assert_eq!(src.tag, "v1");
     }
 
     #[test]
-    fn repo_source_parses_combined_name_tag() {
+    fn deployment_source_parses_combined_name_tag() {
         let src: DeploymentSource = serde_json5::from_str("{ name: \"robot_brain:v1\" }").unwrap();
-        let DeploymentSource::Repo(repo) = src else {
-            panic!("expected repo source");
-        };
-        assert_eq!(repo.name, "robot_brain");
-        assert_eq!(repo.tag, "v1");
+        assert_eq!(src.name, "robot_brain");
+        assert_eq!(src.tag, "v1");
     }
 
     #[test]
-    fn repo_source_rejects_name_without_tag() {
+    fn deployment_source_rejects_name_without_tag() {
         let err: serde_json5::Error =
             serde_json5::from_str::<DeploymentSource>("{ name: \"foo\" }").unwrap_err();
         let ParsingError::InvalidDeploymentSource(msg) = err.into() else {
@@ -423,17 +122,27 @@ mod tests {
     }
 
     #[test]
-    fn repo_source_rejects_empty_name() {
+    fn deployment_source_rejects_empty_name() {
         let err: serde_json5::Error =
             serde_json5::from_str::<DeploymentSource>("{ name: \"\", tag: \"v1\" }").unwrap_err();
         let ParsingError::InvalidDeploymentSource(msg) = err.into() else {
             panic!("expected InvalidDeploymentSource");
         };
-        assert_eq!(msg, "repo source name cannot be empty");
+        assert_eq!(msg, "deployment source name cannot be empty");
     }
 
     #[test]
-    fn repo_source_rejects_combined_with_separate_tag() {
+    fn deployment_source_rejects_missing_name() {
+        let err: serde_json5::Error =
+            serde_json5::from_str::<DeploymentSource>("{ tag: \"v1\" }").unwrap_err();
+        let ParsingError::InvalidDeploymentSource(msg) = err.into() else {
+            panic!("expected InvalidDeploymentSource");
+        };
+        assert!(msg.contains("requires `name`"), "unexpected: {msg}");
+    }
+
+    #[test]
+    fn deployment_source_rejects_combined_with_separate_tag() {
         let err: serde_json5::Error =
             serde_json5::from_str::<DeploymentSource>("{ name: \"foo:v1\", tag: \"v1\" }")
                 .unwrap_err();
@@ -444,7 +153,7 @@ mod tests {
     }
 
     #[test]
-    fn repo_source_rejects_multiple_colons() {
+    fn deployment_source_rejects_multiple_colons() {
         let err: serde_json5::Error =
             serde_json5::from_str::<DeploymentSource>("{ name: \"foo:v1:extra\" }").unwrap_err();
         let ParsingError::InvalidDeploymentSource(msg) = err.into() else {
@@ -454,7 +163,7 @@ mod tests {
     }
 
     #[test]
-    fn repo_source_rejects_dot_in_tag() {
+    fn deployment_source_rejects_dot_in_tag() {
         let err: serde_json5::Error =
             serde_json5::from_str::<DeploymentSource>("{ name: \"foo\", tag: \"v1.2\" }")
                 .unwrap_err();
@@ -468,7 +177,7 @@ mod tests {
     }
 
     #[test]
-    fn repo_source_rejects_tag_not_starting_with_letter() {
+    fn deployment_source_rejects_tag_not_starting_with_letter() {
         let err: serde_json5::Error =
             serde_json5::from_str::<DeploymentSource>("{ name: \"foo\", tag: \"0.1.0\" }")
                 .unwrap_err();
@@ -482,7 +191,7 @@ mod tests {
     }
 
     #[test]
-    fn repo_source_rejects_invalid_name_char() {
+    fn deployment_source_rejects_invalid_name_char() {
         let err: serde_json5::Error =
             serde_json5::from_str::<DeploymentSource>("{ name: \"foo/bar\", tag: \"v1\" }")
                 .unwrap_err();
@@ -490,32 +199,30 @@ mod tests {
             panic!("expected InvalidDeploymentSource");
         };
         assert!(
-            msg.contains("invalid repo source name"),
+            msg.contains("invalid deployment source name"),
             "unexpected: {msg}"
         );
     }
 
+    /// A path is not a node reference: the only source shape is
+    /// `{ name, tag }`, so a `local` key fails the strict field check.
     #[test]
-    fn repo_source_rejects_mixed_with_local() {
-        let err: serde_json5::Error = serde_json5::from_str::<DeploymentSource>(
-            "{ name: \"foo\", tag: \"v1\", local: \"./x\" }",
-        )
-        .unwrap_err();
-        let ParsingError::InvalidDeploymentSource(msg) = err.into() else {
-            panic!("expected InvalidDeploymentSource");
-        };
-        assert!(msg.contains("source must be one of"), "unexpected: {msg}");
+    fn deployment_source_rejects_path_key() {
+        let err = serde_json5::from_str::<DeploymentSource>("{ local: \"./uvc_camera\" }")
+            .expect_err("path-shaped source must be rejected");
+        assert!(
+            err.to_string().contains("local"),
+            "error should name the offending key: {err}"
+        );
     }
 
     #[test]
-    fn repo_source_rejects_mixed_with_git_fields() {
-        let err: serde_json5::Error = serde_json5::from_str::<DeploymentSource>(
-            "{ repo: \"https://github.com/org/repo.git\", name: \"foo\", tag: \"v1\" }",
-        )
-        .unwrap_err();
-        let ParsingError::InvalidDeploymentSource(msg) = err.into() else {
-            panic!("expected InvalidDeploymentSource");
+    fn deployment_source_serializes_name_and_tag() {
+        let src = DeploymentSource {
+            name: "robot_brain".to_owned(),
+            tag: "v1".to_owned(),
         };
-        assert!(msg.contains("cannot mix git fields"), "unexpected: {msg}");
+        let json = serde_json::to_value(&src).unwrap();
+        assert_eq!(json, serde_json::json!({ "name": "robot_brain", "tag": "v1" }));
     }
 }

--- a/crates/daemon-config-internal/tests/fixtures/peppy_launcher.json5
+++ b/crates/daemon-config-internal/tests/fixtures/peppy_launcher.json5
@@ -1,13 +1,16 @@
 // Peppy Configuration
 // This is the main configuration file that defines the deployments on the current machine.
+// Every deployment references a node from the repository index by `name:tag`
+// (see `peppy repo list`); local nodes become resolvable by registering their
+// directory with `peppy repo add <path>`.
 {
   peppy_schema: "launcher/v1",
   deployments: [
     {
-      // Example of a node being pulled from an url
+      // the source property is mandatory
       source: {
-        url: "https://example.com/fake_robot_brain.tar.zst",
-        sha256: "33e83da60a54e3bb487a9a3b67705918602143b30f158143b6909acaf017a36a"
+        name: "fake_robot_brain",
+        tag: "v1",
       },
       instances: [
         {
@@ -17,11 +20,9 @@
       ],
     },
     {
-      // the source property is mandatory
+      // `name: "<name>:<tag>"` is the combined shorthand for { name, tag }
       source: {
-        repo: "https://github.com/Peppy-bot/nodes-hub.git",
-        path: "rust/fake_openarm01_controller",
-        ref: "main",
+        name: "fake_openarm01_controller:v1",
       },
       instances: [
         {
@@ -32,7 +33,7 @@
     },
     {
       source: {
-        local: "./uvc_camera"
+        name: "uvc_camera:v1"
       },
       instances: [
         {
@@ -75,7 +76,7 @@
     },
     {
       source: {
-        local: "./video_reconstruction"
+        name: "video_reconstruction:v1"
       },
       instances: [
         {
@@ -88,7 +89,7 @@
     },
     {
       source: {
-        local: "./esp32_board"
+        name: "esp32_board:v1"
       },
       instances: [
         {

--- a/crates/peppy/src/commands/stack.rs
+++ b/crates/peppy/src/commands/stack.rs
@@ -7,7 +7,6 @@ mod table;
 
 pub use list::{StackListReport, list_nodes_collecting};
 
-use std::path::PathBuf;
 use std::sync::Arc;
 
 use clap::Subcommand;
@@ -21,8 +20,8 @@ use crate::{context::AppContext, error::Error as CommandError};
 pub enum StackCommands {
     /// Launches a deployment, replacing the current node Stack
     Launch {
-        /// Path to the peppy launcher configuration file
-        launcher_config_path: PathBuf,
+        /// Name of the launcher in the repository index (see `peppy repo refresh`)
+        launcher_name: String,
         /// Wire one of the launcher's declared `core_nodes` placeholders to a
         /// real federated core node: `<core-node-link>@<core-node>`. Repeatable,
         /// once per declared link. `@self` targets the daemon this command is
@@ -109,7 +108,7 @@ impl Command for StackCommand {
             StackCommands::List => list::list_nodes(ctx),
             StackCommands::Reset { federated } => reset::reset_stack(ctx, federated),
             StackCommands::Launch {
-                launcher_config_path,
+                launcher_name,
                 place,
                 local,
                 node_add_idle_timeout_secs,
@@ -120,7 +119,7 @@ impl Command for StackCommand {
                 info!("Launching stack...");
                 launch::launch(
                     ctx,
-                    launcher_config_path,
+                    launcher_name,
                     launch::PlacementArgs {
                         places: place,
                         local,

--- a/crates/peppy/src/commands/stack/launch.rs
+++ b/crates/peppy/src/commands/stack/launch.rs
@@ -1,14 +1,13 @@
 use std::collections::{BTreeMap, BTreeSet};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 
 use core_node_api::encoding::{
     LaunchFeedback, LaunchFeedbackStep, LaunchGoal, LaunchGoalResponse, LaunchResult,
-    LauncherOrigin, NodeAddLogEntry, NodeBuildLogEntry, NodeRunLogEntry, PlacementSpec,
+    NodeAddLogEntry, NodeBuildLogEntry, NodeRunLogEntry, PlacementSpec,
 };
 use daemon_config::core_node_name::CoreNodeName;
-use daemon_config::launcher::PeppyLauncherParser;
 use peppylib::ActionMessenger;
 use peppylib::messaging::ResultStatus;
 use tracing::info;
@@ -151,63 +150,6 @@ fn handle_feedback(
     }
 }
 
-/// True when `input` syntactically looks like a filesystem path: it carries a path separator
-/// or a `.json5` extension. Such inputs never fall back to repository lookup so a typoed file
-/// path surfaces a precise file-not-found error instead of a confusing "launcher not in cache".
-fn looks_like_fs_path(input: &Path) -> bool {
-    let s = input.as_os_str().to_string_lossy();
-    if s.contains('/') || s.contains('\\') {
-        return true;
-    }
-    input.extension().is_some_and(|ext| ext == "json5")
-}
-
-/// Resolves a user-supplied launcher path, treating a bare name as shorthand for the `.json5`
-/// file. If the path does not have a `.json5` extension and a sibling `<path>.json5` exists as
-/// a file, that is returned; otherwise the original path is returned unchanged so the caller's
-/// existing not-found error path fires.
-///
-/// Lives in the CLI (the sole caller) rather than `core-node-api`: it touches the filesystem
-/// (`is_file`), which a pure wire-codec crate should not do.
-fn resolve_launcher_path(path: PathBuf) -> PathBuf {
-    if path.extension().is_some_and(|ext| ext == "json5") {
-        return path;
-    }
-    let mut with_ext = path.clone().into_os_string();
-    with_ext.push(".json5");
-    let candidate = PathBuf::from(with_ext);
-    if candidate.is_file() { candidate } else { path }
-}
-
-/// Decide whether the user wants a filesystem launcher or a repository launcher.
-///
-/// `./demo.json5`, `/abs/path`, `foo.json5` → `Fs`, with the path canonicalized so the daemon
-/// finds it regardless of its working directory. A bare name like `openarm01_sim_teleop` first
-/// tries the filesystem (sibling `.json5` shorthand from `resolve_launcher_path`) and only
-/// falls back to `Repository` when no file exists at that name.
-fn infer_launcher_origin(input: PathBuf) -> Result<LauncherOrigin> {
-    if looks_like_fs_path(&input) {
-        let resolved = resolve_launcher_path(input);
-        let canonical = resolved.canonicalize().map_err(|e| {
-            Error::ExecutionFailed(format!(
-                "Failed to resolve launcher config path '{}': {}",
-                resolved.display(),
-                e
-            ))
-        })?;
-        return Ok(LauncherOrigin::Fs(canonical));
-    }
-
-    let resolved = resolve_launcher_path(input.clone());
-    if let Ok(canonical) = resolved.canonicalize() {
-        return Ok(LauncherOrigin::Fs(canonical));
-    }
-
-    Ok(LauncherOrigin::Repository {
-        name: input.to_string_lossy().into_owned(),
-    })
-}
-
 /// The `--place` / `--local` wiring as the user typed it.
 ///
 /// `--local` is a flag rather than a launcher key because the launcher's author
@@ -272,7 +214,7 @@ impl PlacementArgs {
 
 pub fn launch(
     ctx: &Arc<AppContext>,
-    launcher_config_path: PathBuf,
+    launcher_name: String,
     placement: PlacementArgs,
     node_add_idle_timeout_secs: u64,
     node_build_idle_timeout_secs: u64,
@@ -281,7 +223,7 @@ pub fn launch(
 ) -> Result<()> {
     crate::commands::block_on(launch_async(
         ctx,
-        launcher_config_path,
+        launcher_name,
         placement,
         node_add_idle_timeout_secs,
         node_build_idle_timeout_secs,
@@ -292,42 +234,14 @@ pub fn launch(
 
 async fn launch_async(
     ctx: &Arc<AppContext>,
-    launcher_config_path: PathBuf,
+    launcher_name: String,
     placement: PlacementArgs,
     node_add_idle_timeout_secs: u64,
     node_build_idle_timeout_secs: u64,
     node_run_idle_timeout_secs: u64,
     max_timeout_secs: Option<u64>,
 ) -> Result<()> {
-    let launcher_origin = infer_launcher_origin(launcher_config_path)?;
-
-    // Pre-validate the launcher config locally for `Fs` so the user gets a fast, precise parse
-    // error before the daemon round-trip. `Repository` resolution lives daemon-side, so we
-    // skip the local check rather than duplicate the lookup here. Only the parse verdict is
-    // used: placement is resolved against the document the COORDINATOR read, so that a
-    // repository launcher and a file one place identically.
-    if let LauncherOrigin::Fs(path) = &launcher_origin {
-        PeppyLauncherParser::from_path(path).map_err(Error::DaemonConfig)?;
-    }
-
     let conn = ctx.connect_to_daemon().await?;
-
-    // An `Fs` origin names a path on THIS machine's filesystem, so a peer
-    // daemon would open a different tree or nothing at all. Same guard the
-    // other daemon-scoped commands already apply.
-    if matches!(launcher_origin, LauncherOrigin::Fs(_)) {
-        crate::commands::reject_remote_target_for_local_path(&conn, "peppy stack launch").map_err(
-            |_| {
-                Error::ExecutionFailed(format!(
-                    "`peppy stack launch` with a launcher file path cannot target the remote \
-                     daemon `{}`: the path names a tree on this machine. Use a repository \
-                     launcher (`peppy stack launch <name>`), or run the command from the \
-                     machine that holds the file.",
-                    conn.target_core_node
-                ))
-            },
-        )?;
-    }
 
     let placement = placement.resolve(&conn.target_core_node)?;
 
@@ -352,20 +266,13 @@ async fn launch_async(
         );
     }
 
-    match &launcher_origin {
-        LauncherOrigin::Fs(path) => info!(
-            "Calling launcher on daemon '{}' with config={}",
-            conn.target_core_node,
-            path.display()
-        ),
-        LauncherOrigin::Repository { name } => info!(
-            "Calling launcher on daemon '{}' with repository launcher `{}`",
-            conn.target_core_node, name
-        ),
-    }
+    info!(
+        "Calling launcher on daemon '{}' with launcher `{}`",
+        conn.target_core_node, launcher_name
+    );
 
     let goal = LaunchGoal::new(
-        launcher_origin,
+        launcher_name,
         // The launch id is minted here, by the process that starts the launch,
         // and recorded by every participant alongside its slice. That is what
         // makes the global stack reconstructible by query afterwards.
@@ -568,104 +475,6 @@ mod tests {
     fn saturating_add_does_not_panic_at_u64_max() {
         let got = compute_cli_max_timeout(Some(u64::MAX)).expect("some");
         assert_eq!(got, Duration::MAX);
-    }
-
-    #[test]
-    fn resolve_launcher_path_appends_json5_when_sibling_exists() {
-        let tmp = tempfile::tempdir().unwrap();
-        let bare = tmp.path().join("openarm01_sim_teleop");
-        let with_ext = tmp.path().join("openarm01_sim_teleop.json5");
-        std::fs::write(&with_ext, "{}").unwrap();
-
-        assert_eq!(resolve_launcher_path(bare), with_ext);
-    }
-
-    #[test]
-    fn resolve_launcher_path_keeps_explicit_json5_extension() {
-        let tmp = tempfile::tempdir().unwrap();
-        let p = tmp.path().join("foo.json5");
-        std::fs::write(&p, "{}").unwrap();
-
-        assert_eq!(resolve_launcher_path(p.clone()), p);
-    }
-
-    #[test]
-    fn resolve_launcher_path_returns_original_when_no_sibling_exists() {
-        let tmp = tempfile::tempdir().unwrap();
-        let bare = tmp.path().join("does_not_exist");
-
-        assert_eq!(resolve_launcher_path(bare.clone()), bare);
-    }
-
-    #[test]
-    fn resolve_launcher_path_ignores_directory_at_sibling_path() {
-        let tmp = tempfile::tempdir().unwrap();
-        let bare = tmp.path().join("name");
-        std::fs::create_dir(tmp.path().join("name.json5")).unwrap();
-
-        assert_eq!(resolve_launcher_path(bare.clone()), bare);
-    }
-
-    #[test]
-    fn looks_like_fs_path_detects_separators() {
-        assert!(looks_like_fs_path(Path::new("./foo")));
-        assert!(looks_like_fs_path(Path::new("../foo")));
-        assert!(looks_like_fs_path(Path::new("/abs/foo")));
-        assert!(looks_like_fs_path(Path::new("dir/foo")));
-    }
-
-    #[test]
-    fn looks_like_fs_path_detects_json5_extension() {
-        assert!(looks_like_fs_path(Path::new("foo.json5")));
-    }
-
-    #[test]
-    fn looks_like_fs_path_treats_bare_name_as_non_path() {
-        assert!(!looks_like_fs_path(Path::new("openarm01_sim_teleop")));
-        assert!(!looks_like_fs_path(Path::new("foo_bar")));
-    }
-
-    #[test]
-    fn infer_launcher_origin_canonicalizes_existing_fs_path() {
-        let tmp = tempfile::tempdir().unwrap();
-        let p = tmp.path().join("launcher.json5");
-        std::fs::write(&p, "{}").unwrap();
-
-        let origin = infer_launcher_origin(p.clone()).expect("should resolve fs path");
-        match origin {
-            LauncherOrigin::Fs(resolved) => {
-                assert_eq!(resolved, p.canonicalize().unwrap());
-            }
-            other => panic!("expected Fs, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn infer_launcher_origin_errors_when_fs_looking_path_missing() {
-        let tmp = tempfile::tempdir().unwrap();
-        let missing = tmp.path().join("missing.json5");
-
-        let err = infer_launcher_origin(missing).expect_err("should fail on missing file");
-        match err {
-            Error::ExecutionFailed(msg) => assert!(
-                msg.contains("Failed to resolve launcher config path"),
-                "unexpected error: {msg}"
-            ),
-            other => panic!("expected ExecutionFailed, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn infer_launcher_origin_falls_back_to_repository_for_bare_name() {
-        // Use a name that is unlikely to collide with any sibling .json5 in the test cwd.
-        let bare = PathBuf::from("definitely_not_a_real_launcher_xyz123");
-        let origin = infer_launcher_origin(bare.clone()).expect("bare name should not error");
-        match origin {
-            LauncherOrigin::Repository { name } => {
-                assert_eq!(name, "definitely_not_a_real_launcher_xyz123");
-            }
-            other => panic!("expected Repository, got {other:?}"),
-        }
     }
 
     fn places(pairs: &[(&str, &str)]) -> PlacementArgs {

--- a/crates/peppy/tests/stack_launch.rs
+++ b/crates/peppy/tests/stack_launch.rs
@@ -69,6 +69,59 @@ fn write_node_config(
     node_dir
 }
 
+/// Registers node directories and launcher files in the daemon's repo caches
+/// (`cache/nodes.json5` / `cache/launchers.json5`) so the launcher name and its
+/// `name:tag` deployment sources resolve without a full `repo refresh`.
+/// `peppy_root` is the serve emulation's peppy dir root (`serve.temp_dir()`).
+/// Call this AFTER the node configs' final bytes are on disk (a pinned add
+/// verifies the manifest bytes against the entry's fingerprint) and after any
+/// `repo refresh` in the test, which rewrites both cache files.
+fn register_repo_caches(
+    peppy_root: impl AsRef<Path>,
+    nodes: &[(&str, &str, &Path)],
+    launchers: &[(&str, &Path)],
+) {
+    let peppy_dirs = daemon_config::consts::PeppyDirs::new(peppy_root.as_ref());
+    let cache_dir = peppy_dirs.cache_dir();
+    fs::create_dir_all(&cache_dir).expect("failed to create cache dir");
+
+    let node_entries: Vec<serde_json::Value> = nodes
+        .iter()
+        .map(|(name, tag, dir)| {
+            let manifest_path = dir.join(NODE_CONFIG_FILE);
+            let bytes = fs::read(&manifest_path).expect("node manifest should exist");
+            serde_json::json!({
+                "node_name": name,
+                "node_tag": tag,
+                "sha256": config::fingerprint::fingerprint_for_bytes(&bytes),
+                "origin": { "source_type": "fs", "path": manifest_path.to_string_lossy() },
+            })
+        })
+        .collect();
+    fs::write(
+        cache_dir.join("nodes.json5"),
+        serde_json::to_string_pretty(&node_entries).expect("serialize nodes cache"),
+    )
+    .expect("failed to write nodes.json5");
+
+    let launcher_entries: Vec<serde_json::Value> = launchers
+        .iter()
+        .map(|(name, path)| {
+            let bytes = fs::read(path).expect("launcher file should exist");
+            serde_json::json!({
+                "launcher_name": name,
+                "sha256": config::fingerprint::fingerprint_for_bytes(&bytes),
+                "origin": { "source_type": "fs", "path": path.to_string_lossy() },
+            })
+        })
+        .collect();
+    fs::write(
+        cache_dir.join("launchers.json5"),
+        serde_json::to_string_pretty(&launcher_entries).expect("serialize launchers cache"),
+    )
+    .expect("failed to write launchers.json5");
+}
+
 fn read_daemon_git_hash(daemon_state_path: &Path) -> String {
     let contents =
         fs::read_to_string(daemon_state_path).expect("daemon state file should be readable");
@@ -228,20 +281,24 @@ async fn node_launch_command_succeed() {
             peppy_schema: "launcher/v1",
             deployments: [
                 {{
-                    source: {{ local: "{}" }},
+                    source: {{ name: "{node_b_name}:{node_tag}" }},
                     instances: [{{ instance_id: "{instance_id}" }}]
                 }}
             ]
-        }}"#,
-        node_b_path.display()
+        }}"#
     );
     fs::write(&launcher_path, launcher_json5).expect("launcher config should be writable");
+    register_repo_caches(
+        serve.temp_dir(),
+        &[(node_b_name, node_tag, &node_b_path)],
+        &[("peppy_launcher", &launcher_path)],
+    );
 
     StackCommand {
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
-            launcher_config_path: launcher_path,
+            launcher_name: "peppy_launcher".to_string(),
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
             node_run_idle_timeout_secs: 60,
@@ -429,20 +486,24 @@ async fn node_launch_command_fails_when_node_never_becomes_healthy_and_clears_st
             peppy_schema: "launcher/v1",
             deployments: [
                 {{
-                    source: {{ local: "{}" }},
+                    source: {{ name: "{node_b_name}:{node_tag}" }},
                     instances: [{{ instance_id: "node_b_instance" }}]
                 }}
             ]
-        }}"#,
-        node_b_path.display()
+        }}"#
     );
     fs::write(&launcher_path, launcher_json5).expect("launcher config should be writable");
+    register_repo_caches(
+        serve.temp_dir(),
+        &[(node_b_name, node_tag, &node_b_path)],
+        &[("peppy_launcher", &launcher_path)],
+    );
 
     let launch_result = StackCommand {
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
-            launcher_config_path: launcher_path,
+            launcher_name: "peppy_launcher".to_string(),
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
             node_run_idle_timeout_secs: 60,
@@ -507,6 +568,8 @@ async fn node_launch_command_fails_when_node_never_becomes_healthy_and_clears_st
 /// `StackCommand::execute`, so we don't need a `LogCapture` here.
 struct TimeoutTestHarness {
     ctx: Arc<AppContext>,
+    node_b_name: &'static str,
+    node_b_path: PathBuf,
     launcher_path: PathBuf,
     node_b_peppy_json5: PathBuf,
     _serve: ServeCommandEmulation,
@@ -551,21 +614,35 @@ async fn setup_timeout_test(node_b_name: &'static str) -> TimeoutTestHarness {
             peppy_schema: "launcher/v1",
             deployments: [
                 {{
-                    source: {{ local: "{}" }},
+                    source: {{ name: "{node_b_name}:v1" }},
                     instances: [{{ instance_id: "node_b_instance" }}]
                 }}
             ]
-        }}"#,
-        node_b_path.display()
+        }}"#
     );
     fs::write(&launcher_path, launcher_json5).expect("launcher config should be writable");
 
     TimeoutTestHarness {
         ctx,
+        node_b_name,
+        node_b_path,
         launcher_path,
         node_b_peppy_json5,
         _serve: serve,
         _nodes_dir: nodes_dir,
+    }
+}
+
+impl TimeoutTestHarness {
+    /// Registers node_b and the launcher in the daemon's caches. Called by
+    /// each test after its `override_*` edit so the recorded fingerprint
+    /// matches the bytes the launch materializes.
+    fn register_caches(&self) {
+        register_repo_caches(
+            self._serve.temp_dir(),
+            &[(self.node_b_name, "v1", &self.node_b_path)],
+            &[("peppy_launcher", &self.launcher_path)],
+        );
     }
 }
 
@@ -577,13 +654,14 @@ async fn node_launch_fails_when_node_build_idle_timeout_is_hit() {
         &harness.node_b_peppy_json5,
         vec!["sh".to_string(), "-c".to_string(), "sleep 30".to_string()],
     );
+    harness.register_caches();
 
     let started = Instant::now();
     let result = StackCommand {
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
-            launcher_config_path: harness.launcher_path.clone(),
+            launcher_name: "peppy_launcher".to_string(),
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 1,
             node_run_idle_timeout_secs: 60,
@@ -616,13 +694,14 @@ async fn node_launch_fails_when_node_run_idle_timeout_is_hit() {
 
     // Silent run command that never produces output and never becomes ready.
     override_run_cmd_silent(&harness.node_b_peppy_json5);
+    harness.register_caches();
 
     let started = Instant::now();
     let result = StackCommand {
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
-            launcher_config_path: harness.launcher_path.clone(),
+            launcher_name: "peppy_launcher".to_string(),
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
             node_run_idle_timeout_secs: 1,
@@ -663,13 +742,14 @@ async fn node_launch_fails_when_max_timeout_is_hit() {
             "i=0; while [ $i -lt 50 ]; do echo step-$i; i=$((i+1)); sleep 0.2; done".to_string(),
         ],
     );
+    harness.register_caches();
 
     let started = Instant::now();
     let result = StackCommand {
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
-            launcher_config_path: harness.launcher_path.clone(),
+            launcher_name: "peppy_launcher".to_string(),
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
             node_run_idle_timeout_secs: 60,
@@ -902,28 +982,34 @@ async fn stack_launch_populates_link_ids_from_launcher_bindings() {
             peppy_schema: "launcher/v1",
             deployments: [
                 {{
-                    source: {{ local: "{producer_path}" }},
+                    source: {{ name: "{producer_name}:{node_tag}" }},
                     instances: [{{ instance_id: "{producer_instance_id}" }}]
                 }},
                 {{
-                    source: {{ local: "{consumer_path}" }},
+                    source: {{ name: "{consumer_name}:{node_tag}" }},
                     instances: [{{
                         instance_id: "{consumer_instance_id}",
                         links: {{ {link_id}: "{producer_instance_id}" }}
                     }}]
                 }}
             ]
-        }}"#,
-        producer_path = producer_path.display(),
-        consumer_path = consumer_path.display(),
+        }}"#
     );
     fs::write(&launcher_path, launcher_json5).expect("launcher config should be writable");
+    register_repo_caches(
+        serve.temp_dir(),
+        &[
+            (producer_name, node_tag, &producer_path),
+            (consumer_name, node_tag, &consumer_path),
+        ],
+        &[("peppy_launcher", &launcher_path)],
+    );
 
     StackCommand {
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
-            launcher_config_path: launcher_path,
+            launcher_name: "peppy_launcher".to_string(),
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
             node_run_idle_timeout_secs: 60,
@@ -1121,31 +1207,37 @@ async fn stack_launch_binds_multi_cardinality_slot_to_ordered_producer_set() {
             peppy_schema: "launcher/v1",
             deployments: [
                 {{
-                    source: {{ local: "{producer_path}" }},
+                    source: {{ name: "{producer_name}:{node_tag}" }},
                     instances: [
                         {{ instance_id: "{front_instance_id}" }},
                         {{ instance_id: "{rear_instance_id}" }}
                     ]
                 }},
                 {{
-                    source: {{ local: "{consumer_path}" }},
+                    source: {{ name: "{consumer_name}:{node_tag}" }},
                     instances: [{{
                         instance_id: "{consumer_instance_id}",
                         links: {{ {link_id}: ["{rear_instance_id}", "{front_instance_id}"] }}
                     }}]
                 }}
             ]
-        }}"#,
-        producer_path = producer_path.display(),
-        consumer_path = consumer_path.display(),
+        }}"#
     );
     fs::write(&launcher_path, launcher_json5).expect("launcher config should be writable");
+    register_repo_caches(
+        serve.temp_dir(),
+        &[
+            (producer_name, node_tag, &producer_path),
+            (consumer_name, node_tag, &consumer_path),
+        ],
+        &[("peppy_launcher", &launcher_path)],
+    );
 
     StackCommand {
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
-            launcher_config_path: launcher_path,
+            launcher_name: "peppy_launcher".to_string(),
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
             node_run_idle_timeout_secs: 60,
@@ -1260,28 +1352,34 @@ async fn stack_launch_rejects_array_binding_on_a_one_slot() {
             peppy_schema: "launcher/v1",
             deployments: [
                 {{
-                    source: {{ local: "{producer_path}" }},
+                    source: {{ name: "{producer_name}:{node_tag}" }},
                     instances: [{{ instance_id: "solo_prod" }}]
                 }},
                 {{
-                    source: {{ local: "{consumer_path}" }},
+                    source: {{ name: "{consumer_name}:{node_tag}" }},
                     instances: [{{
                         instance_id: "solo_cons",
                         links: {{ main: ["solo_prod"] }}
                     }}]
                 }}
             ]
-        }}"#,
-        producer_path = producer_path.display(),
-        consumer_path = consumer_path.display(),
+        }}"#
     );
     fs::write(&launcher_path, launcher_json5).expect("launcher config should be writable");
+    register_repo_caches(
+        serve.temp_dir(),
+        &[
+            (producer_name, node_tag, &producer_path),
+            (consumer_name, node_tag, &consumer_path),
+        ],
+        &[("peppy_launcher", &launcher_path)],
+    );
 
     let err = StackCommand {
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
-            launcher_config_path: launcher_path,
+            launcher_name: "peppy_launcher".to_string(),
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
             node_run_idle_timeout_secs: 60,
@@ -1355,25 +1453,31 @@ async fn stack_launch_rejects_stack_wide_duplicate_instance_id() {
             peppy_schema: "launcher/v1",
             deployments: [
                 {{
-                    source: {{ local: "{camera}" }},
+                    source: {{ name: "{camera_name}:{node_tag}" }},
                     instances: [{{ instance_id: "shared_inst" }}]
                 }},
                 {{
-                    source: {{ local: "{lidar}" }},
+                    source: {{ name: "{lidar_name}:{node_tag}" }},
                     instances: [{{ instance_id: "shared_inst" }}]
                 }}
             ]
-        }}"#,
-        camera = camera_path.display(),
-        lidar = lidar_path.display(),
+        }}"#
     );
     fs::write(&launcher_path, launcher_json5).expect("launcher config should be writable");
+    register_repo_caches(
+        serve.temp_dir(),
+        &[
+            (camera_name, node_tag, &camera_path),
+            (lidar_name, node_tag, &lidar_path),
+        ],
+        &[("peppy_launcher", &launcher_path)],
+    );
 
     let result = StackCommand {
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
-            launcher_config_path: launcher_path,
+            launcher_name: "peppy_launcher".to_string(),
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
             node_run_idle_timeout_secs: 60,
@@ -1643,28 +1747,36 @@ async fn stack_launch_resolves_implements_binding_with_real_contract_doc() {
             peppy_schema: "launcher/v1",
             deployments: [
                 {{
-                    source: {{ local: "{producer_path}" }},
+                    source: {{ name: "{producer_name}:{node_tag}" }},
                     instances: [{{ instance_id: "{producer_instance_id}" }}]
                 }},
                 {{
-                    source: {{ local: "{consumer_path}" }},
+                    source: {{ name: "{consumer_name}:{node_tag}" }},
                     instances: [{{
                         instance_id: "{consumer_instance_id}",
                         links: {{ {link_id}: "{producer_instance_id}" }}
                     }}]
                 }}
             ]
-        }}"#,
-        producer_path = producer_path.display(),
-        consumer_path = consumer_path.display(),
+        }}"#
     );
     fs::write(&launcher_path, launcher_json5).expect("launcher config should be writable");
+    // After any refresh in this test: refresh rewrites nodes.json5 and
+    // launchers.json5, so registration must come later to survive.
+    register_repo_caches(
+        serve.temp_dir(),
+        &[
+            (producer_name, node_tag, &producer_path),
+            (consumer_name, node_tag, &consumer_path),
+        ],
+        &[("peppy_launcher", &launcher_path)],
+    );
 
     StackCommand {
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
-            launcher_config_path: launcher_path,
+            launcher_name: "peppy_launcher".to_string(),
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
             node_run_idle_timeout_secs: 60,
@@ -1788,28 +1900,36 @@ async fn stack_launch_rejects_binding_when_producer_omits_implements() {
             peppy_schema: "launcher/v1",
             deployments: [
                 {{
-                    source: {{ local: "{producer_path}" }},
+                    source: {{ name: "{producer_name}:{node_tag}" }},
                     instances: [{{ instance_id: "{producer_instance_id}" }}]
                 }},
                 {{
-                    source: {{ local: "{consumer_path}" }},
+                    source: {{ name: "{consumer_name}:{node_tag}" }},
                     instances: [{{
                         instance_id: "{consumer_instance_id}",
                         links: {{ {link_id}: "{producer_instance_id}" }}
                     }}]
                 }}
             ]
-        }}"#,
-        producer_path = producer_path.display(),
-        consumer_path = consumer_path.display(),
+        }}"#
     );
     fs::write(&launcher_path, launcher_json5).expect("launcher config should be writable");
+    // After any refresh in this test: refresh rewrites nodes.json5 and
+    // launchers.json5, so registration must come later to survive.
+    register_repo_caches(
+        serve.temp_dir(),
+        &[
+            (producer_name, node_tag, &producer_path),
+            (consumer_name, node_tag, &consumer_path),
+        ],
+        &[("peppy_launcher", &launcher_path)],
+    );
 
     let result = StackCommand {
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
-            launcher_config_path: launcher_path,
+            launcher_name: "peppy_launcher".to_string(),
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
             node_run_idle_timeout_secs: 60,
@@ -1924,28 +2044,36 @@ async fn stack_launch_rejects_binding_with_wrong_tag_in_implements() {
             peppy_schema: "launcher/v1",
             deployments: [
                 {{
-                    source: {{ local: "{producer_path}" }},
+                    source: {{ name: "{producer_name}:{node_tag}" }},
                     instances: [{{ instance_id: "{producer_instance_id}" }}]
                 }},
                 {{
-                    source: {{ local: "{consumer_path}" }},
+                    source: {{ name: "{consumer_name}:{node_tag}" }},
                     instances: [{{
                         instance_id: "{consumer_instance_id}",
                         links: {{ {link_id}: "{producer_instance_id}" }}
                     }}]
                 }}
             ]
-        }}"#,
-        producer_path = producer_path.display(),
-        consumer_path = consumer_path.display(),
+        }}"#
     );
     fs::write(&launcher_path, launcher_json5).expect("launcher config should be writable");
+    // After any refresh in this test: refresh rewrites nodes.json5 and
+    // launchers.json5, so registration must come later to survive.
+    register_repo_caches(
+        serve.temp_dir(),
+        &[
+            (producer_name, node_tag, &producer_path),
+            (consumer_name, node_tag, &consumer_path),
+        ],
+        &[("peppy_launcher", &launcher_path)],
+    );
 
     let result = StackCommand {
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
-            launcher_config_path: launcher_path,
+            launcher_name: "peppy_launcher".to_string(),
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
             node_run_idle_timeout_secs: 60,
@@ -2191,31 +2319,39 @@ async fn stack_launch_binds_contract_slots_in_both_directions() {
             peppy_schema: "launcher/v1",
             deployments: [
                 {{
-                    source: {{ local: "{controller_path}" }},
+                    source: {{ name: "{controller_name}:{node_tag}" }},
                     instances: [{{
                         instance_id: "{controller_instance_id}",
                         links: {{ {controller_link_id}: "{arm_instance_id}" }}
                     }}]
                 }},
                 {{
-                    source: {{ local: "{arm_path}" }},
+                    source: {{ name: "{arm_name}:{node_tag}" }},
                     instances: [{{
                         instance_id: "{arm_instance_id}",
                         links: {{ {arm_link_id}: "{controller_instance_id}" }}
                     }}]
                 }}
             ]
-        }}"#,
-        controller_path = controller_path.display(),
-        arm_path = arm_path.display(),
+        }}"#
     );
     fs::write(&launcher_path, launcher_json5).expect("launcher config should be writable");
+    // After the refresh above: refresh rewrites nodes.json5/launchers.json5,
+    // so these registrations must come later to survive.
+    register_repo_caches(
+        serve.temp_dir(),
+        &[
+            (controller_name, node_tag, &controller_path),
+            (arm_name, node_tag, &arm_path),
+        ],
+        &[("peppy_launcher", &launcher_path)],
+    );
 
     StackCommand {
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
-            launcher_config_path: launcher_path,
+            launcher_name: "peppy_launcher".to_string(),
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
             node_run_idle_timeout_secs: 60,
@@ -2351,25 +2487,31 @@ async fn stack_launch_rejects_unbound_slot() {
             peppy_schema: "launcher/v1",
             deployments: [
                 {{
-                    source: {{ local: "{producer}" }},
+                    source: {{ name: "{producer_name}:{node_tag}" }},
                     instances: [{{ instance_id: "cam_1" }}]
                 }},
                 {{
-                    source: {{ local: "{consumer}" }},
+                    source: {{ name: "{consumer_name}:{node_tag}" }},
                     instances: [{{ instance_id: "cons_1" }}]
                 }}
             ]
-        }}"#,
-        producer = producer_path.display(),
-        consumer = consumer_path.display(),
+        }}"#
     );
     fs::write(&launcher_path, launcher_json5).expect("launcher config should be writable");
+    register_repo_caches(
+        serve.temp_dir(),
+        &[
+            (producer_name, node_tag, &producer_path),
+            (consumer_name, node_tag, &consumer_path),
+        ],
+        &[("peppy_launcher", &launcher_path)],
+    );
 
     let result = StackCommand {
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
-            launcher_config_path: launcher_path,
+            launcher_name: "peppy_launcher".to_string(),
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
             node_run_idle_timeout_secs: 60,
@@ -2533,33 +2675,39 @@ async fn stack_launch_establishes_launcher_pairings() {
     // The pair is declared once, on the controller instance; the launcher
     // works out the establishment order.
     let launcher_path = nodes_dir.path().join("peppy_launcher.json5");
-    let launcher_json5 = format!(
-        r#"{{
+    let launcher_json5 = r#"{
             peppy_schema: "launcher/v1",
             deployments: [
-                {{
-                    source: {{ local: "{arm_path}" }},
-                    instances: [{{ instance_id: "arm_1" }}]
-                }},
-                {{
-                    source: {{ local: "{ctrl_path}" }},
-                    instances: [{{
+                {
+                    source: { name: "robot_arm:v1" },
+                    instances: [{ instance_id: "arm_1" }]
+                },
+                {
+                    source: { name: "arm_controller:v1" },
+                    instances: [{
                         instance_id: "ctrl_1",
-                        links: {{ arm: "arm_1" }}
-                    }}]
-                }}
+                        links: { arm: "arm_1" }
+                    }]
+                }
             ]
-        }}"#,
-        arm_path = arm_path.display(),
-        ctrl_path = ctrl_path.display(),
-    );
+        }"#;
     fs::write(&launcher_path, launcher_json5).expect("launcher config should be writable");
+    // After `seed_pairing_repo`'s refresh: refresh rewrites the node and
+    // launcher caches, so these registrations must come later to survive.
+    register_repo_caches(
+        serve.temp_dir(),
+        &[
+            ("robot_arm", "v1", &arm_path),
+            ("arm_controller", "v1", &ctrl_path),
+        ],
+        &[("peppy_launcher", &launcher_path)],
+    );
 
     StackCommand {
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
-            launcher_config_path: launcher_path,
+            launcher_name: "peppy_launcher".to_string(),
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
             node_run_idle_timeout_secs: 60,
@@ -2726,33 +2874,37 @@ async fn stack_launch_delivers_observer_source_pin() {
     .expect("observation_update service should start");
 
     let launcher_path = nodes_dir.path().join("peppy_launcher.json5");
-    let launcher_json5 = format!(
-        r#"{{
+    let launcher_json5 = r#"{
             peppy_schema: "launcher/v1",
             deployments: [
-                {{
-                    source: {{ local: "{arm_path}" }},
-                    instances: [{{ instance_id: "arm_1", defer_links: ["controller"] }}]
-                }},
-                {{
-                    source: {{ local: "{recorder_path}" }},
-                    instances: [{{
+                {
+                    source: { name: "robot_arm:v1" },
+                    instances: [{ instance_id: "arm_1", defer_links: ["controller"] }]
+                },
+                {
+                    source: { name: "recorder:v1" },
+                    instances: [{
                         instance_id: "rec_1",
-                        links: {{ watch: "arm_1" }}
-                    }}]
-                }}
+                        links: { watch: "arm_1" }
+                    }]
+                }
             ]
-        }}"#,
-        arm_path = arm_path.display(),
-        recorder_path = recorder_path.display(),
-    );
+        }"#;
     fs::write(&launcher_path, launcher_json5).expect("launcher config should be writable");
+    register_repo_caches(
+        serve.temp_dir(),
+        &[
+            ("robot_arm", "v1", &arm_path),
+            ("recorder", "v1", &recorder_path),
+        ],
+        &[("peppy_launcher", &launcher_path)],
+    );
 
     StackCommand {
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
-            launcher_config_path: launcher_path,
+            launcher_name: "peppy_launcher".to_string(),
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
             node_run_idle_timeout_secs: 60,
@@ -2826,25 +2978,27 @@ async fn stack_launch_rejects_uncovered_pairing_slot() {
     );
 
     let launcher_path = nodes_dir.path().join("peppy_launcher.json5");
-    let launcher_json5 = format!(
-        r#"{{
+    let launcher_json5 = r#"{
             peppy_schema: "launcher/v1",
             deployments: [
-                {{
-                    source: {{ local: "{arm_path}" }},
-                    instances: [{{ instance_id: "arm_1" }}]
-                }}
+                {
+                    source: { name: "robot_arm:v1" },
+                    instances: [{ instance_id: "arm_1" }]
+                }
             ]
-        }}"#,
-        arm_path = arm_path.display(),
-    );
+        }"#;
     fs::write(&launcher_path, launcher_json5).expect("launcher config should be writable");
+    register_repo_caches(
+        serve.temp_dir(),
+        &[("robot_arm", "v1", &arm_path)],
+        &[("peppy_launcher", &launcher_path)],
+    );
 
     let err = StackCommand {
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
-            launcher_config_path: launcher_path,
+            launcher_name: "peppy_launcher".to_string(),
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
             node_run_idle_timeout_secs: 60,

--- a/docs/src/content/docs/advanced_guides/actions.mdx
+++ b/docs/src/content/docs/advanced_guides/actions.mdx
@@ -717,7 +717,7 @@ In a launcher / stack config:
 
 ```json5
 {
-  source: { local: "./consumer" },
+  source: { name: "consumer:v1" },
   instances: [{
     instance_id: "my_consumer",
     links: { brain: "left-arm-1" },

--- a/docs/src/content/docs/advanced_guides/federation.mdx
+++ b/docs/src/content/docs/advanced_guides/federation.mdx
@@ -344,22 +344,14 @@ participants keep running.
 
 - **Same Peppy version on every participant.** A mixed-version federation is
   refused during preflight, before any stack is touched.
-- **`local:` sources cannot cross machines.** The path names a tree on the
-  coordinator's filesystem. A `local:` deployment must keep all of its instances
-  on one core node; publish the node to a repo or git-backed source to split it.
-  That is why the proprietary planner in the example is a registry source.
 - **A filesystem repository cannot back a deployment placed on another
-  machine.** A `repo:` deployment is pinned to wherever the coordinator's cache
+  machine.** A deployment is pinned to wherever the coordinator's cache
   resolved it, and a filesystem repository entry is a path only the coordinator
-  can read, the same rule as `local:` one level down. Two things still work:
-  keep that deployment's instances on one core node, or serve the node from a
-  git repository, which every machine can fetch.
+  can read. Two things still work: keep that deployment's instances on one
+  core node, or serve the node from a git repository, which every machine can
+  fetch.
 - **The unit of byte coherence is one launch.** Two launches submitted while a
   repository moves between them may run different revisions of it; each launch
   is internally coherent, and nothing synchronizes one launch with the next.
-- **A launcher file path cannot target a remote daemon.** `peppy stack launch
-  ./my_launcher.json5 --core-node cn-atlas-h100` is refused for the same reason.
-  Use a repository launcher, or run the command from the machine holding the
-  file.
 - **No re-placement of a running instance.** Moving an instance to another
   machine means launching again.

--- a/docs/src/content/docs/advanced_guides/services.mdx
+++ b/docs/src/content/docs/advanced_guides/services.mdx
@@ -529,7 +529,7 @@ In a launcher / stack config:
 
 ```json5
 {
-  source: { local: "./consumer" },
+  source: { name: "consumer:v1" },
   instances: [{
     instance_id: "my_consumer",
     links: { uvc_camera: "my-camera-instance" },

--- a/docs/src/content/docs/advanced_guides/system_clock.mdx
+++ b/docs/src/content/docs/advanced_guides/system_clock.mdx
@@ -199,7 +199,7 @@ Subscribers see the same shape either way.
   peppy_schema: "launcher/v1",
   deployments: [
     {
-      source: { local: "./uvc_camera" },
+      source: { name: "uvc_camera:v1" },
       instances: [
         {
           instance_id: "camera_front",

--- a/docs/src/content/docs/advanced_guides/topics.mdx
+++ b/docs/src/content/docs/advanced_guides/topics.mdx
@@ -585,7 +585,7 @@ In a launcher / stack config:
 
 ```json5
 {
-  source: { local: "./consumer" },
+  source: { name: "consumer:v1" },
   instances: [{
     instance_id: "my_consumer",
     links: { uvc_camera: "my-camera-instance" },

--- a/docs/src/content/docs/guides/launch_files.mdx
+++ b/docs/src/content/docs/guides/launch_files.mdx
@@ -40,14 +40,12 @@ In the `examples/` directory, you'll find a launcher file for each language. Ope
  2. All deployments are defined in the `deployments` array
  3. Each deployment requires a `source` (where the node comes from) and an `instances` array (how many copies to start, and how each one is configured). Every entry needs an `instance_id`; `arguments`, `env_vars`, `framework`, `links`, and `defer_links` are optional. See [Instance attributes](#instance-attributes) for what each one does
 
-The `source` attribute supports four formats:
- - **URL**: A link to a `.tar.zst` archive, requiring both `url` and `sha256` attributes. The download is retried automatically on transient network failures (connection errors or `5xx` responses); a mismatch against `sha256`, or a client (`4xx`) error, fails immediately
- - **Git repository**: Requires `repo`, `path` (location within the repo), and `ref` attributes
- - **Local path**: Specified via the `local` key, pointing to a directory on your filesystem. The path can be either absolute or relative to the launcher file
- - **Repository**: Reference a node that is already registered in your user repositories. Specify `name` and `tag`, or use the combined `name: "<name>:<tag>"` shorthand. The node is resolved against your local nodes cache at `~/.peppy/cache/nodes.json5`.
+The `source` attribute always references a node from your configured repositories by `name` and `tag`. Specify them as separate fields, or use the combined `name: "<name>:<tag>"` shorthand. The node is resolved against your local nodes cache at `~/.peppy/cache/nodes.json5`.
+
+If a node you want to deploy lives outside your configured repositories, add its location first: register a local directory with `peppy repo add /path/to/my/nodes`, or a git repository with `peppy repo add https://github.com/org/repo.git`, then run `peppy repo refresh` so the node appears in the index (see [Repositories](/advanced_guides/repositories/)).
 
 :::note
-The repository source resolves nodes from the locally cached index of the machine the launch is submitted to. Run `peppy repo refresh` on that machine before launching to ensure its cache is up to date. In a federated launch it is the only machine whose cache matters: it resolves every deployment and its dependencies once and ships the result to the other machines as pinned content, so their caches need no refresh and cannot change what the launch runs.
+The source resolves nodes from the locally cached index of the machine the launch is submitted to. Run `peppy repo refresh` on that machine before launching to ensure its cache is up to date. In a federated launch it is the only machine whose cache matters: it resolves every deployment and its dependencies once and ships the result to the other machines as pinned content, so their caches need no refresh and cannot change what the launch runs.
 
 If a node or tag is missing from the cache, the launch fails with a "not found" error. If the cache instead contains the same `name:tag` **twice from one repository**, the launch fails with a distinct ambiguity error naming both manifests — never "not found", since the node is present rather than absent. The refusal happens while sources are being resolved, before anything is added, built, or run, and it covers transitive dependencies too: an ambiguity two levels down is exactly as fatal as one at the top. See [Using a repository-indexed node](/advanced_guides/repositories/#using-a-repository-indexed-node).
 :::
@@ -78,34 +76,37 @@ If a node or tag is missing from the cache, the launch fails with a "not found" 
 ```
 
 :::caution
-The git `ref` and the node `tag` declared in `peppy.json5` are independent values, and they do not share the same format: git refs can contain dots (e.g. `v0.1.0`), but node tags must start with an ASCII letter and forbid dots (e.g. `v1`, `donut`). This means you could have a git `ref` of `v0.1.0` while `peppy.json5` specifies `tag: "v1"`. Keep them coordinated so a checkout of a given git ref lines up with the tag your launcher expects.
+A git ref pinned in `repositories.json5` and the node `tag` declared in `peppy.json5` are independent values, and they do not share the same format: git refs can contain dots (e.g. `v0.1.0`), but node tags must start with an ASCII letter and forbid dots (e.g. `v1`, `donut`). This means a repository could be pinned to the git ref `v0.1.0` while `peppy.json5` specifies `tag: "v1"`. Keep them coordinated so a checkout of a given git ref lines up with the tag your launcher expects.
 :::
 
-From within the cloned repository, execute the launcher:
+Launchers are invoked by name: every launcher discovered by `peppy repo refresh` (see [Repositories](/advanced_guides/repositories/)) is keyed by the file stem of its `.json5` file and resolved through the cache at `~/.peppy/cache/launchers.json5`. Run `peppy repo refresh` on the machine you submit the launch to; the launcher document, like every node source, resolves on that machine alone. The `launchers-hub` repository you cloned above is one of the default configured repositories, so its example launchers are already indexed after a refresh:
+
 <Tabs>
   <TabItem label="Python">
 ```sh
-peppy stack launch ./examples/python_robot.json5
+peppy repo refresh
+peppy stack launch python_robot
 ```
   </TabItem>
   <TabItem label="Rust">
 ```sh
-peppy stack launch ./examples/rust_robot.json5
+peppy repo refresh
+peppy stack launch rust_robot
 ```
   </TabItem>
 </Tabs>
 
 Peppy automatically inspects the `name` and `tag` of each node, verifies that all dependencies are met, and constructs the node stack in the correct order.
 
-### Launching from a repository
-
-Launchers discovered by `peppy repo refresh` (see [Repositories](/advanced_guides/repositories/)) can be invoked by bare name, no path required:
+To launch a launcher file of your own, register the directory that contains it and refresh:
 
 ```sh
-peppy stack launch openarm01_sim_teleop
+peppy repo add /path/to/my/launchers
+peppy repo refresh
+peppy stack launch my_launcher
 ```
 
-An argument that contains a path separator or ends in `.json5` is always resolved as a filesystem path. A bare name (no separator, no extension) is first tried on disk as `<name>.json5` next to your current directory, and only falls back to the repository cache at `~/.peppy/cache/launchers.json5` when no such file exists. Run `peppy repo refresh` first on the machine you submit the launch to; the launcher document, like every repository source, resolves on that machine alone.
+If the name is missing from the launcher cache, the launch fails with an explicit "not found" error.
 
 If the name resolves neither to a file nor to a cached launcher, the launch fails with an explicit "not found" error. If one repository provides two launcher files with that name, the launch fails with a distinct ambiguity error naming both — launchers are keyed by filename, so two identically named `.json5` files anywhere in one repository contest the same name even in different directories.
 
@@ -164,7 +165,7 @@ Every entry in an `instances` array configures one running copy of the deploymen
 
 ```json5 title="peppy_launcher.json5"
 {
-  source: { local: "./uvc_camera" },
+  source: { name: "uvc_camera:v1" },
   instances: [
     {
       instance_id: "camera_front",
@@ -202,7 +203,7 @@ Environment variables for this instance's process.
 
 ```json5
 {
-  source: { local: "./esp32_board" },
+  source: { name: "esp32_board:v1" },
   instances: [
     { instance_id: "esp32_left",  env_vars: { ESP32_DEVICE: "/dev/ttyUSB0" } },
     { instance_id: "esp32_right", env_vars: { ESP32_DEVICE: "/dev/ttyUSB1" } },


### PR DESCRIPTION
## What

Launchers are now always invoked by name and resolved through the repository cache, and `launcher/v1` deployments always reference nodes by `name:tag`. Filesystem paths (and inline git/url specs) are gone from the whole launch surface:

- **CLI**: `peppy stack launch <launcher_name>` takes a name; the path inference (`./file.json5`, sibling-`.json5` shorthand, canonicalization), local pre-validation, and the Fs remote-target guard are removed. `--place`/`--local` are unchanged.
- **Daemon**: the launcher resolves only via `launchers.json5`; every deployment resolves via the pinned-closure path (`resolve_pinned_closure`). The `local:`/`git:`/`url:` arms of `resolve_one`, the `nodes_directory` plumbing, and `local_source_refusal` are removed.
- **Schema**: `DeploymentSource` collapses from a four-variant enum to a `{ name, tag }` struct (still accepting the `name: "<name>:<tag>"` shorthand). A `local`/`repo`/`url` key in a launcher file is now a parse error naming the offending key.
- To use a node or launcher that lives outside the configured repositories, register its directory (`peppy repo add <path>` + `peppy repo refresh`) — the docs now say exactly that, and `launch_files.mdx` shows the name-based flow.

Tests migrated accordingly: daemon-side launch tests register nodes/launchers through `TestPackagesCache` (new `launcher_fs_entry`; `fs_entry`/`git_entry` now record real manifest fingerprints so pinned adds verify), and the CLI tests get a `register_repo_caches` helper that writes the caches under the serve emulation's peppy root.

## Why

A path names a tree on one machine's filesystem. With federated launches that was already a special case fenced off with dedicated refusals (`local:` portability, Fs-origin remote-target guard); making the repository index the single way to reference launchers and nodes deletes those special cases instead of documenting them.

## Notes for review

- Depends on Peppy-bot/public-peppy-libs#84 (wire change). CI stays red until that merges and the lock is bumped; the lock bump is deliberately not part of this PR.
- Removing the `local:`/`git:`/`url:` launcher arms leaves the source-generic node-config resolution chain (`services::node::resolve_node_config`, `resolve_http_source`, `clone_repo_with_deadline`) without production callers (dead-code warnings). Left in place here to keep the diff reviewable; happy to delete it in this PR or a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)