### PR TITLE
Generate pairing subscriptions that tag messages with their slot identity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,7 +573,7 @@ dependencies = [
 [[package]]
 name = "build-helpers"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#ca05f12ab1b9fd70335353af160a5d5c00e84583"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#1bdb4b479f7f52571ce95c67a8b6ea0dcafa0749"
 dependencies = [
  "sha2",
 ]
@@ -765,7 +765,7 @@ dependencies = [
 [[package]]
 name = "config-test-support"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#ca05f12ab1b9fd70335353af160a5d5c00e84583"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#1bdb4b479f7f52571ce95c67a8b6ea0dcafa0749"
 dependencies = [
  "askama",
  "git2",
@@ -909,7 +909,7 @@ dependencies = [
 [[package]]
 name = "core-node-api"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#ca05f12ab1b9fd70335353af160a5d5c00e84583"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#1bdb4b479f7f52571ce95c67a8b6ea0dcafa0749"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -2581,7 +2581,7 @@ dependencies = [
 [[package]]
 name = "json5-pretty"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#ca05f12ab1b9fd70335353af160a5d5c00e84583"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#1bdb4b479f7f52571ce95c67a8b6ea0dcafa0749"
 dependencies = [
  "serde",
  "serde_json",
@@ -2589,9 +2589,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.49.5"
+version = "0.49.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da60094fc1968bbd091e2cfa004415cb7b19e25e592376e66a64aa832bb6039"
+checksum = "7e17384278234b10419a63c93fc85695ac9fc2da0833e3c59167f9986499590c"
 dependencies = [
  "ahash",
  "bytecount",
@@ -2620,18 +2620,18 @@ dependencies = [
 
 [[package]]
 name = "jsonschema-regex"
-version = "0.49.5"
+version = "0.49.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36539f34ef9e5da418433fbbf7294522d8f930ecf6a540ccd1ec6481c9ff9056"
+checksum = "ac634e339e73bf9629f6fb207f7b064d872253ae3b3f5c6e0ce8fd762b16e40f"
 dependencies = [
  "regex-syntax",
 ]
 
 [[package]]
 name = "jsonschema-value"
-version = "0.49.5"
+version = "0.49.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bc513dfee68c6fe29498451df95a32951ea227801b476f4a1f236433986c891"
+checksum = "92b8e258eb4515a3fc912a9c46e3987040dc07280592280097ea2085527870b8"
 dependencies = [
  "ahash",
  "bytecount",
@@ -3372,7 +3372,7 @@ dependencies = [
 [[package]]
 name = "peppy-config-model"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#ca05f12ab1b9fd70335353af160a5d5c00e84583"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#1bdb4b479f7f52571ce95c67a8b6ea0dcafa0749"
 dependencies = [
  "capnp",
  "clap",
@@ -3395,7 +3395,7 @@ version = "0.0.1"
 [[package]]
 name = "peppylib-rs"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#ca05f12ab1b9fd70335353af160a5d5c00e84583"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#1bdb4b479f7f52571ce95c67a8b6ea0dcafa0749"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -3590,7 +3590,7 @@ dependencies = [
 [[package]]
 name = "pmi"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#ca05f12ab1b9fd70335353af160a5d5c00e84583"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#1bdb4b479f7f52571ce95c67a8b6ea0dcafa0749"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -3984,9 +3984,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.49.5"
+version = "0.49.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05915176d843da9ec5c925e5e2631be9aa61b27430acfdd562e79cae8f559725"
+checksum = "42902112f88a27e9afd5683e2ba31956fed2a5d43395f166dd26775ae9c0dedb"
 dependencies = [
  "ahash",
  "fluent-uri",
@@ -6835,18 +6835,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/core-node-internal/src/services/clock.rs
+++ b/crates/core-node-internal/src/services/clock.rs
@@ -118,7 +118,7 @@ fn handle_clock_request_inner(
     context: &ServiceRequestContext,
     server_recv_time: u64,
 ) -> Result<Payload> {
-    let request = ClockRequest::decode(context.message().payload().as_ref())?;
+    let request = ClockRequest::decode(context.message().payload_bytes().as_ref())?;
 
     debug!(
         "Received clock request from {}, t0={}",
@@ -338,7 +338,7 @@ pub async fn subscribe_external_clock(
                     None => break,
                 },
             };
-            match ClockTick::decode(message.payload().as_ref()) {
+            match ClockTick::decode(message.payload_bytes().as_ref()) {
                 Ok(tick) => {
                     // `0` is reserved as "not ready"; a simulator publishing
                     // a literal zero would be a bug, and clamping it to 1 is a

--- a/crates/core-node-internal/src/services/datastore.rs
+++ b/crates/core-node-internal/src/services/datastore.rs
@@ -195,7 +195,7 @@ pub async fn listen_for_datastore_remove(
 }
 
 fn handle_store_request(store: &Datastore, context: &ServiceRequestContext) -> Result<Payload> {
-    let request = DatastoreStoreRequest::decode(context.message().payload().as_ref())?;
+    let request = DatastoreStoreRequest::decode(context.message().payload_bytes().as_ref())?;
     let last_modified_by = context.message().instance_id().to_owned();
 
     debug!(
@@ -217,7 +217,7 @@ fn handle_store_request(store: &Datastore, context: &ServiceRequestContext) -> R
 }
 
 fn handle_get_request(store: &Datastore, context: &ServiceRequestContext) -> Result<Payload> {
-    let request = DatastoreGetRequest::decode(context.message().payload().as_ref())?;
+    let request = DatastoreGetRequest::decode(context.message().payload_bytes().as_ref())?;
 
     debug!(
         "Received datastore get request from {} for key {:?}",
@@ -237,7 +237,7 @@ fn handle_get_request(store: &Datastore, context: &ServiceRequestContext) -> Res
 
 fn handle_list_request(store: &Datastore, context: &ServiceRequestContext) -> Result<Payload> {
     // Decode to validate the (empty) request shape before answering.
-    DatastoreListRequest::decode(context.message().payload().as_ref())?;
+    DatastoreListRequest::decode(context.message().payload_bytes().as_ref())?;
 
     let entries = store.list();
 
@@ -253,7 +253,7 @@ fn handle_list_request(store: &Datastore, context: &ServiceRequestContext) -> Re
 }
 
 fn handle_remove_request(store: &Datastore, context: &ServiceRequestContext) -> Result<Payload> {
-    let request = DatastoreRemoveRequest::decode(context.message().payload().as_ref())?;
+    let request = DatastoreRemoveRequest::decode(context.message().payload_bytes().as_ref())?;
 
     let removed = store.remove(request.key.as_str());
 

--- a/crates/core-node-internal/src/services/federation/service.rs
+++ b/crates/core-node-internal/src/services/federation/service.rs
@@ -122,7 +122,7 @@ async fn reserve_inner(
     request: &ServiceRequestContext,
     context: &FederationServiceContext,
 ) -> Result<Payload> {
-    let decoded = ParticipantReserveRequest::decode(request.message().payload().as_ref())?;
+    let decoded = ParticipantReserveRequest::decode(request.message().payload_bytes().as_ref())?;
 
     debug!(
         "Received `participant_reserve` for launch `{}` from coordinator `{}`",
@@ -324,7 +324,7 @@ async fn slice_begin_inner(
     request: &ServiceRequestContext,
     context: &FederationServiceContext,
 ) -> Result<Payload> {
-    let decoded = ParticipantSliceBeginRequest::decode(request.message().payload().as_ref())?;
+    let decoded = ParticipantSliceBeginRequest::decode(request.message().payload_bytes().as_ref())?;
 
     let Some((held_launch, coordinator)) = context.ownership.held_reservation() else {
         return ParticipantSliceBeginResponse::refused(format!(
@@ -392,7 +392,7 @@ async fn pair_commit_inner(
     request: &ServiceRequestContext,
     context: &FederationServiceContext,
 ) -> Result<Payload> {
-    let decoded = PairCommitRequest::decode(request.message().payload().as_ref())?;
+    let decoded = PairCommitRequest::decode(request.message().payload_bytes().as_ref())?;
 
     debug!(
         "Received `pair_commit` for `{}`:`{}` with `{}` on `{}`",
@@ -418,7 +418,7 @@ async fn release_inner(
     request: &ServiceRequestContext,
     context: &FederationServiceContext,
 ) -> Result<Payload> {
-    let decoded = ParticipantReleaseRequest::decode(request.message().payload().as_ref())?;
+    let decoded = ParticipantReleaseRequest::decode(request.message().payload_bytes().as_ref())?;
 
     let response = if context.ownership.release(&decoded.launch_id) {
         debug!("Released reservation for launch `{}`", decoded.launch_id);
@@ -448,7 +448,7 @@ async fn notify_inner(
     request: &ServiceRequestContext,
     context: &FederationServiceContext,
 ) -> Result<Payload> {
-    let decoded = RelationshipNotification::decode(request.message().payload().as_ref())?;
+    let decoded = RelationshipNotification::decode(request.message().payload_bytes().as_ref())?;
 
     debug!(
         "Received `relationship_notify` for `{}` on `{}`: {:?}",

--- a/crates/core-node-internal/src/services/health.rs
+++ b/crates/core-node-internal/src/services/health.rs
@@ -55,7 +55,7 @@ fn handle_health_request_inner(
     start_time: Instant,
 ) -> Result<Payload> {
     let sender_instance_id = context.message().instance_id();
-    let payload = context.message().payload();
+    let payload = context.message().payload_bytes();
 
     HealthRequest::decode(payload.as_ref())?;
 

--- a/crates/core-node-internal/src/services/info.rs
+++ b/crates/core-node-internal/src/services/info.rs
@@ -91,7 +91,7 @@ fn handle_info_request_inner(
     messaging_port: u16,
 ) -> Result<Payload> {
     let sender_instance_id = context.message().instance_id();
-    let payload = context.message().payload();
+    let payload = context.message().payload_bytes();
 
     let _request = InfoRequest::decode(payload.as_ref())?;
 

--- a/crates/core-node-internal/src/services/node/info.rs
+++ b/crates/core-node-internal/src/services/node/info.rs
@@ -106,7 +106,7 @@ async fn handle_node_info_request_inner(
     peppy_dirs: PeppyDirs,
 ) -> std::result::Result<Payload, InfoError> {
     let sender_instance_id = context.message().instance_id();
-    let payload = context.message().payload();
+    let payload = context.message().payload_bytes();
 
     let request = NodeInfoRequest::decode(payload.as_ref()).map_err(|e| format!("{}", e))?;
 

--- a/crates/core-node-internal/src/services/node/init.rs
+++ b/crates/core-node-internal/src/services/node/init.rs
@@ -56,7 +56,7 @@ fn handle_node_init_request_inner(
     peppy_dirs: &PeppyDirs,
 ) -> Result<Payload> {
     let sender_instance_id = context.message().instance_id();
-    let payload = context.message().payload();
+    let payload = context.message().payload_bytes();
 
     let request = NodeInitRequest::decode(payload.as_ref())?;
     let toolchain = request.toolchain;

--- a/crates/core-node-internal/src/services/node/observation.rs
+++ b/crates/core-node-internal/src/services/node/observation.rs
@@ -31,7 +31,7 @@ use node_stack::NodeStack;
 use peppylib::MessengerHandle;
 use peppylib::encoding::observation_update::ObservationUpdateRequest;
 use peppylib::messaging::{
-    OBSERVATION_UPDATE_SERVICE, ObservationPin, ObservedMemberState, ProducerRef,
+    OBSERVATION_UPDATE_SERVICE, ObservedMemberState, ObservedSource, ProducerRef,
 };
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::sync::Arc;
@@ -49,6 +49,11 @@ const OBSERVATION_UPDATE_TIMEOUT: Duration = Duration::from_secs(5);
 /// instances, so the pair is the identity: keying the registry on the instance
 /// id alone would let a local `wrist_cam_inst` and a remote one share an
 /// incarnation counter and cross-deliver each other's pins.
+///
+/// Deliberately coarser than the [`ObservedSource`] it is derived from, which
+/// also carries the producer-side link_id: an incarnation counter belongs to
+/// the source instance, so an instance observed through two of its own pairing
+/// slots must advance one counter, not two.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 struct SourceKey {
     core_node: String,
@@ -77,7 +82,7 @@ impl SourceKey {
 #[derive(Debug, Clone)]
 struct ObserverRecord {
     observer_link_id: String,
-    pin: ObservationPin,
+    pin: ObservedSource,
 }
 
 impl ObserverRecord {
@@ -197,7 +202,7 @@ impl ObservationCoordinator {
                 &obs.observer_instance_id,
                 ObserverRecord {
                     observer_link_id: obs.observer_link_id.clone(),
-                    pin: ObservationPin {
+                    pin: ObservedSource {
                         producer: obs.source.clone(),
                         source_link_id: obs.source_link_id.clone(),
                     },
@@ -235,7 +240,7 @@ impl ObservationCoordinator {
                     observer_instance_id,
                     ObserverRecord {
                         observer_link_id: observer_link_id.clone(),
-                        pin: ObservationPin {
+                        pin: ObservedSource {
                             producer: target.source.clone(),
                             source_link_id: target.source_link_id.clone(),
                         },

--- a/crates/core-node-internal/src/services/node/pairing.rs
+++ b/crates/core-node-internal/src/services/node/pairing.rs
@@ -26,7 +26,7 @@ use daemon_config::launcher::{
 use node_stack::{NodeStack, Pairing, PairingNodeSnapshot, RemoteSlotMeta, SlotAddr};
 use peppylib::MessengerHandle;
 use peppylib::encoding::peer_update::PeerUpdateRequest;
-use peppylib::messaging::{PEER_UPDATE_SERVICE, PeerPin, ProducerRef};
+use peppylib::messaging::{PEER_UPDATE_SERVICE, PeerInfo, ProducerRef};
 use std::sync::Arc;
 use std::time::Duration;
 use tracing::{debug, warn};
@@ -205,7 +205,7 @@ impl PairingCoordinator {
                 {
                     continue;
                 }
-                let pin = PeerPin {
+                let pin = PeerInfo {
                     // The peer's OWN core node, not this daemon's: a pin names
                     // where the peer actually runs, and for a cross-daemon pair
                     // those differ.
@@ -340,7 +340,7 @@ impl PairingCoordinator {
             .pair_slot_with_remote(&local, &remote, &remote_meta)
             .map_err(|e| e.to_string())?;
 
-        let pin = PeerPin {
+        let pin = PeerInfo {
             producer: request.peer.clone(),
             peer_link_id: request.peer_link_id.clone(),
         };
@@ -443,7 +443,7 @@ impl PairingCoordinator {
     async fn send_peer_update(
         &self,
         slot: &SlotAddr,
-        pin: Option<PeerPin>,
+        pin: Option<PeerInfo>,
     ) -> std::result::Result<(), String> {
         let request = PeerUpdateRequest {
             link_id: slot.link_id.clone(),

--- a/crates/core-node-internal/src/services/node/remove.rs
+++ b/crates/core-node-internal/src/services/node/remove.rs
@@ -91,7 +91,7 @@ async fn handle_node_remove_request_inner(
     relationships: &RelationshipCoordinators,
 ) -> Result<Payload> {
     let sender_instance_id = context.message().instance_id();
-    let payload = context.message().payload();
+    let payload = context.message().payload_bytes();
 
     let request = NodeRemoveRequest::decode(payload.as_ref())?;
 

--- a/crates/core-node-internal/src/services/node/stop.rs
+++ b/crates/core-node-internal/src/services/node/stop.rs
@@ -100,7 +100,7 @@ async fn handle_node_stop_request_inner(
     relationships: &RelationshipCoordinators,
 ) -> Result<Payload> {
     let sender_instance_id = context.message().instance_id();
-    let payload = context.message().payload();
+    let payload = context.message().payload_bytes();
 
     let request = NodeStopRequest::decode(payload.as_ref())?;
 

--- a/crates/core-node-internal/src/services/node/sync.rs
+++ b/crates/core-node-internal/src/services/node/sync.rs
@@ -73,7 +73,7 @@ async fn handle_node_sync_request_inner(
     peppy_dirs: PeppyDirs,
 ) -> Result<Payload> {
     let sender_instance_id = context.message().instance_id();
-    let payload = context.message().payload();
+    let payload = context.message().payload_bytes();
 
     let request = NodeSyncRequest::decode(payload.as_ref())?;
 

--- a/crates/core-node-internal/src/services/repo/add.rs
+++ b/crates/core-node-internal/src/services/repo/add.rs
@@ -55,7 +55,7 @@ fn handle_repo_add_request_inner(
     peppy_dirs: &PeppyDirs,
 ) -> Result<Payload> {
     let sender_instance_id = context.message().instance_id();
-    let payload = context.message().payload();
+    let payload = context.message().payload_bytes();
 
     let request = RepoAddRequest::decode(payload.as_ref())?;
 

--- a/crates/core-node-internal/src/services/repo/exclude.rs
+++ b/crates/core-node-internal/src/services/repo/exclude.rs
@@ -159,7 +159,7 @@ fn handle_repo_exclude_request_inner(
     peppy_dirs: &PeppyDirs,
 ) -> Result<(RepoExcludeResponse, bool)> {
     let sender_instance_id = context.message().instance_id();
-    let payload = context.message().payload();
+    let payload = context.message().payload_bytes();
 
     let request = RepoExcludeRequest::decode(payload.as_ref())?;
 

--- a/crates/core-node-internal/src/services/repo/list.rs
+++ b/crates/core-node-internal/src/services/repo/list.rs
@@ -68,7 +68,7 @@ fn handle_repo_list_request_inner(
     context: &ServiceRequestContext,
     peppy_dirs: &PeppyDirs,
 ) -> Result<Payload> {
-    let payload = context.message().payload();
+    let payload = context.message().payload_bytes();
     let _request = RepoListRequest::decode(payload.as_ref())?;
 
     let repos = match read_or_create_repos(peppy_dirs) {

--- a/crates/core-node-internal/src/services/repo/remove.rs
+++ b/crates/core-node-internal/src/services/repo/remove.rs
@@ -66,7 +66,7 @@ fn handle_repo_remove_request_inner(
     peppy_dirs: &PeppyDirs,
 ) -> Result<(RepoRemoveResponse, bool)> {
     let sender_instance_id = context.message().instance_id();
-    let payload = context.message().payload();
+    let payload = context.message().payload_bytes();
 
     let request = RepoRemoveRequest::decode(payload.as_ref())?;
 

--- a/crates/core-node-internal/src/services/stack/benchmark.rs
+++ b/crates/core-node-internal/src/services/stack/benchmark.rs
@@ -938,7 +938,7 @@ async fn poll_producer_offset(
         )
         .await;
         let Ok(reply) = reply else { continue };
-        let Ok(decoded) = ClockOffsetResponse::decode(reply.payload().as_ref()) else {
+        let Ok(decoded) = ClockOffsetResponse::decode(reply.payload_bytes().as_ref()) else {
             continue;
         };
         let sample = (decoded.offset_ns, decoded.round_trip_delay_ns);

--- a/crates/core-node-internal/src/services/stack/launch/federated/dispatch.rs
+++ b/crates/core-node-internal/src/services/stack/launch/federated/dispatch.rs
@@ -213,7 +213,7 @@ pub(in crate::services::stack) async fn run_remote_goal<G: RemoteGoal>(
             match tokio::time::timeout_at(wake_at, handle.on_next_feedback()).await {
                 Ok(Ok(message)) => {
                     last_activity = tokio::time::Instant::now();
-                    if let Some(line) = G::decode_feedback_line(message.payload().as_ref()) {
+                    if let Some(line) = G::decode_feedback_line(message.payload_bytes().as_ref()) {
                         publish_stdout(ctx, format!("[{core_node}] {line}"), G::STEP).await;
                     }
                 }

--- a/crates/core-node-internal/src/services/stack/list.rs
+++ b/crates/core-node-internal/src/services/stack/list.rs
@@ -74,7 +74,7 @@ fn handle_node_list_request_inner(
     ownership: &crate::services::federation::SliceOwnership,
 ) -> Result<Payload> {
     let sender_instance_id = context.message().instance_id();
-    let payload = context.message().payload();
+    let payload = context.message().payload_bytes();
 
     let _request = StackListRequest::decode(payload.as_ref())?;
 

--- a/crates/core-node-internal/src/services/stack/reset.rs
+++ b/crates/core-node-internal/src/services/stack/reset.rs
@@ -124,7 +124,7 @@ async fn handle_stack_reset_request_inner(
     ownership: &crate::services::federation::SliceOwnership,
 ) -> Result<Payload> {
     let sender_instance_id = context.message().instance_id();
-    let payload = context.message().payload();
+    let payload = context.message().payload_bytes();
 
     let _request = StackResetRequest::decode(payload.as_ref())?;
 

--- a/crates/generator-internal/src/generator/python/tests/pairings.rs
+++ b/crates/generator-internal/src/generator/python/tests/pairings.rs
@@ -4,7 +4,7 @@
 //! binding-slot involvement.
 
 use super::*;
-use config::node::NativeEmittedTopic;
+use config::node::{Cardinality, NativeEmittedTopic};
 
 const JOINT_STATES: &str = r#"
 {
@@ -87,6 +87,10 @@ fn peer_consumed_topic_wraps_subscribe_peer_without_binding_slots() {
         "PAIRING_TAG,",
         "TOPIC_NAME,",
         "class Subscription:",
+        // The tagged pair: the same PeerInfo that paired() returns.
+        "async def next(self) -> Optional[Tuple[peppylib.PeerInfo, Message]]:",
+        "peer, raw_message = item",
+        "return peer, message",
         "async def wait_paired(",
         "_deserialize_payload",
     ] {
@@ -95,6 +99,44 @@ fn peer_consumed_topic_wraps_subscribe_peer_without_binding_slots() {
     assert!(
         !code.contains("bound_producer") && !code.contains("TopicMessenger.subscribe("),
         "peer subscriptions must ride subscribe_peer, not the binding-slot path:\n{code}"
+    );
+    assert!(
+        !code.contains("ProducerRef"),
+        "a peer module tags every message with PeerInfo:\n{code}"
+    );
+}
+
+#[test]
+fn observed_consumed_topic_yields_observed_source_tagged_pairs() {
+    let topic = parse_topic(JOINT_STATES);
+    let mut generator = PythonGenerator::new();
+    generator
+        .add_observed_topic(&topic, &peer_context(), Cardinality::ZeroOrMore)
+        .unwrap();
+    let artifacts = generator.into_artifacts();
+    assert_eq!(artifacts.len(), 1);
+    let artifact = &artifacts[0];
+    assert_eq!(artifact.kind, InterfaceKind::ObservedTopic);
+
+    let code = &artifact.code_output;
+    for needle in [
+        "node_runner.subscribe_observed(",
+        "class Subscription:",
+        // The tagged pair: the full member identity, so members sharing one
+        // instance stay distinct.
+        "async def next(self) -> Optional[Tuple[peppylib.ObservedSource, Message]]:",
+        "source, raw_message = item",
+        "return source, message",
+        "async def __anext__(self) -> Tuple[peppylib.ObservedSource, Message]:",
+        // The multi-cardinality slot accessor speaks the same type.
+        "def sources(",
+        "_deserialize_payload",
+    ] {
+        assert!(code.contains(needle), "missing `{needle}` in:\n{code}");
+    }
+    assert!(
+        !code.contains("ProducerRef"),
+        "an observer module tags every message with ObservedSource:\n{code}"
     );
 }
 

--- a/crates/generator-internal/src/generator/python/tests/pairings.rs
+++ b/crates/generator-internal/src/generator/python/tests/pairings.rs
@@ -80,22 +80,22 @@ fn peer_consumed_topic_wraps_subscribe_peer_without_binding_slots() {
     assert_eq!(artifact.kind, InterfaceKind::PeerConsumedTopic);
 
     let code = &artifact.code_output;
-    for needle in [
-        "node_runner.subscribe_peer(",
-        "LINK_ID,",
-        "PAIRING_NAME,",
-        "PAIRING_TAG,",
-        "TOPIC_NAME,",
-        "class Subscription:",
-        // The tagged pair: the same PeerInfo that paired() returns.
-        "async def next(self) -> Optional[Tuple[peppylib.PeerInfo, Message]]:",
-        "peer, raw_message = item",
-        "return peer, message",
-        "async def wait_paired(",
-        "_deserialize_payload",
-    ] {
-        assert!(code.contains(needle), "missing `{needle}` in:\n{code}");
-    }
+    assert_contains_all(
+        code,
+        &[
+            "node_runner.subscribe_peer(",
+            "LINK_ID,",
+            "PAIRING_NAME,",
+            "PAIRING_TAG,",
+            "TOPIC_NAME,",
+            "class Subscription:",
+            // The tagged pair: the same PeerInfo that paired() returns.
+            "async def next(self) -> Optional[Tuple[peppylib.PeerInfo, Message]]:",
+            "return peer, message",
+            "async def wait_paired(",
+            "_deserialize_payload",
+        ],
+    );
     assert!(
         !code.contains("bound_producer") && !code.contains("TopicMessenger.subscribe("),
         "peer subscriptions must ride subscribe_peer, not the binding-slot path:\n{code}"
@@ -119,21 +119,21 @@ fn observed_consumed_topic_yields_observed_source_tagged_pairs() {
     assert_eq!(artifact.kind, InterfaceKind::ObservedTopic);
 
     let code = &artifact.code_output;
-    for needle in [
-        "node_runner.subscribe_observed(",
-        "class Subscription:",
-        // The tagged pair: the full member identity, so members sharing one
-        // instance stay distinct.
-        "async def next(self) -> Optional[Tuple[peppylib.ObservedSource, Message]]:",
-        "source, raw_message = item",
-        "return source, message",
-        "async def __anext__(self) -> Tuple[peppylib.ObservedSource, Message]:",
-        // The multi-cardinality slot accessor speaks the same type.
-        "def sources(",
-        "_deserialize_payload",
-    ] {
-        assert!(code.contains(needle), "missing `{needle}` in:\n{code}");
-    }
+    assert_contains_all(
+        code,
+        &[
+            "node_runner.subscribe_observed(",
+            "class Subscription:",
+            // The tagged pair: the full member identity, so members sharing one
+            // instance stay distinct.
+            "async def next(self) -> Optional[Tuple[peppylib.ObservedSource, Message]]:",
+            "return source, message",
+            "async def __anext__(self) -> Tuple[peppylib.ObservedSource, Message]:",
+            // The multi-cardinality slot accessor speaks the same type.
+            "def sources(",
+            "_deserialize_payload",
+        ],
+    );
     assert!(
         !code.contains("ProducerRef"),
         "an observer module tags every message with ObservedSource:\n{code}"

--- a/crates/generator-internal/src/generator/python/topics.rs
+++ b/crates/generator-internal/src/generator/python/topics.rs
@@ -91,24 +91,44 @@ fn emit_build_message_fn(
     builder.blank_line();
 }
 
-/// How the held-`Subscription` class receives its next `(producer,
-/// message)` pair: a bound-set subscription yields the pair pre-tagged by
-/// the source that delivered it, while a peer subscription yields the raw
-/// message alone and the producer is read off its headers.
-pub(crate) enum SubscriptionYield {
-    TaggedPair,
-    RawMessage,
+/// The per-message identity tag a held-`Subscription`'s `next()` yields
+/// alongside the decoded message: each module kind tags with its slot
+/// accessor's own identity type, received pre-tagged from the inner
+/// subscription.
+pub(crate) enum SubscriptionTag {
+    /// `(peppylib.ProducerRef, message)`: bound-set consumer modules.
+    Producer,
+    /// `(peppylib.PeerInfo, message)`: peer pairing modules.
+    Peer,
+    /// `(peppylib.ObservedSource, message)`: observer modules.
+    ObservedSource,
 }
 
-/// Emits the held-`Subscription` class shared by the bound-set and peer
-/// consumer modules; the docstring and the receive step differ. `next()`
-/// mirrors the Rust `Subscription::next`: a `(producer, message)` tuple, or
-/// `None` once the subscription has closed.
-fn emit_subscription_class(
-    builder: &mut PythonCodeBuilder,
-    docstring: &str,
-    yields: SubscriptionYield,
-) {
+impl SubscriptionTag {
+    fn annotation(&self) -> &'static str {
+        match self {
+            Self::Producer => "peppylib.ProducerRef",
+            Self::Peer => "peppylib.PeerInfo",
+            Self::ObservedSource => "peppylib.ObservedSource",
+        }
+    }
+
+    fn binding(&self) -> &'static str {
+        match self {
+            Self::Producer => "producer",
+            Self::Peer => "peer",
+            Self::ObservedSource => "source",
+        }
+    }
+}
+
+/// Emits the held-`Subscription` class shared by the bound-set, peer, and
+/// observer consumer modules; the docstring and the identity tag differ.
+/// `next()` mirrors the Rust `Subscription::next`: a `(tag, message)` tuple,
+/// or `None` once the subscription has closed.
+fn emit_subscription_class(builder: &mut PythonCodeBuilder, docstring: &str, tag: SubscriptionTag) {
+    let annotation = tag.annotation();
+    let binding = tag.binding();
     builder.line("class Subscription:");
     builder.indent();
     builder.line(&format!("\"\"\"{docstring}\"\"\""));
@@ -118,28 +138,18 @@ fn emit_subscription_class(
     builder.line("self._inner = inner");
     builder.dedent();
     builder.blank_line();
-    builder.line("async def next(self) -> Optional[Tuple[peppylib.ProducerRef, Message]]:");
+    builder.line(&format!(
+        "async def next(self) -> Optional[Tuple[{annotation}, Message]]:"
+    ));
     builder.indent();
-    match yields {
-        SubscriptionYield::TaggedPair => {
-            builder.line("item = await self._inner.on_next_message()");
-            builder.line("if item is None:");
-            builder.indent();
-            builder.line("return None");
-            builder.dedent();
-            builder.line("producer, raw_message = item");
-        }
-        SubscriptionYield::RawMessage => {
-            builder.line("raw_message = await self._inner.on_next_message()");
-            builder.line("if raw_message is None:");
-            builder.indent();
-            builder.line("return None");
-            builder.dedent();
-            builder.line("producer = raw_message.producer");
-        }
-    }
+    builder.line("item = await self._inner.on_next_message()");
+    builder.line("if item is None:");
+    builder.indent();
+    builder.line("return None");
+    builder.dedent();
+    builder.line(&format!("{binding}, raw_message = item"));
     builder.line("message = _deserialize_payload(raw_message.payload)");
-    builder.line("return producer, message");
+    builder.line(&format!("return {binding}, message"));
     builder.dedent();
     builder.blank_line();
     builder.line("def __aiter__(self) -> \"Subscription\":");
@@ -147,7 +157,9 @@ fn emit_subscription_class(
     builder.line("return self");
     builder.dedent();
     builder.blank_line();
-    builder.line("async def __anext__(self) -> Tuple[peppylib.ProducerRef, Message]:");
+    builder.line(&format!(
+        "async def __anext__(self) -> Tuple[{annotation}, Message]:"
+    ));
     builder.indent();
     builder.line("result = await self.next()");
     builder.line("if result is None:");
@@ -420,12 +432,12 @@ pub fn build_pair_topic_consumer(
     );
 
     let qos = qos_profile_python(&topic.qos_profile);
-    let (subscription_doc, subscription_yield, subscribe_doc, subscribe_method) = match kind {
+    let (subscription_doc, subscription_tag, subscribe_doc, subscribe_method) = match kind {
         PairTopicConsumerKind::Peer => {
             emit_peer_module_header(&mut builder, &topic.name, qos, peer);
             (
-                "A held subscription that follows the slot's live pin: silent while unpaired, only the paired peer while paired.",
-                SubscriptionYield::RawMessage,
+                "A held subscription that follows the slot's live pin: silent while unpaired, only the paired peer while paired. Each message is tagged with the PeerInfo of the paired peer, the same identity paired() returns.",
+                SubscriptionTag::Peer,
                 "\"\"\"Subscribe to this pairing topic. Legal while unpaired: the subscription stays silent until a peer pairs.\"\"\"",
                 "subscribe_peer",
             )
@@ -433,15 +445,15 @@ pub fn build_pair_topic_consumer(
         PairTopicConsumerKind::Observed(cardinality) => {
             emit_observer_module_header(&mut builder, &topic.name, qos, peer, cardinality);
             (
-                "A held subscription fanned in across the observer slot's whole member set: silent until a member is live and emitting; a live stream, not a mailbox. Each message is tagged with the member that published it.",
-                SubscriptionYield::TaggedPair,
+                "A held subscription fanned in across the observer slot's whole member set: silent until a member is live and emitting; a live stream, not a mailbox. Each message is tagged with the ObservedSource that published it, the same identity the slot's accessors enumerate, so members stay distinct even when they share one instance.",
+                SubscriptionTag::ObservedSource,
                 "\"\"\"Subscribe to this observed pairing topic. Legal before any source is resolved or live: the subscription stays silent until a member emits.\"\"\"",
                 "subscribe_observed",
             )
         }
     };
 
-    emit_subscription_class(&mut builder, subscription_doc, subscription_yield);
+    emit_subscription_class(&mut builder, subscription_doc, subscription_tag);
 
     builder.blank_line();
     builder.line("async def subscribe(node_runner: peppylib.NodeRunner) -> Subscription:");
@@ -522,7 +534,7 @@ pub fn build_consumed_topic(
 Per-producer order is preserved (no total order across producers), ready \
 producers are merged fairly, and the bound set is fixed at startup; filter \
 on the yielded producer to follow a single member.",
-        SubscriptionYield::TaggedPair,
+        SubscriptionTag::Producer,
     );
 
     builder.blank_line();

--- a/crates/generator-internal/src/generator/python/topics.rs
+++ b/crates/generator-internal/src/generator/python/topics.rs
@@ -5,7 +5,7 @@ use super::serialization;
 use super::services::sender_target_python_expr;
 use super::type_mapping::{collect_fields_from_format, qos_profile_python, uses_optional};
 use crate::error::Result;
-use crate::generator::types::PairTopicConsumerKind;
+use crate::generator::types::{PairTopicConsumerKind, SubscriptionTag};
 use config::node::{Cardinality, ConsumedTopic, MessageFormat, NativeEmittedTopic};
 
 pub(crate) fn capnp_loader_fn_name(schema_info: &PythonSchemaInfo) -> String {
@@ -91,34 +91,12 @@ fn emit_build_message_fn(
     builder.blank_line();
 }
 
-/// The per-message identity tag a held-`Subscription`'s `next()` yields
-/// alongside the decoded message: each module kind tags with its slot
-/// accessor's own identity type, received pre-tagged from the inner
-/// subscription.
-pub(crate) enum SubscriptionTag {
-    /// `(peppylib.ProducerRef, message)`: bound-set consumer modules.
-    Producer,
-    /// `(peppylib.PeerInfo, message)`: peer pairing modules.
-    Peer,
-    /// `(peppylib.ObservedSource, message)`: observer modules.
-    ObservedSource,
-}
-
-impl SubscriptionTag {
-    fn annotation(&self) -> &'static str {
-        match self {
-            Self::Producer => "peppylib.ProducerRef",
-            Self::Peer => "peppylib.PeerInfo",
-            Self::ObservedSource => "peppylib.ObservedSource",
-        }
-    }
-
-    fn binding(&self) -> &'static str {
-        match self {
-            Self::Producer => "producer",
-            Self::Peer => "peer",
-            Self::ObservedSource => "source",
-        }
+/// The tag's Python type annotation, spliced into `next()`'s signature.
+fn tag_annotation(tag: SubscriptionTag) -> &'static str {
+    match tag {
+        SubscriptionTag::Producer => "peppylib.ProducerRef",
+        SubscriptionTag::Peer => "peppylib.PeerInfo",
+        SubscriptionTag::ObservedSource => "peppylib.ObservedSource",
     }
 }
 
@@ -127,7 +105,7 @@ impl SubscriptionTag {
 /// `next()` mirrors the Rust `Subscription::next`: a `(tag, message)` tuple,
 /// or `None` once the subscription has closed.
 fn emit_subscription_class(builder: &mut PythonCodeBuilder, docstring: &str, tag: SubscriptionTag) {
-    let annotation = tag.annotation();
+    let annotation = tag_annotation(tag);
     let binding = tag.binding();
     builder.line("class Subscription:");
     builder.indent();
@@ -397,7 +375,7 @@ fn emit_observer_module_header(
 /// subscription that follows the slot's live pin (silent while unpaired, only
 /// the paired peer while paired); a [`PairTopicConsumerKind::Observed`] slot
 /// gets a `subscribe_observed`-backed one that follows each observed source
-/// instance's lifecycle and yields `(producer, message)`. An observer plays no
+/// instance's lifecycle and yields `(source, message)`. An observer plays no
 /// role, so it has no publisher.
 pub fn build_pair_topic_consumer(
     topic: &NativeEmittedTopic,

--- a/crates/generator-internal/src/generator/rust.rs
+++ b/crates/generator-internal/src/generator/rust.rs
@@ -538,7 +538,7 @@ impl RustGenerator {
                     timeout,
                 )
                 .await?;
-                let state = match peppylib::messaging::decode_cancel_ack(response.payload().as_ref())? {
+                let state = match peppylib::messaging::decode_cancel_ack(response.payload_bytes().as_ref())? {
                     peppylib::messaging::CancelState::Signalled => #state_ident::Signalled,
                     peppylib::messaging::CancelState::AlreadyTerminal => #state_ident::AlreadyTerminal,
                     peppylib::messaging::CancelState::Unknown => #state_ident::Unknown,
@@ -638,7 +638,7 @@ impl RustGenerator {
                 &mut self,
             ) -> crate::Result<#struct_ident> {
                 let feedback = self.inner.on_next_feedback().await?;
-                let payload = feedback.payload();
+                let payload = feedback.payload_bytes();
                 #helper_fn_ident(payload.as_ref())
             }
         };
@@ -1432,8 +1432,8 @@ impl LanguageGenerator for RustGenerator {
                     .add_metadata_struct(response_struct_ident.clone(), Some(&response_data_ident));
 
                 let response_tokens = quote! {
-                    let payload = response_message.payload();
-                    let response_data = deserialize_response(&payload)?;
+                    let payload = response_message.payload_bytes();
+                    let response_data = deserialize_response(payload.as_ref())?;
                     Ok(#response_struct_ident {
                         instance_id: response_message.instance_id().to_string(),
                         core_node: response_message.core_node().to_string(),

--- a/crates/generator-internal/src/generator/rust/services.rs
+++ b/crates/generator-internal/src/generator/rust/services.rs
@@ -296,10 +296,10 @@ pub fn build_exposed_service_method(
         // instance_from_request_context without use_service_name_const (preserves
         // existing generated code shape).
         if has_payload || (instance_from_request_context && !use_service_name_const) {
-            call_preamble.push(quote!(let payload = message.payload();));
+            call_preamble.push(quote!(let payload = message.payload_bytes();));
         }
     } else if has_payload {
-        call_preamble.push(quote!(let payload = #request_context_ident.message().payload();));
+        call_preamble.push(quote!(let payload = #request_context_ident.message().payload_bytes();));
     }
 
     if has_payload {

--- a/crates/generator-internal/src/generator/rust/tests/pairings.rs
+++ b/crates/generator-internal/src/generator/rust/tests/pairings.rs
@@ -4,7 +4,7 @@
 //! any binding-slot involvement.
 
 use super::*;
-use config::node::NativeEmittedTopic;
+use config::node::{Cardinality, NativeEmittedTopic};
 
 const JOINT_COMMANDS: &str = r#"
 {
@@ -102,10 +102,12 @@ fn peer_consumed_topic_wraps_subscribe_peer_without_binding_slots() {
             "PAIRING_NAME",
             "PAIRING_TAG",
             "TOPIC_NAME",
-            // The held-subscription surface, yielding (producer, Message).
+            // The held-subscription surface, yielding (peer, Message).
             "pub struct Subscription",
-            "peppylib::runtime::PeerSubscription",
-            "peppylib::messaging::ProducerRef",
+            "inner: peppylib::runtime::PeerSubscription",
+            "-> crate::Result<Option<(peppylib::messaging::PeerInfo, Message)>>",
+            "let Some((peer, message)) = self.inner.on_next_message().await",
+            "Ok(Some((peer, message)))",
             "pub async fn wait_paired(",
         ],
     );
@@ -118,6 +120,52 @@ fn peer_consumed_topic_wraps_subscribe_peer_without_binding_slots() {
             && !rendered.contains("TopicMessenger::subscribe(")
             && !rendered.contains("bound_producer"),
         "peer subscriptions must ride subscribe_peer, not the binding-slot path:\n{rendered}"
+    );
+    // The tag is the slot accessor's identity type, never a bare ProducerRef.
+    assert!(
+        !rendered.contains("ProducerRef"),
+        "a peer module tags every message with PeerInfo:\n{rendered}"
+    );
+}
+
+#[test]
+fn observed_consumed_topic_yields_observed_source_tagged_pairs() {
+    let topic = parse_topic(JOINT_COMMANDS);
+    let mut generator = RustGenerator::new();
+    generator
+        .add_observed_topic(&topic, &peer_context(), Cardinality::ZeroOrMore)
+        .unwrap();
+    let artifacts = generator.into_artifacts();
+    assert_eq!(artifacts.len(), 1);
+    let artifact = &artifacts[0];
+    assert_eq!(artifact.kind, InterfaceKind::ObservedTopic);
+    assert_eq!(
+        artifact.module_path,
+        vec!["arm".to_string(), "joint_commands".to_string()]
+    );
+
+    let rendered = &artifact.code_output;
+    assert_contains_all(
+        rendered,
+        &[
+            // The subscribe_observed seam with the slot consts spliced.
+            "peppylib::runtime::subscribe_observed(",
+            "inner: peppylib::runtime::ObservedTopicSubscription",
+            // The held-subscription surface, yielding (source, Message):
+            // the full member identity, so members sharing one instance
+            // stay distinct.
+            "pub struct Subscription",
+            "-> crate::Result<Option<(peppylib::messaging::ObservedSource, Message)>>",
+            "let Some((source, message)) = self.inner.on_next_message().await",
+            "Ok(Some((source, message)))",
+            // The multi-cardinality slot accessor speaks the same type.
+            "pub fn sources(",
+        ],
+    );
+    // The tag is the slot accessor's identity type, never a bare ProducerRef.
+    assert!(
+        !rendered.contains("ProducerRef"),
+        "an observer module tags every message with ObservedSource:\n{rendered}"
     );
 }
 

--- a/crates/generator-internal/src/generator/rust/topics.rs
+++ b/crates/generator-internal/src/generator/rust/topics.rs
@@ -532,7 +532,7 @@ fn build_subscription_struct(
                     return Ok(None);
                 };
 
-                let payload = message.payload();
+                let payload = message.payload_bytes();
                 let message = #helper_fn_ident(payload.as_ref())?;
                 Ok(Some((#tag_binding, message)))
             }

--- a/crates/generator-internal/src/generator/rust/topics.rs
+++ b/crates/generator-internal/src/generator/rust/topics.rs
@@ -2,6 +2,7 @@ use super::deserialization::build_deserialize_fn;
 use super::serialization::{MessageEncodingSpec, build_serialize_payload};
 use super::services::deserialize_fields_from_format;
 use crate::error::Result;
+use crate::generator::types::SubscriptionTag;
 use config::node::{Cardinality, ConsumedTopic, NativeEmittedTopic, QoSProfile};
 use encoding::{CapnpSchemaArtifacts, FunctionParam};
 use proc_macro2::{Ident, Literal, TokenStream};
@@ -364,20 +365,8 @@ enum PairTopicSubscriptionKind {
     Observed,
 }
 
-/// The per-message identity tag a held subscription's `next()` yields
-/// alongside the decoded message: each module kind tags with its slot
-/// accessor's own identity type.
-#[derive(Clone, Copy)]
-enum SubscriptionTag {
-    /// `(ProducerRef, message)`: bound-set consumer modules.
-    Producer,
-    /// `(PeerInfo, message)`: peer pairing modules.
-    Peer,
-    /// `(ObservedSource, message)`: observer modules.
-    ObservedSource,
-}
-
 impl SubscriptionTag {
+    /// The tag's Rust type, spliced into `next()`'s return type.
     fn ty(self) -> TokenStream {
         match self {
             Self::Producer => quote!(peppylib::messaging::ProducerRef),
@@ -386,13 +375,8 @@ impl SubscriptionTag {
         }
     }
 
-    fn binding(self) -> Ident {
-        let name = match self {
-            Self::Producer => "producer",
-            Self::Peer => "peer",
-            Self::ObservedSource => "source",
-        };
-        Ident::new(name, proc_macro2::Span::call_site())
+    fn binding_ident(self) -> Ident {
+        Ident::new(self.binding(), proc_macro2::Span::call_site())
     }
 }
 
@@ -419,7 +403,7 @@ fn build_pair_topic_subscription(
         struct_prefix,
     )?;
 
-    let (struct_doc, inner_type, next_doc, recv_tokens, subscribe_doc, subscribe_fn) = match kind {
+    let (struct_doc, inner_type, next_doc, tag, subscribe_doc, subscribe_fn) = match kind {
         PairTopicSubscriptionKind::Peer => (
             quote! {
                 /// A held subscription to this pairing topic. Yields nothing while
@@ -439,11 +423,7 @@ fn build_pair_topic_subscription(
                 /// complementary slot: the same `PeerInfo` that `paired()`
                 /// returns.
             },
-            quote! {
-                let Some((peer, message)) = self.inner.on_next_message().await else {
-                    return Ok(None);
-                };
-            },
+            SubscriptionTag::Peer,
             quote! {
                 /// Subscribes to this pairing topic and returns a held
                 /// `Subscription` that follows the slot's live pin. Legal while
@@ -474,11 +454,7 @@ fn build_pair_topic_subscription(
                 /// multi-member slot tells its sources apart even when several
                 /// members share one instance.
             },
-            quote! {
-                let Some((source, message)) = self.inner.on_next_message().await else {
-                    return Ok(None);
-                };
-            },
+            SubscriptionTag::ObservedSource,
             quote! {
                 /// Subscribes to this observed pairing topic and returns a held
                 /// `Subscription` pinned to the observer slot's source. Legal before
@@ -488,15 +464,10 @@ fn build_pair_topic_subscription(
             quote!(peppylib::runtime::subscribe_observed),
         ),
     };
-    let tag = match kind {
-        PairTopicSubscriptionKind::Peer => SubscriptionTag::Peer,
-        PairTopicSubscriptionKind::Observed => SubscriptionTag::ObservedSource,
-    };
     let subscription_tokens = build_subscription_struct(
         struct_doc,
         inner_type,
         next_doc,
-        recv_tokens,
         tag,
         helper_fn_ident,
         args_struct_ident,
@@ -527,23 +498,22 @@ fn build_pair_topic_subscription(
 }
 
 /// The held-`Subscription` struct plus its `next()` impl, shared by the
-/// bound-set, peer, and observer consumer modules: same decode contract,
-/// differing in the inner subscription type, the identity tag `next()` yields
-/// (`tag`, which fixes the tag's type and binding name), how the tagged pair
-/// is received from the inner subscription (`recv_tokens`, statements that
-/// bind the tag and `message` or early-return `Ok(None)`), and the doc text
-/// (passed as `quote!`d `///` blocks so the generated docs stay per-module).
+/// bound-set, peer, and observer consumer modules: same decode contract and
+/// same receive step (every inner subscription yields a `(tag, message)`
+/// pair), differing in the inner subscription type, the identity tag `next()`
+/// yields (`tag`, which fixes the tag's type and binding name), and the doc
+/// text (passed as `quote!`d `///` blocks so the generated docs stay
+/// per-module).
 fn build_subscription_struct(
     struct_doc: TokenStream,
     inner_type: TokenStream,
     next_doc: TokenStream,
-    recv_tokens: TokenStream,
     tag: SubscriptionTag,
     helper_fn_ident: &Ident,
     args_struct_ident: &Ident,
 ) -> TokenStream {
     let tag_ty = tag.ty();
-    let tag_binding = tag.binding();
+    let tag_binding = tag.binding_ident();
     quote! {
         #struct_doc
         pub struct Subscription {
@@ -558,7 +528,9 @@ fn build_subscription_struct(
             pub async fn next(
                 &mut self,
             ) -> crate::Result<Option<(#tag_ty, #args_struct_ident)>> {
-                #recv_tokens
+                let Some((#tag_binding, message)) = self.inner.on_next_message().await else {
+                    return Ok(None);
+                };
 
                 let payload = message.payload();
                 let message = #helper_fn_ident(payload.as_ref())?;
@@ -639,11 +611,6 @@ pub fn build_consumed_topic_subscription(
             /// set (a `zero_or_more` slot bound to nothing, or a vacant
             /// `zero_or_one` slot) this pends until shutdown, then returns
             /// `Ok(None)`.
-        },
-        quote! {
-            let Some((producer, message)) = self.inner.on_next_message().await else {
-                return Ok(None);
-            };
         },
         SubscriptionTag::Producer,
         helper_fn_ident,

--- a/crates/generator-internal/src/generator/rust/topics.rs
+++ b/crates/generator-internal/src/generator/rust/topics.rs
@@ -364,6 +364,38 @@ enum PairTopicSubscriptionKind {
     Observed,
 }
 
+/// The per-message identity tag a held subscription's `next()` yields
+/// alongside the decoded message: each module kind tags with its slot
+/// accessor's own identity type.
+#[derive(Clone, Copy)]
+enum SubscriptionTag {
+    /// `(ProducerRef, message)`: bound-set consumer modules.
+    Producer,
+    /// `(PeerInfo, message)`: peer pairing modules.
+    Peer,
+    /// `(ObservedSource, message)`: observer modules.
+    ObservedSource,
+}
+
+impl SubscriptionTag {
+    fn ty(self) -> TokenStream {
+        match self {
+            Self::Producer => quote!(peppylib::messaging::ProducerRef),
+            Self::Peer => quote!(peppylib::messaging::PeerInfo),
+            Self::ObservedSource => quote!(peppylib::messaging::ObservedSource),
+        }
+    }
+
+    fn binding(self) -> Ident {
+        let name = match self {
+            Self::Producer => "producer",
+            Self::Peer => "peer",
+            Self::ObservedSource => "source",
+        };
+        Ident::new(name, proc_macro2::Span::call_site())
+    }
+}
+
 fn build_pair_topic_subscription(
     spec: PeerTopicSubscriptionSpec<'_>,
     kind: PairTopicSubscriptionKind,
@@ -400,19 +432,17 @@ fn build_pair_topic_subscription(
             quote! {
                 /// Awaits the next message from the currently paired peer.
                 ///
-                /// Returns `Ok(Some((producer, message)))` for each message,
+                /// Returns `Ok(Some((peer, message)))` for each message,
                 /// `Ok(None)` once the runtime shuts down, and `Err(..)` if a
-                /// received payload fails to deserialize. `producer` is always
-                /// the paired peer's identity.
+                /// received payload fails to deserialize. `peer` is the paired
+                /// peer's identity, its wire address plus the link_id of its
+                /// complementary slot: the same `PeerInfo` that `paired()`
+                /// returns.
             },
             quote! {
-                let Some(message) = self.inner.on_next_message().await else {
+                let Some((peer, message)) = self.inner.on_next_message().await else {
                     return Ok(None);
                 };
-                let producer = peppylib::messaging::ProducerRef::new(
-                    message.core_node(),
-                    message.instance_id(),
-                );
             },
             quote! {
                 /// Subscribes to this pairing topic and returns a held
@@ -435,14 +465,17 @@ fn build_pair_topic_subscription(
             quote! {
                 /// Awaits the next message from any currently observed source.
                 ///
-                /// Returns `Ok(Some((producer, message)))` for each message,
+                /// Returns `Ok(Some((source, message)))` for each message,
                 /// `Ok(None)` once the runtime shuts down, and `Err(..)` if a
-                /// received payload fails to deserialize. `producer` is the
-                /// observed member that published it, which is how a multi-member
-                /// slot tells its sources apart.
+                /// received payload fails to deserialize. `source` is the
+                /// observed pairing that published it, the producer's wire
+                /// address plus the producer-side link_id: the same
+                /// `ObservedSource` the slot's accessors enumerate, so a
+                /// multi-member slot tells its sources apart even when several
+                /// members share one instance.
             },
             quote! {
-                let Some((producer, message)) = self.inner.on_next_message().await else {
+                let Some((source, message)) = self.inner.on_next_message().await else {
                     return Ok(None);
                 };
             },
@@ -455,11 +488,16 @@ fn build_pair_topic_subscription(
             quote!(peppylib::runtime::subscribe_observed),
         ),
     };
+    let tag = match kind {
+        PairTopicSubscriptionKind::Peer => SubscriptionTag::Peer,
+        PairTopicSubscriptionKind::Observed => SubscriptionTag::ObservedSource,
+    };
     let subscription_tokens = build_subscription_struct(
         struct_doc,
         inner_type,
         next_doc,
         recv_tokens,
+        tag,
         helper_fn_ident,
         args_struct_ident,
     );
@@ -489,19 +527,23 @@ fn build_pair_topic_subscription(
 }
 
 /// The held-`Subscription` struct plus its `next()` impl, shared by the
-/// bound-set and peer consumer modules: same decode contract, differing in
-/// the inner subscription type, how `(producer, message)` is received from
-/// it (`recv_tokens`, statements that bind `producer` and `message` or
-/// early-return `Ok(None)`), and the doc text (passed as `quote!`d `///`
-/// blocks so the generated docs stay per-module).
+/// bound-set, peer, and observer consumer modules: same decode contract,
+/// differing in the inner subscription type, the identity tag `next()` yields
+/// (`tag`, which fixes the tag's type and binding name), how the tagged pair
+/// is received from the inner subscription (`recv_tokens`, statements that
+/// bind the tag and `message` or early-return `Ok(None)`), and the doc text
+/// (passed as `quote!`d `///` blocks so the generated docs stay per-module).
 fn build_subscription_struct(
     struct_doc: TokenStream,
     inner_type: TokenStream,
     next_doc: TokenStream,
     recv_tokens: TokenStream,
+    tag: SubscriptionTag,
     helper_fn_ident: &Ident,
     args_struct_ident: &Ident,
 ) -> TokenStream {
+    let tag_ty = tag.ty();
+    let tag_binding = tag.binding();
     quote! {
         #struct_doc
         pub struct Subscription {
@@ -515,12 +557,12 @@ fn build_subscription_struct(
             #[allow(clippy::should_implement_trait)]
             pub async fn next(
                 &mut self,
-            ) -> crate::Result<Option<(peppylib::messaging::ProducerRef, #args_struct_ident)>> {
+            ) -> crate::Result<Option<(#tag_ty, #args_struct_ident)>> {
                 #recv_tokens
 
                 let payload = message.payload();
                 let message = #helper_fn_ident(payload.as_ref())?;
-                Ok(Some((producer, message)))
+                Ok(Some((#tag_binding, message)))
             }
         }
     }
@@ -603,6 +645,7 @@ pub fn build_consumed_topic_subscription(
                 return Ok(None);
             };
         },
+        SubscriptionTag::Producer,
         helper_fn_ident,
         args_struct_ident,
     );

--- a/crates/generator-internal/src/generator/types.rs
+++ b/crates/generator-internal/src/generator/types.rs
@@ -111,6 +111,33 @@ pub enum PairTopicConsumerKind {
     Observed(Cardinality),
 }
 
+/// The per-message identity tag a held `Subscription`'s `next()` yields
+/// alongside the decoded message: each module kind tags with its slot
+/// accessor's own identity type, received pre-tagged from the inner
+/// subscription. Which kind tags with which identity, and the name the
+/// generated code binds it to, is the same fact in both languages, so it lives
+/// here; each generator renders only the type name in its own syntax.
+#[derive(Clone, Copy)]
+pub enum SubscriptionTag {
+    /// `(ProducerRef, message)`: bound-set consumer modules.
+    Producer,
+    /// `(PeerInfo, message)`: peer pairing modules.
+    Peer,
+    /// `(ObservedSource, message)`: observer modules.
+    ObservedSource,
+}
+
+impl SubscriptionTag {
+    /// The name the generated `next()` binds the tag to.
+    pub fn binding(self) -> &'static str {
+        match self {
+            Self::Producer => "producer",
+            Self::Peer => "peer",
+            Self::ObservedSource => "source",
+        }
+    }
+}
+
 /// Backstop for the pairing document's flat topic-name uniqueness rule:
 /// two peer artifacts must never land on the same `paired_topics/<link_id>/<topic>`
 /// module path. Shared by the Rust and Python generators so the invariant

--- a/crates/generator-internal/tests/python/pairing_lib.rs
+++ b/crates/generator-internal/tests/python/pairing_lib.rs
@@ -232,6 +232,12 @@ for module in (sole, maybe, many):
     assert inspect.isclass(module.Subscription)
     for absent in ("build_message", "declare_publisher", "paired", "wait_paired"):
         assert not hasattr(module, absent), absent
+
+# next() tags every message with the ObservedSource that published it, the
+# same identity the slot accessors enumerate, at every cardinality.
+for module in (sole, maybe, many):
+    return_annotation = str(module.Subscription.next.__annotations__["return"])
+    assert "ObservedSource" in return_annotation, return_annotation
 print("observer modules imported")
 "#;
     let output = std::process::Command::new(user_node.join(".venv/bin/python"))

--- a/crates/generator-internal/tests/rust/pairing_lib.rs
+++ b/crates/generator-internal/tests/rust/pairing_lib.rs
@@ -139,12 +139,14 @@ fn main() -> Result<()> {
             let payload = joint_commands::build_message([0.0, 0.5, 1.0], 0.25)?;
             publisher.publish(payload).await?;
 
-            if let Some((producer, states)) = subscription.next().await? {
+            // Every message rides with the same PeerInfo `paired()` reports.
+            if let Some((peer, states)) = subscription.next().await? {
                 println!(
-                    "{} joints from {}/{}",
+                    "{} joints from {}/{} (their slot: {})",
                     states.positions.len(),
-                    producer.core_node,
-                    producer.instance_id
+                    peer.producer.core_node,
+                    peer.producer.instance_id,
+                    peer.peer_link_id
                 );
             }
         }
@@ -262,13 +264,16 @@ fn main() -> Result<()> {
         let source: Option<peppygen::ObservedSource> = joint_states::source(&node_runner)?;
         if source.is_none() {
             // A held observer subscription is legal before the source resolves.
+            // Every message rides with the same ObservedSource `source()`
+            // reports.
             let mut subscription = joint_states::subscribe(&node_runner).await?;
-            if let Some((producer, states)) = subscription.next().await? {
+            if let Some((source, states)) = subscription.next().await? {
                 println!(
-                    "{} joints from {}/{}",
+                    "{} joints from {}/{} via {}",
                     states.positions.len(),
-                    producer.core_node,
-                    producer.instance_id
+                    source.producer.core_node,
+                    source.producer.instance_id,
+                    source.source_link_id
                 );
             }
         }
@@ -324,17 +329,24 @@ fn main() -> Result<()> {
         let sources: Vec<peppygen::ObservedSource> = joint_states::sources(&node_runner)?;
         println!("observing {} arms", sources.len());
 
-        // One subscription fans in across every member; the producer tag is
-        // what tells the members apart.
+        // One subscription fans in across every member; the source tag (the
+        // producer's wire address plus the producer-side link_id) is what
+        // tells the members apart, even when members share one instance, so
+        // it keys per-member demux maps directly.
+        let mut states_seen: std::collections::HashMap<peppygen::ObservedSource, usize> =
+            std::collections::HashMap::new();
         let mut subscription = joint_states::subscribe(&node_runner).await?;
-        if let Some((producer, states)) = subscription.next().await? {
+        if let Some((source, states)) = subscription.next().await? {
             println!(
-                "{} joints from {}/{}",
+                "{} joints from {}/{} via {}",
                 states.positions.len(),
-                producer.core_node,
-                producer.instance_id
+                source.producer.core_node,
+                source.producer.instance_id,
+                source.source_link_id
             );
+            *states_seen.entry(source).or_default() += 1;
         }
+        println!("heard from {} distinct sources", states_seen.len());
         Ok(())
     })
 }

--- a/crates/peppy/src/commands/action_poll.rs
+++ b/crates/peppy/src/commands/action_poll.rs
@@ -136,7 +136,7 @@ pub(crate) async fn poll_action_to_completion<R>(
         match tokio::time::timeout(FEEDBACK_DRAIN_TIMEOUT, action_handle.on_next_feedback()).await {
             Ok(Ok(msg)) => {
                 last_activity = tokio::time::Instant::now();
-                on_feedback(&msg.payload(), scrolling_output);
+                on_feedback(msg.payload_bytes().as_ref(), scrolling_output);
             }
             Ok(Err(_)) => break, // end-of-stream: the goal has completed
             Err(_) => {}         // drain slice elapsed; re-check timeouts and keep draining

--- a/crates/peppy/src/commands/stack/benchmark.rs
+++ b/crates/peppy/src/commands/stack/benchmark.rs
@@ -131,7 +131,7 @@ async fn benchmark_async(
         match tokio::time::timeout(FEEDBACK_DRAIN_TIMEOUT, action_handle.on_next_feedback()).await {
             Ok(Ok(msg)) => {
                 last_activity = tokio::time::Instant::now();
-                if let Ok(feedback) = StackBenchmarkFeedback::decode(&msg.payload()) {
+                if let Ok(feedback) = StackBenchmarkFeedback::decode(msg.payload_bytes().as_ref()) {
                     scrolling.add_line(&feedback.line);
                 }
             }

--- a/crates/peppy/src/commands/stack/launch.rs
+++ b/crates/peppy/src/commands/stack/launch.rs
@@ -457,8 +457,8 @@ async fn launch_async(
         match tokio::time::timeout(FEEDBACK_DRAIN_TIMEOUT, action_handle.on_next_feedback()).await {
             Ok(Ok(msg)) => {
                 last_activity = tokio::time::Instant::now();
-                let payload = msg.payload();
-                if let Ok(feedback) = LaunchFeedback::decode(&payload) {
+                let payload = msg.payload_bytes();
+                if let Ok(feedback) = LaunchFeedback::decode(payload.as_ref()) {
                     handle_feedback(
                         &feedback,
                         &mut scrolling_output,

--- a/crates/peppy/tests/fixtures/hub/nodes/deliberative_planner/src/deliberative_planner/__main__.py
+++ b/crates/peppy/tests/fixtures/hub/nodes/deliberative_planner/src/deliberative_planner/__main__.py
@@ -69,7 +69,7 @@ async def watch_executor(node_runner: NodeRunner, scene: Scene) -> None:
         received = await subscription.next()
         if received is None:
             break
-        _producer, message = received
+        _peer, message = received
         scene.executor_positions = list(message.joint_positions)
         scene.adopted_subgoal_id = message.active_subgoal_id
         if message.escalated:

--- a/crates/peppy/tests/fixtures/hub/nodes/episode_recorder/src/episode_recorder/__main__.py
+++ b/crates/peppy/tests/fixtures/hub/nodes/episode_recorder/src/episode_recorder/__main__.py
@@ -32,7 +32,7 @@ async def record(params: Parameters, node_runner: NodeRunner) -> None:
         received = await subscription.next()
         if received is None:
             break
-        producer, message = received
+        source, message = received
 
         captured += 1
         if message.escalated:
@@ -41,7 +41,8 @@ async def record(params: Parameters, node_runner: NodeRunner) -> None:
         if captured == 1:
             print(
                 f"[episode_recorder] observing execution on "
-                f"{producer.core_node}/{producer.instance_id}",
+                f"{source.producer.core_node}/{source.producer.instance_id} "
+                f"via {source.source_link_id}",
                 flush=True,
             )
         elif captured % params.report_every == 0:

--- a/crates/peppy/tests/fixtures/hub/nodes/reactive_policy/src/reactive_policy/__main__.py
+++ b/crates/peppy/tests/fixtures/hub/nodes/reactive_policy/src/reactive_policy/__main__.py
@@ -110,7 +110,7 @@ async def adopt_subgoals(node_runner: NodeRunner, state: Situation) -> None:
         received = await subscription.next()
         if received is None:
             break
-        _producer, message = received
+        _peer, message = received
         state.adopt(message.subgoal_id)
         print(
             f"[reactive_policy] adopted subgoal {message.subgoal_id} "

--- a/docs/src/content/docs/advanced_guides/pairing.mdx
+++ b/docs/src/content/docs/advanced_guides/pairing.mdx
@@ -330,7 +330,7 @@ Among observer slots vacancy is only for the `zero_or_one` row, which is the obs
 
 On the CLI the array becomes repetition: `--link watch@arm_1 --link watch@arm_2`. Either way the order you write is the order the node reads back, so a deployment can associate the Nth observed pairing with its own Nth command slot.
 
-The declared cardinality types the generated accessor, so flipping it surfaces at every call site rather than silently reading one member of many: a scalar slot (`one` or `zero_or_one`) exposes `source()` returning a single observed pairing, and the multi cardinalities expose `sources()` returning the whole set in plan order. `subscribe` keeps its shape at every cardinality and fans in across the whole set, tagging each message with the member that published it.
+The declared cardinality types the generated accessor, so flipping it surfaces at every call site rather than silently reading one member of many: a scalar slot (`one` or `zero_or_one`) exposes `source()` returning a single observed pairing, and the multi cardinalities expose `sources()` returning the whole set in plan order. `subscribe` keeps its shape at every cardinality and fans in across the whole set, tagging each message with the `ObservedSource` that published it: the producer's wire address plus the producer-side link_id, the same identity the accessors enumerate, so members stay distinct even when several observe the same instance.
 
 <Tabs>
   <TabItem label="Python">
@@ -341,10 +341,11 @@ from peppygen.paired_topics.watch import joint_states
 for source in joint_states.sources(node_runner):
     print(source.producer.instance_id, source.source_link_id)
 
-# One subscription covers every member; the producer tag says who sent what.
+# One subscription covers every member; the source tag says which pairing
+# sent what, even when members share one instance.
 subscription = await joint_states.subscribe(node_runner)
-async for producer, states in subscription:
-    print(producer.instance_id, states.positions)
+async for source, states in subscription:
+    print(source.producer.instance_id, source.source_link_id, states.positions)
 ```
   </TabItem>
   <TabItem label="Rust">
@@ -356,10 +357,14 @@ for source in joint_states::sources(&node_runner)? {
     println!("{} {}", source.producer.instance_id, source.source_link_id);
 }
 
-// One subscription covers every member; the producer tag says who sent what.
+// One subscription covers every member; the source tag says which pairing
+// sent what, even when members share one instance.
 let mut subscription = joint_states::subscribe(&node_runner).await?;
-while let Some((producer, states)) = subscription.next().await? {
-    println!("{} {:?}", producer.instance_id, states.positions);
+while let Some((source, states)) = subscription.next().await? {
+    println!(
+        "{} {} {:?}",
+        source.producer.instance_id, source.source_link_id, states.positions
+    );
 }
 ```
   </TabItem>
@@ -393,7 +398,7 @@ Pairing and [contract implementation](/advanced_guides/contract_implementation/)
 | Cardinality | Exactly 1:1 per slot, exclusive (no `cardinality` key); `optional: true` says the slot may also run with no peer | Declared per slot: exactly one by default, at most one for `zero_or_one`, an application-selected set for `one_or_more` / `zero_or_more` |
 | Directionality | Both directions in one contract (two roles) | One direction per contract |
 | Establishment | Declared once on either side (`--link arm@peer`), covering both endpoints, at instance start | Each consumer slot bound to its producer(s) (`--link slot@producer`), at instance start |
-| Peer identity | The slot *is* the identity; the runtime guarantees whose messages you get | Per-message `ProducerRef`; the consumer tells producers apart itself |
+| Peer identity | The slot *is* the identity; the runtime guarantees whose messages you get, and each message rides with the peer's `PeerInfo` | Per-message `ProducerRef`; the consumer tells producers apart itself |
 | Lifecycle | Pair dissolves on death; survivor's slot goes silent until re-paired | Producers come and go freely |
 | Natural fit | Control loops, teleoperation, any "these two specific instances belong together" relationship | Telemetry, monitoring, swappable sources (dedicated slots or one multi-cardinality slot) |
 

--- a/docs/src/content/docs/guides/snippets/python/arm_controller/src/arm_controller/__main__.py
+++ b/docs/src/content/docs/guides/snippets/python/arm_controller/src/arm_controller/__main__.py
@@ -53,11 +53,11 @@ async def control_loop(node_runner: NodeRunner):
 
         if received is None:
             break  # subscription closed
-        producer, state = received
+        peer, state = received
 
-        # `producer` is always the paired arm's identity.
+        # `peer` is always the paired arm's identity.
         print(
-            f"state from {producer.core_node}/{producer.instance_id}: "
+            f"state from {peer.producer.core_node}/{peer.producer.instance_id}: "
             f"positions={state.positions}"
         )
 

--- a/docs/src/content/docs/guides/snippets/python/robot_arm/src/robot_arm/__main__.py
+++ b/docs/src/content/docs/guides/snippets/python/robot_arm/src/robot_arm/__main__.py
@@ -50,11 +50,11 @@ async def handle_commands(node_runner: NodeRunner):
 
         if received is None:
             break  # subscription closed
-        producer, command = received
+        peer, command = received
 
-        # `producer` is always the paired controller's identity.
+        # `peer` is always the paired controller's identity.
         print(
-            f"command from {producer.core_node}/{producer.instance_id}: "
+            f"command from {peer.producer.core_node}/{peer.producer.instance_id}: "
             f"target={command.target_positions} max_vel={command.max_velocity}"
         )
 

--- a/docs/src/content/docs/guides/snippets/rust/arm_controller/src/main.rs
+++ b/docs/src/content/docs/guides/snippets/rust/arm_controller/src/main.rs
@@ -40,7 +40,7 @@ fn main() -> Result<()> {
             }
 
             loop {
-                let (producer, state) = match subscription.next().await {
+                let (peer, state) = match subscription.next().await {
                     Ok(Some(received)) => received,
                     Ok(None) => break,
                     Err(e) => {
@@ -49,10 +49,10 @@ fn main() -> Result<()> {
                     }
                 };
 
-                // `producer` is always the paired arm's identity.
+                // `peer` is always the paired arm's identity.
                 println!(
                     "state from {}/{}: positions={:?}",
-                    producer.core_node, producer.instance_id, state.positions
+                    peer.producer.core_node, peer.producer.instance_id, state.positions
                 );
 
                 // Compute the next target from the reported state, then command it.

--- a/docs/src/content/docs/guides/snippets/rust/robot_arm/src/main.rs
+++ b/docs/src/content/docs/guides/snippets/rust/robot_arm/src/main.rs
@@ -42,7 +42,7 @@ fn main() -> Result<()> {
             }
 
             loop {
-                let (producer, command) = match subscription.next().await {
+                let (peer, command) = match subscription.next().await {
                     Ok(Some(received)) => received,
                     Ok(None) => break,
                     Err(e) => {
@@ -51,11 +51,11 @@ fn main() -> Result<()> {
                     }
                 };
 
-                // `producer` is always the paired controller's identity.
+                // `peer` is always the paired controller's identity.
                 println!(
                     "command from {}/{}: target={:?} max_vel={}",
-                    producer.core_node,
-                    producer.instance_id,
+                    peer.producer.core_node,
+                    peer.producer.instance_id,
                     command.target_positions,
                     command.max_velocity
                 );


### PR DESCRIPTION
## What

The generated `Subscription::next()` of a pairing module now tags each message with the identity type that module's own slot accessor returns, in Rust and Python:

- An **observer** module yields `(ObservedSource, message)`, the same type `source()` / `sources()` return. The tag carries the producer's wire address **plus the producer-side link_id**, so members of one slot stay distinct even when several observe the same instance. That case is real: four `commanded_*` observer links bound to one backbone instance previously arrived with an identical `ProducerRef`, making left and right arm setpoints indistinguishable.
- A **peer** module yields `(PeerInfo, message)`, the same type `paired()` / `wait_paired()` return.
- **Bound-set consumer** modules are unchanged and keep yielding `ProducerRef`.

The shared subscription builders (`build_subscription_struct` in Rust, `emit_subscription_class` in Python) take the tag as a parameter. That retires the Python `RawMessage` yield path and the peer module's rebuild of a `ProducerRef` out of message headers, since peers are now tagged at the source.

## Depends on

public-peppy-libs#92, which makes the runtime yield these types. **That PR must merge first**, and this branch needs a `cargo update peppylib-rs` lock bump to the resulting commit before it lands (git deps resolve on the default branch only). Everything here was developed and tested against that branch through the `local-libs.sh` path override; the committed `Cargo.lock` is still the git-resolved pinned form.

## Breaking change

Rust consumers that read fields off the tag fail at compile time; Python consumers fail at runtime. Call sites that discard the tag are unaffected, since tuple arity is preserved. No compatibility layer. nodes-hub#50 carries the matching consumer fix.

## Tests

- New rendered-string unit tests for observer modules in both backends, which did not exist before; the peer tests now pin `PeerInfo` and both assert the module contains no `ProducerRef`. The existing bound-set assertions still pin `ProducerRef` byte for byte, so a regression in the shared builders is caught.
- The multi-observer compile test demuxes into a `HashMap<ObservedSource, _>` keyed on the yielded tag, which exercises the motivating use case and the new `Hash` derive.
- The Python introspection test asserts the observer `next` return annotation names `ObservedSource` at every cardinality.
- Generator suite (245 tests), `node_observe` and `stack_launch` observer e2e, full workspace `cargo test`, clippy and fmt all green. Note the workspace run needs `PEPPY_CROSS_BUILD=1`: a shared-crate change stales the cached Linux container `.so`, which a debug build does not refresh, exactly as `peppylib-build-policy` documents. CI test workflows set it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Subscriptions now provide clear identity metadata for producers, peers, and observed sources.
  * Observer messages include the originating producer and source link details.
  * Rust and Python APIs now expose typed subscription results for peer and observed-source data.
* **Bug Fixes**
  * Improved message payload decoding across clock, datastore, node, repository, stack, and feedback operations.
* **Documentation**
  * Updated pairing guides and examples to demonstrate the new subscription identities and source metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->