### PR TITLE
Report the repositories a refresh could not read instead of failing the run

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,7 +573,7 @@ dependencies = [
 [[package]]
 name = "build-helpers"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#7ddc29b99b02ea4382c470bf8be4b22fae6e0c0a"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs?branch=calm-elephant#d05a136e8f65fb0869e5c514c4b5fa46c5bd09f5"
 dependencies = [
  "sha2",
 ]
@@ -765,7 +765,7 @@ dependencies = [
 [[package]]
 name = "config-test-support"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#7ddc29b99b02ea4382c470bf8be4b22fae6e0c0a"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs?branch=calm-elephant#d05a136e8f65fb0869e5c514c4b5fa46c5bd09f5"
 dependencies = [
  "askama",
  "git2",
@@ -909,7 +909,7 @@ dependencies = [
 [[package]]
 name = "core-node-api"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#7ddc29b99b02ea4382c470bf8be4b22fae6e0c0a"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs?branch=calm-elephant#d05a136e8f65fb0869e5c514c4b5fa46c5bd09f5"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -1248,7 +1248,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1396,7 +1396,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2581,7 +2581,7 @@ dependencies = [
 [[package]]
 name = "json5-pretty"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#7ddc29b99b02ea4382c470bf8be4b22fae6e0c0a"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs?branch=calm-elephant#d05a136e8f65fb0869e5c514c4b5fa46c5bd09f5"
 dependencies = [
  "serde",
  "serde_json",
@@ -2985,7 +2985,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3372,7 +3372,7 @@ dependencies = [
 [[package]]
 name = "peppy-config-model"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#7ddc29b99b02ea4382c470bf8be4b22fae6e0c0a"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs?branch=calm-elephant#d05a136e8f65fb0869e5c514c4b5fa46c5bd09f5"
 dependencies = [
  "capnp",
  "clap",
@@ -3395,7 +3395,7 @@ version = "0.0.1"
 [[package]]
 name = "peppylib-rs"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#7ddc29b99b02ea4382c470bf8be4b22fae6e0c0a"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs?branch=calm-elephant#d05a136e8f65fb0869e5c514c4b5fa46c5bd09f5"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -3590,7 +3590,7 @@ dependencies = [
 [[package]]
 name = "pmi"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#7ddc29b99b02ea4382c470bf8be4b22fae6e0c0a"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs?branch=calm-elephant#d05a136e8f65fb0869e5c514c4b5fa46c5bd09f5"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -3808,7 +3808,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.5",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4058,7 +4058,7 @@ dependencies = [
  "pin-project-lite",
  "rustls",
  "rustls-pki-types",
- "rustls-platform-verifier 0.6.2",
+ "rustls-platform-verifier 0.7.0",
  "serde",
  "serde_json",
  "sync_wrapper",
@@ -4244,7 +4244,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4312,7 +4312,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4333,7 +4333,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4709,7 +4709,7 @@ version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
 dependencies = [
- "dirs 4.0.0",
+ "dirs 6.0.0",
 ]
 
 [[package]]
@@ -5045,7 +5045,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5948,7 +5948,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,7 +573,7 @@ dependencies = [
 [[package]]
 name = "build-helpers"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs?branch=calm-elephant#d05a136e8f65fb0869e5c514c4b5fa46c5bd09f5"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#06ad339a922acb00792bda4078ac7c5585d4224c"
 dependencies = [
  "sha2",
 ]
@@ -765,7 +765,7 @@ dependencies = [
 [[package]]
 name = "config-test-support"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs?branch=calm-elephant#d05a136e8f65fb0869e5c514c4b5fa46c5bd09f5"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#06ad339a922acb00792bda4078ac7c5585d4224c"
 dependencies = [
  "askama",
  "git2",
@@ -909,7 +909,7 @@ dependencies = [
 [[package]]
 name = "core-node-api"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs?branch=calm-elephant#d05a136e8f65fb0869e5c514c4b5fa46c5bd09f5"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#06ad339a922acb00792bda4078ac7c5585d4224c"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -1248,7 +1248,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1396,7 +1396,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2581,7 +2581,7 @@ dependencies = [
 [[package]]
 name = "json5-pretty"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs?branch=calm-elephant#d05a136e8f65fb0869e5c514c4b5fa46c5bd09f5"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#06ad339a922acb00792bda4078ac7c5585d4224c"
 dependencies = [
  "serde",
  "serde_json",
@@ -2985,7 +2985,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3372,7 +3372,7 @@ dependencies = [
 [[package]]
 name = "peppy-config-model"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs?branch=calm-elephant#d05a136e8f65fb0869e5c514c4b5fa46c5bd09f5"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#06ad339a922acb00792bda4078ac7c5585d4224c"
 dependencies = [
  "capnp",
  "clap",
@@ -3395,7 +3395,7 @@ version = "0.0.1"
 [[package]]
 name = "peppylib-rs"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs?branch=calm-elephant#d05a136e8f65fb0869e5c514c4b5fa46c5bd09f5"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#06ad339a922acb00792bda4078ac7c5585d4224c"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -3590,7 +3590,7 @@ dependencies = [
 [[package]]
 name = "pmi"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs?branch=calm-elephant#d05a136e8f65fb0869e5c514c4b5fa46c5bd09f5"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#06ad339a922acb00792bda4078ac7c5585d4224c"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -3808,7 +3808,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.5",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4058,7 +4058,7 @@ dependencies = [
  "pin-project-lite",
  "rustls",
  "rustls-pki-types",
- "rustls-platform-verifier 0.7.0",
+ "rustls-platform-verifier 0.6.2",
  "serde",
  "serde_json",
  "sync_wrapper",
@@ -4244,7 +4244,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4312,7 +4312,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4333,7 +4333,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4709,7 +4709,7 @@ version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
 dependencies = [
- "dirs 6.0.0",
+ "dirs 4.0.0",
 ]
 
 [[package]]
@@ -5045,7 +5045,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5948,7 +5948,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,20 +24,20 @@ rstest = "0.26"
 
 # Shared, public-facing crates consumed from the `public-peppy-libs` repo (the
 # `peppy-shared` virtual workspace) as git dependencies, so `peppy` holds no
-# path references outside its own tree. No `branch`/`tag`/`rev` is given, so each
-# crate follows the repo's default branch (`main`); the resolved revision is
+# path references outside its own tree. Every crate names the same branch, the
+# one carrying the repo-refresh failure report; the resolved revision is
 # recorded in Cargo.lock and moved forward with `cargo update`. `config` and
 # `peppylib` are renamed via `package` (their crate names are `peppy-config-model`
 # and `peppylib-rs`), and `pmi` is the package name of the `peppy-messaging-interface`
 # directory. Per-crate features (e.g. `zenoh`, `fingerprint_test_helpers`,
 # `git_fixtures`) are added at each use site with `{ workspace = true, features = [...] }`.
-config = { git = "https://github.com/Peppy-bot/public-peppy-libs", package = "peppy-config-model" }
-peppylib = { git = "https://github.com/Peppy-bot/public-peppy-libs", package = "peppylib-rs" }
-pmi = { git = "https://github.com/Peppy-bot/public-peppy-libs" }
-core-node-api = { git = "https://github.com/Peppy-bot/public-peppy-libs" }
-json5-pretty = { git = "https://github.com/Peppy-bot/public-peppy-libs" }
-config-test-support = { git = "https://github.com/Peppy-bot/public-peppy-libs" }
-build-helpers = { git = "https://github.com/Peppy-bot/public-peppy-libs" }
+config = { git = "https://github.com/Peppy-bot/public-peppy-libs", branch = "calm-elephant", package = "peppy-config-model" }
+peppylib = { git = "https://github.com/Peppy-bot/public-peppy-libs", branch = "calm-elephant", package = "peppylib-rs" }
+pmi = { git = "https://github.com/Peppy-bot/public-peppy-libs", branch = "calm-elephant" }
+core-node-api = { git = "https://github.com/Peppy-bot/public-peppy-libs", branch = "calm-elephant" }
+json5-pretty = { git = "https://github.com/Peppy-bot/public-peppy-libs", branch = "calm-elephant" }
+config-test-support = { git = "https://github.com/Peppy-bot/public-peppy-libs", branch = "calm-elephant" }
+build-helpers = { git = "https://github.com/Peppy-bot/public-peppy-libs", branch = "calm-elephant" }
 
 # Internal workspace crates (members under `crates/`). Centralized here so each
 # member references them with `{ workspace = true }` instead of repeating a

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,20 +24,20 @@ rstest = "0.26"
 
 # Shared, public-facing crates consumed from the `public-peppy-libs` repo (the
 # `peppy-shared` virtual workspace) as git dependencies, so `peppy` holds no
-# path references outside its own tree. Every crate names the same branch, the
-# one carrying the repo-refresh failure report; the resolved revision is
+# path references outside its own tree. No `branch`/`tag`/`rev` is given, so each
+# crate follows the repo's default branch (`main`); the resolved revision is
 # recorded in Cargo.lock and moved forward with `cargo update`. `config` and
 # `peppylib` are renamed via `package` (their crate names are `peppy-config-model`
 # and `peppylib-rs`), and `pmi` is the package name of the `peppy-messaging-interface`
 # directory. Per-crate features (e.g. `zenoh`, `fingerprint_test_helpers`,
 # `git_fixtures`) are added at each use site with `{ workspace = true, features = [...] }`.
-config = { git = "https://github.com/Peppy-bot/public-peppy-libs", branch = "calm-elephant", package = "peppy-config-model" }
-peppylib = { git = "https://github.com/Peppy-bot/public-peppy-libs", branch = "calm-elephant", package = "peppylib-rs" }
-pmi = { git = "https://github.com/Peppy-bot/public-peppy-libs", branch = "calm-elephant" }
-core-node-api = { git = "https://github.com/Peppy-bot/public-peppy-libs", branch = "calm-elephant" }
-json5-pretty = { git = "https://github.com/Peppy-bot/public-peppy-libs", branch = "calm-elephant" }
-config-test-support = { git = "https://github.com/Peppy-bot/public-peppy-libs", branch = "calm-elephant" }
-build-helpers = { git = "https://github.com/Peppy-bot/public-peppy-libs", branch = "calm-elephant" }
+config = { git = "https://github.com/Peppy-bot/public-peppy-libs", package = "peppy-config-model" }
+peppylib = { git = "https://github.com/Peppy-bot/public-peppy-libs", package = "peppylib-rs" }
+pmi = { git = "https://github.com/Peppy-bot/public-peppy-libs" }
+core-node-api = { git = "https://github.com/Peppy-bot/public-peppy-libs" }
+json5-pretty = { git = "https://github.com/Peppy-bot/public-peppy-libs" }
+config-test-support = { git = "https://github.com/Peppy-bot/public-peppy-libs" }
+build-helpers = { git = "https://github.com/Peppy-bot/public-peppy-libs" }
 
 # Internal workspace crates (members under `crates/`). Centralized here so each
 # member references them with `{ workspace = true }` instead of repeating a

--- a/crates/core-node-internal/src/services/repo/refresh.rs
+++ b/crates/core-node-internal/src/services/repo/refresh.rs
@@ -164,7 +164,21 @@ impl GoalHandler for RepoRefreshGoalHandler {
                     counts.contracts,
                     counts.pairings,
                 ),
-                Ok(Ok(counts)) => RepoRefreshResult::failure(failure_report(&counts.failures)),
+                // A repository that could not be read does not fail the
+                // run. The refresh did everything it could: it published
+                // the caches, every other repository is current, and this
+                // one still serves what it last published. Reporting that
+                // as a failure takes down whatever ran the refresh, which
+                // on a fresh install is the installer itself, over a hub
+                // that was briefly unreachable. The report names them so
+                // the caller can say so and offer the retry.
+                Ok(Ok(counts)) => RepoRefreshResult::success_with_failure_report(
+                    counts.nodes,
+                    counts.launchers,
+                    counts.contracts,
+                    counts.pairings,
+                    failure_report(&counts.failures),
+                ),
                 Ok(Err(e)) => {
                     warn!("Repo refresh failed: {}", e);
                     RepoRefreshResult::failure(e.to_string())

--- a/crates/core-node-internal/tests/listen_for_repo_refresh.rs
+++ b/crates/core-node-internal/tests/listen_for_repo_refresh.rs
@@ -498,6 +498,73 @@ async fn refresh_empty_repos() {
     );
 }
 
+/// A repository that cannot be read is reported, not fatal. The run
+/// publishes the caches, the repositories that read cleanly are current,
+/// and the result names the ones that were not so the caller can offer a
+/// retry instead of stopping. Both ways a repository goes unreadable are
+/// covered: a root with no committed `peppy_repository.json5`, and a
+/// path that is not there at all (an offline git remote fails the same
+/// way, without needing a network in a test).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn refresh_reports_unreadable_repos_without_failing() {
+    let started = start_core_node_with_mock_messenger().await;
+
+    let healthy = started.peppy_dirs.root().join("healthy_repo");
+    create_node_dir(&healthy, "reachable_node", "v1");
+    common::publish_repo_index(&healthy);
+
+    // Holds a node but never published an index, so it states nothing
+    // about what it holds.
+    let unpublished = started.peppy_dirs.root().join("unpublished_repo");
+    create_node_dir(&unpublished, "unpublished_node", "v1");
+
+    let never_mounted = started.peppy_dirs.root().join("never_mounted");
+
+    write_repositories_json5(
+        &started,
+        &format!(
+            r#"[{{ "id": 1, "type": "fs", "path": "{}" }},
+                {{ "id": 2, "type": "fs", "path": "{}" }},
+                {{ "id": 3, "type": "fs", "path": "{}" }}]"#,
+            healthy.display(),
+            unpublished.display(),
+            never_mounted.display(),
+        ),
+    );
+
+    let result = send_refresh_and_wait(&started).await;
+
+    assert!(
+        result.result.success,
+        "an unreadable repository does not fail the run: {:?}",
+        result.result.error_message
+    );
+    assert_eq!(
+        result.result.total_nodes_found, 1,
+        "the readable repository still updated"
+    );
+
+    let report = &result.result.failure_report;
+    assert!(
+        report.contains("2 of the configured repositories could not be updated"),
+        "one message names every repository that failed: {report}"
+    );
+    assert!(
+        report.contains("peppy_repository.json5 is missing"),
+        "a root with no published index says so: {report}"
+    );
+    assert!(
+        report.contains("path does not exist"),
+        "a repository that is not on this machine says so: {report}"
+    );
+
+    let cache_path = nodes_repo_cache_path(&started.peppy_dirs);
+    let content = std::fs::read_to_string(&cache_path).expect("the node cache is published");
+    let entries: Vec<serde_json::Value> = serde_json5::from_str(&content).expect("parse cache");
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0]["node_name"], "reachable_node");
+}
+
 // ── Exclusion tests ──────────────────────────────────────────────
 
 /// When one of two FS repos is excluded, only nodes from the non-excluded

--- a/crates/peppy/src/commands/repo/refresh.rs
+++ b/crates/peppy/src/commands/repo/refresh.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use core_node_api::encoding::{
     RepoRefreshFeedback, RepoRefreshGoal, RepoRefreshGoalResponse, RepoRefreshResult,
 };
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::commands::action_poll::poll_action_to_completion;
 use crate::commands::node::TimeoutConfig;
@@ -90,6 +90,16 @@ async fn repo_refresh_async(ctx: &Arc<AppContext>) -> Result<()> {
         result.total_contracts_found,
         result.total_pairings_found
     );
+
+    // A repository that could not be read is not a failed command: every
+    // other repository updated, and this one still serves the entries it
+    // last published. Naming it and naming the retry is the whole
+    // response, and it is what lets an install finish on a hub that was
+    // briefly unreachable rather than stopping there.
+    if !result.failure_report.is_empty() {
+        warn!("{}", result.failure_report);
+        warn!("Run `peppy repo refresh` again to pick those repositories up.");
+    }
     Ok(())
 }
 

--- a/crates/peppy/tests/repo_refresh.rs
+++ b/crates/peppy/tests/repo_refresh.rs
@@ -57,6 +57,73 @@ fn repo_refresh_succeeds_after_adding_fs_repo() {
     );
 }
 
+/// A repository that cannot be read does not fail the command. The
+/// installer runs `repo refresh` as its last step, so a hub that is
+/// offline, or a repository root with no committed
+/// `peppy_repository.json5`, would otherwise end an install that had
+/// worked up to that point. The command reports what it could not read
+/// and leaves the user with a retry.
+#[test]
+fn repo_refresh_succeeds_when_a_repository_cannot_be_read() {
+    let (_rt, serve, ctx, _work_dir) = setup();
+
+    let healthy = tempfile::tempdir().expect("temp node dir");
+    std::fs::write(
+        healthy.path().join("peppy.json5"),
+        r#"{
+            peppy_schema: "node/v1",
+            manifest: { name: "reachable_node", tag: "v1" },
+            execution: { language: "rust", run_cmd: ["sleep", "1"] }
+        }"#,
+    )
+    .expect("write peppy.json5");
+    super::common::publish_repo_index(healthy.path());
+
+    // Never published an index, so the repository states nothing about
+    // what it holds.
+    let unpublished = tempfile::tempdir().expect("temp unpublished repo");
+    std::fs::write(
+        unpublished.path().join("peppy.json5"),
+        r#"{
+            peppy_schema: "node/v1",
+            manifest: { name: "unpublished_node", tag: "v1" },
+            execution: { language: "rust", run_cmd: ["sleep", "1"] }
+        }"#,
+    )
+    .expect("write peppy.json5");
+
+    let conf_dir = serve.temp_dir().join("conf");
+    std::fs::create_dir_all(&conf_dir).expect("create conf dir");
+    let repos_content = serde_json::to_string_pretty(&serde_json::json!([
+        { "id": 1, "type": "fs", "path": healthy.path().to_string_lossy() },
+        { "id": 2, "type": "fs", "path": unpublished.path().to_string_lossy() },
+        { "id": 3, "type": "fs", "path": serve.temp_dir().join("never_mounted").to_string_lossy() },
+    ]))
+    .expect("serialize repos");
+    std::fs::write(conf_dir.join("repositories.json5"), repos_content).expect("write repos");
+
+    let result = RepoCommand {
+        command: RepoCommands::Refresh,
+    }
+    .execute(&ctx);
+
+    assert!(
+        result.is_ok(),
+        "a repository that cannot be read must not fail the command: {:?}",
+        result.err()
+    );
+
+    // The repositories that did read are current: containment is only
+    // worth anything if the rest of the run still lands.
+    let peppy_dirs = daemon_config::consts::PeppyDirs::new(serve.temp_dir());
+    let cache = std::fs::read_to_string(core_node::nodes_repo_cache_path(&peppy_dirs))
+        .expect("the node cache should be published");
+    assert!(
+        cache.contains("reachable_node"),
+        "the readable repository still updated:\n{cache}"
+    );
+}
+
 /// A `pairing/v1` document in an fs repo is discovered by `repo refresh`
 /// and lands in the daemon's pairing cache file.
 #[test]

--- a/docs/src/content/docs/advanced_guides/repositories.mdx
+++ b/docs/src/content/docs/advanced_guides/repositories.mdx
@@ -111,13 +111,19 @@ A failure is scoped to the repository that caused it. The repositories that read
 
 A repository that fails **keeps the entries it last published**. Nothing disappears out from under a launcher that references it, and the machine keeps launching everything it could launch before. `peppy repo list` marks those entries as retained, with the date they were read.
 
-The run itself still fails, and names every repository that failed in one message, so you fix everything after one run rather than running repeatedly:
+The run itself still succeeds. A repository that could not be read is a state to report, not a reason to stop: everything the run could do, it did. It names every repository that failed in one message, so you fix everything after one run rather than running repeatedly, and ends by pointing you back at the retry:
 
 ```text
+Repository refresh complete. 26 node(s), 4 launcher(s), 8 contract(s), 2 pairing(s) found.
 2 of the configured repositories could not be updated. Every other repository was updated normally.
   - repository 1000 (https://github.com/Peppy-bot/nodes-hub.git (ref: main)) contradicts itself [conflict]: duplicate key `v1`: already declared at uvc_camera_video_reconstruction/python/peppy.json5, declared again at uvc_camera_video_reconstruction/rust/peppy.json5. Kept 18 entries from its last successful read
   - repository 1003 (https://github.com/Peppy-bot/contracts-hub.git (ref: main)) could not be read [unreachable]: failed to connect to github.com. Kept 8 entries from its last successful read
+Run `peppy repo refresh` again to pick those repositories up.
 ```
+
+This is also what lets the [installer](/guides/installation/) finish on a machine whose network is flaky. Its last step is a refresh, so a hub that happens to be unreachable used to end an install that had otherwise worked. Now the install completes, tells you which repositories it could not read, and leaves you the same retry.
+
+Only a refresh that could not run at all fails: a `repositories.json5` that does not parse or that lists the same `id` twice, or caches that cannot be written. Nothing was read in that case, so there is nothing to contain.
 
 Two kinds of failure are reported, and the distinction matters because they send you to different places:
 

--- a/docs/src/content/docs/reference/faq.mdx
+++ b/docs/src/content/docs/reference/faq.mdx
@@ -54,9 +54,9 @@ Peppy's default repositories track a moving branch, so a change merged upstream 
 </details>
 
 <details>
-<summary>Why did <code>peppy repo refresh</code> start failing, and can I still work?</summary>
+<summary>Why is <code>peppy repo refresh</code> reporting repositories it could not update, and can I still work?</summary>
 
-Yes, you can almost certainly still work. A refresh failure is scoped to the repository that caused it: every other repository is indexed as usual, and the failing one **keeps the entries it last published**, so everything that launched before still launches. The run reports failure so you know the state is not current, and names every repository that failed in one message.
+Yes, you can almost certainly still work. A refresh failure is scoped to the repository that caused it: every other repository is indexed as usual, and the failing one **keeps the entries it last published**, so everything that launched before still launches. The run itself succeeds, names every repository that failed in one message so you know which parts of the state are not current, and asks you to run `peppy repo refresh` again.
 
 Read the failure kind. `unreachable` means the repository could not be read at all: network, a bad ref, an unmounted path, or a root with no committed `peppy_repository.json5` (the fix for that last one is authoring, not waiting: run `peppy repo index` in the repository and commit the result). `conflict` means the repository was read fine but its committed index contradicts itself or the tree, and the message names what to fix.
 


### PR DESCRIPTION
## What

`peppy repo refresh` now exits 0 when it could not read some of the configured
repositories. It prints its usual summary, then warns with the report naming
every repository that was not updated and tells you to run `peppy repo refresh`
again.

## Why

`scripts/install.sh` runs a refresh as its last step. A repository that is
offline, or whose root carries no committed `peppy_repository.json5`, made that
refresh fail, which failed the whole install even though everything else had
worked.

The refresh already contains a failure to the repository that caused it: it
publishes the caches, every other repository is current, and the failing one
keeps serving the entries it last published. Reporting the run as a failure
anyway contradicted that design, and took down the caller over a hub that was
briefly unreachable.

Only a refresh that could not run at all still fails: a `repositories.json5`
that does not parse or that lists the same `id` twice, or caches that cannot be
written. Nothing was read in that case, so there is nothing to contain.

`install.sh` is unchanged. The decision belongs in the `peppy` code, and the
script's `repo update` branch still exits 1 for the cases above.

## Note

`conflict` (a repository whose committed index contradicts its tree) is
contained the same way as `unreachable`. Both are scoped to one repository by
the same mechanism, and failing the run for one but not the other would be
arbitrary. Say so if you want `conflict` to stay fatal.

## Depends on

Peppy-bot/public-peppy-libs#88, which adds the `failureReport` field the daemon
fills in. The second commit here pins the libs git dependencies to that branch
and must be reverted once it merges.

## Testing

- `cargo test -p core-node --test listen_for_repo_refresh`: new case covering a
  root with no published index and a path that is not mounted, asserting the run
  succeeds, the readable repository still updated, and the report names both.
- `cargo test -p peppy --test integration repo_`: new case asserting the command
  itself does not fail.
- Manually, against a throwaway `PEPPY_HOME` with an unpublished root, an
  unmounted path and an unresolvable git remote: every failure named, retry line
  printed, exit code 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)