### PR TITLE
Expand ~ in container mount_paths on the machine that binds them

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -830,6 +830,7 @@ dependencies = [
  "build-helpers",
  "config-test-support",
  "daemon-config",
+ "dirs 6.0.0",
  "peppy-config-model",
  "serde_yaml",
  "tempfile",

--- a/crates/containers-internal/Cargo.toml
+++ b/crates/containers-internal/Cargo.toml
@@ -10,6 +10,9 @@ config = { workspace = true }
 # `APPTAINER_TMPDIR`, so it lands on the same peppy-owned tree as every other
 # peppy temporary instead of the host's `/tmp`.
 daemon-config = { workspace = true }
+# Home lookup for `~` expansion in mount-spec sources. `dirs` falls back to
+# the passwd database when `$HOME` is unset (daemons under systemd/cron).
+dirs = "6"
 serde_yaml = "0.9"
 thiserror = "2.0"
 tracing = "0.1"

--- a/crates/containers-internal/src/lib.rs
+++ b/crates/containers-internal/src/lib.rs
@@ -14,7 +14,8 @@ pub use apptainer::CacheUsageProbe;
 pub use apptainer::{SetupStatus, check_setup_status};
 pub use error::{Error, Result};
 pub use mount_source::{
-    auto_created_warning, ensure_bind_source, is_host_provided_mount_source, mount_spec_source,
+    auto_created_warning, ensure_bind_source, expand_home_in_mount_spec,
+    home_mount_source_rejection, is_host_provided_mount_source, mount_spec_source,
 };
 
 /// Pinned Apptainer version bundled at build time.

--- a/crates/containers-internal/src/mount_source.rs
+++ b/crates/containers-internal/src/mount_source.rs
@@ -77,6 +77,78 @@ pub fn auto_created_warning(src: &str) -> String {
     )
 }
 
