### PR TITLE
Add the v0.22.1 release note

### DIFF
--- a/docs/src/content/releases/v0.22.1.html
+++ b/docs/src/content/releases/v0.22.1.html
@@ -1,0 +1,21 @@
+<entry>
+  <title>v0.22.1</title>
+  <id>https://docs.peppy.bot/releases/v0-22-1/</id>
+  <updated>2026-08-06T00:00:00Z</updated>
+
+  <summary>Generated pairing subscriptions now tag each message with the subscribing slot's identity.</summary>
+
+  <content type="html">&lt;article&gt;
+  &lt;header&gt;
+    &lt;h1&gt;v0.22.1&lt;/h1&gt;
+    &lt;p&gt;&lt;em&gt;Generated pairing subscriptions now tag each message with the subscribing slot's identity.&lt;/em&gt;&lt;/p&gt;
+    &lt;p&gt;&lt;small&gt;
+      Released on August 6, 2026
+    &lt;/small&gt;&lt;/p&gt;
+  &lt;/header&gt;
+&lt;h3&gt;Pairing&lt;/h3&gt;
+&lt;ul&gt;
+&lt;li&gt;Generated pairing subscriptions now tag every message with the subscribing slot's identity, so paired nodes can tell which slot a message came from.&lt;/li&gt;
+&lt;/ul&gt;
+&lt;/article&gt;</content>
+</entry>


### PR DESCRIPTION
The release note generated by `build_release.sh` when publishing [v0.22.1](https://github.com/Peppy-bot/peppy/releases/tag/v0.22.1).

`docs/src/content/releases/` is the `releases` content collection (`docs/src/content.config.ts`), loaded by `releaseHtmlLoader`, so the file becomes the `/releases/v0-22-1/` docs page and feeds the changelog and announcements.

Targets `main` because the release was cut from `main` at a5347070, which is the commit `v0.22.1` tags.