### PR TITLE
Keep slow-connection launches alive with genuine build progress feedback

### DIFF
--- a/crates/containers-internal/src/apptainer.rs
+++ b/crates/containers-internal/src/apptainer.rs
@@ -8,4 +8,4 @@ mod tests;
 pub use facade::Apptainer;
 #[cfg(target_os = "linux")]
 pub use facade::{SetupStatus, check_setup_status};
-pub use usage::{CacheUsageProbe, effective_host_cache_dir};
+pub use usage::CacheUsageProbe;

--- a/crates/containers-internal/src/apptainer.rs
+++ b/crates/containers-internal/src/apptainer.rs
@@ -1,5 +1,6 @@
 pub mod facade;
 pub(crate) mod lima;
+pub mod usage;
 
 #[cfg(test)]
 mod tests;
@@ -7,3 +8,4 @@ mod tests;
 pub use facade::Apptainer;
 #[cfg(target_os = "linux")]
 pub use facade::{SetupStatus, check_setup_status};
+pub use usage::{CacheUsageProbe, effective_host_cache_dir};

--- a/crates/containers-internal/src/apptainer/tests.rs
+++ b/crates/containers-internal/src/apptainer/tests.rs
@@ -2005,3 +2005,77 @@ fn wait_for_child_bounded_returns_none_and_reaps_on_timeout() {
         "the timeout path must kill and reap the wedged child"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Cache usage probe (build progress sampling)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn effective_host_cache_dir_prefers_the_env_override() {
+    use super::usage::effective_host_cache_dir_from;
+    use std::ffi::OsString;
+
+    // The env override wins over $HOME, and an empty override is ignored the
+    // way apptainer ignores it (fall back to the default location).
+    let dir = effective_host_cache_dir_from(
+        Some(OsString::from("/custom/cache")),
+        Some(OsString::from("/home/user")),
+    );
+    assert_eq!(dir, Some(PathBuf::from("/custom/cache")));
+
+    let dir =
+        effective_host_cache_dir_from(Some(OsString::new()), Some(OsString::from("/home/user")));
+    assert_eq!(dir, Some(PathBuf::from("/home/user/.apptainer/cache")));
+
+    assert_eq!(effective_host_cache_dir_from(None, None), None);
+}
+
+#[test]
+fn cache_usage_probe_sums_a_tree_and_ignores_missing_roots() {
+    use super::usage::CacheUsageProbe;
+
+    let root = TempDir::new().expect("tempdir");
+    fs::create_dir_all(root.path().join("blobs/sha256")).expect("mkdir");
+    fs::write(root.path().join("blobs/sha256/aa"), vec![0u8; 1024]).expect("write");
+    fs::write(root.path().join("blobs/sha256/bb"), vec![0u8; 512]).expect("write");
+    fs::write(root.path().join("top"), vec![0u8; 64]).expect("write");
+
+    let probe = CacheUsageProbe {
+        host_roots: vec![
+            root.path().to_path_buf(),
+            PathBuf::from("/nonexistent-peppy-usage-root"),
+        ],
+        guest: None,
+    };
+    assert_eq!(probe.usage_bytes(), 1024 + 512 + 64);
+
+    let missing_only = CacheUsageProbe {
+        host_roots: vec![PathBuf::from("/nonexistent-peppy-usage-root")],
+        guest: None,
+    };
+    assert_eq!(missing_only.usage_bytes(), 0);
+}
+
+#[cfg(unix)]
+#[test]
+fn cache_usage_probe_counts_a_symlink_itself_not_its_target() {
+    use super::usage::CacheUsageProbe;
+
+    // A symlink pointing outside the root must not pull the target's size (or
+    // an unbounded tree) into the sample; only the link's own metadata counts.
+    let target = TempDir::new().expect("tempdir");
+    fs::write(target.path().join("big"), vec![0u8; 4096]).expect("write");
+    let root = TempDir::new().expect("tempdir");
+    fs::write(root.path().join("real"), vec![0u8; 128]).expect("write");
+    std::os::unix::fs::symlink(target.path(), root.path().join("link")).expect("symlink");
+
+    let probe = CacheUsageProbe {
+        host_roots: vec![root.path().to_path_buf()],
+        guest: None,
+    };
+    let total = probe.usage_bytes();
+    assert!(
+        (128..4096).contains(&total),
+        "the symlink target's 4096-byte file must not be counted, got {total}"
+    );
+}

--- a/crates/containers-internal/src/apptainer/usage.rs
+++ b/crates/containers-internal/src/apptainer/usage.rs
@@ -27,7 +27,7 @@ const APPTAINER_CACHEDIR_ENV: &str = "APPTAINER_CACHEDIR";
 /// `APPTAINER_CACHEDIR`: pointing an existing installation at a fresh cache
 /// directory would cold-start multi-GB re-downloads for exactly the
 /// slow-connection users the progress probe serves.
-pub fn effective_host_cache_dir() -> Option<PathBuf> {
+fn effective_host_cache_dir() -> Option<PathBuf> {
     effective_host_cache_dir_from(
         std::env::var_os(APPTAINER_CACHEDIR_ENV),
         std::env::var_os("HOME"),
@@ -77,13 +77,12 @@ impl Apptainer {
     /// scratch, plus the extras. Lima (macOS): the guest cache is sampled via
     /// `du` inside the VM; only the extras are sampled host-side (the build's
     /// working dir is host-mounted, so they remain visible).
-    pub fn cache_usage_probe(&self, extra_host_roots: &[PathBuf]) -> CacheUsageProbe {
+    pub fn cache_usage_probe(&self, extra_host_roots: Vec<PathBuf>) -> CacheUsageProbe {
+        let mut host_roots = extra_host_roots;
         match &self.backend {
             Backend::Native { tmp_dir, .. } => {
-                let mut host_roots = Vec::with_capacity(extra_host_roots.len() + 2);
                 host_roots.extend(effective_host_cache_dir());
                 host_roots.push(tmp_dir.clone());
-                host_roots.extend(extra_host_roots.iter().cloned());
                 CacheUsageProbe {
                     host_roots,
                     guest: None,
@@ -94,7 +93,7 @@ impl Apptainer {
                 lima_home,
                 ..
             } => CacheUsageProbe {
-                host_roots: extra_host_roots.to_vec(),
+                host_roots,
                 guest: Some(GuestUsageProbe {
                     limactl_path: limactl_path.clone(),
                     lima_home: lima_home.clone(),
@@ -126,14 +125,16 @@ impl CacheUsageProbe {
 
 impl GuestUsageProbe {
     /// `du -sb` of the guest-side apptainer cache, through the same
-    /// `limactl shell` plumbing every other guest command uses. Any failure
-    /// (VM unreachable, `du` missing, unparseable output) reads as 0.
+    /// `limactl shell` plumbing every other guest command uses. The guest
+    /// shell resolves the cache dir with the same override-then-default rule
+    /// as [`effective_host_cache_dir`], so the two spellings cannot fork. Any
+    /// failure (VM unreachable, `du` missing, unparseable output) reads as 0.
     fn usage_bytes(&self) -> u64 {
         let output = lima::lima_shell_cmd(&self.limactl_path, &self.lima_home, lima::LIMA_INSTANCE)
             .args([
                 "sh",
                 "-c",
-                r#"du -sb "$HOME/.apptainer/cache" 2>/dev/null | cut -f1"#,
+                r#"du -sb "${APPTAINER_CACHEDIR:-$HOME/.apptainer/cache}" 2>/dev/null | cut -f1"#,
             ])
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
@@ -157,16 +158,30 @@ fn dir_size_bytes(root: &Path) -> u64 {
         Ok(meta) => meta,
         Err(_) => return 0,
     };
-    if !meta.is_dir() {
-        return meta.len();
+    if meta.is_dir() {
+        dir_tree_size(root)
+    } else {
+        meta.len()
     }
-    let entries = match std::fs::read_dir(root) {
+}
+
+/// Sums the entries of a directory known to exist. Leans on `read_dir`'s own
+/// per-entry handles — `file_type` (free on most filesystems) to pick the
+/// recursion, `metadata` (lstat, no path building) for sizes — because this
+/// runs over the whole apptainer cache every sample tick.
+fn dir_tree_size(dir: &Path) -> u64 {
+    let entries = match std::fs::read_dir(dir) {
         Ok(entries) => entries,
         Err(_) => return 0,
     };
     entries
         .filter_map(|entry| entry.ok())
         .fold(0, |sum, entry| {
-            sum.saturating_add(dir_size_bytes(&entry.path()))
+            let size = match entry.file_type() {
+                Ok(file_type) if file_type.is_dir() => dir_tree_size(&entry.path()),
+                Ok(_) => entry.metadata().map_or(0, |meta| meta.len()),
+                Err(_) => 0,
+            };
+            sum.saturating_add(size)
         })
 }

--- a/crates/containers-internal/src/apptainer/usage.rs
+++ b/crates/containers-internal/src/apptainer/usage.rs
@@ -1,0 +1,172 @@
+//! Backend-aware disk-usage probe for observing container build progress.
+//!
+//! `apptainer build` is mostly silent off-TTY while it downloads a docker base
+//! image and assembles the SIF: one "Copying blob …" line per blob, then
+//! nothing until the phase completes. The bytes it moves do land on disk,
+//! though — in its cache directory, its `--tmpdir` scratch, and the output
+//! image — so sampling the total footprint of those write surfaces
+//! distinguishes "slow but downloading" from "wedged". The probe deliberately
+//! samples whole directory roots rather than any cache-internal layout:
+//! apptainer's cache structure varies across versions, and a whole-root sum is
+//! layout-agnostic.
+
+use super::facade::{Apptainer, Backend};
+use super::lima;
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+
+/// Apptainer's env spelling of its cache-directory override.
+const APPTAINER_CACHEDIR_ENV: &str = "APPTAINER_CACHEDIR";
+
+/// The host-side directory apptainer caches OCI blobs and converted layers in:
+/// `$APPTAINER_CACHEDIR` when set in this process's environment, else
+/// `~/.apptainer/cache` (apptainer's own default).
+///
+/// peppy deliberately reads this rather than setting or relocating
+/// `APPTAINER_CACHEDIR`: pointing an existing installation at a fresh cache
+/// directory would cold-start multi-GB re-downloads for exactly the
+/// slow-connection users the progress probe serves.
+pub fn effective_host_cache_dir() -> Option<PathBuf> {
+    effective_host_cache_dir_from(
+        std::env::var_os(APPTAINER_CACHEDIR_ENV),
+        std::env::var_os("HOME"),
+    )
+}
+
+/// Env-injectable core of [`effective_host_cache_dir`], split out so the
+/// resolution order is testable without racing other tests over the process
+/// environment.
+pub(crate) fn effective_host_cache_dir_from(
+    cachedir_env: Option<OsString>,
+    home: Option<OsString>,
+) -> Option<PathBuf> {
+    if let Some(dir) = cachedir_env.filter(|v| !v.is_empty()) {
+        return Some(PathBuf::from(dir));
+    }
+    home.filter(|v| !v.is_empty())
+        .map(|home| PathBuf::from(home).join(".apptainer/cache"))
+}
+
+/// Samples the total on-disk footprint of every surface an `apptainer build`
+/// writes to. Self-contained (owns every path it needs, borrows nothing from
+/// the facade) so callers can hold it across facade moves and hand it to
+/// long-lived monitor tasks; obtained via [`Apptainer::cache_usage_probe`].
+#[derive(Clone, Debug)]
+pub struct CacheUsageProbe {
+    /// Host-side roots, each summed recursively without following symlinks.
+    pub(super) host_roots: Vec<PathBuf>,
+    /// Guest-side cache sampling for the Lima backend (macOS), where the
+    /// apptainer cache lives inside the VM.
+    pub(super) guest: Option<GuestUsageProbe>,
+}
+
+/// The `limactl shell` plumbing needed to `du` the guest-side apptainer cache.
+#[derive(Clone, Debug)]
+pub(super) struct GuestUsageProbe {
+    pub(super) limactl_path: PathBuf,
+    pub(super) lima_home: PathBuf,
+}
+
+impl Apptainer {
+    /// Builds a [`CacheUsageProbe`] over every surface a build on this backend
+    /// writes to, plus `extra_host_roots` supplied by the caller (typically
+    /// the output SIF path and the container build cache bind directory).
+    ///
+    /// Native (Linux): the host cache dir and the facade's `APPTAINER_TMPDIR`
+    /// scratch, plus the extras. Lima (macOS): the guest cache is sampled via
+    /// `du` inside the VM; only the extras are sampled host-side (the build's
+    /// working dir is host-mounted, so they remain visible).
+    pub fn cache_usage_probe(&self, extra_host_roots: &[PathBuf]) -> CacheUsageProbe {
+        match &self.backend {
+            Backend::Native { tmp_dir, .. } => {
+                let mut host_roots = Vec::with_capacity(extra_host_roots.len() + 2);
+                host_roots.extend(effective_host_cache_dir());
+                host_roots.push(tmp_dir.clone());
+                host_roots.extend(extra_host_roots.iter().cloned());
+                CacheUsageProbe {
+                    host_roots,
+                    guest: None,
+                }
+            }
+            Backend::Lima {
+                limactl_path,
+                lima_home,
+                ..
+            } => CacheUsageProbe {
+                host_roots: extra_host_roots.to_vec(),
+                guest: Some(GuestUsageProbe {
+                    limactl_path: limactl_path.clone(),
+                    lima_home: lima_home.clone(),
+                }),
+            },
+        }
+    }
+}
+
+impl CacheUsageProbe {
+    /// Total bytes currently on disk across every sampled root.
+    ///
+    /// Blocking (filesystem walks; a `limactl shell du` subprocess under
+    /// Lima), so call it from a blocking context. Missing roots count 0 and
+    /// per-root errors are skipped, so a partial sum still detects growth; a
+    /// persistently failing probe reads as a flat 0, which emits no progress
+    /// and leaves timeout behavior exactly as it is today — the probe can
+    /// defer an idle timeout only while bytes are really landing, never
+    /// neuter it.
+    pub fn usage_bytes(&self) -> u64 {
+        let host: u64 = self
+            .host_roots
+            .iter()
+            .fold(0, |sum, root| sum.saturating_add(dir_size_bytes(root)));
+        let guest = self.guest.as_ref().map_or(0, GuestUsageProbe::usage_bytes);
+        host.saturating_add(guest)
+    }
+}
+
+impl GuestUsageProbe {
+    /// `du -sb` of the guest-side apptainer cache, through the same
+    /// `limactl shell` plumbing every other guest command uses. Any failure
+    /// (VM unreachable, `du` missing, unparseable output) reads as 0.
+    fn usage_bytes(&self) -> u64 {
+        let output = lima::lima_shell_cmd(&self.limactl_path, &self.lima_home, lima::LIMA_INSTANCE)
+            .args([
+                "sh",
+                "-c",
+                r#"du -sb "$HOME/.apptainer/cache" 2>/dev/null | cut -f1"#,
+            ])
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .output();
+        match output {
+            Ok(out) if out.status.success() => String::from_utf8_lossy(&out.stdout)
+                .trim()
+                .parse()
+                .unwrap_or(0),
+            _ => 0,
+        }
+    }
+}
+
+/// Recursive file-size sum of `root`, never following symlinks (a symlink's
+/// own metadata is counted, not its target's). Missing paths and unreadable
+/// entries contribute 0 so one bad subtree cannot zero out the whole sample.
+fn dir_size_bytes(root: &Path) -> u64 {
+    let meta = match std::fs::symlink_metadata(root) {
+        Ok(meta) => meta,
+        Err(_) => return 0,
+    };
+    if !meta.is_dir() {
+        return meta.len();
+    }
+    let entries = match std::fs::read_dir(root) {
+        Ok(entries) => entries,
+        Err(_) => return 0,
+    };
+    entries
+        .filter_map(|entry| entry.ok())
+        .fold(0, |sum, entry| {
+            sum.saturating_add(dir_size_bytes(&entry.path()))
+        })
+}

--- a/crates/containers-internal/src/lib.rs
+++ b/crates/containers-internal/src/lib.rs
@@ -9,7 +9,7 @@ mod error;
 mod mount_source;
 
 pub use apptainer::Apptainer;
-pub use apptainer::{CacheUsageProbe, effective_host_cache_dir};
+pub use apptainer::CacheUsageProbe;
 #[cfg(target_os = "linux")]
 pub use apptainer::{SetupStatus, check_setup_status};
 pub use error::{Error, Result};

--- a/crates/containers-internal/src/lib.rs
+++ b/crates/containers-internal/src/lib.rs
@@ -9,6 +9,7 @@ mod error;
 mod mount_source;
 
 pub use apptainer::Apptainer;
+pub use apptainer::{CacheUsageProbe, effective_host_cache_dir};
 #[cfg(target_os = "linux")]
 pub use apptainer::{SetupStatus, check_setup_status};
 pub use error::{Error, Result};

--- a/crates/core-node-internal/src/lib.rs
+++ b/crates/core-node-internal/src/lib.rs
@@ -18,5 +18,6 @@ pub use services::repo::index::{
 pub use services::repo::{InitOutcome, ensure_default_repos};
 pub use services::{
     CoreNode, CoreNodeArguments, CoreNodeConfig, NAME_CLAIM_LINKED_SETTLE, TEARDOWN_REAP_BUDGET,
-    check_runtime_prerequisites, force_kill_deadline, teardown_all_instances,
+    check_runtime_prerequisites, force_kill_deadline, idle_timeout_flag, slow_connection_hint,
+    teardown_all_instances,
 };

--- a/crates/core-node-internal/src/services.rs
+++ b/crates/core-node-internal/src/services.rs
@@ -14,6 +14,7 @@ use clock::{ClockSource, SimClockSource, WallClockSource};
 
 pub use node::{TEARDOWN_REAP_BUDGET, force_kill_deadline, teardown_all_instances};
 pub use presence::NAME_CLAIM_LINKED_SETTLE;
+pub use stack::{idle_timeout_flag, slow_connection_hint};
 
 use crate::Result;
 use config::{

--- a/crates/core-node-internal/src/services/node.rs
+++ b/crates/core-node-internal/src/services/node.rs
@@ -41,7 +41,7 @@ pub use sync::listen_for_node_sync;
 
 pub(crate) use add::{NodeAddActionContext, dispatch_node_add, log_label_from_source};
 pub(crate) use builder::{NodeBuildActionContext, run_node_build_for_entity};
-pub(crate) use feedback::{FeedbackLine, FeedbackStream};
+pub(crate) use feedback::{FeedbackLine, FeedbackStream, stdout_line_sender};
 pub(crate) use git_utils::{
     checkout_repo_ref, clone_repo_shallow, clone_with_progress, format_bytes, head_commit,
 };

--- a/crates/core-node-internal/src/services/node/add_batch.rs
+++ b/crates/core-node-internal/src/services/node/add_batch.rs
@@ -48,15 +48,8 @@ pub(crate) async fn run_pinned_add(
     log_path: PathBuf,
 ) -> NodeAddResult {
     let peppy_dirs = action_context.peppy_dirs.clone();
-    let on_feedback: super::cache::MaterializeFeedback = {
-        let fb = feedback_tx.clone();
-        Arc::new(move |line: &str| {
-            let _ = fb.send(FeedbackLine {
-                stream: FeedbackStream::Stdout,
-                line: line.to_owned(),
-            });
-        })
-    };
+    let on_feedback: super::cache::MaterializeFeedback =
+        Arc::new(super::stdout_line_sender(feedback_tx.clone()));
 
     // An ABSENT cache is not a problem on the pinned path: content this
     // machine does not hold is fetched from each pin's own origin, which is

--- a/crates/core-node-internal/src/services/node/feedback.rs
+++ b/crates/core-node-internal/src/services/node/feedback.rs
@@ -8,7 +8,7 @@
 //! The forwarder consumes those lines from an in-process mpsc channel and
 //! republishes each one onto a peppylib topic.
 
-pub(crate) use node_stack::{FeedbackLine, FeedbackStream};
+pub(crate) use node_stack::{FeedbackLine, FeedbackStream, stdout_line_sender};
 
 /// Spawns a task that consumes `FeedbackLine` values from `feedback_rx`,
 /// converts each one via `encode` and publishes the resulting payload. Shared

--- a/crates/core-node-internal/src/services/node/git_utils.rs
+++ b/crates/core-node-internal/src/services/node/git_utils.rs
@@ -20,19 +20,10 @@ fn is_local_url(repo_url: &str) -> bool {
     repo_url.starts_with('/') || repo_url.starts_with("file://")
 }
 
-/// Renders byte counts in the compact form used by all clone/fetch progress
-/// lines (`KB`/`MB`).
+/// Renders byte counts in the compact `KB`/`MB`/`GB` form shared by all of
+/// peppy's progress lines (delegates to the one formatter in `node-stack`).
 pub(crate) fn format_bytes(bytes: usize) -> String {
-    const KB: f64 = 1024.0;
-    const MB: f64 = 1024.0 * 1024.0;
-    let b = bytes as f64;
-    if b >= MB {
-        format!("{:.1} MB", b / MB)
-    } else if b >= KB {
-        format!("{:.0} KB", b / KB)
-    } else {
-        format!("{} B", bytes)
-    }
+    node_stack::build_io::format_bytes(bytes as u64)
 }
 
 pub(crate) fn sanitize_repo_path(repo_path: &str) -> std::result::Result<PathBuf, String> {

--- a/crates/core-node-internal/src/services/stack.rs
+++ b/crates/core-node-internal/src/services/stack.rs
@@ -9,6 +9,7 @@ pub(crate) use container_mounts::prepare_container_mounts;
 pub use launch::STACK_LAUNCH_GIT_HASH;
 pub use launch::listen_for_stack_launch;
 pub use launch::{StackLaunchDefaults, StackLaunchTimeouts};
+pub use launch::{idle_timeout_flag, slow_connection_hint};
 pub use list::listen_for_stack_list;
 pub(crate) use reset::clear_stack_slice;
 pub use reset::listen_for_stack_reset;

--- a/crates/core-node-internal/src/services/stack/launch.rs
+++ b/crates/core-node-internal/src/services/stack/launch.rs
@@ -4,6 +4,8 @@ mod orchestrate;
 mod phases;
 mod resolve;
 
+pub use phases::{idle_timeout_flag, slow_connection_hint};
+
 use self::feedback::{publish_stderr, publish_stdout};
 use self::orchestrate::{
     add_node_directly, build_node_directly, fail_and_clear_stack, start_node_directly,

--- a/crates/core-node-internal/src/services/stack/launch/phases.rs
+++ b/crates/core-node-internal/src/services/stack/launch/phases.rs
@@ -182,10 +182,15 @@ where
     {
         PhaseOutcome::Completed(result) => result,
         PhaseOutcome::IdleTimeout => {
+            // The three phases run through here (add/build/run) each have a
+            // matching `--node-<phase>-idle-timeout-secs` flag on
+            // `peppy stack launch`, so the label doubles as the flag name.
             let reason = format!(
-                "timeout: {} idle timeout exceeded ({}s without output)",
-                step.phase_label(),
-                idle_timeout.as_secs()
+                "timeout: {label} idle timeout exceeded ({secs}s without output); if this \
+                 machine is on a slow connection, retry with a larger \
+                 --node-{label}-idle-timeout-secs (progress output resets this clock)",
+                label = step.phase_label(),
+                secs = idle_timeout.as_secs()
             );
             write_error_to_log(log_file, &reason);
             build_failure(reason)

--- a/crates/core-node-internal/src/services/stack/launch/phases.rs
+++ b/crates/core-node-internal/src/services/stack/launch/phases.rs
@@ -9,6 +9,32 @@ use tokio::sync::Notify;
 use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
 
+/// The `peppy stack launch` flag that raises the idle budget of the phase a
+/// feedback step belongs to. `None` for the launcher step, whose work
+/// (parse/resolve) has no per-phase flag — the CLI watchdog alone bounds it.
+///
+/// The one place the step→flag mapping lives: both the daemon's per-phase
+/// timeout message (below) and the CLI watchdog's timeout message consume it,
+/// so a flag rename cannot leave the two giving different advice.
+pub fn idle_timeout_flag(step: LaunchFeedbackStep) -> Option<&'static str> {
+    match step {
+        LaunchFeedbackStep::AddingNode => Some("--node-add-idle-timeout-secs"),
+        LaunchFeedbackStep::BuildingNode => Some("--node-build-idle-timeout-secs"),
+        LaunchFeedbackStep::RunningNode => Some("--node-run-idle-timeout-secs"),
+        LaunchFeedbackStep::LauncherStep => None,
+    }
+}
+
+/// The retry advice appended to an idle-timeout error, pointing a
+/// slow-connection user at the flag that raises the budget. Shared by the
+/// daemon and CLI timeout messages so the wording cannot drift.
+pub fn slow_connection_hint(flag: &str) -> String {
+    format!(
+        "if this machine is on a slow connection, retry with a larger {flag} \
+         (progress output resets this clock)"
+    )
+}
+
 /// Watches for an idle period: returns when no `notify_one()` arrives for `idle_timeout`.
 /// Each call to `notify_one()` on `notify` resets the clock.
 async fn watch_idle(notify: Arc<Notify>, idle_timeout: Duration) {
@@ -182,16 +208,14 @@ where
     {
         PhaseOutcome::Completed(result) => result,
         PhaseOutcome::IdleTimeout => {
-            // The three phases run through here (add/build/run) each have a
-            // matching `--node-<phase>-idle-timeout-secs` flag on
-            // `peppy stack launch`, so the label doubles as the flag name.
-            let reason = format!(
-                "timeout: {label} idle timeout exceeded ({secs}s without output); if this \
-                 machine is on a slow connection, retry with a larger \
-                 --node-{label}-idle-timeout-secs (progress output resets this clock)",
-                label = step.phase_label(),
-                secs = idle_timeout.as_secs()
+            let mut reason = format!(
+                "timeout: {} idle timeout exceeded ({}s without output)",
+                step.phase_label(),
+                idle_timeout.as_secs()
             );
+            if let Some(flag) = idle_timeout_flag(step) {
+                reason = format!("{reason}; {}", slow_connection_hint(flag));
+            }
             write_error_to_log(log_file, &reason);
             build_failure(reason)
         }

--- a/crates/core-node-internal/src/services/stack/launch/resolve.rs
+++ b/crates/core-node-internal/src/services/stack/launch/resolve.rs
@@ -1,7 +1,7 @@
 use super::feedback::{publish_stderr, publish_stdout, spawn_feedback_forwarder};
 use super::{NodeKey, PlannedDeployment, ProcessLaunchContext};
 use crate::services::node::pins;
-use crate::services::node::{FeedbackLine, FeedbackStream};
+use crate::services::node::{FeedbackLine, stdout_line_sender};
 use crate::services::repo::cache as repo_cache;
 use core_node_api::encoding::{
     LaunchFeedbackStep, LaunchGoal, LaunchResult, LauncherOrigin, PlacementSpec,
@@ -245,12 +245,7 @@ async fn resolve_launcher_origin(
                 crate::services::repo::cache::resolve_repo_launcher_path(
                     &name_for_blocking,
                     &peppy_dirs,
-                    &|line| {
-                        let _ = feedback_tx.send(FeedbackLine {
-                            stream: FeedbackStream::Stdout,
-                            line: line.to_owned(),
-                        });
-                    },
+                    &stdout_line_sender(feedback_tx),
                 )
             })
             .await
@@ -445,15 +440,8 @@ async fn resolve_one(
     )
     .await;
     let remote = has_remote_instances(deployment, placements);
-    let feedback: crate::services::node::cache::MaterializeFeedback = {
-        let tx = feedback_tx.clone();
-        Arc::new(move |line: &str| {
-            let _ = tx.send(FeedbackLine {
-                stream: FeedbackStream::Stdout,
-                line: line.to_owned(),
-            });
-        })
-    };
+    let feedback: crate::services::node::cache::MaterializeFeedback =
+        Arc::new(stdout_line_sender(feedback_tx.clone()));
 
     let closure = pins::resolve_pinned_closure(
         &ctx.peppy_dirs,

--- a/crates/core-node-internal/src/services/stack/launch/resolve.rs
+++ b/crates/core-node-internal/src/services/stack/launch/resolve.rs
@@ -1,6 +1,7 @@
-use super::feedback::{publish_stderr, publish_stdout};
+use super::feedback::{publish_stderr, publish_stdout, spawn_feedback_forwarder};
 use super::{NodeKey, PlannedDeployment, ProcessLaunchContext};
 use crate::services::node::pins;
+use crate::services::node::{FeedbackLine, FeedbackStream};
 use crate::services::repo::cache as repo_cache;
 use core_node_api::encoding::{
     LaunchFeedbackStep, LaunchGoal, LaunchResult, LauncherOrigin, PlacementSpec,
@@ -217,8 +218,11 @@ fn wire_core_node_links<'a>(
 ///
 /// `Fs` is a no-op; `Repository` looks up the launcher in the cache and, for git-sourced
 /// entries, materializes the checkout via `ensure_checkout`. Progress lines emitted by the
-/// (blocking) checkout are buffered into a `Vec` and flushed to the launch feedback topic
-/// after the resolver returns: quiet for cached/Fs entries, a few lines for fresh clones.
+/// (blocking) checkout STREAM to the launch feedback topic as they happen — a slow clone
+/// used to buffer them until the checkout returned, leaving the CLI watchdog staring at
+/// silence for the whole download. `activity_notify: None` is correct here: no daemon
+/// idle watcher runs during resolve; the streaming exists for the CLI watchdog, which
+/// resets on any published feedback.
 async fn resolve_launcher_origin(
     ctx: &ProcessLaunchContext,
     origin: &LauncherOrigin,
@@ -228,25 +232,31 @@ async fn resolve_launcher_origin(
         LauncherOrigin::Repository { name } => {
             let peppy_dirs = ctx.peppy_dirs.clone();
             let name_for_blocking = name.clone();
-            let collected = Arc::new(StdMutex::new(Vec::<String>::new()));
-            let collected_for_cb = Arc::clone(&collected);
+            let (feedback_tx, forwarder) = spawn_feedback_forwarder(
+                &ctx.feedback_publisher,
+                LaunchFeedbackStep::LauncherStep,
+                &ctx.log_file,
+                None,
+            );
 
+            // The sender moves into the blocking closure, so the channel
+            // closes when the checkout ends and the forwarder drains out.
             let result = tokio::task::spawn_blocking(move || {
                 crate::services::repo::cache::resolve_repo_launcher_path(
                     &name_for_blocking,
                     &peppy_dirs,
                     &|line| {
-                        collected_for_cb.lock().push(line.to_owned());
+                        let _ = feedback_tx.send(FeedbackLine {
+                            stream: FeedbackStream::Stdout,
+                            line: line.to_owned(),
+                        });
                     },
                 )
             })
             .await
             .map_err(|e| format!("launcher resolver join error: {e}"))?;
 
-            let captured: Vec<String> = std::mem::take(&mut *collected.lock());
-            for line in captured {
-                publish_stdout(ctx, line, LaunchFeedbackStep::LauncherStep).await;
-            }
+            let _ = forwarder.await;
             result
         }
     }
@@ -306,16 +316,22 @@ pub(super) async fn resolve_deployments(
             continue;
         }
 
-        // Resolution runs partly on blocking threads, so progress lines are
-        // buffered through a shared Vec and flushed here, the same shape
-        // `resolve_launcher_origin` uses: quiet for cached entries, a few
-        // clone lines for fresh fetches, published in order either way.
-        let collected = Arc::new(StdMutex::new(Vec::<String>::new()));
-        let resolved = resolve_one(ctx, &deployment, placements, &node_entries, &collected).await;
-        let captured: Vec<String> = std::mem::take(&mut *collected.lock());
-        for line in captured {
-            publish_stdout(ctx, line, LaunchFeedbackStep::LauncherStep).await;
-        }
+        // Resolution runs partly on blocking threads; progress lines stream
+        // through a per-deployment forwarder (the same seam
+        // `resolve_launcher_origin` uses) so a slow clone shows live progress
+        // instead of a silent stretch that trips the CLI watchdog. The
+        // forwarder is drained before the "resolved" line below is published,
+        // preserving the old per-deployment ordering. Single channel, single
+        // consumer: lines stay in emission order.
+        let (feedback_tx, forwarder) = spawn_feedback_forwarder(
+            &ctx.feedback_publisher,
+            LaunchFeedbackStep::LauncherStep,
+            &ctx.log_file,
+            None,
+        );
+        let resolved = resolve_one(ctx, &deployment, placements, &node_entries, &feedback_tx).await;
+        drop(feedback_tx);
+        let _ = forwarder.await;
         let ResolvedDeployment {
             config,
             root_pin,
@@ -419,7 +435,7 @@ async fn resolve_one(
     deployment: &Deployment,
     placements: &Placements,
     node_entries: &Arc<Vec<repo_cache::NodeCacheEntry>>,
-    collected: &Arc<StdMutex<Vec<String>>>,
+    feedback_tx: &tokio::sync::mpsc::UnboundedSender<FeedbackLine>,
 ) -> std::result::Result<ResolvedDeployment, String> {
     let label = deployment_label(deployment);
     publish_stdout(
@@ -430,8 +446,13 @@ async fn resolve_one(
     .await;
     let remote = has_remote_instances(deployment, placements);
     let feedback: crate::services::node::cache::MaterializeFeedback = {
-        let sink = Arc::clone(collected);
-        Arc::new(move |line: &str| sink.lock().push(line.to_owned()))
+        let tx = feedback_tx.clone();
+        Arc::new(move |line: &str| {
+            let _ = tx.send(FeedbackLine {
+                stream: FeedbackStream::Stdout,
+                line: line.to_owned(),
+            });
+        })
     };
 
     let closure = pins::resolve_pinned_closure(

--- a/crates/node-stack-internal/Cargo.toml
+++ b/crates/node-stack-internal/Cargo.toml
@@ -33,3 +33,5 @@ process-wrap = { version = "9.1.0", features = ["tokio1", "process-group"] }
 
 [dev-dependencies]
 serde_json5 = "0.2.1"
+# `start_paused` virtual-clock tests for the build progress monitor.
+tokio = { version = "1", features = ["test-util"] }

--- a/crates/node-stack-internal/src/build_io.rs
+++ b/crates/node-stack-internal/src/build_io.rs
@@ -86,6 +86,39 @@ pub struct FeedbackLine {
     pub line: String,
 }
 
+/// Wraps `tx` as a `&str` line sink that forwards each line as a stdout
+/// [`FeedbackLine`], the adapter shape blocking checkout/materialize progress
+/// callbacks expect. Send errors are ignored: a closed channel means the
+/// consumer is gone and the lines have nowhere to go.
+pub fn stdout_line_sender(
+    tx: mpsc::UnboundedSender<FeedbackLine>,
+) -> impl Fn(&str) + Send + Sync + 'static {
+    move |line: &str| {
+        let _ = tx.send(FeedbackLine {
+            stream: FeedbackStream::Stdout,
+            line: line.to_owned(),
+        });
+    }
+}
+
+/// Renders byte counts in the compact `KB`/`MB`/`GB` form shared by peppy's
+/// progress lines (clone/fetch transfer reports, build disk-growth feedback).
+pub fn format_bytes(bytes: u64) -> String {
+    const KB: f64 = 1024.0;
+    const MB: f64 = 1024.0 * 1024.0;
+    const GB: f64 = 1024.0 * 1024.0 * 1024.0;
+    let b = bytes as f64;
+    if b >= GB {
+        format!("{:.1} GB", b / GB)
+    } else if b >= MB {
+        format!("{:.1} MB", b / MB)
+    } else if b >= KB {
+        format!("{:.0} KB", b / KB)
+    } else {
+        format!("{} B", bytes)
+    }
+}
+
 /// Hooks called by [`spawn_output_reader_async`] at meaningful moments in the
 /// reader loop. This trait exists so `node-stack-internal` does not have to
 /// know about the daemon's `FeedbackSync` drain primitive: the daemon
@@ -379,7 +412,12 @@ impl LineSplitter {
     }
 
     fn take_partial(&mut self) -> String {
-        String::from_utf8_lossy(&std::mem::take(&mut self.partial)).into_owned()
+        // Reuse the buffer's allocation on the (overwhelmingly common) valid
+        // UTF-8 path; only invalid bytes pay for a lossy re-encode.
+        match String::from_utf8(std::mem::take(&mut self.partial)) {
+            Ok(line) => line,
+            Err(err) => String::from_utf8_lossy(err.as_bytes()).into_owned(),
+        }
     }
 }
 
@@ -391,29 +429,23 @@ impl LineSplitter {
 pub(crate) const REPAINT_FORWARD_MIN_INTERVAL: Duration = Duration::from_millis(500);
 
 /// Decides which fragments forward: `\n`-terminated lines always do, bare-`\r`
-/// repaints only when at least `min_interval` has passed since the last
-/// forwarded line. Suppressed fragments are dropped entirely (no log write, no
-/// stderr tail), matching their pre-`\r`-splitting invisibility.
+/// repaints only when at least [`REPAINT_FORWARD_MIN_INTERVAL`] has passed
+/// since the last forwarded line. Suppressed fragments are dropped entirely
+/// (no log write, no stderr tail), matching their pre-`\r`-splitting
+/// invisibility.
+#[derive(Default)]
 pub(crate) struct RepaintCoalescer {
-    min_interval: Duration,
     last_forward: Option<Instant>,
 }
 
 impl RepaintCoalescer {
-    pub(crate) fn new(min_interval: Duration) -> Self {
-        Self {
-            min_interval,
-            last_forward: None,
-        }
-    }
-
     /// Whether a fragment with `terminator` observed at `now` forwards.
     pub(crate) fn should_forward(&mut self, terminator: LineTerminator, now: Instant) -> bool {
         let forward = match terminator {
             LineTerminator::Newline => true,
             LineTerminator::CarriageReturn => self
                 .last_forward
-                .is_none_or(|last| now.duration_since(last) >= self.min_interval),
+                .is_none_or(|last| now.duration_since(last) >= REPAINT_FORWARD_MIN_INTERVAL),
         };
         if forward {
             self.last_forward = Some(now);
@@ -441,7 +473,7 @@ impl RepaintCoalescer {
 /// for as long as the spawned node is alive, which is the desired behavior so
 /// the daemon keeps streaming the running node's stdout/stderr.
 pub fn spawn_output_reader_async<R>(
-    reader: R,
+    mut reader: R,
     feedback_tx: mpsc::UnboundedSender<FeedbackLine>,
     publish_enabled: Arc<AtomicBool>,
     hooks: Arc<dyn OutputReaderHooks>,
@@ -455,9 +487,8 @@ where
     use tokio::io::AsyncReadExt;
 
     tokio::spawn(async move {
-        let mut reader = reader;
         let mut splitter = LineSplitter::default();
-        let mut coalescer = RepaintCoalescer::new(REPAINT_FORWARD_MIN_INTERVAL);
+        let mut coalescer = RepaintCoalescer::default();
         let mut buf = vec![0u8; 8192];
         // Tracks whether we have already signalled idle for the current quiet
         // stretch, so `on_reader_idle` fires once per active-to-idle transition.
@@ -528,15 +559,13 @@ where
                 hooks.on_reader_active();
             }
 
-            let mut fragments = Vec::new();
+            // One timestamp per chunk: every fragment in it arrived together.
+            let now = Instant::now();
             splitter.push(&buf[..n], |line, terminator| {
-                fragments.push((line, terminator));
-            });
-            for (line, terminator) in fragments {
-                if coalescer.should_forward(terminator, Instant::now()) {
+                if coalescer.should_forward(terminator, now) {
                     forward_line(line);
                 }
-            }
+            });
         };
 
         // Report exit so the daemon stops counting this reader as live.
@@ -675,7 +704,7 @@ mod tests {
     #[test]
     fn coalescer_throttles_repaints_but_never_newlines() {
         let t0 = std::time::Instant::now();
-        let mut coalescer = RepaintCoalescer::new(Duration::from_millis(500));
+        let mut coalescer = RepaintCoalescer::default();
 
         // First repaint forwards; a rapid follow-up is suppressed.
         assert!(coalescer.should_forward(LineTerminator::CarriageReturn, t0));
@@ -692,8 +721,16 @@ mod tests {
         // …and a repaint after the interval forwards again.
         assert!(coalescer.should_forward(
             LineTerminator::CarriageReturn,
-            t0 + Duration::from_millis(600)
+            t0 + Duration::from_millis(20) + REPAINT_FORWARD_MIN_INTERVAL
         ));
+    }
+
+    #[test]
+    fn format_bytes_scales_units() {
+        assert_eq!(format_bytes(512), "512 B");
+        assert_eq!(format_bytes(2048), "2 KB");
+        assert_eq!(format_bytes(3 * 1024 * 1024 / 2), "1.5 MB");
+        assert_eq!(format_bytes(19 * 1024 * 1024 * 1024 / 10), "1.9 GB");
     }
 
     // -- spawn_output_reader_async end-to-end --

--- a/crates/node-stack-internal/src/build_io.rs
+++ b/crates/node-stack-internal/src/build_io.rs
@@ -10,8 +10,11 @@
 //!   exit before continuing; no concurrent monitoring of `child.try_wait()`
 //!   is needed.
 //!
-//! - [`spawn_output_reader_async`] uses `tokio::io::AsyncBufReadExt` on a
-//!   `tokio::process::ChildStdout`/`ChildStderr`. This is required by the
+//! - [`spawn_output_reader_async`] reads raw bytes from a
+//!   `tokio::process::ChildStdout`/`ChildStderr` and splits them into lines on
+//!   `\n`, `\r`, and `\r\n` (see [`LineSplitter`]), so TTY-style `\r` progress
+//!   repaints surface as feedback instead of accumulating silently inside one
+//!   never-terminated line. This variant is required by the
 //!   start path, where the daemon must call `child.try_wait()` concurrently
 //!   with reading stdout/stderr (so it can detect early child exit while
 //!   polling the ready/health signals). The reader tasks also outlive the
@@ -29,7 +32,7 @@ use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::task::Poll;
-use tokio::io::AsyncBufReadExt;
+use std::time::{Duration, Instant};
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
@@ -305,13 +308,132 @@ fn spawn_output_reader<R: Read + Send + 'static>(
     })
 }
 
+/// How a fragment produced by [`LineSplitter`] was terminated, which decides
+/// whether it forwards unconditionally or is subject to repaint coalescing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LineTerminator {
+    /// `\n` or `\r\n`: a real line. Always forwarded — this is the
+    /// compatibility guarantee that keeps output containing no bare `\r`
+    /// byte-identical to the previous `BufRead::lines` behavior.
+    Newline,
+    /// A bare `\r`: a terminal repaint (progress bars). Forwarded at most
+    /// once per coalescing interval.
+    CarriageReturn,
+}
+
+/// Splits a byte stream into fragments on `\n`, `\r`, and `\r\n` (one break),
+/// decoding each fragment as lossy UTF-8.
+///
+/// `apptainer` (and the tools it drives) repaint progress with bare `\r`, so a
+/// `\n`-only splitter buffers the whole progress stream as one giant
+/// never-terminated line and the feedback channel sees nothing. Splitting on
+/// `\r` as well surfaces those repaints as fragments.
+///
+/// A fragment ending in `\r` is held until the next byte arrives: only then is
+/// it known whether the terminator was a bare `\r` (repaint) or the first half
+/// of `\r\n` (a real line ending, which must forward unconditionally).
+#[derive(Default)]
+pub(crate) struct LineSplitter {
+    /// Bytes of the fragment currently being accumulated.
+    partial: Vec<u8>,
+    /// A `\r` was seen and the fragment is complete, but its classification
+    /// (bare `\r` vs `\r\n`) waits on the next byte.
+    pending_cr: bool,
+}
+
+impl LineSplitter {
+    /// Feeds `bytes` through the splitter, invoking `emit` for each completed
+    /// fragment in order.
+    pub(crate) fn push(&mut self, bytes: &[u8], mut emit: impl FnMut(String, LineTerminator)) {
+        for &byte in bytes {
+            if self.pending_cr {
+                self.pending_cr = false;
+                let line = self.take_partial();
+                if byte == b'\n' {
+                    emit(line, LineTerminator::Newline);
+                    continue;
+                }
+                emit(line, LineTerminator::CarriageReturn);
+            }
+            match byte {
+                b'\n' => {
+                    let line = self.take_partial();
+                    emit(line, LineTerminator::Newline);
+                }
+                b'\r' => self.pending_cr = true,
+                _ => self.partial.push(byte),
+            }
+        }
+    }
+
+    /// The trailing fragment at EOF, if any: an unterminated partial line, or
+    /// a fragment whose `\r` classification never resolved. Callers forward it
+    /// unconditionally so the last repaint (the "100%" that matters) lands.
+    pub(crate) fn finish(&mut self) -> Option<String> {
+        if self.pending_cr || !self.partial.is_empty() {
+            self.pending_cr = false;
+            Some(self.take_partial())
+        } else {
+            None
+        }
+    }
+
+    fn take_partial(&mut self) -> String {
+        String::from_utf8_lossy(&std::mem::take(&mut self.partial)).into_owned()
+    }
+}
+
+/// Minimum spacing between forwarded bare-`\r` repaint fragments.
+///
+/// A TTY-style progress bar can repaint hundreds of times per second; at this
+/// cap the scrolling feedback still animates while the channel, log file, and
+/// idle-clock notifications see at most two lines per second from repaints.
+pub(crate) const REPAINT_FORWARD_MIN_INTERVAL: Duration = Duration::from_millis(500);
+
+/// Decides which fragments forward: `\n`-terminated lines always do, bare-`\r`
+/// repaints only when at least `min_interval` has passed since the last
+/// forwarded line. Suppressed fragments are dropped entirely (no log write, no
+/// stderr tail), matching their pre-`\r`-splitting invisibility.
+pub(crate) struct RepaintCoalescer {
+    min_interval: Duration,
+    last_forward: Option<Instant>,
+}
+
+impl RepaintCoalescer {
+    pub(crate) fn new(min_interval: Duration) -> Self {
+        Self {
+            min_interval,
+            last_forward: None,
+        }
+    }
+
+    /// Whether a fragment with `terminator` observed at `now` forwards.
+    pub(crate) fn should_forward(&mut self, terminator: LineTerminator, now: Instant) -> bool {
+        let forward = match terminator {
+            LineTerminator::Newline => true,
+            LineTerminator::CarriageReturn => self
+                .last_forward
+                .is_none_or(|last| now.duration_since(last) >= self.min_interval),
+        };
+        if forward {
+            self.last_forward = Some(now);
+        }
+        forward
+    }
+}
+
 /// Async sibling of [`spawn_output_reader`], used by both the start path
 /// (via `start_steps`) and the build path (via [`stream_child_output`]).
 ///
-/// Reads lines from a `tokio::io::AsyncRead` (typically a
-/// `tokio::process::ChildStdout`/`ChildStderr`), writes each line to the log
-/// file, captures stderr lines into the optional `stderr_buffer`, and forwards
-/// each line over `feedback_tx` (gated by `publish_enabled`).
+/// Reads output from a `tokio::io::AsyncRead` (typically a
+/// `tokio::process::ChildStdout`/`ChildStderr`), splits it into lines on `\n`,
+/// `\r`, and `\r\n` (see [`LineSplitter`]), writes each forwarded line to the
+/// log file, captures forwarded stderr lines into the optional
+/// `stderr_buffer`, and forwards each over `feedback_tx` (gated by
+/// `publish_enabled`). `\n`-terminated lines always forward; bare-`\r` repaint
+/// fragments are coalesced (see [`RepaintCoalescer`]) and suppressed ones skip
+/// the log file and stderr tail too. The final fragment before EOF always
+/// forwards so a progress stream's last repaint lands.
 ///
 /// The reader task is spawned via `tokio::spawn` and remains alive as long as
 /// the underlying reader yields data. On the start path, this means the reader
@@ -330,43 +452,20 @@ pub fn spawn_output_reader_async<R>(
 where
     R: tokio::io::AsyncRead + Unpin + Send + 'static,
 {
+    use tokio::io::AsyncReadExt;
+
     tokio::spawn(async move {
-        let mut lines = tokio::io::BufReader::new(reader).lines();
+        let mut reader = reader;
+        let mut splitter = LineSplitter::default();
+        let mut coalescer = RepaintCoalescer::new(REPAINT_FORWARD_MIN_INTERVAL);
+        let mut buf = vec![0u8; 8192];
         // Tracks whether we have already signalled idle for the current quiet
         // stretch, so `on_reader_idle` fires once per active-to-idle transition.
         let mut idle = false;
 
-        let outcome = loop {
-            // Poll the next-line future once without committing to awaiting it.
-            // A `Pending` result means every complete line currently buffered
-            // has been consumed, so the reader is caught up: signal idle before
-            // blocking for more. A reader that is slow to be scheduled never
-            // reaches this point, so it never falsely reports being drained.
-            let next = lines.next_line();
-            tokio::pin!(next);
-            let read = match std::future::poll_fn(|cx| Poll::Ready(next.as_mut().poll(cx))).await {
-                Poll::Ready(read) => read,
-                Poll::Pending => {
-                    if !idle {
-                        idle = true;
-                        hooks.on_reader_idle();
-                    }
-                    next.await
-                }
-            };
-
-            let line = match read {
-                Ok(Some(line)) => line,
-                Ok(None) => break Ok(()),
-                Err(e) => break Err(e),
-            };
-
-            // A line arrived: the reader is active again until it next blocks.
-            if idle {
-                idle = false;
-                hooks.on_reader_active();
-            }
-
+        // Forwards one line: log file, first-stdout signal, stderr tail,
+        // publish gate, feedback channel. Suppressed repaints never reach it.
+        let forward_line = |line: String| {
             write_feedback_log_line(&log_file, stream, &line);
 
             // Signal when the first stdout line arrives so container drains can
@@ -383,11 +482,60 @@ where
             }
 
             if !publish_enabled.load(Ordering::Acquire) {
-                continue;
+                return;
             }
 
             if feedback_tx.send(FeedbackLine { stream, line }).is_ok() {
                 hooks.on_line_read();
+            }
+        };
+
+        let outcome = loop {
+            // Poll the read future once without committing to awaiting it.
+            // A `Pending` result means every byte currently buffered has been
+            // consumed, so the reader is caught up: signal idle before
+            // blocking for more. A reader that is slow to be scheduled never
+            // reaches this point, so it never falsely reports being drained.
+            let next = reader.read(&mut buf);
+            tokio::pin!(next);
+            let read = match std::future::poll_fn(|cx| Poll::Ready(next.as_mut().poll(cx))).await {
+                Poll::Ready(read) => read,
+                Poll::Pending => {
+                    if !idle {
+                        idle = true;
+                        hooks.on_reader_idle();
+                    }
+                    next.await
+                }
+            };
+
+            let n = match read {
+                Ok(0) => {
+                    // EOF: the trailing fragment always forwards, so the last
+                    // repaint of a progress stream is never lost.
+                    if let Some(line) = splitter.finish() {
+                        forward_line(line);
+                    }
+                    break Ok(());
+                }
+                Ok(n) => n,
+                Err(e) => break Err(e),
+            };
+
+            // Data arrived: the reader is active again until it next blocks.
+            if idle {
+                idle = false;
+                hooks.on_reader_active();
+            }
+
+            let mut fragments = Vec::new();
+            splitter.push(&buf[..n], |line, terminator| {
+                fragments.push((line, terminator));
+            });
+            for (line, terminator) in fragments {
+                if coalescer.should_forward(terminator, Instant::now()) {
+                    forward_line(line);
+                }
             }
         };
 
@@ -454,6 +602,150 @@ mod tests {
         assert!(
             result.is_err(),
             "spawn_output_reader should propagate the synthetic read error"
+        );
+    }
+
+    // -- LineSplitter --
+
+    fn split_all(chunks: &[&[u8]]) -> Vec<(String, Option<LineTerminator>)> {
+        let mut splitter = LineSplitter::default();
+        let mut out = Vec::new();
+        for chunk in chunks {
+            splitter.push(chunk, |line, term| out.push((line, Some(term))));
+        }
+        if let Some(line) = splitter.finish() {
+            out.push((line, None));
+        }
+        out
+    }
+
+    #[test]
+    fn splitter_breaks_on_cr_lf_and_crlf() {
+        let got = split_all(&[b"a\rb\r\nc\nd"]);
+        assert_eq!(
+            got,
+            vec![
+                ("a".to_string(), Some(LineTerminator::CarriageReturn)),
+                ("b".to_string(), Some(LineTerminator::Newline)),
+                ("c".to_string(), Some(LineTerminator::Newline)),
+                ("d".to_string(), None),
+            ]
+        );
+    }
+
+    #[test]
+    fn splitter_resolves_crlf_split_across_chunks() {
+        // The `\r` classification must wait for the `\n` in the next chunk:
+        // classifying eagerly would demote a real `\r\n` line ending to a
+        // throttleable repaint.
+        let got = split_all(&[b"x\r", b"\ny"]);
+        assert_eq!(
+            got,
+            vec![
+                ("x".to_string(), Some(LineTerminator::Newline)),
+                ("y".to_string(), None),
+            ]
+        );
+    }
+
+    #[test]
+    fn splitter_yields_a_trailing_cr_fragment_at_eof() {
+        let got = split_all(&[b"50%\r"]);
+        assert_eq!(got, vec![("50%".to_string(), None)]);
+    }
+
+    #[test]
+    fn splitter_preserves_newline_only_streams_verbatim() {
+        // The compatibility guarantee for the run path: without bare `\r`,
+        // fragments match `BufRead::lines` exactly (including empty lines and
+        // a final unterminated line).
+        let got = split_all(&[b"a\n", b"\nb"]);
+        assert_eq!(
+            got,
+            vec![
+                ("a".to_string(), Some(LineTerminator::Newline)),
+                ("".to_string(), Some(LineTerminator::Newline)),
+                ("b".to_string(), None),
+            ]
+        );
+    }
+
+    // -- RepaintCoalescer --
+
+    #[test]
+    fn coalescer_throttles_repaints_but_never_newlines() {
+        let t0 = std::time::Instant::now();
+        let mut coalescer = RepaintCoalescer::new(Duration::from_millis(500));
+
+        // First repaint forwards; a rapid follow-up is suppressed.
+        assert!(coalescer.should_forward(LineTerminator::CarriageReturn, t0));
+        assert!(!coalescer.should_forward(
+            LineTerminator::CarriageReturn,
+            t0 + Duration::from_millis(10)
+        ));
+        // A newline always forwards, and resets the spacing clock…
+        assert!(coalescer.should_forward(LineTerminator::Newline, t0 + Duration::from_millis(20)));
+        assert!(!coalescer.should_forward(
+            LineTerminator::CarriageReturn,
+            t0 + Duration::from_millis(30)
+        ));
+        // …and a repaint after the interval forwards again.
+        assert!(coalescer.should_forward(
+            LineTerminator::CarriageReturn,
+            t0 + Duration::from_millis(600)
+        ));
+    }
+
+    // -- spawn_output_reader_async end-to-end --
+
+    async fn read_all_lines(input: Vec<u8>) -> Vec<String> {
+        let log_file = Arc::new(StdMutex::new(
+            NamedTempFile::new()
+                .expect("temp log")
+                .reopen()
+                .expect("reopen"),
+        ));
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let handle = spawn_output_reader_async(
+            std::io::Cursor::new(input),
+            tx,
+            Arc::new(AtomicBool::new(true)),
+            Arc::new(NoOpHooks) as Arc<dyn OutputReaderHooks>,
+            FeedbackStream::Stdout,
+            None,
+            log_file,
+        );
+        handle
+            .await
+            .expect("join should succeed")
+            .expect("read should succeed");
+        let mut lines = Vec::new();
+        while let Ok(line) = rx.try_recv() {
+            lines.push(line.line);
+        }
+        lines
+    }
+
+    #[tokio::test]
+    async fn async_reader_coalesces_repaints_and_delivers_the_final_one() {
+        // All repaints arrive within one coalescing interval: the first one
+        // forwards, the middle is suppressed, and the trailing fragment at
+        // EOF always lands so the last "100%" is never lost.
+        let lines = read_all_lines(b"10%\r20%\r100%".to_vec()).await;
+        assert_eq!(lines, vec!["10%".to_string(), "100%".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn async_reader_forwards_every_newline_terminated_line() {
+        let lines = read_all_lines(b"line1\nline2\r\n\nline3".to_vec()).await;
+        assert_eq!(
+            lines,
+            vec![
+                "line1".to_string(),
+                "line2".to_string(),
+                "".to_string(),
+                "line3".to_string(),
+            ]
         );
     }
 }

--- a/crates/node-stack-internal/src/build_progress.rs
+++ b/crates/node-stack-internal/src/build_progress.rs
@@ -19,17 +19,18 @@ use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 
-use crate::build_io::{FeedbackLine, FeedbackStream};
+use crate::build_io::{FeedbackLine, FeedbackStream, format_bytes};
 
 /// Cadence of usage samples. Each tick is one blocking probe (a filesystem
 /// walk; a `limactl shell du` subprocess under Lima), so the interval also
 /// bounds the probe overhead.
 pub(crate) const BUILD_PROGRESS_SAMPLE_INTERVAL: Duration = Duration::from_secs(5);
 
-/// Byte-count sampler the monitor polls each tick. Boxed as a closure rather
-/// than a concrete probe type so tests can drive the monitor with a synthetic
+/// Byte-count sampler the monitor polls each tick. A closure rather than a
+/// concrete probe type so tests can drive the monitor with a synthetic
 /// counter; production passes `containers::CacheUsageProbe::usage_bytes`.
-pub(crate) type UsageSampler = Arc<dyn Fn() -> u64 + Send + Sync>;
+/// Arc'd internally so [`sample`] can clone it into `spawn_blocking`.
+type UsageSampler = Arc<dyn Fn() -> u64 + Send + Sync>;
 
 /// Guard around the sampling task: dropping it aborts the task, so tying it to
 /// the build future's stack scopes the monitor to `stream_child_output` — the
@@ -41,14 +42,14 @@ pub(crate) struct BuildProgressMonitor {
 
 impl BuildProgressMonitor {
     /// Starts the sampling task: a baseline sample immediately, then one
-    /// sample per `interval`, emitting a stdout `FeedbackLine` only on growth
-    /// since the last sample. Each sample runs on the blocking pool (the
-    /// probe walks filesystems and may shell out).
+    /// sample per [`BUILD_PROGRESS_SAMPLE_INTERVAL`], emitting a stdout
+    /// `FeedbackLine` only on growth since the last sample. Each sample runs
+    /// on the blocking pool (the probe walks filesystems and may shell out).
     pub(crate) fn spawn(
-        sampler: UsageSampler,
+        sampler: impl Fn() -> u64 + Send + Sync + 'static,
         feedback_tx: mpsc::UnboundedSender<FeedbackLine>,
-        interval: Duration,
     ) -> Self {
+        let sampler: UsageSampler = Arc::new(sampler);
         let task = tokio::spawn(async move {
             // Baseline before the first tick, so the first line reports growth
             // since the build started rather than the preexisting cache size.
@@ -56,7 +57,7 @@ impl BuildProgressMonitor {
                 return;
             };
             loop {
-                tokio::time::sleep(interval).await;
+                tokio::time::sleep(BUILD_PROGRESS_SAMPLE_INTERVAL).await;
                 let Some(total) = sample(&sampler).await else {
                     return;
                 };
@@ -99,25 +100,6 @@ async fn sample(sampler: &UsageSampler) -> Option<u64> {
     tokio::task::spawn_blocking(move || sampler()).await.ok()
 }
 
-/// Renders byte counts in the compact `KB`/`MB`/`GB` form used by peppy's
-/// clone/fetch progress lines, extended with `GB` because base-image pulls
-/// routinely cross it.
-fn format_bytes(bytes: u64) -> String {
-    const KB: f64 = 1024.0;
-    const MB: f64 = 1024.0 * 1024.0;
-    const GB: f64 = 1024.0 * 1024.0 * 1024.0;
-    let b = bytes as f64;
-    if b >= GB {
-        format!("{:.1} GB", b / GB)
-    } else if b >= MB {
-        format!("{:.1} MB", b / MB)
-    } else if b >= KB {
-        format!("{:.0} KB", b / KB)
-    } else {
-        format!("{} B", bytes)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -126,13 +108,16 @@ mod tests {
     /// Sampler over a shared counter that also counts its own invocations, so
     /// tests can wait for the baseline sample before mutating the total
     /// (mutating earlier would fold the "growth" into the baseline).
-    fn counter_sampler(bytes: &Arc<AtomicU64>, calls: &Arc<AtomicU64>) -> UsageSampler {
+    fn counter_sampler(
+        bytes: &Arc<AtomicU64>,
+        calls: &Arc<AtomicU64>,
+    ) -> impl Fn() -> u64 + Send + Sync + 'static {
         let bytes = Arc::clone(bytes);
         let calls = Arc::clone(calls);
-        Arc::new(move || {
+        move || {
             calls.fetch_add(1, Ordering::SeqCst);
             bytes.load(Ordering::SeqCst)
-        })
+        }
     }
 
     /// Parks the test until the sampler has run at least `at_least` times.
@@ -144,14 +129,14 @@ mod tests {
         }
     }
 
-    const INTERVAL: Duration = Duration::from_secs(5);
+    const INTERVAL: Duration = BUILD_PROGRESS_SAMPLE_INTERVAL;
 
     #[tokio::test(start_paused = true)]
     async fn emits_on_growth_and_stays_silent_when_flat() {
         let bytes = Arc::new(AtomicU64::new(1_000));
         let calls = Arc::new(AtomicU64::new(0));
         let (tx, mut rx) = mpsc::unbounded_channel();
-        let _monitor = BuildProgressMonitor::spawn(counter_sampler(&bytes, &calls), tx, INTERVAL);
+        let _monitor = BuildProgressMonitor::spawn(counter_sampler(&bytes, &calls), tx);
         wait_for_calls(&calls, 1).await;
 
         // Growth after the baseline produces a line reporting the delta.
@@ -188,7 +173,7 @@ mod tests {
         let bytes = Arc::new(AtomicU64::new(10 * 1024 * 1024));
         let calls = Arc::new(AtomicU64::new(0));
         let (tx, mut rx) = mpsc::unbounded_channel();
-        let _monitor = BuildProgressMonitor::spawn(counter_sampler(&bytes, &calls), tx, INTERVAL);
+        let _monitor = BuildProgressMonitor::spawn(counter_sampler(&bytes, &calls), tx);
         wait_for_calls(&calls, 1).await;
 
         // Shrink (e.g. cache cleanup): no line, but only assert once at least
@@ -210,7 +195,7 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn dropping_the_guard_aborts_the_sampling_task() {
         let (tx, mut rx) = mpsc::unbounded_channel::<FeedbackLine>();
-        let monitor = BuildProgressMonitor::spawn(Arc::new(|| 0), tx, INTERVAL);
+        let monitor = BuildProgressMonitor::spawn(|| 0, tx);
         drop(monitor);
         // The aborted task drops its sender, so the channel closes; a live
         // task would hold it open forever.
@@ -218,13 +203,5 @@ mod tests {
             .await
             .expect("the channel must close once the guard is dropped");
         assert!(closed.is_none());
-    }
-
-    #[test]
-    fn format_bytes_scales_units() {
-        assert_eq!(format_bytes(512), "512 B");
-        assert_eq!(format_bytes(2048), "2 KB");
-        assert_eq!(format_bytes(3 * 1024 * 1024 / 2), "1.5 MB");
-        assert_eq!(format_bytes(19 * 1024 * 1024 * 1024 / 10), "1.9 GB");
     }
 }

--- a/crates/node-stack-internal/src/build_progress.rs
+++ b/crates/node-stack-internal/src/build_progress.rs
@@ -1,0 +1,230 @@
+//! Synthetic build-progress feedback derived from disk growth.
+//!
+//! During `apptainer build`, a docker base image download is mostly silent
+//! off-TTY: one "Copying blob …" line per blob, then nothing while multi-GB
+//! blobs stream into apptainer's cache, and nothing again while the SIF is
+//! assembled. The daemon's per-phase idle watchdog and the CLI watchdog both
+//! reset only when a line flows through the feedback channel, so that silence
+//! reads as "idle" and a slow-but-progressing build gets killed.
+//!
+//! [`BuildProgressMonitor`] closes that gap: it samples the total on-disk
+//! footprint of every surface the build writes to and emits a feedback line
+//! **only when the total grew**. A wedged apptainer moves no bytes, produces
+//! no lines, and still trips the idle timeout exactly as it does today; the
+//! monitor can defer the timeout only while real bytes are landing on disk,
+//! never neuter it.
+
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+
+use crate::build_io::{FeedbackLine, FeedbackStream};
+
+/// Cadence of usage samples. Each tick is one blocking probe (a filesystem
+/// walk; a `limactl shell du` subprocess under Lima), so the interval also
+/// bounds the probe overhead.
+pub(crate) const BUILD_PROGRESS_SAMPLE_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Byte-count sampler the monitor polls each tick. Boxed as a closure rather
+/// than a concrete probe type so tests can drive the monitor with a synthetic
+/// counter; production passes `containers::CacheUsageProbe::usage_bytes`.
+pub(crate) type UsageSampler = Arc<dyn Fn() -> u64 + Send + Sync>;
+
+/// Guard around the sampling task: dropping it aborts the task, so tying it to
+/// the build future's stack scopes the monitor to `stream_child_output` — the
+/// phase runner dropping the future on idle timeout, a cancelled `--force`
+/// supersede, and normal completion all tear it down the same way.
+pub(crate) struct BuildProgressMonitor {
+    task: JoinHandle<()>,
+}
+
+impl BuildProgressMonitor {
+    /// Starts the sampling task: a baseline sample immediately, then one
+    /// sample per `interval`, emitting a stdout `FeedbackLine` only on growth
+    /// since the last sample. Each sample runs on the blocking pool (the
+    /// probe walks filesystems and may shell out).
+    pub(crate) fn spawn(
+        sampler: UsageSampler,
+        feedback_tx: mpsc::UnboundedSender<FeedbackLine>,
+        interval: Duration,
+    ) -> Self {
+        let task = tokio::spawn(async move {
+            // Baseline before the first tick, so the first line reports growth
+            // since the build started rather than the preexisting cache size.
+            let Some(mut last_total) = sample(&sampler).await else {
+                return;
+            };
+            loop {
+                tokio::time::sleep(interval).await;
+                let Some(total) = sample(&sampler).await else {
+                    return;
+                };
+                if total > last_total {
+                    let line = format!(
+                        "Fetching/assembling container image: {} written (+{})",
+                        format_bytes(total),
+                        format_bytes(total - last_total),
+                    );
+                    if feedback_tx
+                        .send(FeedbackLine {
+                            stream: FeedbackStream::Stdout,
+                            line,
+                        })
+                        .is_err()
+                    {
+                        // Channel closed: the build is over; stop sampling.
+                        return;
+                    }
+                }
+                // A shrink (cache cleanup) emits nothing but still rebases the
+                // total, so growth after it is measured from the new floor.
+                last_total = total;
+            }
+        });
+        Self { task }
+    }
+}
+
+impl Drop for BuildProgressMonitor {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+/// One blocking probe call on the blocking pool. `None` when the runtime is
+/// shutting down (join error), which ends the monitor quietly.
+async fn sample(sampler: &UsageSampler) -> Option<u64> {
+    let sampler = Arc::clone(sampler);
+    tokio::task::spawn_blocking(move || sampler()).await.ok()
+}
+
+/// Renders byte counts in the compact `KB`/`MB`/`GB` form used by peppy's
+/// clone/fetch progress lines, extended with `GB` because base-image pulls
+/// routinely cross it.
+fn format_bytes(bytes: u64) -> String {
+    const KB: f64 = 1024.0;
+    const MB: f64 = 1024.0 * 1024.0;
+    const GB: f64 = 1024.0 * 1024.0 * 1024.0;
+    let b = bytes as f64;
+    if b >= GB {
+        format!("{:.1} GB", b / GB)
+    } else if b >= MB {
+        format!("{:.1} MB", b / MB)
+    } else if b >= KB {
+        format!("{:.0} KB", b / KB)
+    } else {
+        format!("{} B", bytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    /// Sampler over a shared counter that also counts its own invocations, so
+    /// tests can wait for the baseline sample before mutating the total
+    /// (mutating earlier would fold the "growth" into the baseline).
+    fn counter_sampler(bytes: &Arc<AtomicU64>, calls: &Arc<AtomicU64>) -> UsageSampler {
+        let bytes = Arc::clone(bytes);
+        let calls = Arc::clone(calls);
+        Arc::new(move || {
+            calls.fetch_add(1, Ordering::SeqCst);
+            bytes.load(Ordering::SeqCst)
+        })
+    }
+
+    /// Parks the test until the sampler has run at least `at_least` times.
+    /// The 1 ms paused-clock sleeps yield to the scheduler while the blocking
+    /// pool finishes the sample in real time.
+    async fn wait_for_calls(calls: &Arc<AtomicU64>, at_least: u64) {
+        while calls.load(Ordering::SeqCst) < at_least {
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+    }
+
+    const INTERVAL: Duration = Duration::from_secs(5);
+
+    #[tokio::test(start_paused = true)]
+    async fn emits_on_growth_and_stays_silent_when_flat() {
+        let bytes = Arc::new(AtomicU64::new(1_000));
+        let calls = Arc::new(AtomicU64::new(0));
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let _monitor = BuildProgressMonitor::spawn(counter_sampler(&bytes, &calls), tx, INTERVAL);
+        wait_for_calls(&calls, 1).await;
+
+        // Growth after the baseline produces a line reporting the delta.
+        bytes.store(300 * 1024 * 1024 + 1_000, Ordering::SeqCst);
+        let line = tokio::time::timeout(INTERVAL * 3, rx.recv())
+            .await
+            .expect("a growth tick must emit within an interval")
+            .expect("channel open");
+        assert!(matches!(line.stream, FeedbackStream::Stdout));
+        assert!(
+            line.line.contains("(+300.0 MB)"),
+            "the line must report the growth delta, got: {}",
+            line.line
+        );
+
+        // Flat samples emit nothing: several intervals pass in silence.
+        tokio::time::sleep(INTERVAL * 4).await;
+        assert!(
+            rx.try_recv().is_err(),
+            "a flat total must not emit progress lines"
+        );
+
+        // Growth resumes → another line.
+        bytes.fetch_add(1024 * 1024, Ordering::SeqCst);
+        let line = tokio::time::timeout(INTERVAL * 3, rx.recv())
+            .await
+            .expect("growth after a flat stretch must emit again")
+            .expect("channel open");
+        assert!(line.line.contains("(+1.0 MB)"), "got: {}", line.line);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn a_shrink_emits_nothing_and_rebases_the_total() {
+        let bytes = Arc::new(AtomicU64::new(10 * 1024 * 1024));
+        let calls = Arc::new(AtomicU64::new(0));
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let _monitor = BuildProgressMonitor::spawn(counter_sampler(&bytes, &calls), tx, INTERVAL);
+        wait_for_calls(&calls, 1).await;
+
+        // Shrink (e.g. cache cleanup): no line, but only assert once at least
+        // one post-shrink sample has actually run.
+        bytes.store(1024 * 1024, Ordering::SeqCst);
+        let seen = calls.load(Ordering::SeqCst);
+        wait_for_calls(&calls, seen + 2).await;
+        assert!(rx.try_recv().is_err(), "a shrink must not emit");
+
+        // Growth from the new floor emits, measured from the rebased total.
+        bytes.store(3 * 1024 * 1024, Ordering::SeqCst);
+        let line = tokio::time::timeout(INTERVAL * 3, rx.recv())
+            .await
+            .expect("growth after a shrink must emit")
+            .expect("channel open");
+        assert!(line.line.contains("(+2.0 MB)"), "got: {}", line.line);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn dropping_the_guard_aborts_the_sampling_task() {
+        let (tx, mut rx) = mpsc::unbounded_channel::<FeedbackLine>();
+        let monitor = BuildProgressMonitor::spawn(Arc::new(|| 0), tx, INTERVAL);
+        drop(monitor);
+        // The aborted task drops its sender, so the channel closes; a live
+        // task would hold it open forever.
+        let closed = tokio::time::timeout(INTERVAL * 12, rx.recv())
+            .await
+            .expect("the channel must close once the guard is dropped");
+        assert!(closed.is_none());
+    }
+
+    #[test]
+    fn format_bytes_scales_units() {
+        assert_eq!(format_bytes(512), "512 B");
+        assert_eq!(format_bytes(2048), "2 KB");
+        assert_eq!(format_bytes(3 * 1024 * 1024 / 2), "1.5 MB");
+        assert_eq!(format_bytes(19 * 1024 * 1024 * 1024 / 10), "1.9 GB");
+    }
+}

--- a/crates/node-stack-internal/src/lib.rs
+++ b/crates/node-stack-internal/src/lib.rs
@@ -31,6 +31,7 @@
 
 pub mod archive;
 pub mod build_io;
+mod build_progress;
 mod error;
 mod node_stack;
 mod service_action_cycle;

--- a/crates/node-stack-internal/src/lib.rs
+++ b/crates/node-stack-internal/src/lib.rs
@@ -40,7 +40,7 @@ mod virtual_deptree;
 pub use error::Error as NodeStackError;
 
 pub use archive::extract_tar_zst;
-pub use build_io::{FeedbackLine, FeedbackStream, OutputReaderHooks};
+pub use build_io::{FeedbackLine, FeedbackStream, OutputReaderHooks, stdout_line_sender};
 pub use core_node_api::InstanceState;
 pub use node_stack::add_steps;
 pub use node_stack::{

--- a/crates/node-stack-internal/src/node_stack/build_steps.rs
+++ b/crates/node-stack-internal/src/node_stack/build_steps.rs
@@ -13,7 +13,7 @@ use tracing::debug;
 use zstd::stream::write::Encoder as ZstdEncoder;
 
 use crate::build_io::{FeedbackLine, FeedbackStream, spawn_in_process_group, stream_child_output};
-use crate::build_progress::{BUILD_PROGRESS_SAMPLE_INTERVAL, BuildProgressMonitor};
+use crate::build_progress::BuildProgressMonitor;
 use crate::node_stack::container_build_cache;
 use config::node::PeppygenLanguage;
 
@@ -264,12 +264,11 @@ pub(super) async fn build_container_image(
         if let Some(cache) = &build_cache {
             extra_roots.push(cache.host_dir.clone());
         }
-        apptainer.cache_usage_probe(&extra_roots)
+        apptainer.cache_usage_probe(extra_roots)
     };
     let progress_monitor = BuildProgressMonitor::spawn(
-        Arc::new(move || usage_probe.usage_bytes()),
+        move || usage_probe.usage_bytes(),
         inputs.feedback_tx.clone(),
-        BUILD_PROGRESS_SAMPLE_INTERVAL,
     );
 
     let stream_result = stream_child_output(

--- a/crates/node-stack-internal/src/node_stack/build_steps.rs
+++ b/crates/node-stack-internal/src/node_stack/build_steps.rs
@@ -13,6 +13,7 @@ use tracing::debug;
 use zstd::stream::write::Encoder as ZstdEncoder;
 
 use crate::build_io::{FeedbackLine, FeedbackStream, spawn_in_process_group, stream_child_output};
+use crate::build_progress::{BUILD_PROGRESS_SAMPLE_INTERVAL, BuildProgressMonitor};
 use crate::node_stack::container_build_cache;
 use config::node::PeppygenLanguage;
 
@@ -248,6 +249,29 @@ pub(super) async fn build_container_image(
     let child = spawn_in_process_group(cmd)
         .map_err(|e| format!("Failed to spawn apptainer build: {}", e))?;
 
+    // Disk-growth progress: apptainer suppresses per-blob download progress
+    // off-TTY, so a slow base-image pull (and the silent "Creating SIF file..."
+    // stretch) would otherwise produce no feedback for minutes and trip the
+    // idle timeout. The probe samples every surface this build writes to —
+    // apptainer's cache and scratch, the build cache bind (a `%post` that
+    // compiles writes mostly there), and the output SIF — and the monitor
+    // emits a line only when the total grew, so genuine progress resets the
+    // idle clocks while a wedged build still times out. The guard lives on
+    // this future's stack: the phase runner dropping the future on timeout,
+    // cancellation, and normal completion all abort the monitor.
+    let usage_probe = {
+        let mut extra_roots = vec![output_path.clone()];
+        if let Some(cache) = &build_cache {
+            extra_roots.push(cache.host_dir.clone());
+        }
+        apptainer.cache_usage_probe(&extra_roots)
+    };
+    let progress_monitor = BuildProgressMonitor::spawn(
+        Arc::new(move || usage_probe.usage_bytes()),
+        inputs.feedback_tx.clone(),
+        BUILD_PROGRESS_SAMPLE_INTERVAL,
+    );
+
     let stream_result = stream_child_output(
         child,
         inputs.feedback_tx,
@@ -256,6 +280,7 @@ pub(super) async fn build_container_image(
         inputs.cancel_token,
     )
     .await;
+    drop(progress_monitor);
 
     // A `--force` supersede SIGKILL'd + reaped the host child above; now reach
     // into the VM and kill the guest process group too (no-op on Linux). Reuses

--- a/crates/peppy/src/commands/node.rs
+++ b/crates/peppy/src/commands/node.rs
@@ -36,6 +36,16 @@ pub(crate) use env::caller_env_overrides;
 
 /// Default idle timeout in seconds (resets on output).
 pub(crate) const DEFAULT_IDLE_TIMEOUT_SECS: u64 = 600;
+/// Default idle timeout for the container BUILD phase (`peppy node build`,
+/// `peppy stack launch --node-build-idle-timeout-secs`), tighter than
+/// [`DEFAULT_IDLE_TIMEOUT_SECS`] on purpose: the build's idle clock no longer
+/// depends on sporadic subprocess chatter — it also resets whenever bytes land
+/// on disk (image download, cache writes, SIF assembly), sampled every 5 s. So
+/// 180 s of silence is 36 consecutive zero-growth samples: not "maybe still
+/// downloading", but wedged. Add and run keep the 600 s default because their
+/// signal did not improve: add has quiet delta-resolution stretches, and run
+/// has no progress proxy at all (nodes legitimately initialize silently).
+pub(crate) const DEFAULT_BUILD_IDLE_TIMEOUT_SECS: u64 = 180;
 /// Default absolute max timeout in seconds (safety net).
 pub(crate) const DEFAULT_MAX_TIMEOUT_SECS: u64 = 3600;
 
@@ -335,8 +345,8 @@ pub enum NodeCommands {
         /// Node reference in the format node_name:tag (e.g., my_node:v1)
         #[arg(value_parser = parse_node_ref)]
         node_ref: (String, String),
-        /// Idle timeout in seconds; resets whenever output is received
-        #[arg(long, default_value_t = DEFAULT_IDLE_TIMEOUT_SECS)]
+        /// Idle timeout in seconds; resets on build output or image-download/write progress
+        #[arg(long, default_value_t = DEFAULT_BUILD_IDLE_TIMEOUT_SECS)]
         idle_timeout: u64,
         /// Absolute max timeout in seconds (safety net)
         #[arg(long, default_value_t = DEFAULT_MAX_TIMEOUT_SECS)]

--- a/crates/peppy/src/commands/stack.rs
+++ b/crates/peppy/src/commands/stack.rs
@@ -14,7 +14,7 @@ use clap::Subcommand;
 use tracing::info;
 
 use super::Command;
-use super::node::DEFAULT_IDLE_TIMEOUT_SECS;
+use super::node::{DEFAULT_BUILD_IDLE_TIMEOUT_SECS, DEFAULT_IDLE_TIMEOUT_SECS};
 use crate::{context::AppContext, error::Error as CommandError};
 
 #[derive(Subcommand)]
@@ -42,8 +42,9 @@ pub enum StackCommands {
         /// Idle timeout in seconds for the node add phase (resets on git/http progress or sub-process output)
         #[arg(long, default_value_t = DEFAULT_IDLE_TIMEOUT_SECS)]
         node_add_idle_timeout_secs: u64,
-        /// Idle timeout in seconds for the node build phase (resets on build_cmd output)
-        #[arg(long, default_value_t = DEFAULT_IDLE_TIMEOUT_SECS)]
+        /// Idle timeout in seconds for the node build phase (resets on build output or
+        /// image-download/write progress)
+        #[arg(long, default_value_t = DEFAULT_BUILD_IDLE_TIMEOUT_SECS)]
         node_build_idle_timeout_secs: u64,
         /// Idle timeout in seconds for the node run-startup phase (resets on subprocess output until the node signals ready)
         #[arg(long, default_value_t = DEFAULT_IDLE_TIMEOUT_SECS)]

--- a/crates/peppy/src/commands/stack/launch.rs
+++ b/crates/peppy/src/commands/stack/launch.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
+use core_node::{idle_timeout_flag, slow_connection_hint};
 use core_node_api::encoding::{
     LaunchFeedback, LaunchFeedbackStep, LaunchGoal, LaunchGoalResponse, LaunchResult,
     LauncherOrigin, NodeAddLogEntry, NodeBuildLogEntry, NodeRunLogEntry, PlacementSpec,
@@ -110,18 +111,6 @@ fn display_node_log_files(
                 info!("    {text}");
             }
         }
-    }
-}
-
-/// The `peppy stack launch` flag that raises the idle budget of the phase a
-/// feedback step belongs to. `None` for the launcher step, whose work
-/// (parse/resolve) has no per-phase flag — the CLI watchdog alone bounds it.
-fn idle_timeout_flag(step: LaunchFeedbackStep) -> Option<&'static str> {
-    match step {
-        LaunchFeedbackStep::AddingNode => Some("--node-add-idle-timeout-secs"),
-        LaunchFeedbackStep::BuildingNode => Some("--node-build-idle-timeout-secs"),
-        LaunchFeedbackStep::RunningNode => Some("--node-run-idle-timeout-secs"),
-        LaunchFeedbackStep::LauncherStep => None,
     }
 }
 
@@ -462,18 +451,15 @@ async fn launch_async(
             // Name the phase that went quiet and the flag that raises its
             // budget, so a slow-connection user is pointed at the fix instead
             // of a bare timeout.
-            let phase = current_scrolling_step
-                .map(|step| format!(" during the {} phase", step.phase_label()))
-                .unwrap_or_default();
-            let hint = current_scrolling_step
-                .and_then(idle_timeout_flag)
-                .map(|flag| {
-                    format!(
-                        "; if this machine is on a slow connection, retry with a larger \
-                         {flag} (progress output resets this clock)"
-                    )
-                })
-                .unwrap_or_default();
+            let (phase, hint) = match current_scrolling_step {
+                Some(step) => (
+                    format!(" during the {} phase", step.phase_label()),
+                    idle_timeout_flag(step)
+                        .map(|flag| format!("; {}", slow_connection_hint(flag)))
+                        .unwrap_or_default(),
+                ),
+                None => (String::new(), String::new()),
+            };
             return Err(Error::ExecutionFailed(format!(
                 "Launch timed out: no output received for {}s{phase}{hint}. Log file: {}",
                 cli_idle_timeout.as_secs(),

--- a/crates/peppy/src/commands/stack/launch.rs
+++ b/crates/peppy/src/commands/stack/launch.rs
@@ -113,6 +113,18 @@ fn display_node_log_files(
     }
 }
 
+/// The `peppy stack launch` flag that raises the idle budget of the phase a
+/// feedback step belongs to. `None` for the launcher step, whose work
+/// (parse/resolve) has no per-phase flag — the CLI watchdog alone bounds it.
+fn idle_timeout_flag(step: LaunchFeedbackStep) -> Option<&'static str> {
+    match step {
+        LaunchFeedbackStep::AddingNode => Some("--node-add-idle-timeout-secs"),
+        LaunchFeedbackStep::BuildingNode => Some("--node-build-idle-timeout-secs"),
+        LaunchFeedbackStep::RunningNode => Some("--node-run-idle-timeout-secs"),
+        LaunchFeedbackStep::LauncherStep => None,
+    }
+}
+
 fn handle_feedback(
     feedback: &LaunchFeedback,
     scrolling_output: &mut Option<ScrollingOutput>,
@@ -447,8 +459,23 @@ async fn launch_async(
             if let Some(output) = scrolling_output.as_mut() {
                 output.clear();
             }
+            // Name the phase that went quiet and the flag that raises its
+            // budget, so a slow-connection user is pointed at the fix instead
+            // of a bare timeout.
+            let phase = current_scrolling_step
+                .map(|step| format!(" during the {} phase", step.phase_label()))
+                .unwrap_or_default();
+            let hint = current_scrolling_step
+                .and_then(idle_timeout_flag)
+                .map(|flag| {
+                    format!(
+                        "; if this machine is on a slow connection, retry with a larger \
+                         {flag} (progress output resets this clock)"
+                    )
+                })
+                .unwrap_or_default();
             return Err(Error::ExecutionFailed(format!(
-                "Launch timed out: no output received for {}s. Log file: {}",
+                "Launch timed out: no output received for {}s{phase}{hint}. Log file: {}",
                 cli_idle_timeout.as_secs(),
                 goal_response.log_path.display()
             )));

--- a/docs/src/content/docs/quickstart.mdx
+++ b/docs/src/content/docs/quickstart.mdx
@@ -62,7 +62,7 @@ Every circle is one instance the launcher started, and every arrow a link betwee
 :::
 
 :::note
-The first launch pulls the MuJoCo simulation image (a few hundred megabytes) and converts it into a local Apptainer image, so expect it to take a while; later launches reuse the cached image. `--node-build-idle-timeout-secs` raises the window the daemon allows without build output, which keeps it from killing that first download partway through. Subsequent launches don't need the flag.
+The first launch pulls the MuJoCo simulation image (a few hundred megabytes) and converts it into a local Apptainer image, so expect it to take a while; later launches reuse the cached image. Download and image-assembly progress counts as build output, so a slow connection won't trip the build idle timeout on its own. If a build of yours genuinely goes quiet for minutes (no output *and* no bytes written to disk), raise the window with `--node-build-idle-timeout-secs`.
 :::
 
 ## Step 3: Drive the arms


### PR DESCRIPTION
## Problem

Two user-facing failures on slow connections, one root cause:

1. `peppy stack launch <launcher>` times out with `build idle timeout exceeded (600s without output)` even though the launch is progressing — the timeout blames the launch for what is really a slow base-image download.
2. When `apptainer build` implicitly pulls a docker base image, the user sees "Creating SIF file..." and then nothing.

Apptainer suppresses per-blob progress off-TTY (one "Copying blob …" line per blob, then silence), and the output reader split on `\n` only, so `\r`-repaint progress never surfaced. The daemon's per-phase idle watchdog and the CLI watchdog reset only when a line flows through the feedback channel, so a >600 s silent blob download read as "idle" and the build was SIGKILLed. A secondary silent window: resolve-phase git-clone progress was buffered into a `Vec` and flushed only after the blocking checkout returned.

## Fix

Make genuine progress visible and let it reset the idle clocks:

- **`containers`: disk-usage probe.** `Apptainer::cache_usage_probe()` returns a self-contained `CacheUsageProbe` over every surface a build writes to: the apptainer cache dir (`$APPTAINER_CACHEDIR` else `~/.apptainer/cache` — read, never relocated, to avoid cold-starting multi-GB re-downloads), the `APPTAINER_TMPDIR` scratch, and caller extras. Under Lima the guest cache is sampled via `du` through `limactl shell`. Missing roots/errors read as 0: a broken probe degrades to today's behavior and can never neuter the timeout.
- **`node-stack`: `BuildProgressMonitor`.** During `apptainer build`, samples the probe every 5 s (extras: the output SIF and the container-build-cache bind, so a `%post` that compiles also counts) and emits a feedback line **only when bytes grew**: `Fetching/assembling container image: 1.9 GB written (+320 MB)`. That single seam resets both the daemon idle clock and the CLI watchdog; a wedged build moves no bytes and still times out. The `Drop` guard lives on the build future's stack, so timeout-drop, `--force` cancel, and normal completion all abort it.
- **`build_io`: `\r`-aware output splitting.** The async reader splits on `\n`/`\r`/`\r\n` (lossy UTF-8). `\n` lines always forward — byte-identical compatibility for `\r`-free output (the run path shares this reader). Bare-`\r` repaints coalesce at 500 ms; the final fragment before EOF always lands; suppressed repaints skip the log file and stderr tail too. A `\r` at a chunk boundary is held one byte so a split `\r\n` is never misclassified as a throttleable repaint.
- **`launch/resolve`: streamed clone progress.** Launcher-origin and per-deployment resolution progress now streams through `spawn_feedback_forwarder` instead of buffering, drained before each "Deployment resolved" line so ordering is preserved.
- **Actionable timeout messages.** The daemon idle-timeout error keeps its prefix and appends the right `--node-<phase>-idle-timeout-secs` flag; the CLI watchdog error names the phase that went quiet plus the same hint.
- **Build idle default 600 s → 180 s** (`stack launch --node-build-idle-timeout-secs`, `node build --idle-timeout`). With the clock reset by bytes landing on disk at a 5 s cadence, 180 s of silence is 36 consecutive zero-growth samples — wedged, not slow. `node add`/`node run` keep 600 s (their signal did not improve), so the CLI launch watchdog stays max(add, build, run) + 60 s = 660 s. The wire-level default in `public-peppy-libs` is untouched — the CLI always sends explicit values, and 600 stays the conservative default for older clients.

Deliberately **not** done: the optional grace tweak for `node build`'s CLI poll. The daemon enforces only the max timeout for standalone builds (no daemon-side idle watchdog), so the CLI `--idle-timeout` is the sole idle enforcement there — adding grace would loosen it, and the growth lines already reset its clock.

## What the user sees now

- Resolve: live `Cloning https://…: received 1200/5300 objects (14.2 MB)` lines instead of silence.
- Build/pull: apptainer's `Copying blob …` lines plus a growth line every ~5 s, continuing through the previously-silent "Creating SIF file..." stretch.
- True hang: idle timeout at 180 s with a message naming the phase and the flag to raise.

## Testing

- New unit tests: probe sums a tempdir tree / ignores missing roots / does not follow symlinks; `effective_host_cache_dir` env-override order; monitor emits on growth, stays silent when flat, rebases on shrink, guard-drop aborts (paused-clock tests); splitter `a\rb\r\nc\nd` → `a,b,c,d`, cross-chunk `\r\n`, EOF repaint delivery, `\n`-only streams verbatim; coalescer throttling; end-to-end reader repaint coalescing.
- Full suites green: `containers` 96, `node-stack` 148, `core-node` 581, `peppy` 369 passed, 0 failed; `container_e2e` and `multi_daemon_e2e` targets compile under `--locked`; `cargo fmt --check` clean; no `Cargo.lock` change.
- `--help` verified: build shows 180, add/run show 600.
- Not yet run: manual throttled-network E2E (`tc netem` rate-limit → growth lines and no timeout at `--node-build-idle-timeout-secs 60`; registry blackhole mid-pull → timeout with the new message). Needs sudo on a test box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)