+/// Expands a leading `~` in the host-source segment of a
+/// `host_path[:container_path[:options]]` mount spec against THIS machine's
+/// home directory. The container path and options pass through verbatim: a
+/// `~` there belongs to the container, not the host.
+///
+/// Expansion is deliberately machine-local. A launch coordinator ships mount
+/// sources to peer machines as the raw `~/...` token, because the peer's home
+/// is not the coordinator's; whichever daemon is about to create, register,
+/// or bind a source calls this at that moment. Without it the literal `~` is
+/// a relative path, and the auto-create/`--bind` grow a stray `~/` tree in
+/// whatever directory the daemon happened to be started from.
+///
+/// `~user` sources are rejected via [`home_mount_source_rejection`], and an
+/// expansion landing in a blocked system directory (a pathological `$HOME`
+/// like `/tmp`) is refused with the phrasing the spec validation uses, so the
+/// "nothing handed to the auto-create or the runtime is a blocked top-level
+/// dir" invariant survives expansion.
+pub fn expand_home_in_mount_spec(spec: &str) -> std::result::Result<String, String> {
+    expand_home_in_mount_spec_with(spec, dirs::home_dir().as_deref())
+}
+
+/// Why `src` cannot name a home-relative mount source, or `None` if it can.
+///
+/// Only the `~user` form is unsupported: resolving another user's home is a
+/// passwd lookup peppy has no business doing on a node's behalf. Shared so
+/// the coordinator-side plan validation (which must not expand, only reject)
+/// and the machine-local expansion above refuse with the same words.
+pub fn home_mount_source_rejection(src: &str) -> Option<String> {
+    let is_tilde_user = src.starts_with('~') && src != "~" && !src.starts_with("~/");
+    is_tilde_user.then(|| {
+        format!(
+            "~user paths are not supported in mount path source `{src}`; \
+             use an absolute path or ~/..."
+        )
+    })
+}
+
+/// [`expand_home_in_mount_spec`] with the home directory injected, so tests
+/// don't depend on the runner's real `$HOME`.
+fn expand_home_in_mount_spec_with(
+    spec: &str,
+    home: Option<&Path>,
+) -> std::result::Result<String, String> {
+    let src = mount_spec_source(spec);
+    if !src.starts_with('~') {
+        return Ok(spec.to_owned());
+    }
+    if let Some(rejection) = home_mount_source_rejection(src) {
+        return Err(rejection);
+    }
+    let home = home.ok_or_else(|| {
+        format!("cannot expand `~` in mount path `{spec}`: the home directory is unavailable")
+    })?;
+    let expanded = if src == "~" {
+        home.to_path_buf()
+    } else {
+        home.join(&src["~/".len()..])
+    };
+    let expanded_src = expanded.to_str().ok_or_else(|| {
+        format!(
+            "cannot expand `~` in mount path `{spec}`: the home directory path is not valid UTF-8"
+        )
+    })?;
+    if config::node::is_blocked_mount_source(expanded_src) {
+        return Err(format!(
+            "mount path `{spec}` expands its source to a blocked system directory \
+             `{expanded_src}`; use a subdirectory instead"
+        ));
+    }
+    Ok(format!("{expanded_src}{}", &spec[src.len()..]))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -188,6 +260,93 @@ mod tests {
         assert!(
             message.contains(target.to_string_lossy().as_ref()),
             "error must name the offending path, got: {message}"
+        );
+    }
+
+    #[test]
+    fn expand_home_expands_bare_tilde_source() {
+        let expanded = expand_home_in_mount_spec_with("~", Some(Path::new("/home/me")))
+            .expect("a bare ~ is a valid source");
+        assert_eq!(expanded, "/home/me");
+    }
+
+    #[test]
+    fn expand_home_expands_tilde_source_and_keeps_dest_and_opts() {
+        let expanded = expand_home_in_mount_spec_with(
+            "~/.cache/kit:/isaac-sim/kit/cache:rw",
+            Some(Path::new("/home/me")),
+        )
+        .expect("a home-relative source is a valid spec");
+        assert_eq!(expanded, "/home/me/.cache/kit:/isaac-sim/kit/cache:rw");
+    }
+
+    #[test]
+    fn expand_home_rejects_tilde_user_sources() {
+        let error = expand_home_in_mount_spec_with("~bob/data:/data", Some(Path::new("/home/me")))
+            .expect_err("~user sources are unsupported");
+        assert!(
+            error.contains("~user paths are not supported"),
+            "the rejection must say why, got: {error}"
+        );
+        assert!(
+            error.contains("~bob/data"),
+            "the rejection must name the offending source, got: {error}"
+        );
+    }
+
+    /// Everything without a leading `~` in the SOURCE comes back verbatim: an
+    /// absolute spec, a plain relative source (whose cwd anchoring is the
+    /// documented Lima behavior, not ours to change here), and a spec whose
+    /// only `~` is on the container side.
+    #[test]
+    fn expand_home_leaves_non_tilde_specs_alone() {
+        for spec in [
+            "/data/models:/opt/models:ro",
+            "robot_assets",
+            "/data:~/inside:rw",
+        ] {
+            let expanded = expand_home_in_mount_spec_with(spec, Some(Path::new("/home/me")))
+                .expect("a non-tilde source is always valid");
+            assert_eq!(expanded, spec, "{spec} must pass through unchanged");
+        }
+    }
+
+    #[test]
+    fn expand_home_fails_without_a_home_directory() {
+        let error = expand_home_in_mount_spec_with("~/.cache/kit", None)
+            .expect_err("no home means no expansion");
+        assert!(
+            error.contains("home directory is unavailable"),
+            "the failure must say what is missing, got: {error}"
+        );
+    }
+
+    /// A pathological home (say the daemon was started with `HOME=/tmp`) must
+    /// not let a bare `~` smuggle a blocked top-level directory past the spec
+    /// validation, which ran before expansion and saw only the token.
+    #[test]
+    fn expand_home_rejects_a_blocked_expansion() {
+        let error = expand_home_in_mount_spec_with("~", Some(Path::new("/tmp")))
+            .expect_err("an expansion into a blocked directory must be refused");
+        assert!(
+            error.contains("blocked system directory"),
+            "the refusal must keep the canonical phrase, got: {error}"
+        );
+    }
+
+    /// The public wrapper wires the real home lookup to the expansion. Skipped
+    /// when the environment has no resolvable home, where the error branch is
+    /// already covered above.
+    #[test]
+    fn expand_home_public_wrapper_uses_the_real_home() {
+        let Some(home) = dirs::home_dir() else {
+            return;
+        };
+        let expanded =
+            expand_home_in_mount_spec("~/.cache/kit:/kit:rw").expect("expansion must succeed");
+        assert_eq!(
+            expanded,
+            format!("{}/.cache/kit:/kit:rw", home.to_str().expect("utf-8 home"))
         );
     }
 }

