### PR TITLE
Put the release scripts workspace root on PYTHONPATH

### DIFF
--- a/scripts/pixi.toml
+++ b/scripts/pixi.toml
@@ -22,6 +22,14 @@ pytest = "*"
 pytest-xdist = "*"
 respx = "*"
 
+# CPython ignores .pth files that carry the macOS UF_HIDDEN flag, and pixi sets that
+# flag on everything it writes under .pixi. The editable install ships its path in
+# such a .pth, so on macOS the workspace root never reaches sys.path and every console
+# script dies with "No module named 'functions'". Putting the root on PYTHONPATH makes
+# the imports independent of whether the .pth is honoured.
+[activation.env]
+PYTHONPATH = "$PIXI_PROJECT_ROOT"
+
 [tasks]
 build-release = "build-release"
 build-base-images = "build-base-images"


### PR DESCRIPTION
## Problem

`./scripts/build_release.sh` dies before it does anything:

```
File ".../.pixi/envs/default/bin/build-release", line 4, in <module>
    from functions.build_release import main
ModuleNotFoundError: No module named 'functions'
```

pixi sets the macOS `UF_HIDDEN` flag on everything it writes under `.pixi`, and CPython's `site.addpackage` ignores `.pth` files that carry that flag. The editable install of `peppy-release-scripts` ships its path in exactly such a `.pth`, so the workspace root never reaches `sys.path`:

```
$ stat -f %Xf .../site-packages/_editable_impl_peppy_release_scripts.pth
8040        # 0x8000 UF_HIDDEN | 0x40 UF_TRACKED
```

Every console script (`build-release`, `build-base-images`, `is-doc-up-to-date`, `update-docs`) is affected, because a console script puts its own `bin/` directory on `sys.path[0]` rather than the caller's working directory. It only appears to work when the task is launched from `scripts/`.

## Fix

Set `PYTHONPATH` to the workspace root during environment activation, so imports no longer depend on whether the `.pth` is honoured.

## Verification

In a scratch worktree, with the flag set on the `.pth` to reproduce the failure:

```
$ chflags hidden .../site-packages/_editable_impl_peppy_release_scripts.pth
$ (cd / && env -u PYTHONPATH .../bin/build-release --help)
ModuleNotFoundError: No module named 'functions'
$ (cd / && pixi run --manifest-path scripts/pixi.toml build-release --help)
usage: build-release [-h] [--local] [--base-images] [--skip-prod-cert-check]
```

`pytest tests/test_cli.py tests/test_github.py` passes (48 tests).