### PR TITLE
Add the v0.23.0 release note

### DIFF
--- a/docs/src/content/releases/v0.23.0.html
+++ b/docs/src/content/releases/v0.23.0.html
@@ -1,0 +1,18 @@
+<entry>
+  <title>v0.23.0</title>
+  <id>https://docs.peppy.bot/releases/v0-23-0/</id>
+  <updated>2026-08-07T00:00:00Z</updated>
+
+  <summary>This release contains no user-facing changes.</summary>
+
+  <content type="html">&lt;article&gt;
+  &lt;header&gt;
+    &lt;h1&gt;v0.23.0&lt;/h1&gt;
+    &lt;p&gt;&lt;em&gt;This release contains no user-facing changes.&lt;/em&gt;&lt;/p&gt;
+    &lt;p&gt;&lt;small&gt;
+      Released on August 7, 2026
+    &lt;/small&gt;&lt;/p&gt;
+  &lt;/header&gt;
+&lt;p&gt;No user-facing changes in this release.&lt;/p&gt;
+&lt;/article&gt;</content>
+</entry>


### PR DESCRIPTION
The release note generated by `build_release.sh` when publishing [v0.23.0](https://github.com/Peppy-bot/peppy/releases/tag/v0.23.0).

`docs/src/content/releases/` is the `releases` content collection (`docs/src/content.config.ts`), loaded by `releaseHtmlLoader`, so the file becomes the `/releases/v0-23-0/` docs page and feeds the changelog and announcements.