### PR TITLE
Stamp cross-daemon pairing peers with their own core node in display reads

### DIFF
--- a/crates/node-stack-internal/src/node_stack.rs
+++ b/crates/node-stack-internal/src/node_stack.rs
@@ -616,17 +616,24 @@ impl NodeStackInner {
     }
 
     /// Live pairs, liveness-filtered without mutating the registry (for
-    /// read-lock paths; write paths use [`Self::prune_dead_pairs`]).
+    /// read-lock paths; write paths use [`Self::prune_dead_pairs`]). Same
+    /// rule as [`PairingRegistry::prune_dead`]: only LOCAL endpoints are
+    /// judged, because this daemon cannot see whether an instance on
+    /// another machine is alive, and "cannot see" must not read as "dead".
     fn live_pairs_filtered(&self) -> Vec<Pairing> {
         if self.pairing_registry.pairs().is_empty() {
             return Vec::new();
         }
         let live = self.live_instance_ids_for_pairing();
+        let local_core_node = self.root_core_node_name();
         self.pairing_registry
             .pairs()
             .iter()
             .filter(|p| {
-                live.contains(&p.a.slot.instance_id) && live.contains(&p.b.slot.instance_id)
+                [&p.a, &p.b].into_iter().all(|endpoint| {
+                    !endpoint.slot.is_on(&local_core_node)
+                        || live.contains(&endpoint.slot.instance_id)
+                })
             })
             .cloned()
             .collect()
@@ -882,9 +889,9 @@ impl NodeStackInner {
         // Paired (`to_serialized_graph` holds a read lock, so filtering
         // replaces the write-path pruning here).
         let live_pairs = self.live_pairs_filtered();
-        // Stack-scoped v1: every pair lives under this daemon, so the peer's
-        // core_node is the daemon's own (the root entity's manifest name —
-        // the core node binds to itself).
+        // `core_node` (the root entity's manifest name) addresses this
+        // daemon's own slots in the view; the peer half of each binding
+        // carries its own address, which may name another daemon.
         for (node, config) in nodes.iter_mut().zip(&configs) {
             let Some(deps) = config.manifest.depends_on.as_ref() else {
                 continue;
@@ -1490,8 +1497,9 @@ pub struct PairingNodeSnapshot {
 /// `depends_on.pairings` slot joined with its live binding from
 /// `live_pairs`. Shared by the stack-list graph overlay and the daemon's
 /// `node_info` handler so the join rule stays in one place. `core_node`
-/// stamps the peer's `ProducerRef` (stack-scoped v1: every pair lives
-/// under this daemon, so the peer's core_node is the daemon's own).
+/// addresses the LOCAL slot being viewed; the peer's `ProducerRef` is
+/// stamped from the pair's recorded endpoint address, which names another
+/// daemon when the pair crosses machines.
 pub fn pairing_slot_view(
     core_node: &str,
     instance_id: &str,
@@ -1505,7 +1513,10 @@ pub fn pairing_slot_view(
             .iter()
             .find_map(|pair| pair.peer_of(&slot))
             .map(|peer| config::runtime::PairingSlotBinding::Paired {
-                peer: config::runtime::ProducerRef::new(core_node, peer.slot.instance_id.as_str()),
+                peer: config::runtime::ProducerRef::new(
+                    peer.slot.core_node.as_str(),
+                    peer.slot.instance_id.as_str(),
+                ),
                 peer_link_id: peer.slot.link_id.clone(),
             })
             .unwrap_or(config::runtime::PairingSlotBinding::Unpaired);

--- a/crates/node-stack-internal/tests/tests_modules/pairing_registry.rs
+++ b/crates/node-stack-internal/tests/tests_modules/pairing_registry.rs
@@ -390,9 +390,47 @@ async fn serialized_graph_overlays_pairing_slots() {
     assert_eq!(peer.instance_id, "arm_1");
     assert_eq!(
         peer.core_node, "core",
-        "stamped with the daemon's own core node"
+        "a local peer's address names this daemon, where it lives"
     );
     assert_eq!(peer_link_id, "controller");
+}
+
+/// A pair whose peer lives on ANOTHER daemon must surface with the peer's
+/// own core node, not this daemon's: labelling `ctrl_remote` as local would
+/// send the operator to the wrong machine.
+#[tokio::test]
+async fn serialized_graph_stamps_a_remote_peer_with_its_own_core_node() {
+    let stack = NodeStack::new(core_node_config(), None, PathBuf::from("/tmp"));
+    let harness = real_lifecycle::lifecycle_harness();
+    let _arm =
+        fixtures::push_started(&stack, &harness, robot_arm_config(), Some(&name("arm_1"))).await;
+
+    let arm_slot = SlotAddr::new(TEST_CORE_NODE, "arm_1", "controller");
+    let remote_slot = SlotAddr::new("core_b", "ctrl_remote", "arm");
+    let remote_meta = RemoteSlotMeta {
+        pairing_name: "arm_link".to_string(),
+        pairing_tag: "v1".to_string(),
+        role: "controller".to_string(),
+    };
+    stack
+        .pair_slot_with_remote(&arm_slot, &remote_slot, &remote_meta)
+        .expect("the coordinator's verdict authorizes the far half");
+
+    let graph = stack.to_serialized_graph();
+    let arm_node = graph.find_node("robot_arm", "v1").expect("arm in graph");
+    let slot = arm_node.instances[0]
+        .pairing_slots
+        .get("controller")
+        .expect("declared slot surfaces");
+    let PairingSlotBinding::Paired { peer, peer_link_id } = &slot.binding else {
+        panic!("expected Paired, got {:?}", slot.binding);
+    };
+    assert_eq!(peer.instance_id, "ctrl_remote");
+    assert_eq!(
+        peer.core_node, "core_b",
+        "the peer's address must name the daemon that hosts it"
+    );
+    assert_eq!(peer_link_id, "arm");
 }
 
 /// `depends_on.pairings` contributes no DAG edges: two nodes joined only by


### PR DESCRIPTION
## Summary

`stack list` and `node info` misrepresented cross-daemon pairs. Two defects, one masking the other:

- **Wrong peer address**: `pairing_slot_view` built the peer's `ProducerRef` from the local daemon's `core_node` parameter instead of the pair's recorded endpoint address (`peer.slot.core_node`) — a leftover of the stack-scoped v1 assumption that every pair lives under one daemon. A remote peer would render as `ctrl_remote:arm@<local-daemon>`, pointing the operator at the wrong machine.
- **Remote pairs dropped from display reads**: `live_pairs_filtered` required *both* endpoints' instance ids to be live in the local graph. A remote instance is never in the local graph, so every cross-daemon pair was filtered out and the slot showed as *unpaired* — which is why the wrong-address bug never surfaced. This contradicted the registry's documented invariant (a remote pair must survive registry reads; "cannot see" must not read as "dead") that the write-path `prune_dead` already implements. The filter now judges only local endpoints, mirroring that rule.

Also updates the two stale "stack-scoped v1" comments.

Side effect worth noting: `node_run`'s pairing exclusivity re-check reads `live_pairs()` too, so a slot claimed by a cross-daemon pair is now correctly seen as claimed there as well.

## Testing

- New regression test `serialized_graph_stamps_a_remote_peer_with_its_own_core_node`: pairs a local slot with a remote one via `pair_slot_with_remote`, asserts the serialized graph shows `Paired` with the peer's own core node. Fails as `Unpaired` without the filter fix, and as the local name without the stamp fix.
- Corrected the misleading assertion message in `serialized_graph_overlays_pairing_slots` (its two slots share a daemon, so it cannot distinguish the two stampings).
- Full `node-stack` suite (126 tests), `peppy` stack_list tests, `core-node` lib tests (358), and `listen_for_node_run` / `listen_for_node_info` service tests all pass; workspace clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)