--- a/crates/core-node-internal/src/services/node/run.rs
+++ b/crates/core-node-internal/src/services/node/run.rs
@@ -997,10 +997,17 @@ async fn process_node_run(
     let raw_mount_paths = container_config
         .and_then(|c| c.mount_paths.as_deref())
         .unwrap_or_default();
+    // Parameter substitution first, then `~` expansion: this daemon is the
+    // machine the instance runs on, so its home is the right one. The launch
+    // coordinator's copy of these specs stays unexpanded (see
+    // `resolve_mount_path_parameters`), because its per-machine mount lists
+    // travel to peers whose home is not the coordinator's.
     let resolved_mount_paths = match resolve_mount_path_parameters(
         raw_mount_paths,
         &runtime_config.node_instance.arguments,
-    ) {
+    )
+    .and_then(expand_home_in_mount_specs)
+    {
         Ok(paths) => paths,
         Err(msg) => {
             write_error_to_log(&ctx.log_file, &msg);
@@ -1526,13 +1533,35 @@ fn startup_abort_reason(outcome: &StartupOutcome) -> Option<&str> {
     }
 }
 
+/// Expands `~` in the host-source segment of already-resolved mount specs
+/// against this machine's home directory.
+///
+/// Applied only on the machine that runs the instance (never on the launch
+/// coordinator's copies, which travel to peers): from here on, everything
+/// downstream — the restart-refusal check, the bind-source auto-create, Lima
+/// registration, and the apptainer `--bind` — sees the same absolute path,
+/// instead of treating the literal `~/...` as a path relative to whatever
+/// directory the daemon was started from.
+fn expand_home_in_mount_specs(specs: Vec<String>) -> std::result::Result<Vec<String>, String> {
+    specs
+        .into_iter()
+        .map(|spec| containers::expand_home_in_mount_spec(&spec))
+        .collect()
+}
+
 /// Replaces `${parameters:...}` tokens in mount paths with actual argument values.
 ///
 /// Each `${parameters:<dot.path>}` is resolved against the runtime `arguments`.
 /// Only `AnyType::String` values are accepted; other types produce an error.
 ///
 /// After resolution, the source (host) portion of each mount path is validated
-/// against the blocked system directories list.
+/// against the blocked system directories list, and unsupported `~user` forms
+/// are rejected. `~`/`~/...` sources are NOT expanded here: the launch
+/// coordinator calls this for every machine in the plan and ships the results
+/// to peers whose home is not the coordinator's, so the token must stay
+/// machine-independent. Expansion happens machine-locally, via
+/// [`expand_home_in_mount_specs`] at instance start and
+/// [`crate::services::stack::prepare_container_mounts`] at launch preflight.
 pub(crate) fn resolve_mount_path_parameters(
     mount_paths: &[String],
     arguments: &BTreeMap<String, AnyType>,
@@ -1576,6 +1605,12 @@ pub(crate) fn resolve_mount_path_parameters(
             return Err(format!(
                 "Resolved mount path `{result}` uses a blocked system directory `{src}` as source; use a subdirectory instead"
             ));
+        }
+        // A `~user` source can never be expanded (on any machine), so a launch
+        // fails on it here, while a failure is still free, instead of on the
+        // machine that would have had to bind it.
+        if let Some(rejection) = containers::home_mount_source_rejection(src) {
+            return Err(rejection);
         }
 
         resolved.push(result);
@@ -2375,6 +2410,59 @@ mod tests {
         let result = resolve_mount_path_parameters(&mount_paths, &arguments);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("blocked system directory"));
+    }
+
+    /// The `~user` form is rejected during plan resolution — the launch
+    /// coordinator runs this, so a launcher naming an unexpandable source
+    /// fails before any stack is replaced — and the rejection sees the
+    /// post-substitution source, so a parameter cannot smuggle one in.
+    #[test]
+    fn test_resolve_mount_path_parameters_rejects_tilde_user() {
+        let literal = vec!["~bob/data:/data:rw".to_string()];
+        let error = resolve_mount_path_parameters(&literal, &BTreeMap::new()).unwrap_err();
+        assert!(error.contains("~user paths are not supported"), "{error}");
+
+        let via_parameter = vec!["${parameters:path}:/data:rw".to_string()];
+        let mut arguments = BTreeMap::new();
+        arguments.insert("path".to_string(), AnyType::String("~bob/data".to_string()));
+        let error = resolve_mount_path_parameters(&via_parameter, &arguments).unwrap_err();
+        assert!(error.contains("~user paths are not supported"), "{error}");
+    }
+
+    /// A `~/...` source must come back UNEXPANDED: the coordinator resolves
+    /// mount paths for every machine in the plan and ships them to peers whose
+    /// home is not the coordinator's. Expansion is machine-local
+    /// ([`expand_home_in_mount_specs`] at instance start,
+    /// `prepare_container_mounts` at launch preflight); expanding here would
+    /// bake the coordinator's home into another machine's bind.
+    #[test]
+    fn test_resolve_mount_path_parameters_passes_home_relative_source_through() {
+        let mount_paths = vec!["~/.cache/kit:/kit:rw".to_string()];
+        let resolved = resolve_mount_path_parameters(&mount_paths, &BTreeMap::new()).unwrap();
+        assert_eq!(resolved, vec!["~/.cache/kit:/kit:rw"]);
+    }
+
+    /// The machine-local half: at instance start the resolved specs go through
+    /// home expansion, so everything downstream (auto-create, Lima
+    /// registration, `--bind`) sees an absolute path instead of a literal
+    /// `~/...` treated as relative to the daemon's working directory.
+    #[test]
+    fn test_expand_home_in_mount_specs_expands_tilde_sources() {
+        let Some(home) = dirs::home_dir() else {
+            return;
+        };
+        let specs = vec![
+            "~/.cache/kit:/kit:rw".to_string(),
+            "/data/models:/opt/models:ro".to_string(),
+        ];
+        let expanded = expand_home_in_mount_specs(specs).unwrap();
+        assert_eq!(
+            expanded,
+            vec![
+                format!("{}/.cache/kit:/kit:rw", home.to_str().unwrap()),
+                "/data/models:/opt/models:ro".to_string(),
+            ]
+        );
     }
 
     // ---- FeedbackSync::wait_for_drain ----

--- a/crates/core-node-internal/src/services/stack/container_mounts.rs
+++ b/crates/core-node-internal/src/services/stack/container_mounts.rs
@@ -11,6 +11,11 @@
 //! On Linux there is no VM and `ensure_host_mounts` is a no-op, so what remains
 //! is the auto-create of missing sources, which every machine owes its own
 //! instances.
+//!
+//! Sources may arrive as raw `~/...` tokens: the coordinator resolves the
+//! plan's mount paths but deliberately leaves `~` alone, because a peer's home
+//! is not the coordinator's. This is the place they become this machine's
+//! absolute paths — before anything is created or registered.
 
 use std::path::{Path, PathBuf};
 
@@ -25,18 +30,29 @@ use containers::{Apptainer, is_host_provided_mount_source};
 /// The returned paths are the ones that did not exist. Each is an operator
 /// warning its caller must surface in whatever stream it owns, because an
 /// auto-created source is also what a bind meant to name an existing file looks
-/// like when the name is misspelled.
+/// like when the name is misspelled. A `~` source is reported (and created,
+/// registered) in its expanded form: the expanded path is what actually lands
+/// on this machine's disk.
 pub(crate) async fn prepare_container_mounts(
     mount_sources: &[String],
 ) -> std::result::Result<Vec<String>, String> {
+    // Expanding here and at instance start through the one shared helper keeps
+    // both sides byte-identical: `host_mounts_need_restart` at start compares
+    // against what was registered now, and a `~` source registered in one form
+    // but checked in another would demand a spurious VM restart.
+    let mount_sources = mount_sources
+        .iter()
+        .map(|src| containers::expand_home_in_mount_spec(src))
+        .collect::<std::result::Result<Vec<String>, String>>()?;
+
     let mut auto_created = Vec::new();
-    for src in mount_sources {
+    for src in &mount_sources {
         if containers::ensure_bind_source(Path::new(src)).map_err(|e| e.to_string())? {
             auto_created.push(src.clone());
         }
     }
 
-    let lima_mount_sources = external_lima_mount_sources(mount_sources);
+    let lima_mount_sources = external_lima_mount_sources(&mount_sources);
     if lima_mount_sources.is_empty() {
         return Ok(auto_created);
     }
@@ -148,6 +164,32 @@ mod tests {
         assert!(
             error.contains(target.to_string_lossy().as_ref()),
             "the failure must name the offending path, got: {error}"
+        );
+    }
+
+    /// The regression this module's expansion exists for: a `~` source arriving
+    /// from the coordinator must be expanded to this machine's home BEFORE the
+    /// auto-create, not `mkdir -p`'d as a literal relative path. The home
+    /// already exists, so nothing is created and nothing is reported — and in
+    /// particular no stray `~/` directory appears under the process cwd, which
+    /// is exactly what the unexpanded token used to produce.
+    #[tokio::test]
+    async fn prepare_expands_home_relative_sources() {
+        let Some(home) = dirs::home_dir() else {
+            return;
+        };
+        assert!(home.exists(), "the test needs a real home to expand into");
+
+        let auto_created = prepare_container_mounts(&["~".to_string()])
+            .await
+            .expect("a home-relative source must be preparable");
+        assert!(
+            auto_created.is_empty(),
+            "the home exists, so nothing may be auto-created, got: {auto_created:?}"
+        );
+        assert!(
+            !Path::new("~").exists(),
+            "a literal ./~ directory must never be created"
         );
     }
 

--- a/docs/src/content/docs/advanced_guides/containers.mdx
+++ b/docs/src/content/docs/advanced_guides/containers.mdx
@@ -295,6 +295,8 @@ Each entry follows the format `host_path:container_path[:options]`:
 | `host_path:container_path` | `"/data/models:/opt/models"` | Mounted at a different path inside the container |
 | `host_path:container_path:options` | `"/data/models:/opt/models:ro"` | Mounted with explicit options (`ro` for read-only, `rw` for read-write) |
 
+`host_path` may start with `~`, which expands to the home directory of the user running the daemon **on the machine where the instance runs** — in a federated launch, each machine expands `~` against its own home, so a single manifest works across machines with different usernames (`"~/.cache/my_node:/cache:rw"`). The `~user` form is not supported and is rejected while the launch is being validated, before any stack is replaced. Only the host side is expanded: a `~` in `container_path` is passed to the container verbatim.
+
 A source under `/dev` with no remap (no destination, or a destination equal to the source) is passed through rather than bound: host devices reach the container through Apptainer's device mount, and only a remapped device bind emits an explicit `--bind`.
 
 A missing mount source is created on the host as a directory before the container starts, and a warning names each auto-created path, so a typo in a file bind shows up as an unexpectedly created empty directory. Sources under the host runtime trees (`/dev`, `/proc`, `/run`, `/sys`) are used as-is and never created.


### PR DESCRIPTION
## Problem

Running `peppy stack launch` with a launcher whose node declares home-relative container binds (e.g. `openarm_sim_isaac`'s `mount_paths: ["~/.cache/isaac-sim/kit/cache:/isaac-sim/kit/cache:rw", ...]`) leaves a literal `~/` directory tree inside the daemon's working directory — in practice, the peppy checkout the daemon was started from — and Isaac Sim's shader caches and kit logs land in it at runtime.

## Root cause

Tilde expansion is a shell feature; peppy never expanded `~` in mount-spec host sources. The literal `~/...` is a *relative* path, so:

1. the bind-source auto-create (`containers::ensure_bind_source`) ran `mkdir -p ~/.cache/...` relative to the daemon's cwd, creating the stray tree, and
2. the same literal string reached `apptainer run --bind`, so the container's writes went into that stray tree instead of the real `~/.cache`.

## Fix

Expand `~`/`~/...` in the host-source segment of mount specs — **machine-locally**, in the two places a daemon is about to act on a source:

- instance start, right after `${parameters:...}` resolution (`services/node/run.rs`), covering the restart-refusal check, the auto-create, Lima registration, and the `--bind`;
- launch-preflight mount preparation (`services/stack/container_mounts.rs`), covering both the coordinator's own slice and a participant's.

Expansion deliberately does **not** happen in `resolve_mount_path_parameters`: the launch coordinator calls it for every machine in the plan and ships the resulting sources to peers whose home is not the coordinator's, so `~` travels as a machine-independent token and each machine expands it against its own home. A test pins this invariant. Both machine-local sites share one helper (`containers::expand_home_in_mount_spec`), keeping the registered and later-rechecked strings byte-identical so a `~` source can't trigger a spurious Lima VM-restart refusal on macOS.

Guard rails:

- the unsupported `~user` form is rejected during plan resolution, before a launch replaces any stack;
- an expansion landing in a blocked system directory (a pathological `$HOME` like `/tmp`) is refused with the existing "blocked system directory" phrasing;
- only the host side expands — a `~` in the container path passes through verbatim.

No wire-format changes: federated `mount_sources` stay `Vec<String>` of raw tokens, so there is no version-skew regression (an old peer keeps today's behavior; a new peer is fixed).

Docs: the mount-format section in `advanced_guides/containers.mdx` now documents `~` support and its per-machine expansion semantics.

## Testing

- 7 new unit tests on the helper (injected home, so deterministic): bare `~`, src-only expansion with dest/opts preserved, `~user` rejection, non-tilde passthrough (absolute, plain relative, `~` in dest only), missing home, blocked expansion, real-home wrapper.
- 2 new tests pinning `resolve_mount_path_parameters` behavior: `~user` rejected (literal and via parameter substitution), `~/...` passes through unexpanded (the federation invariant).
- 1 seam test: `prepare_container_mounts(["~"])` succeeds, creates nothing, and no literal `./~` directory appears.
- Full `cargo test -p containers -p core-node` and `cargo clippy --all-targets` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)