### PR TITLE
Composable launchers: components, --with, and stack resolve

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -587,7 +587,7 @@ dependencies = [
 [[package]]
 name = "build-helpers"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#f419b849ff8ec3e8f9d099e9ea8375b070d07507"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#3c2986192b7bfb5b11a108af6cbe3648a2b857bb"
 dependencies = [
  "sha2",
 ]
@@ -785,7 +785,7 @@ dependencies = [
 [[package]]
 name = "config-test-support"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#f419b849ff8ec3e8f9d099e9ea8375b070d07507"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#3c2986192b7bfb5b11a108af6cbe3648a2b857bb"
 dependencies = [
  "askama",
  "git2",
@@ -930,7 +930,7 @@ dependencies = [
 [[package]]
 name = "core-node-api"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#f419b849ff8ec3e8f9d099e9ea8375b070d07507"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#3c2986192b7bfb5b11a108af6cbe3648a2b857bb"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -2686,7 +2686,7 @@ dependencies = [
 [[package]]
 name = "json5-pretty"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#f419b849ff8ec3e8f9d099e9ea8375b070d07507"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#3c2986192b7bfb5b11a108af6cbe3648a2b857bb"
 dependencies = [
  "serde",
  "serde_json",
@@ -3512,7 +3512,7 @@ dependencies = [
 [[package]]
 name = "peppy-config-model"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#f419b849ff8ec3e8f9d099e9ea8375b070d07507"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#3c2986192b7bfb5b11a108af6cbe3648a2b857bb"
 dependencies = [
  "capnp",
  "clap",
@@ -3531,7 +3531,7 @@ dependencies = [
 [[package]]
 name = "peppy-mcp-catalog"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#f419b849ff8ec3e8f9d099e9ea8375b070d07507"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#3c2986192b7bfb5b11a108af6cbe3648a2b857bb"
 dependencies = [
  "serde",
  "serde_json",
@@ -3540,7 +3540,7 @@ dependencies = [
 [[package]]
 name = "peppy-mcp-runtime"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#f419b849ff8ec3e8f9d099e9ea8375b070d07507"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#3c2986192b7bfb5b11a108af6cbe3648a2b857bb"
 dependencies = [
  "axum",
  "base64 0.23.1",
@@ -3562,7 +3562,7 @@ version = "0.0.1"
 [[package]]
 name = "peppylib-rs"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#f419b849ff8ec3e8f9d099e9ea8375b070d07507"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#3c2986192b7bfb5b11a108af6cbe3648a2b857bb"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -3757,7 +3757,7 @@ dependencies = [
 [[package]]
 name = "pmi"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#f419b849ff8ec3e8f9d099e9ea8375b070d07507"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#3c2986192b7bfb5b11a108af6cbe3648a2b857bb"
 dependencies = [
  "build-helpers",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -588,7 +588,7 @@ dependencies = [
 [[package]]
 name = "build-helpers"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#b5010288d5309443b0e8dc89bd45b975323a2abd"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#f3fd31a124e539074d67e0d4cf26434acab35228"
 dependencies = [
  "sha2",
 ]
@@ -652,9 +652,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d262e149917187838d5b42777c8253bcb64500067342904e7d429499a6f277e"
+checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -786,7 +786,7 @@ dependencies = [
 [[package]]
 name = "config-test-support"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#b5010288d5309443b0e8dc89bd45b975323a2abd"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#f3fd31a124e539074d67e0d4cf26434acab35228"
 dependencies = [
  "askama",
  "git2",
@@ -931,7 +931,7 @@ dependencies = [
 [[package]]
 name = "core-node-api"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#b5010288d5309443b0e8dc89bd45b975323a2abd"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#f3fd31a124e539074d67e0d4cf26434acab35228"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -1539,9 +1539,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "fixedbitset"
@@ -2312,9 +2312,9 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
 dependencies = [
  "displaydoc",
  "potential_utf",
@@ -2326,9 +2326,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -2339,9 +2339,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -2353,16 +2353,17 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
 
 [[package]]
 name = "icu_properties"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
 dependencies = [
+ "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
@@ -2373,15 +2374,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+checksum = "92a7ed671a6aad807a8651a2e1782a6598fda9ce5185dd8158549e95a91c6428"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -2686,7 +2687,7 @@ dependencies = [
 [[package]]
 name = "json5-pretty"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#b5010288d5309443b0e8dc89bd45b975323a2abd"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#f3fd31a124e539074d67e0d4cf26434acab35228"
 dependencies = [
  "serde",
  "serde_json",
@@ -2829,9 +2830,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
+checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
 dependencies = [
  "libc",
 ]
@@ -2862,9 +2863,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "litrs"
@@ -3512,7 +3513,7 @@ dependencies = [
 [[package]]
 name = "peppy-config-model"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#b5010288d5309443b0e8dc89bd45b975323a2abd"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#f3fd31a124e539074d67e0d4cf26434acab35228"
 dependencies = [
  "capnp",
  "clap",
@@ -3531,7 +3532,7 @@ dependencies = [
 [[package]]
 name = "peppy-mcp-catalog"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#b5010288d5309443b0e8dc89bd45b975323a2abd"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#f3fd31a124e539074d67e0d4cf26434acab35228"
 dependencies = [
  "serde",
  "serde_json",
@@ -3540,7 +3541,7 @@ dependencies = [
 [[package]]
 name = "peppy-mcp-runtime"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#b5010288d5309443b0e8dc89bd45b975323a2abd"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#f3fd31a124e539074d67e0d4cf26434acab35228"
 dependencies = [
  "axum",
  "base64 0.23.1",
@@ -3562,7 +3563,7 @@ version = "0.0.1"
 [[package]]
 name = "peppylib-rs"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#b5010288d5309443b0e8dc89bd45b975323a2abd"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#f3fd31a124e539074d67e0d4cf26434acab35228"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -3737,9 +3738,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "plist"
@@ -3757,7 +3758,7 @@ dependencies = [
 [[package]]
 name = "pmi"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#b5010288d5309443b0e8dc89bd45b975323a2abd"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#f3fd31a124e539074d67e0d4cf26434acab35228"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -3824,9 +3825,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
 dependencies = [
  "zerovec",
 ]
@@ -5342,9 +5343,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -5896,9 +5897,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.24.0"
+version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
+checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -6381,9 +6382,9 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
 
 [[package]]
 name = "x509-parser"
@@ -7011,9 +7012,9 @@ checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -7022,9 +7023,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.6"
+version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+checksum = "94b5c6b5976d66c1d703c4fd17d3f5e43c8cedaacf604961b171adc7130896d8"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -7033,13 +7034,13 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+checksum = "47402523226a02bfe5230160dc3ccc089aa6f6f19e7fcbb4e6f824bbb1b4aa62"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -487,9 +487,9 @@ dependencies = [
 
 [[package]]
 name = "bollard"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9d0a013e3d3ee4edd61e779adf117944c08902d375f18630a0c5b8f95659734"
+checksum = "dbe8358268799ebb3e4df23cb9d47f4c72bbc4f5247e2fa6a1bf7b6c0baea220"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -532,15 +532,14 @@ dependencies = [
 
 [[package]]
 name = "bollard-buildkit-proto"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06961b3a889aadf51ad938dfcd07a29e49bd77c6e25ed8c1021764ea888ec7bd"
+checksum = "b5c97450e79c7c565302dd92e86b08823b47550fcb4fc5ce910194d1b087a1a3"
 dependencies = [
  "prost",
  "prost-types",
  "tonic",
  "tonic-prost",
- "ureq",
 ]
 
 [[package]]
@@ -588,7 +587,7 @@ dependencies = [
 [[package]]
 name = "build-helpers"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#f3fd31a124e539074d67e0d4cf26434acab35228"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#f419b849ff8ec3e8f9d099e9ea8375b070d07507"
 dependencies = [
  "sha2",
 ]
@@ -786,7 +785,7 @@ dependencies = [
 [[package]]
 name = "config-test-support"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#f3fd31a124e539074d67e0d4cf26434acab35228"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#f419b849ff8ec3e8f9d099e9ea8375b070d07507"
 dependencies = [
  "askama",
  "git2",
@@ -931,7 +930,7 @@ dependencies = [
 [[package]]
 name = "core-node-api"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#f3fd31a124e539074d67e0d4cf26434acab35228"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#f419b849ff8ec3e8f9d099e9ea8375b070d07507"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -2687,7 +2686,7 @@ dependencies = [
 [[package]]
 name = "json5-pretty"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#f3fd31a124e539074d67e0d4cf26434acab35228"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#f419b849ff8ec3e8f9d099e9ea8375b070d07507"
 dependencies = [
  "serde",
  "serde_json",
@@ -3513,7 +3512,7 @@ dependencies = [
 [[package]]
 name = "peppy-config-model"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#f3fd31a124e539074d67e0d4cf26434acab35228"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#f419b849ff8ec3e8f9d099e9ea8375b070d07507"
 dependencies = [
  "capnp",
  "clap",
@@ -3532,7 +3531,7 @@ dependencies = [
 [[package]]
 name = "peppy-mcp-catalog"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#f3fd31a124e539074d67e0d4cf26434acab35228"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#f419b849ff8ec3e8f9d099e9ea8375b070d07507"
 dependencies = [
  "serde",
  "serde_json",
@@ -3541,7 +3540,7 @@ dependencies = [
 [[package]]
 name = "peppy-mcp-runtime"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#f3fd31a124e539074d67e0d4cf26434acab35228"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#f419b849ff8ec3e8f9d099e9ea8375b070d07507"
 dependencies = [
  "axum",
  "base64 0.23.1",
@@ -3563,7 +3562,7 @@ version = "0.0.1"
 [[package]]
 name = "peppylib-rs"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#f3fd31a124e539074d67e0d4cf26434acab35228"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#f419b849ff8ec3e8f9d099e9ea8375b070d07507"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -3758,7 +3757,7 @@ dependencies = [
 [[package]]
 name = "pmi"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#f3fd31a124e539074d67e0d4cf26434acab35228"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#f419b849ff8ec3e8f9d099e9ea8375b070d07507"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -6455,9 +6454,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e22d7002ac149ef17fe400bb40a267ebbba40a83413bab03da7762256fa94e"
+checksum = "6f7ad636296bfdb8a86bbbc9bae1b6a57f0e77b715769f99885ca2ca2368c73a"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -6506,19 +6505,20 @@ dependencies = [
 
 [[package]]
 name = "zenoh-buffers"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89c9e2427102e8efd533716f0935389a3900a818e7334004dd647ac0bd029dc"
+checksum = "a81e52197e18bc75587c566df732726aee6e0a1c8779d7a2ff609f461f6b1a07"
 dependencies = [
  "zenoh-collections",
 ]
 
 [[package]]
 name = "zenoh-codec"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31930531a8e387160bc3680c6d62f80a201020cf4d8aa36bd46988b425a66306"
+checksum = "31b792ce46854f252af31869030224c2da6bd9d72a1cd2812e29b457444a07b1"
 dependencies = [
+ "rand 0.8.7",
  "tracing",
  "uhlc",
  "zenoh-buffers",
@@ -6527,18 +6527,18 @@ dependencies = [
 
 [[package]]
 name = "zenoh-collections"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fc5195efe3ad44786275f559bbd6f13c6612470e9706c9a9a8b5b47388d51e1"
+checksum = "42b897fae0ddce178e3e58d3bb9ca131dd2a301dd869ebded37d9e1f3784aac0"
 dependencies = [
  "ahash",
 ]
 
 [[package]]
 name = "zenoh-config"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8672f4eaf88fd486f0503c59d19edfc25e7dd689bccd90d3cb731a5f627e0df"
+checksum = "1b39224e3029571e0572f88590eb9078bcd60dedc6381ad1a5c8ad5fb7a474bf"
 dependencies = [
  "json5",
  "nonempty-collections",
@@ -6561,9 +6561,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-core"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1525319e4d9ef2af54fc9c74abf419236e32e6535081339321f3f55e2f34ce2f"
+checksum = "9335e8f6509fcbec68a073372c13a69ba90c3a284a86427257607d75586b6344"
 dependencies = [
  "lazy_static",
  "tokio",
@@ -6573,9 +6573,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-crypto"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44b80a042fc71419fc4952a90c9cbcfb323c0ced048125d8b44fd362f184045f"
+checksum = "1b496e8c984260c4d80ce58b42956081dc8656f0b875766e5ae0f8e39510fdee"
 dependencies = [
  "aes",
  "hmac",
@@ -6587,9 +6587,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-keyexpr"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80f04c82f0728f6704a1a397a04b38de5b2fd5a9a886a232cf650c9af294ba5d"
+checksum = "af891f8d9f52c3e8617712b65b08fa9ae02f1f1b57e2739ff194bb65df1255df"
 dependencies = [
  "getrandom 0.2.17",
  "hashbrown 0.16.1",
@@ -6603,9 +6603,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a71103cfe96a851ef5ff781d64dda95c70e70208f74e186d6d294ba21e89cc64"
+checksum = "04f796c9df0ef7736d140363507498d8c5d0acf621c158113f122aa992979d3d"
 dependencies = [
  "zenoh-config",
  "zenoh-link-commons",
@@ -6622,9 +6622,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-commons"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dc91a5163793f842b4b016b2d50640db5a3533370348eb796e7078c576e87cf"
+checksum = "4dd110109f4f89450491bd8942152020f632eb86d8fac10349a186185f654873"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6659,9 +6659,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-quic"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17d065833147be895b7091cc3e505433c2c8b3172e36c9e06e84a5779a4aa655"
+checksum = "1038b5c97aeca14bbba31d6bed629bd2d354488850c27eddde07726e90ce9a48"
 dependencies = [
  "async-trait",
  "rustls-webpki",
@@ -6676,9 +6676,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-quic_datagram"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e81b15df31a3d0ddde9a4fb3fbc928e9a2a6d6a4de38bcf55badd3a5208947a4"
+checksum = "97b2cddd28955877b7eceedfaf09c801aac31ab8f0cac32c936f31358f5af133"
 dependencies = [
  "async-trait",
  "rustls-webpki",
@@ -6693,9 +6693,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-tcp"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e912ac36902173dfc295317e001dc630e5ac9a70c2780f2d2eac500b205a700"
+checksum = "4801cc6fb608b5069f3ea6b82484c5f727019764e90e14838fe6930a9dffd9a1"
 dependencies = [
  "async-trait",
  "socket2 0.5.10",
@@ -6711,9 +6711,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-tls"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6f6b308ae2599f9c1344fbcd3418b2c3a3a9fe287ec39501ba834168493ba37"
+checksum = "a123220c7aedf285cfeaaaf2f05d88787a164a92fa5c64c09156b861feb16134"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6741,9 +6741,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-udp"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca106ca8c3b7625e7071b9d7408955726e994c8f35fd68e00de8ac58b185d52d"
+checksum = "6785a0b6f0b94131c002a8358aaef3eb99f5ab0e0cd444f28d1f1fac38bd4091"
 dependencies = [
  "async-trait",
  "libc",
@@ -6764,9 +6764,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-unixsock_stream"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2b7f60cdb5ad771d1a4f8e2eda15529e96dbe81c0ad2c1015b4c194347676"
+checksum = "e000c7d101a3d2e5e3350a19ead2f7914276583d9d3a5787fde005465a1271d7"
 dependencies = [
  "async-trait",
  "nix 0.29.0",
@@ -6783,9 +6783,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-ws"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a7fb54899f7fbdfc4fd02e647f9bba0d6e089cca4355acafb9499c510ebea79"
+checksum = "be8a5dc8ab07d0ccb46b187f58b9ee5e38a1cacaaf780ad38398f6c2669dfb53"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -6804,9 +6804,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-macros"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9310b02a8f6dc4bd04d9ce6b318b9d00182aeeeeca60410003307d63a2569a3f"
+checksum = "0c813ccde166cf0527402d46615257e0d152140e66f8ecd685721f9399251407"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6816,9 +6816,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-plugin-trait"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e235815d14b22448aa1db948560328761530932fa7a2f9a3c14853b3f0267941"
+checksum = "95cd9d698675a5b2f3e958a35df56f6d60f0388669158055b436c0cbe5357ad8"
 dependencies = [
  "git-version",
  "libloading",
@@ -6834,9 +6834,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-protocol"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeab45020bbecc077f14f06ee8f5aee65ce760af72481e663cac58b5dbfa66dd"
+checksum = "ce5505e2569421d3cb6792d4b3d9a6589d04add3bf34c0a7c37c03c2573b79ad"
 dependencies = [
  "const_format",
  "rand 0.8.7",
@@ -6850,18 +6850,18 @@ dependencies = [
 
 [[package]]
 name = "zenoh-result"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cca8e65b08f211833fe31cf38d73a48c6e1d6d900914e1ddd8cb176b3355b75b"
+checksum = "cf23203517d6dfe04393c42053093c7cffd9e385015e21c85dafaff9a342cccf"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "zenoh-runtime"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd3d0c1558f909c9a74bde5e398c5733f81eb954818451baac2a6c09f48d6a5e"
+checksum = "ddf72c7310a090b0b22496649274661de8a17ca0d0674af8f72f184a3ed78664"
 dependencies = [
  "lazy_static",
  "ron",
@@ -6874,9 +6874,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-sync"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9588f87db82b414a3e73d13312026be826332f53d270966e3e19f77f7fa1f06d"
+checksum = "9792a8fa9b0f30ebabd3e6b278441178b6832462e959388aa18f92a93527935b"
 dependencies = [
  "arc-swap",
  "event-listener",
@@ -6889,9 +6889,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-task"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e2ac601598a27152b366ba1c6825216f01f77bb898f719b7752099a3594ce72"
+checksum = "fbb419757b0c6e824bebf34959302e6edf5a7caea4e725de88007a56f3ba4d4d"
 dependencies = [
  "futures",
  "tokio",
@@ -6903,9 +6903,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-transport"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80800c4adc26dbe81418735068541cf39820a95ec988114f04dd014775ba7c97"
+checksum = "fc431ec1c066d7047c601ae4b4d4a359882c5464cd9c4ff3fe905ff6e10017af"
 dependencies = [
  "async-trait",
  "crossbeam-utils",
@@ -6938,9 +6938,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-util"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b10369df18a781a3e675c9a2cbf54adb44c9dc2a376c1014c5e488410df2179"
+checksum = "3f99b13044636f453bcb49ca520db4b1400c8e444fdf578e63a1aad0ed9004e0"
 dependencies = [
  "async-trait",
  "const_format",

--- a/crates/core-node-internal/src/lib.rs
+++ b/crates/core-node-internal/src/lib.rs
@@ -10,6 +10,7 @@ pub use error::{Error, Result};
 pub use services::repo::cache::{
     contracts_repo_cache_path, launchers_repo_cache_path, mcp_exposures_repo_cache_path,
     nodes_repo_cache_path, pairings_repo_cache_path, repositories_list_path,
+    resolve_repo_launcher_path,
 };
 pub use services::repo::exposure::{
     ExposureDrift, PublishedExposure, check_exposure, exposure_bundle_path, publish_exposure,

--- a/crates/core-node-internal/src/services/repo/cache.rs
+++ b/crates/core-node-internal/src/services/repo/cache.rs
@@ -530,8 +530,9 @@ pub fn load_pairing_cache(peppy_dirs: &PeppyDirs) -> Result<Vec<PairingCacheEntr
 /// For Git entries this materializes the repo's checkout via
 /// [`crate::services::node::cache::git::ensure_checkout`] (blocking; wrap
 /// callers in `spawn_blocking` when running inside Tokio). `on_feedback`
-/// receives clone/refresh progress lines.
-pub(crate) fn resolve_repo_launcher_path(
+/// receives clone/refresh progress lines. Touches no stack state, so
+/// read-only callers (`stack resolve`) share it with the launch flow.
+pub fn resolve_repo_launcher_path(
     name: &str,
     peppy_dirs: &PeppyDirs,
     on_feedback: &dyn Fn(&str),

--- a/crates/core-node-internal/src/services/repo/index.rs
+++ b/crates/core-node-internal/src/services/repo/index.rs
@@ -34,7 +34,7 @@ use daemon_config::repository::{
 use serde::Deserialize;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
-use tracing::debug;
+use tracing::{debug, warn};
 
 /// Directory names that are never descended into while looking for the
 /// files that declare items.
@@ -342,6 +342,13 @@ pub(crate) fn build_cache_entries(
                 origin: item.origin,
                 repo_id: 0,
             }),
+            RepoItemKind::LauncherFragment => {
+                return Err(format!(
+                    "fragment `{}` reached the cache builder: a fragment is referenced by the \
+                     launcher whose option names it, never published as an item of its own",
+                    item.name
+                ));
+            }
         }
     }
     Ok(built)
@@ -368,7 +375,27 @@ pub enum IndexError {
     /// while the item is invisible to peppy.
     #[error("{0}")]
     Unrepresentable(String),
+    /// A composed launcher that cannot deliver what it declares: a missing
+    /// or malformed fragment, an option that does not provide its axis's
+    /// interface, or a legal selection that does not flatten. Author-time,
+    /// so `--check` refuses the commit that introduced it.
+    #[error("{}", format_composition_problems(.0))]
+    CompositionFailed(Vec<String>),
 }
+
+fn format_composition_problems(problems: &[String]) -> String {
+    problems
+        .iter()
+        .map(|problem| format!("\n  - {problem}"))
+        .collect::<String>()
+}
+
+/// The ceiling on the selection space `check_repository_index` enumerates.
+/// Above it the check degrades to per-axis validation (every fragment
+/// exists, parses, provides, and guards cleanly) and says so, because a
+/// check that skips combinations must say so or it looks like it checked
+/// them all.
+const COMBINATION_CEILING: usize = 512;
 
 fn format_conflicts(conflicts: &[RepoConflict]) -> String {
     conflicts
@@ -599,6 +626,11 @@ fn identity_of(
                 parsed.manifest.tag.clone(),
             ))
         }
+        RepoItemKind::LauncherFragment => Err(
+            "a fragment has no repository identity: it is referenced by the launcher whose \
+             option names it, never listed in peppy_repository.json5"
+                .to_owned(),
+        ),
     }
 }
 
@@ -673,10 +705,82 @@ pub fn check_repository_index(root: &Path) -> Result<Vec<IndexDrift>, IndexError
         }
     }
 
+    check_compositions(&root, &generated)?;
+
     // Sorted by rendered text so the report is reproducible in a test and
     // comparable between two machines.
     drifts.sort_by_key(|drift| drift.to_string());
     Ok(drifts)
+}
+
+/// The composition checks on every composed launcher the repository lists:
+/// every referenced fragment exists and parses, every option provides its
+/// axis's interface ids, every adjustment target is defined somewhere, and
+/// every legal selection flattens into a valid flat launcher.
+///
+/// All of this is launcher-local (no node manifests, no daemon), which is
+/// what lets it run on a contributor's branch: the commit that adds an
+/// option whose shape contradicts an existing adjustment is the commit whose
+/// check fails, rather than the first launch that selects it.
+fn check_compositions(root: &Path, generated: &RepositoryIndex) -> Result<(), IndexError> {
+    let mut problems = Vec::new();
+    for item in generated
+        .declared_items()
+        .filter(|item| item.kind == RepoItemKind::Launcher)
+    {
+        let launcher_file = root.join(item.path.as_str());
+        let Ok(parsed) = PeppyLauncherParser::from_path(&launcher_file) else {
+            // An unparseable launcher is the walk's failure to report (it
+            // skips the file, so the item is not listed) or the committed
+            // index's (reported as Unmatched above). Either way it is not a
+            // composition problem.
+            continue;
+        };
+        if parsed.components.is_empty() {
+            continue;
+        }
+        let label = launcher_file
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+            .unwrap_or_else(|| launcher_file.display().to_string());
+        let Some(launcher_dir) = launcher_file.parent() else {
+            continue;
+        };
+
+        let loaded = match daemon_config::launcher::load_composition(&parsed, launcher_dir) {
+            Ok(loaded) => loaded,
+            Err(e) => {
+                problems.push(format!("{label}: {e}"));
+                continue;
+            }
+        };
+
+        let space = daemon_config::launcher::selection_space_size(&parsed.components);
+        if space > COMBINATION_CEILING {
+            // Per-axis validation above (fragments, provides, guards,
+            // targets) still ran; what is skipped is every CROSS-axial
+            // combination, and the count of those is the space itself.
+            warn!(
+                "skipped all {space} cross-combination checks for {label}: the selection space \
+                 exceeds the {COMBINATION_CEILING}-combination ceiling, so each axis was \
+                 validated on its own instead"
+            );
+            continue;
+        }
+        for selection in daemon_config::launcher::enumerate_selections(&parsed.components) {
+            if let Err(e) = daemon_config::launcher::flatten(&parsed, &loaded, &selection, &label) {
+                problems.push(format!(
+                    "{label} ({}): {e}",
+                    selection.echo()
+                ));
+            }
+        }
+    }
+    if problems.is_empty() {
+        Ok(())
+    } else {
+        Err(IndexError::CompositionFailed(problems))
+    }
 }
 
 fn identity_label(item: &DeclaredItem<'_>) -> String {
@@ -789,6 +893,12 @@ pub(crate) fn walk_directory(root: &Path, excluded_paths: &[PathBuf]) -> WalkRes
             // The repository's own index declares no item. It is the
             // output of this walk, not an input to it.
             PeppySchema::RepositoryV1 => {}
+            // A fragment file declares no item either: it is a piece of the
+            // launcher whose option references it. The walk recognizes the
+            // tag so a fragment is never mistaken for an unrecognized
+            // schema; the composition checks in `check_repository_index`
+            // read and validate the fragments each launcher references.
+            PeppySchema::LauncherFragmentV1 => {}
         }
     }
 
@@ -1724,5 +1834,200 @@ mod tests {
 
         let err = check_repository_index(&repo).expect_err("a missing index is refused");
         assert!(err.to_string().contains("peppy_repository.json5"), "{err}");
+    }
+
+    /// A fragment file is recognized by the walk but never listed: it is a
+    /// piece of the launcher whose option references it, so it neither takes
+    /// a launcher name nor needs an index entry.
+    #[test]
+    fn a_fragment_file_is_never_a_listed_item() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("hub");
+        write_launcher_json5(&repo.join("teleop.json5"));
+        std::fs::create_dir_all(repo.join("fragments")).unwrap();
+        std::fs::write(
+            repo.join("fragments/cameras.json5"),
+            r#"{ peppy_schema: "launcher_fragment/v1", deployments: [] }"#,
+        )
+        .unwrap();
+
+        let walked = walk_directory(&repo, &[]);
+
+        assert_eq!(walked.conflicts, Vec::new());
+        assert_eq!(
+            found(&walked, RepoItemKind::Launcher),
+            vec!["teleop".to_owned()],
+            "the fragment must not claim a launcher identity"
+        );
+        let index = generate_repository_index(&repo).expect("generates");
+        assert_eq!(index.declared_count(), 1);
+    }
+
+    /// A composed launcher whose every legal selection flattens passes
+    /// `--check`, and the fragment it references is validated through the
+    /// launcher's reference (not as an item).
+    #[test]
+    fn check_passes_a_composed_launcher_with_fragments() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("hub");
+        std::fs::create_dir_all(repo.join("fragments")).unwrap();
+        std::fs::write(
+            repo.join("fragments/mujoco.json5"),
+            r#"{
+                peppy_schema: "launcher_fragment/v1",
+                deployments: [
+                    { source: { name: "sim", tag: "v1" },
+                      instances: [{ instance_id: "arm_inst" }] },
+                ],
+            }"#,
+        )
+        .unwrap();
+        std::fs::write(
+            repo.join("teleop.json5"),
+            r#"{
+                peppy_schema: "launcher/v1",
+                components: [
+                    { name: "robot", default: "real",
+                      provides: ["arm_inst"],
+                      options: {
+                          real: { deployments: [
+                              { source: { name: "can", tag: "v1" },
+                                instances: [{ instance_id: "arm_inst" }] } ] },
+                          mujoco: "fragments/mujoco.json5",
+                      } },
+                ],
+                deployments: [],
+            }"#,
+        )
+        .unwrap();
+        let index = generate_repository_index(&repo).expect("generates");
+        write_repository_index(&repo, &index).expect("writes");
+
+        let drifts = check_repository_index(&repo).expect("checks");
+        assert_eq!(drifts, Vec::new(), "every selection should flatten");
+    }
+
+    /// The composition checks are author-time refusals, not drift: a
+    /// fragment that is missing, an option that does not provide its axis's
+    /// interface, or a selection that cannot flatten each fail `--check`
+    /// naming the launcher, so the commit that breaks a selection is the
+    /// commit whose check fails.
+    #[test]
+    fn check_refuses_broken_compositions() {
+        // A fragment reference to a file that is not there.
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("hub");
+        write_composed_launcher_referencing(&repo, "teleop.json5", "fragments/missing.json5");
+        let index = generate_repository_index(&repo).expect("generates");
+        write_repository_index(&repo, &index).expect("writes");
+        let err = check_repository_index(&repo).expect_err("a missing fragment must be refused");
+        let IndexError::CompositionFailed(problems) = &err else {
+            panic!("expected a composition failure, got: {err}");
+        };
+        assert!(
+            problems[0].contains("teleop.json5") && problems[0].contains("fragments/missing.json5"),
+            "the problem should name the launcher and the fragment: {problems:?}"
+        );
+
+        // An option that does not provide the axis's interface ids.
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("hub");
+        write_composed_launcher_referencing(&repo, "teleop.json5", "fragments/sparse.json5");
+        std::fs::create_dir_all(repo.join("fragments")).unwrap();
+        std::fs::write(
+            repo.join("fragments/sparse.json5"),
+            r#"{ peppy_schema: "launcher_fragment/v1", deployments: [] }"#,
+        )
+        .unwrap();
+        let index = generate_repository_index(&repo).expect("generates");
+        write_repository_index(&repo, &index).expect("writes");
+        let err = check_repository_index(&repo).expect_err("an unmet provides must be refused");
+        let IndexError::CompositionFailed(problems) = &err else {
+            panic!("expected a composition failure, got: {err}");
+        };
+        assert!(
+            problems[0].contains("arm_inst"),
+            "the problem should name the promised id: {problems:?}"
+        );
+
+        // A selection that cannot flatten: the sim fragment defines an id
+        // the base already deploys, which only the selection that picks it
+        // trips over. The real option's selection still flattens, so the
+        // failure names the one broken selection rather than the launcher.
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("hub");
+        std::fs::create_dir_all(repo.join("fragments")).unwrap();
+        std::fs::write(
+            repo.join("fragments/dup.json5"),
+            r#"{
+                peppy_schema: "launcher_fragment/v1",
+                deployments: [
+                    { source: { name: "sim", tag: "v1" },
+                      instances: [
+                          { instance_id: "arm_inst" },
+                          { instance_id: "viewer_inst" },
+                      ] },
+                ],
+            }"#,
+        )
+        .unwrap();
+        std::fs::write(
+            repo.join("teleop.json5"),
+            r#"{
+                peppy_schema: "launcher/v1",
+                components: [
+                    { name: "robot", default: "real",
+                      provides: ["arm_inst"],
+                      options: {
+                          real: { deployments: [
+                              { source: { name: "can", tag: "v1" },
+                                instances: [{ instance_id: "arm_inst" }] } ] },
+                          sim: "fragments/dup.json5",
+                      } },
+                ],
+                deployments: [
+                    { source: { name: "web", tag: "v1" },
+                      instances: [{ instance_id: "viewer_inst" }] },
+                ],
+            }"#,
+        )
+        .unwrap();
+        let index = generate_repository_index(&repo).expect("generates");
+        write_repository_index(&repo, &index).expect("writes");
+        let err = check_repository_index(&repo).expect_err("an unflattenable selection must be refused");
+        let IndexError::CompositionFailed(problems) = &err else {
+            panic!("expected a composition failure, got: {err}");
+        };
+        assert!(
+            problems.iter().any(|problem| problem.contains("robot=sim") && problem.contains("viewer_inst")),
+            "the problem should name the selection and the id: {problems:?}"
+        );
+    }
+
+    /// Writes a composed launcher whose `sim` option references `fragment`,
+    /// with a base and a `real` option that both define `arm_inst` (the
+    /// axis's `provides`), so the fragment's content is the only variable.
+    fn write_composed_launcher_referencing(repo: &Path, launcher: &str, fragment: &str) {
+        std::fs::create_dir_all(repo).unwrap();
+        std::fs::write(
+            repo.join(launcher),
+            format!(
+                r#"{{
+                    peppy_schema: "launcher/v1",
+                    components: [
+                        {{ name: "robot", default: "real",
+                          provides: ["arm_inst"],
+                          options: {{
+                              real: {{ deployments: [
+                                  {{ source: {{ name: "can", tag: "v1" }},
+                                    instances: [{{ instance_id: "arm_inst" }}] }} ] }},
+                              sim: "{fragment}",
+                          }} }},
+                    ],
+                    deployments: [],
+                }}"#
+            ),
+        )
+        .unwrap();
     }
 }

--- a/crates/core-node-internal/src/services/repo/index.rs
+++ b/crates/core-node-internal/src/services/repo/index.rs
@@ -34,7 +34,7 @@ use daemon_config::repository::{
 use serde::Deserialize;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
-use tracing::{debug, warn};
+use tracing::debug;
 
 /// Directory names that are never descended into while looking for the
 /// files that declare items.
@@ -342,13 +342,6 @@ pub(crate) fn build_cache_entries(
                 origin: item.origin,
                 repo_id: 0,
             }),
-            RepoItemKind::LauncherFragment => {
-                return Err(format!(
-                    "fragment `{}` reached the cache builder: a fragment is referenced by the \
-                     launcher whose option names it, never published as an item of its own",
-                    item.name
-                ));
-            }
         }
     }
     Ok(built)
@@ -379,23 +372,9 @@ pub enum IndexError {
     /// or malformed fragment, an option that does not provide its axis's
     /// interface, or a legal selection that does not flatten. Author-time,
     /// so `--check` refuses the commit that introduced it.
-    #[error("{}", format_composition_problems(.0))]
+    #[error("{}", daemon_config::format_bulleted(.0))]
     CompositionFailed(Vec<String>),
 }
-
-fn format_composition_problems(problems: &[String]) -> String {
-    problems
-        .iter()
-        .map(|problem| format!("\n  - {problem}"))
-        .collect::<String>()
-}
-
-/// The ceiling on the selection space `check_repository_index` enumerates.
-/// Above it the check degrades to per-axis validation (every fragment
-/// exists, parses, provides, and guards cleanly) and says so, because a
-/// check that skips combinations must say so or it looks like it checked
-/// them all.
-const COMBINATION_CEILING: usize = 512;
 
 fn format_conflicts(conflicts: &[RepoConflict]) -> String {
     conflicts
@@ -626,11 +605,6 @@ fn identity_of(
                 parsed.manifest.tag.clone(),
             ))
         }
-        RepoItemKind::LauncherFragment => Err(
-            "a fragment has no repository identity: it is referenced by the launcher whose \
-             option names it, never listed in peppy_repository.json5"
-                .to_owned(),
-        ),
     }
 }
 
@@ -713,10 +687,11 @@ pub fn check_repository_index(root: &Path) -> Result<Vec<IndexDrift>, IndexError
     Ok(drifts)
 }
 
-/// The composition checks on every composed launcher the repository lists:
-/// every referenced fragment exists and parses, every option provides its
-/// axis's interface ids, every adjustment target is defined somewhere, and
-/// every legal selection flattens into a valid flat launcher.
+/// The composition checks on every composed launcher the repository lists,
+/// delegated whole to `daemon_config::launcher::check_composition`: every
+/// referenced fragment exists and parses, every option provides its axis's
+/// interface ids, every adjustment target is defined somewhere, and every
+/// legal selection flattens into a valid flat launcher.
 ///
 /// All of this is launcher-local (no node manifests, no daemon), which is
 /// what lets it run on a contributor's branch: the commit that adds an
@@ -739,42 +714,10 @@ fn check_compositions(root: &Path, generated: &RepositoryIndex) -> Result<(), In
         if parsed.components.is_empty() {
             continue;
         }
-        let label = launcher_file
-            .file_name()
-            .map(|name| name.to_string_lossy().into_owned())
-            .unwrap_or_else(|| launcher_file.display().to_string());
-        let Some(launcher_dir) = launcher_file.parent() else {
-            continue;
-        };
-
-        let loaded = match daemon_config::launcher::load_composition(&parsed, launcher_dir) {
-            Ok(loaded) => loaded,
-            Err(e) => {
-                problems.push(format!("{label}: {e}"));
-                continue;
-            }
-        };
-
-        let space = daemon_config::launcher::selection_space_size(&parsed.components);
-        if space > COMBINATION_CEILING {
-            // Per-axis validation above (fragments, provides, guards,
-            // targets) still ran; what is skipped is every CROSS-axial
-            // combination, and the count of those is the space itself.
-            warn!(
-                "skipped all {space} cross-combination checks for {label}: the selection space \
-                 exceeds the {COMBINATION_CEILING}-combination ceiling, so each axis was \
-                 validated on its own instead"
-            );
-            continue;
-        }
-        for selection in daemon_config::launcher::enumerate_selections(&parsed.components) {
-            if let Err(e) = daemon_config::launcher::flatten(&parsed, &loaded, &selection, &label) {
-                problems.push(format!(
-                    "{label} ({}): {e}",
-                    selection.echo()
-                ));
-            }
-        }
+        problems.extend(daemon_config::launcher::check_composition(
+            &parsed,
+            &launcher_file,
+        ));
     }
     if problems.is_empty() {
         Ok(())

--- a/crates/core-node-internal/src/services/repo/index.rs
+++ b/crates/core-node-internal/src/services/repo/index.rs
@@ -1937,12 +1937,15 @@ mod tests {
         .unwrap();
         let index = generate_repository_index(&repo).expect("generates");
         write_repository_index(&repo, &index).expect("writes");
-        let err = check_repository_index(&repo).expect_err("an unflattenable selection must be refused");
+        let err =
+            check_repository_index(&repo).expect_err("an unflattenable selection must be refused");
         let IndexError::CompositionFailed(problems) = &err else {
             panic!("expected a composition failure, got: {err}");
         };
         assert!(
-            problems.iter().any(|problem| problem.contains("robot=sim") && problem.contains("viewer_inst")),
+            problems
+                .iter()
+                .any(|problem| problem.contains("robot=sim") && problem.contains("viewer_inst")),
             "the problem should name the selection and the id: {problems:?}"
         );
     }

--- a/crates/core-node-internal/src/services/stack/launch/resolve.rs
+++ b/crates/core-node-internal/src/services/stack/launch/resolve.rs
@@ -76,35 +76,31 @@ pub(super) async fn parse_launcher_config(
         }
     };
 
-    let peppy_launcher = match daemon_config::launcher::compose(&parsed, &launch_file, &goal.selections)
-    {
-        Ok((flat, report)) => {
-            if !parsed.components.is_empty() {
-                // The full resolution is echoed before anything runs, so the
-                // operator sees which stack this launch is of while there is
-                // still time to interrupt it.
-                publish_stdout(
-                    ctx,
-                    format!("components: {}", report.selection.echo()),
-                    LaunchFeedbackStep::LauncherStep,
-                )
-                .await;
+    let peppy_launcher =
+        match daemon_config::launcher::compose(&parsed, &launch_file, &goal.selections) {
+            Ok((flat, report)) => {
+                if !parsed.components.is_empty() {
+                    // The full resolution is echoed before anything runs, so the
+                    // operator sees which stack this launch is of while there is
+                    // still time to interrupt it.
+                    publish_stdout(
+                        ctx,
+                        format!("components: {}", report.selection.echo()),
+                        LaunchFeedbackStep::LauncherStep,
+                    )
+                    .await;
+                }
+                flat
             }
-            flat
-        }
-        Err(e) => {
-            publish_stderr(
-                ctx,
-                format!("Invalid launcher config: {e}"),
-                LaunchFeedbackStep::LauncherStep,
-            )
-            .await;
-            return Err(LaunchResult::failure(
-                &ctx.log_path,
-                format!("Invalid launcher config: {e}"),
-            ));
-        }
-    };
+            Err(e) => {
+                // Not a parse failure: the document was already read fine. The
+                // composition errors themselves name the axis and its options,
+                // so the prefix only says which step refused.
+                let msg = format!("Cannot resolve the launcher's components: {e}");
+                publish_stderr(ctx, &msg, LaunchFeedbackStep::LauncherStep).await;
+                return Err(LaunchResult::failure(&ctx.log_path, msg));
+            }
+        };
 
     let placements = match resolve_placements(&peppy_launcher, goal, ctx.bound_core_node.as_str()) {
         Ok(placements) => placements,

--- a/crates/core-node-internal/src/services/stack/launch/resolve.rs
+++ b/crates/core-node-internal/src/services/stack/launch/resolve.rs
@@ -19,7 +19,16 @@ fn deployment_label(deployment: &Deployment) -> String {
     format!("{}:{}", deployment.source.name, deployment.source.tag)
 }
 
-/// Step 1: Parse launcher configuration from file path.
+/// Step 1: Parse launcher configuration from file path, resolving the
+/// `--with` selection the caller asked for when the launcher declares
+/// component axes.
+///
+/// The selection words travel on the goal verbatim and are resolved HERE,
+/// for the same reason placement is: only the coordinator holds a
+/// repository launcher's document, so only it knows which axes exist. A
+/// caller that resolved selections itself could do so for a filesystem
+/// launcher and not for a repository one, and the two origins would drift
+/// into meaning different things.
 pub(super) async fn parse_launcher_config(
     ctx: &ProcessLaunchContext,
     goal: &LaunchGoal,
@@ -51,8 +60,38 @@ pub(super) async fn parse_launcher_config(
         return Err(LaunchResult::failure(&ctx.log_path, msg));
     }
 
-    let peppy_launcher = match PeppyLauncherParser::from_path(&launch_file) {
+    let parsed = match PeppyLauncherParser::from_path(&launch_file) {
         Ok(cfg) => cfg,
+        Err(e) => {
+            publish_stderr(
+                ctx,
+                format!("Invalid launcher config: {e}"),
+                LaunchFeedbackStep::LauncherStep,
+            )
+            .await;
+            return Err(LaunchResult::failure(
+                &ctx.log_path,
+                format!("Invalid launcher config: {e}"),
+            ));
+        }
+    };
+
+    let peppy_launcher = match daemon_config::launcher::compose(&parsed, &launch_file, &goal.selections)
+    {
+        Ok((flat, report)) => {
+            if !parsed.components.is_empty() {
+                // The full resolution is echoed before anything runs, so the
+                // operator sees which stack this launch is of while there is
+                // still time to interrupt it.
+                publish_stdout(
+                    ctx,
+                    format!("components: {}", report.selection.echo()),
+                    LaunchFeedbackStep::LauncherStep,
+                )
+                .await;
+            }
+            flat
+        }
         Err(e) => {
             publish_stderr(
                 ctx,

--- a/crates/daemon-config-internal/src/launcher.rs
+++ b/crates/daemon-config-internal/src/launcher.rs
@@ -18,8 +18,7 @@ pub use composition::{
 };
 pub use flatten::{
     AppliedAdjustment, AppliedChange, ComponentSelection, CompositionError, FlattenReport,
-    SelectionEntry, SelectionSource, SkipReason, SkippedAdjustment, compose, enumerate_selections,
-    flatten, load_composition, resolve_selection, selection_space_size,
+    SelectionEntry, SelectionSource, SkipReason, SkippedAdjustment, check_composition, compose,
 };
 pub use links::{ValidatedLinkPlan, validate_link_plan, validate_link_slots};
 pub use observations::{PlannedObservation, ValidatedObservations, validate_observations};

--- a/crates/daemon-config-internal/src/launcher.rs
+++ b/crates/daemon-config-internal/src/launcher.rs
@@ -1,4 +1,6 @@
 mod bindings;
+mod composition;
+mod flatten;
 mod links;
 mod observations;
 mod pairings;
@@ -10,6 +12,15 @@ mod types;
 // but the parser is filename-agnostic; repository discovery accepts any
 // `.json5` file whose body declares the launcher schema.
 pub use bindings::{BindingValidationItem, ValidatedBindings, validate_bindings};
+pub use composition::{
+    Adjustment, ComponentAxis, Fragment, FragmentPart, FragmentSpec, LauncherFragment,
+    LauncherFragmentParser,
+};
+pub use flatten::{
+    AppliedAdjustment, AppliedChange, ComponentSelection, CompositionError, FlattenReport,
+    SelectionEntry, SelectionSource, SkipReason, SkippedAdjustment, compose, enumerate_selections,
+    flatten, load_composition, resolve_selection, selection_space_size,
+};
 pub use links::{ValidatedLinkPlan, validate_link_plan, validate_link_slots};
 pub use observations::{PlannedObservation, ValidatedObservations, validate_observations};
 pub use pairings::{

--- a/crates/daemon-config-internal/src/launcher/composition.rs
+++ b/crates/daemon-config-internal/src/launcher/composition.rs
@@ -11,7 +11,7 @@
 //! and no selection.
 
 use super::types::{Deployment, LinkValue};
-use config::{AnyType, consts::ALLOWED_CONFIG_CHARS, runtime::Name, schema::PeppySchema};
+use config::{AnyType, runtime::Name, schema::PeppySchema};
 use serde::{
     Deserialize, Serialize,
     de::{self, Deserializer, MapAccess, SeqAccess, Visitor},
@@ -180,6 +180,25 @@ impl Serialize for FragmentSpec {
     }
 }
 
+/// One fragment part read from a path string: the fragment lives in its
+/// own `launcher_fragment/v1` file next to the launcher.
+fn fragment_part_from_str<E: de::Error>(v: &str) -> Result<FragmentPart, E> {
+    if v.trim().is_empty() {
+        return Err(de::Error::custom(
+            "a fragment path cannot be empty: name a `launcher_fragment/v1` file relative to \
+             the launcher's directory",
+        ));
+    }
+    Ok(FragmentPart::File(v.to_owned()))
+}
+
+/// One fragment part read from a map: an inline fragment body, written
+/// where the option is.
+fn fragment_part_from_map<'de, A: MapAccess<'de>>(map: A) -> Result<FragmentPart, A::Error> {
+    let fragment = Fragment::deserialize(serde::de::value::MapAccessDeserializer::new(map))?;
+    Ok(FragmentPart::Inline(fragment))
+}
+
 impl<'de> Deserialize<'de> for FragmentSpec {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -197,23 +216,14 @@ impl<'de> Deserialize<'de> for FragmentSpec {
                 )
             }
 
-            /// A path string: the fragment lives in its own
-            /// `launcher_fragment/v1` file next to the launcher.
+            /// A path string or an inline fragment: one part, read the same
+            /// way a lone [`FragmentPart`] is.
             fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {
-                if v.trim().is_empty() {
-                    return Err(de::Error::custom(
-                        "a fragment path cannot be empty: name a `launcher_fragment/v1` file \
-                         relative to the launcher's directory",
-                    ));
-                }
-                Ok(FragmentSpec(vec![FragmentPart::File(v.to_owned())]))
+                Ok(FragmentSpec(vec![fragment_part_from_str(v)?]))
             }
 
-            /// An inline fragment: the body is written here, in the option.
             fn visit_map<A: MapAccess<'de>>(self, map: A) -> Result<Self::Value, A::Error> {
-                let fragment =
-                    Fragment::deserialize(serde::de::value::MapAccessDeserializer::new(map))?;
-                Ok(FragmentSpec(vec![FragmentPart::Inline(fragment)]))
+                Ok(FragmentSpec(vec![fragment_part_from_map(map)?]))
             }
 
             /// The list form: parts merge in list order before the option's
@@ -253,19 +263,11 @@ impl<'de> Deserialize<'de> for FragmentPart {
             }
 
             fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {
-                if v.trim().is_empty() {
-                    return Err(de::Error::custom(
-                        "a fragment path cannot be empty: name a `launcher_fragment/v1` file \
-                         relative to the launcher's directory",
-                    ));
-                }
-                Ok(FragmentPart::File(v.to_owned()))
+                fragment_part_from_str(v)
             }
 
             fn visit_map<A: MapAccess<'de>>(self, map: A) -> Result<Self::Value, A::Error> {
-                let fragment =
-                    Fragment::deserialize(serde::de::value::MapAccessDeserializer::new(map))?;
-                Ok(FragmentPart::Inline(fragment))
+                fragment_part_from_map(map)
             }
         }
 
@@ -304,16 +306,17 @@ impl LauncherFragmentParser {
 }
 
 /// Axis and option names share the identifier grammar of every other name in
-/// a peppy document, and for the same reason: an axis name is one half of
-/// `--with axis=option` and a bare `--with` word is an option name, so a name
-/// carrying an `=`, a `,`, or whitespace would be unwireable from the very
-/// surface it exists for. (`,` separates `--with` entries and `=` splits the
-/// `axis=option` form; both are outside [`ALLOWED_CONFIG_CHARS`].)
+/// a peppy document — the one [`Name`] enforces — and for the same reason: an
+/// axis name is one half of `--with axis=option` and a bare `--with` word is
+/// an option name, so a name carrying an `=`, a `,`, or whitespace would be
+/// unwireable from the very surface it exists for. (`,` separates `--with`
+/// entries and `=` splits the `axis=option` form; both are outside the
+/// identifier grammar.)
 pub(crate) fn check_axis_or_option_name(kind: &str, name: &str) -> Result<(), String> {
     if name.is_empty() {
         return Err(format!("`components` declares {kind} with an empty name"));
     }
-    if !name.chars().all(|c| ALLOWED_CONFIG_CHARS.contains(c)) {
+    if Name::try_from(name.to_owned()).is_err() {
         return Err(format!(
             "`components` declares {kind} `{name}`, which is not a plain identifier \
              (letters, digits, `_`, `-`): the name appears in `--with` entries and `when` \

--- a/crates/daemon-config-internal/src/launcher/composition.rs
+++ b/crates/daemon-config-internal/src/launcher/composition.rs
@@ -101,19 +101,30 @@ impl<'de> Deserialize<'de> for LauncherFragment {
     where
         D: Deserializer<'de>,
     {
+        // The body's fields are declared here rather than `#[serde(flatten)]`ed
+        // in: serde ignores `deny_unknown_fields` on both sides of a flatten,
+        // so a misspelled field would be silently dropped instead of refused.
         #[derive(Deserialize)]
         #[serde(deny_unknown_fields)]
         struct RawLauncherFragment {
             #[serde(deserialize_with = "deserialize_launcher_fragment_v1_schema")]
             peppy_schema: PeppySchema,
-            #[serde(flatten)]
-            body: Fragment,
+            #[serde(default)]
+            deployments: Vec<Deployment>,
+            #[serde(default)]
+            adjustments: Vec<Adjustment>,
+            #[serde(default)]
+            core_nodes: Vec<String>,
         }
 
         let raw = RawLauncherFragment::deserialize(deserializer)?;
         Ok(LauncherFragment {
             peppy_schema: raw.peppy_schema,
-            body: raw.body,
+            body: Fragment {
+                deployments: raw.deployments,
+                adjustments: raw.adjustments,
+                core_nodes: raw.core_nodes,
+            },
         })
     }
 }
@@ -306,7 +317,7 @@ impl LauncherFragmentParser {
 }
 
 /// Axis and option names share the identifier grammar of every other name in
-/// a peppy document — the one [`Name`] enforces — and for the same reason: an
+/// a peppy document (the one [`Name`] enforces) and for the same reason: an
 /// axis name is one half of `--with axis=option` and a bare `--with` word is
 /// an option name, so a name carrying an `=`, a `,`, or whitespace would be
 /// unwireable from the very surface it exists for. (`,` separates `--with`
@@ -416,10 +427,16 @@ pub(crate) fn validate_adjustment(adjustment: &Adjustment, origin: &str) -> Resu
         ));
     }
 
-    let has_operation = adjustment.set_arguments.as_ref().is_some_and(|m| !m.is_empty())
+    let has_operation = adjustment
+        .set_arguments
+        .as_ref()
+        .is_some_and(|m| !m.is_empty())
         || adjustment.set_links.as_ref().is_some_and(|m| !m.is_empty())
         || adjustment.add_links.as_ref().is_some_and(|m| !m.is_empty())
-        || adjustment.unset_links.as_ref().is_some_and(|v| !v.is_empty());
+        || adjustment
+            .unset_links
+            .as_ref()
+            .is_some_and(|v| !v.is_empty());
     if !has_operation {
         return Err(format!(
             "adjustment on `{}` in {origin} names no operation: state at least one of \
@@ -515,7 +532,11 @@ fn check_non_empty_keys<'a>(
 /// That a `when` guard names axes this launcher declares and options those
 /// axes declare. A guard is what licenses an adjustment to depend on the
 /// shape those options define, so naming something else is a dead reference.
-pub(crate) fn validate_guard(when: &BTreeMap<String, String>, axes: &[ComponentAxis], origin: &str) -> Result<(), String> {
+pub(crate) fn validate_guard(
+    when: &BTreeMap<String, String>,
+    axes: &[ComponentAxis],
+    origin: &str,
+) -> Result<(), String> {
     for (axis_name, option_name) in when {
         let Some(axis) = axes.iter().find(|axis| axis.name == *axis_name) else {
             return Err(format!(
@@ -602,7 +623,9 @@ mod tests {
         .expect("list parses");
         assert_eq!(spec.0.len(), 2);
         assert!(matches!(&spec.0[0], FragmentPart::File(p) if p == "fragments/sim_relays.json5"));
-        assert!(matches!(&spec.0[1], FragmentPart::File(p) if p == "fragments/mujoco_engine.json5"));
+        assert!(
+            matches!(&spec.0[1], FragmentPart::File(p) if p == "fragments/mujoco_engine.json5")
+        );
     }
 
     #[test]
@@ -629,9 +652,8 @@ mod tests {
 
     #[test]
     fn an_inline_fragment_cannot_declare_a_schema() {
-        let error =
-            parse_fragment_spec(r#"{ peppy_schema: "launcher/v1", deployments: [] }"#)
-                .expect_err("inline fragments take no peppy_schema");
+        let error = parse_fragment_spec(r#"{ peppy_schema: "launcher/v1", deployments: [] }"#)
+            .expect_err("inline fragments take no peppy_schema");
         assert!(error.contains("peppy_schema"), "got: {error}");
     }
 
@@ -644,8 +666,7 @@ mod tests {
         ] {
             let spec = serde_json5::from_str::<FragmentSpec>(&written).expect("parses");
             let reserialized = serde_json5::to_string(&spec).expect("serializes");
-            let reparsed = serde_json5::from_str::<FragmentSpec>(&reserialized)
-                .expect("reparses");
+            let reparsed = serde_json5::from_str::<FragmentSpec>(&reserialized).expect("reparses");
             assert_eq!(spec.0.len(), reparsed.0.len(), "round trip of {written}");
         }
     }
@@ -659,6 +680,15 @@ mod tests {
         let fragment = LauncherFragmentParser::from_content(content).expect("fragment parses");
         assert_eq!(fragment.peppy_schema, PeppySchema::LauncherFragmentV1);
         assert!(fragment.body.deployments.is_empty());
+    }
+
+    #[test]
+    fn a_fragment_file_refuses_an_unknown_field() {
+        let error = LauncherFragmentParser::from_content(
+            r#"{ peppy_schema: "launcher_fragment/v1", deploymnts: [] }"#,
+        )
+        .expect_err("a misspelled field must not silently vanish");
+        assert!(error.to_string().contains("deploymnts"), "got: {error}");
     }
 
     #[test]
@@ -676,8 +706,8 @@ mod tests {
     // -- validate_axes ------------------------------------------------------
 
     fn one_axis(body: &str) -> Result<Vec<ComponentAxis>, String> {
-        let axes: Vec<ComponentAxis> = serde_json5::from_str(&format!("[{body}]"))
-            .map_err(|e| e.to_string())?;
+        let axes: Vec<ComponentAxis> =
+            serde_json5::from_str(&format!("[{body}]")).map_err(|e| e.to_string())?;
         validate_axes(&axes).map(|()| axes)
     }
 
@@ -781,7 +811,11 @@ mod tests {
         .expect("a full adjustment parses");
         assert_eq!(adjustment.target.as_str(), "backbone_inst");
         assert_eq!(
-            adjustment.when.as_ref().and_then(|w| w.get("commander")).map(String::as_str),
+            adjustment
+                .when
+                .as_ref()
+                .and_then(|w| w.get("commander"))
+                .map(String::as_str),
             Some("xr_commander")
         );
     }
@@ -795,40 +829,32 @@ mod tests {
 
     #[test]
     fn an_empty_guard_is_refused() {
-        let error = parse_adjustment(
-            r#"{ target: "backbone_inst", when: {}, set_arguments: { a: 1 } }"#,
-        )
-        .expect_err("an empty guard means nothing");
+        let error =
+            parse_adjustment(r#"{ target: "backbone_inst", when: {}, set_arguments: { a: 1 } }"#)
+                .expect_err("an empty guard means nothing");
         assert!(error.contains("empty `when`"), "got: {error}");
     }
 
     #[test]
     fn add_links_targets_are_shape_checked() {
-        let error = parse_adjustment(
-            r#"{ target: "c", add_links: { cameras: [] } }"#,
-        )
-        .expect_err("an empty target list appends nothing");
+        let error = parse_adjustment(r#"{ target: "c", add_links: { cameras: [] } }"#)
+            .expect_err("an empty target list appends nothing");
         assert!(error.contains("no target"), "got: {error}");
 
-        let error = parse_adjustment(
-            r#"{ target: "c", add_links: { cameras: ["a", "a"] } }"#,
-        )
-        .expect_err("a duplicate target is a mistake");
+        let error = parse_adjustment(r#"{ target: "c", add_links: { cameras: ["a", "a"] } }"#)
+            .expect_err("a duplicate target is a mistake");
         assert!(error.contains("more than once"), "got: {error}");
 
-        let error = parse_adjustment(
-            r#"{ target: "c", add_links: { cameras: ["a//b"] } }"#,
-        )
-        .expect_err("a malformed target is refused");
+        let error = parse_adjustment(r#"{ target: "c", add_links: { cameras: ["a//b"] } }"#)
+            .expect_err("a malformed target is refused");
         assert!(error.contains("malformed"), "got: {error}");
     }
 
     #[test]
     fn a_guard_naming_an_unknown_axis_is_refused() {
-        let axes: Vec<ComponentAxis> = serde_json5::from_str(
-            r#"[{ name: "robot", options: { real: { deployments: [] } } }]"#,
-        )
-        .expect("axes parse");
+        let axes: Vec<ComponentAxis> =
+            serde_json5::from_str(r#"[{ name: "robot", options: { real: { deployments: [] } } }]"#)
+                .expect("axes parse");
         let error = validate_guard(
             &BTreeMap::from([("commander".to_owned(), "web".to_owned())]),
             &axes,
@@ -841,10 +867,9 @@ mod tests {
 
     #[test]
     fn a_guard_naming_an_unknown_option_is_refused() {
-        let axes: Vec<ComponentAxis> = serde_json5::from_str(
-            r#"[{ name: "robot", options: { real: { deployments: [] } } }]"#,
-        )
-        .expect("axes parse");
+        let axes: Vec<ComponentAxis> =
+            serde_json5::from_str(r#"[{ name: "robot", options: { real: { deployments: [] } } }]"#)
+                .expect("axes parse");
         let error = validate_guard(
             &BTreeMap::from([("robot".to_owned(), "sim".to_owned())]),
             &axes,

--- a/crates/daemon-config-internal/src/launcher/composition.rs
+++ b/crates/daemon-config-internal/src/launcher/composition.rs
@@ -1,0 +1,853 @@
+//! The composition grammar: the `components` axes and `adjustments` a
+//! `launcher/v1` document may declare, and the `launcher_fragment/v1`
+//! documents its options reference.
+//!
+//! A launcher without `components` is a flat stack and never reaches this
+//! module's types. A launcher with them describes a FAMILY of stacks whose
+//! members differ in which implementation fills each axis, selected at launch
+//! time with `--with`. Flattening ( [`super::flatten`] ) turns a launcher plus
+//! a selection into the ordinary flat document the rest of the pipeline
+//! consumes; this module is only the grammar and the checks that need no I/O
+//! and no selection.
+
+use super::types::{Deployment, LinkValue};
+use config::{AnyType, consts::ALLOWED_CONFIG_CHARS, runtime::Name, schema::PeppySchema};
+use serde::{
+    Deserialize, Serialize,
+    de::{self, Deserializer, MapAccess, SeqAccess, Visitor},
+    ser::SerializeSeq,
+};
+use std::collections::{BTreeMap, HashSet};
+
+/// One axis declaration in a launcher's `components` list.
+///
+/// The list is ORDERED, and the order is load-bearing: it fixes the order
+/// fragments are collected in and therefore the order adjustments apply and
+/// deployments appear, the same way `deployments` order fixes start order.
+/// An axis names the alternative `options` that fill it; exactly one option
+/// per axis is ever selected (§ "an axis takes one option, never two").
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ComponentAxis {
+    /// The axis's name, unique within the launcher and spelled with the same
+    /// identifier grammar as every other name in a peppy document. Used by
+    /// `--with axis=option` and by `when` guards.
+    pub name: String,
+    /// The alternatives that fill this axis, at least one. A value is an
+    /// inline fragment object, a path relative to the launcher's own
+    /// directory, or a list mixing both (merged in list order).
+    pub options: BTreeMap<String, FragmentSpec>,
+    /// Chosen when `--with` names nothing on this axis. Forbidden together
+    /// with `optional`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default: Option<String>,
+    /// When true the axis may be left unfilled: an unselected optional axis
+    /// contributes nothing to the stack.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub optional: bool,
+    /// The axis's interface: every option must define all of these instance
+    /// ids in its deployments, so a link or adjustment written against one is
+    /// valid regardless of which option the operator picks.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub provides: Vec<Name>,
+}
+
+/// One option's fragment set, in the order the option declared it: an inline
+/// fragment, a path, or a list mixing both all parse into the same shape.
+///
+/// The two origins parse identically but live differently: an inline fragment
+/// is part of the launcher file, while a path is resolved and read when the
+/// composition is loaded ( [`super::flatten`] ), never here.
+#[derive(Debug, Clone, Default)]
+pub struct FragmentSpec(pub Vec<FragmentPart>);
+
+/// One piece of an option's body: a fragment written inline, or a path to a
+/// `launcher_fragment/v1` file.
+#[derive(Debug, Clone)]
+pub enum FragmentPart {
+    Inline(Fragment),
+    File(String),
+}
+
+/// The body of one fragment: what a `--with` selection pulls in.
+///
+/// `deployments` uses the same grammar as the launcher's own, `core_nodes`
+/// are unioned with the base's, and `adjustments` reach instances the
+/// fragment does not own. A fragment cannot declare `components` (no
+/// nesting) and cannot declare `peppy_schema` when inline: the file form
+/// wraps this body in [`LauncherFragment`].
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Fragment {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub deployments: Vec<Deployment>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub adjustments: Vec<Adjustment>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub core_nodes: Vec<String>,
+}
+
+/// A `launcher_fragment/v1` document: a [`Fragment`] body in its own file,
+/// tagged so the repository indexer can tell a fragment from a launcher and
+/// so a mis-tagged document refuses to parse as the wrong kind.
+#[derive(Debug, Clone)]
+pub struct LauncherFragment {
+    pub peppy_schema: PeppySchema,
+    pub body: Fragment,
+}
+
+impl<'de> Deserialize<'de> for LauncherFragment {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct RawLauncherFragment {
+            #[serde(deserialize_with = "deserialize_launcher_fragment_v1_schema")]
+            peppy_schema: PeppySchema,
+            #[serde(flatten)]
+            body: Fragment,
+        }
+
+        let raw = RawLauncherFragment::deserialize(deserializer)?;
+        Ok(LauncherFragment {
+            peppy_schema: raw.peppy_schema,
+            body: raw.body,
+        })
+    }
+}
+
+/// Reject any `peppy_schema` value other than `launcher_fragment/v1` so a
+/// whole launcher (or a node document) that happens to share the fragment
+/// body cannot slip through the fragment parser.
+fn deserialize_launcher_fragment_v1_schema<'de, D>(deserializer: D) -> Result<PeppySchema, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    PeppySchema::deserialize_expecting(deserializer, PeppySchema::LauncherFragmentV1)
+}
+
+/// One change to an instance defined elsewhere, in the base or in another
+/// selected fragment. Every change names its operation; nothing is inferred
+/// from a value's JSON type.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Adjustment {
+    /// The instance to change. Whether an instance exists is declared by the
+    /// base and the axes' options, so an adjustment whose target the resolved
+    /// selection does not define is skipped, not refused; a target no option
+    /// of the launcher defines anywhere is a dead reference and a parse error.
+    pub target: Name,
+    /// Guard: every named axis must match the named option for this
+    /// adjustment to run. Absent means unconditional.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub when: Option<BTreeMap<String, String>>,
+    /// Replaces the target's value for each named top-level argument key,
+    /// creating it when absent. Nested objects replace wholesale; the node's
+    /// parameter schema validates the final value.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub set_arguments: Option<BTreeMap<String, AnyType>>,
+    /// Replaces the target's whole entry for each named slot, creating it
+    /// when absent, using the ordinary launcher link grammar.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub set_links: Option<BTreeMap<String, LinkValue>>,
+    /// Appends targets to each named slot's array binding, creating the
+    /// binding when the slot has no entry. Refused (at flatten time) when the
+    /// slot holds a scalar or a vacancy.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub add_links: Option<BTreeMap<String, Vec<String>>>,
+    /// Drops each named slot's entry entirely, returning the slot to absent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub unset_links: Option<Vec<String>>,
+}
+
+impl Serialize for FragmentSpec {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self.0.as_slice() {
+            [single] => single.serialize(serializer),
+            parts => {
+                let mut seq = serializer.serialize_seq(Some(parts.len()))?;
+                for part in parts {
+                    seq.serialize_element(part)?;
+                }
+                seq.end()
+            }
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for FragmentSpec {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct FragmentSpecVisitor;
+
+        impl<'de> Visitor<'de> for FragmentSpecVisitor {
+            type Value = FragmentSpec;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.write_str(
+                    "a fragment object, a path string, or a list mixing both, e.g. \
+                     [\"fragments/sim_relays.json5\", { deployments: [...] }]",
+                )
+            }
+
+            /// A path string: the fragment lives in its own
+            /// `launcher_fragment/v1` file next to the launcher.
+            fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {
+                if v.trim().is_empty() {
+                    return Err(de::Error::custom(
+                        "a fragment path cannot be empty: name a `launcher_fragment/v1` file \
+                         relative to the launcher's directory",
+                    ));
+                }
+                Ok(FragmentSpec(vec![FragmentPart::File(v.to_owned())]))
+            }
+
+            /// An inline fragment: the body is written here, in the option.
+            fn visit_map<A: MapAccess<'de>>(self, map: A) -> Result<Self::Value, A::Error> {
+                let fragment =
+                    Fragment::deserialize(serde::de::value::MapAccessDeserializer::new(map))?;
+                Ok(FragmentSpec(vec![FragmentPart::Inline(fragment)]))
+            }
+
+            /// The list form: parts merge in list order before the option's
+            /// contribution enters flattening.
+            fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
+                let mut parts = Vec::with_capacity(seq.size_hint().unwrap_or(0));
+                while let Some(part) = seq.next_element::<FragmentPart>()? {
+                    parts.push(part);
+                }
+                if parts.is_empty() {
+                    return Err(de::Error::custom(
+                        "a fragment list cannot be empty: an option with no body has nothing to \
+                         contribute, and an off-by-default feature is written as an optional axis \
+                         instead",
+                    ));
+                }
+                Ok(FragmentSpec(parts))
+            }
+        }
+
+        deserializer.deserialize_any(FragmentSpecVisitor)
+    }
+}
+
+impl<'de> Deserialize<'de> for FragmentPart {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct FragmentPartVisitor;
+
+        impl<'de> Visitor<'de> for FragmentPartVisitor {
+            type Value = FragmentPart;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.write_str("a fragment object or a path string")
+            }
+
+            fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {
+                if v.trim().is_empty() {
+                    return Err(de::Error::custom(
+                        "a fragment path cannot be empty: name a `launcher_fragment/v1` file \
+                         relative to the launcher's directory",
+                    ));
+                }
+                Ok(FragmentPart::File(v.to_owned()))
+            }
+
+            fn visit_map<A: MapAccess<'de>>(self, map: A) -> Result<Self::Value, A::Error> {
+                let fragment =
+                    Fragment::deserialize(serde::de::value::MapAccessDeserializer::new(map))?;
+                Ok(FragmentPart::Inline(fragment))
+            }
+        }
+
+        deserializer.deserialize_any(FragmentPartVisitor)
+    }
+}
+
+impl Serialize for FragmentPart {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            FragmentPart::Inline(fragment) => fragment.serialize(serializer),
+            FragmentPart::File(path) => serializer.serialize_str(path),
+        }
+    }
+}
+
+/// Parser for `launcher_fragment/v1` documents.
+///
+/// Fragment files have no fixed name: any `.json5` file whose body declares
+/// the fragment schema is one. A fragment is inert on its own; it only ever
+/// contributes to the launcher whose option references it.
+pub struct LauncherFragmentParser;
+
+impl LauncherFragmentParser {
+    pub fn from_path(file: impl AsRef<std::path::Path>) -> crate::error::Result<LauncherFragment> {
+        let content = crate::parsing::read_non_empty_file(file.as_ref())?;
+        Self::from_content(&content)
+    }
+
+    pub fn from_content(content: &str) -> crate::error::Result<LauncherFragment> {
+        crate::error::deserialize_json5_with_path(content)
+    }
+}
+
+/// Axis and option names share the identifier grammar of every other name in
+/// a peppy document, and for the same reason: an axis name is one half of
+/// `--with axis=option` and a bare `--with` word is an option name, so a name
+/// carrying an `=`, a `,`, or whitespace would be unwireable from the very
+/// surface it exists for. (`,` separates `--with` entries and `=` splits the
+/// `axis=option` form; both are outside [`ALLOWED_CONFIG_CHARS`].)
+pub(crate) fn check_axis_or_option_name(kind: &str, name: &str) -> Result<(), String> {
+    if name.is_empty() {
+        return Err(format!("`components` declares {kind} with an empty name"));
+    }
+    if !name.chars().all(|c| ALLOWED_CONFIG_CHARS.contains(c)) {
+        return Err(format!(
+            "`components` declares {kind} `{name}`, which is not a plain identifier \
+             (letters, digits, `_`, `-`): the name appears in `--with` entries and `when` \
+             guards, where `=` and `,` already carry meaning and whitespace separates words"
+        ));
+    }
+    Ok(())
+}
+
+/// The launcher-local checks on a `components` list: the ones needing no
+/// fragment file and no selection. Runs while the launcher document parses,
+/// so an author hears them from any reader of the file.
+///
+/// What it deliberately does NOT check: that an option defines its axis's
+/// `provides` ids (needs the fragments loaded, [`super::flatten`]) and that
+/// `when` guards name real axes and options (checked for base and inline
+/// adjustments here, for file fragments when they are read).
+pub(crate) fn validate_axes(axes: &[ComponentAxis]) -> Result<(), String> {
+    let mut axis_names = HashSet::with_capacity(axes.len());
+    for axis in axes {
+        check_axis_or_option_name("an axis", &axis.name)?;
+        if !axis_names.insert(axis.as_str()) {
+            return Err(format!(
+                "`components` declares the axis `{}` more than once; axis names must be unique",
+                axis.name
+            ));
+        }
+        if axis.options.is_empty() {
+            return Err(format!(
+                "axis `{}` declares no `options`; an axis with nothing to choose between is \
+                 not a component. State its alternatives, or drop the axis",
+                axis.name
+            ));
+        }
+        for option in axis.options.keys() {
+            check_axis_or_option_name(&format!("an option of axis `{}`", axis.name), option)?;
+        }
+        if axis.optional && axis.default.is_some() {
+            return Err(format!(
+                "axis `{}` declares both `optional: true` and a `default`: an optional axis is \
+                 left unfilled by omitting it, so it has nothing to fall back to",
+                axis.name
+            ));
+        }
+        if let Some(default) = &axis.default
+            && !axis.options.contains_key(default)
+        {
+            return Err(format!(
+                "axis `{}` names `{}` as its `default`, which is not one of its options: {}",
+                axis.name,
+                default,
+                crate::error::format_quoted_list(axis.options.keys())
+            ));
+        }
+    }
+
+    // A bare `--with` word resolves against option names, so an axis name
+    // sharing a name with another axis's option would make that word name two
+    // different things. An axis and its OWN option may share a name: a
+    // single-option optional axis is a feature toggle, and both readings of
+    // the word select the same option.
+    for axis in axes {
+        for other in axes {
+            if other.name == axis.name {
+                continue;
+            }
+            if other.options.contains_key(axis.name.as_str()) {
+                return Err(format!(
+                    "axis `{}` cannot share a name with the `{}` option of axis `{}`: a bare \
+                     `--with {}` would not say which of the two it selects",
+                    axis.name, axis.name, other.name, axis.name
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+impl ComponentAxis {
+    pub fn as_str(&self) -> &str {
+        &self.name
+    }
+}
+
+/// The shape checks on one adjustment: names that say something, operations
+/// that exist, targets that are well-formed. Selection-independent, so they
+/// run wherever the adjustment is read (launcher parse for the base and
+/// inline fragments, fragment load for files).
+pub(crate) fn validate_adjustment(adjustment: &Adjustment, origin: &str) -> Result<(), String> {
+    if let Some(when) = &adjustment.when
+        && when.is_empty()
+    {
+        return Err(format!(
+            "adjustment on `{}` in {origin} declares an empty `when`: a guard names at least \
+             one `axis: option` pair, or omits `when` entirely",
+            adjustment.target
+        ));
+    }
+
+    let has_operation = adjustment.set_arguments.as_ref().is_some_and(|m| !m.is_empty())
+        || adjustment.set_links.as_ref().is_some_and(|m| !m.is_empty())
+        || adjustment.add_links.as_ref().is_some_and(|m| !m.is_empty())
+        || adjustment.unset_links.as_ref().is_some_and(|v| !v.is_empty());
+    if !has_operation {
+        return Err(format!(
+            "adjustment on `{}` in {origin} names no operation: state at least one of \
+             `set_arguments`, `set_links`, `add_links`, `unset_links`",
+            adjustment.target
+        ));
+    }
+
+    if let Some(arguments) = &adjustment.set_arguments {
+        check_non_empty_keys(arguments.keys(), "argument", &adjustment.target, origin)?;
+    }
+    if let Some(links) = &adjustment.set_links {
+        check_non_empty_keys(links.keys(), "link", &adjustment.target, origin)?;
+    }
+    if let Some(links) = &adjustment.add_links {
+        check_non_empty_keys(links.keys(), "link", &adjustment.target, origin)?;
+        for (slot, targets) in links {
+            if targets.is_empty() {
+                return Err(format!(
+                    "adjustment on `{}` in {origin} adds no target to slot `{slot}`: an empty \
+                     `add_links` entry appends nothing",
+                    adjustment.target
+                ));
+            }
+            let mut seen = HashSet::with_capacity(targets.len());
+            for target in targets {
+                if target.trim().is_empty() {
+                    return Err(format!(
+                        "adjustment on `{}` in {origin} adds an empty target to slot `{slot}`",
+                        adjustment.target
+                    ));
+                }
+                let (instance, link_suffix) = super::types::split_link_target(target);
+                if instance.is_empty()
+                    || link_suffix.is_some_and(|l| l.is_empty() || l.contains('/'))
+                {
+                    return Err(format!(
+                        "adjustment on `{}` in {origin} adds target `{target}` to slot \
+                         `{slot}`, which is malformed: expected `<instance>` or \
+                         `<instance>/<link_id>`",
+                        adjustment.target
+                    ));
+                }
+                if !seen.insert(target.as_str()) {
+                    return Err(format!(
+                        "adjustment on `{}` in {origin} adds target `{target}` to slot \
+                         `{slot}` more than once: a slot's bound set lists each producer once",
+                        adjustment.target
+                    ));
+                }
+            }
+        }
+    }
+    if let Some(slots) = &adjustment.unset_links {
+        let mut seen = HashSet::with_capacity(slots.len());
+        for slot in slots {
+            if slot.trim().is_empty() {
+                return Err(format!(
+                    "adjustment on `{}` in {origin} unsets an empty link key",
+                    adjustment.target
+                ));
+            }
+            if !seen.insert(slot.as_str()) {
+                return Err(format!(
+                    "adjustment on `{}` in {origin} unsets slot `{slot}` more than once",
+                    adjustment.target
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// The keys an adjustment names must say something, whatever map they arrive
+/// in. Duplicates inside one JSON5 object are collapsed by the map itself,
+/// exactly as the per-instance `arguments` and `links` maps are.
+fn check_non_empty_keys<'a>(
+    keys: impl Iterator<Item = &'a String>,
+    kind: &str,
+    target: &Name,
+    origin: &str,
+) -> Result<(), String> {
+    for key in keys {
+        if key.trim().is_empty() {
+            return Err(format!(
+                "adjustment on `{target}` in {origin} names an empty {kind} key"
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// That a `when` guard names axes this launcher declares and options those
+/// axes declare. A guard is what licenses an adjustment to depend on the
+/// shape those options define, so naming something else is a dead reference.
+pub(crate) fn validate_guard(when: &BTreeMap<String, String>, axes: &[ComponentAxis], origin: &str) -> Result<(), String> {
+    for (axis_name, option_name) in when {
+        let Some(axis) = axes.iter().find(|axis| axis.name == *axis_name) else {
+            return Err(format!(
+                "a `when` guard in {origin} names axis `{axis_name}`, which this launcher does \
+                 not declare. Axes: {}",
+                crate::error::format_quoted_list(axes.iter().map(ComponentAxis::as_str))
+            ));
+        };
+        if !axis.options.contains_key(option_name) {
+            return Err(format!(
+                "a `when` guard in {origin} names option `{option_name}` on axis \
+                 `{axis_name}`, which the axis does not declare. Its options: {}",
+                crate::error::format_quoted_list(axis.options.keys())
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Every adjustment the launcher document itself carries: the base
+/// `adjustments` list, plus the adjustments of every INLINE fragment (file
+/// fragments are checked when they are read, against the same axes).
+pub(crate) fn validate_launcher_adjustments(
+    adjustments: &[Adjustment],
+    axes: &[ComponentAxis],
+) -> Result<(), String> {
+    for adjustment in adjustments {
+        validate_adjustment(adjustment, "the launcher's `adjustments`")?;
+        if let Some(when) = &adjustment.when {
+            validate_guard(when, axes, "the launcher's `adjustments`")?;
+        }
+    }
+    for axis in axes {
+        for (option, spec) in &axis.options {
+            for part in &spec.0 {
+                if let FragmentPart::Inline(fragment) = part {
+                    let origin = format!("inline option `{}.{}`", axis.name, option);
+                    for adjustment in &fragment.adjustments {
+                        validate_adjustment(adjustment, &origin)?;
+                        if let Some(when) = &adjustment.when {
+                            validate_guard(when, axes, &origin)?;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_fragment_spec(content: &str) -> Result<FragmentSpec, String> {
+        serde_json5::from_str(content).map_err(|e| e.to_string())
+    }
+
+    #[test]
+    fn a_path_option_parses_as_one_file_part() {
+        let spec = parse_fragment_spec(r#""fragments/web_commander.json5""#).expect("path parses");
+        assert!(matches!(
+            spec.0.as_slice(),
+            [FragmentPart::File(p)] if p == "fragments/web_commander.json5"
+        ));
+    }
+
+    #[test]
+    fn an_inline_option_parses_as_one_fragment_body() {
+        let spec = parse_fragment_spec(r#"{ deployments: [], core_nodes: ["cloud"] }"#)
+            .expect("inline fragment parses");
+        let [FragmentPart::Inline(fragment)] = spec.0.as_slice() else {
+            panic!("expected one inline part, got {spec:?}");
+        };
+        assert!(fragment.deployments.is_empty());
+        assert_eq!(fragment.core_nodes, ["cloud"]);
+    }
+
+    #[test]
+    fn a_list_option_keeps_its_order() {
+        let spec = parse_fragment_spec(
+            r#"["fragments/sim_relays.json5", "fragments/mujoco_engine.json5"]"#,
+        )
+        .expect("list parses");
+        assert_eq!(spec.0.len(), 2);
+        assert!(matches!(&spec.0[0], FragmentPart::File(p) if p == "fragments/sim_relays.json5"));
+        assert!(matches!(&spec.0[1], FragmentPart::File(p) if p == "fragments/mujoco_engine.json5"));
+    }
+
+    #[test]
+    fn a_mixed_list_parses_both_kinds() {
+        let spec = parse_fragment_spec(
+            r#"["fragments/relays.json5", { deployments: [], core_nodes: ["edge"] }]"#,
+        )
+        .expect("mixed list parses");
+        assert!(matches!(&spec.0[0], FragmentPart::File(_)));
+        assert!(matches!(&spec.0[1], FragmentPart::Inline(_)));
+    }
+
+    #[test]
+    fn an_empty_fragment_list_is_refused() {
+        let error = parse_fragment_spec("[]").expect_err("empty list must be refused");
+        assert!(error.contains("cannot be empty"), "got: {error}");
+    }
+
+    #[test]
+    fn an_empty_path_is_refused() {
+        let error = parse_fragment_spec(r#""   ""#).expect_err("empty path must be refused");
+        assert!(error.contains("cannot be empty"), "got: {error}");
+    }
+
+    #[test]
+    fn an_inline_fragment_cannot_declare_a_schema() {
+        let error =
+            parse_fragment_spec(r#"{ peppy_schema: "launcher/v1", deployments: [] }"#)
+                .expect_err("inline fragments take no peppy_schema");
+        assert!(error.contains("peppy_schema"), "got: {error}");
+    }
+
+    #[test]
+    fn a_fragment_spec_round_trips_through_its_written_shape() {
+        for written in [
+            r#""fragments/a.json5""#.to_owned(),
+            r#"{ deployments: [] }"#.to_owned(),
+            r#"["fragments/a.json5", { deployments: [] }]"#.to_owned(),
+        ] {
+            let spec = serde_json5::from_str::<FragmentSpec>(&written).expect("parses");
+            let reserialized = serde_json5::to_string(&spec).expect("serializes");
+            let reparsed = serde_json5::from_str::<FragmentSpec>(&reserialized)
+                .expect("reparses");
+            assert_eq!(spec.0.len(), reparsed.0.len(), "round trip of {written}");
+        }
+    }
+
+    #[test]
+    fn a_fragment_file_document_parses_with_its_own_schema() {
+        let content = r#"{
+            peppy_schema: "launcher_fragment/v1",
+            deployments: [],
+        }"#;
+        let fragment = LauncherFragmentParser::from_content(content).expect("fragment parses");
+        assert_eq!(fragment.peppy_schema, PeppySchema::LauncherFragmentV1);
+        assert!(fragment.body.deployments.is_empty());
+    }
+
+    #[test]
+    fn a_fragment_file_refuses_the_launcher_schema() {
+        let error = LauncherFragmentParser::from_content(
+            r#"{ peppy_schema: "launcher/v1", deployments: [] }"#,
+        )
+        .expect_err("a launcher is not a fragment");
+        assert!(
+            error.to_string().contains("launcher_fragment/v1"),
+            "got: {error}"
+        );
+    }
+
+    // -- validate_axes ------------------------------------------------------
+
+    fn one_axis(body: &str) -> Result<Vec<ComponentAxis>, String> {
+        let axes: Vec<ComponentAxis> = serde_json5::from_str(&format!("[{body}]"))
+            .map_err(|e| e.to_string())?;
+        validate_axes(&axes).map(|()| axes)
+    }
+
+    #[test]
+    fn a_well_formed_axis_passes() {
+        let axes = one_axis(
+            r#"{ name: "robot", provides: ["left_arm_inst"], default: "real",
+                 options: { real: { deployments: [] } } }"#,
+        )
+        .expect("valid axis");
+        assert_eq!(axes[0].name, "robot");
+        assert_eq!(axes[0].default.as_deref(), Some("real"));
+    }
+
+    #[test]
+    fn an_unwireable_axis_name_is_refused() {
+        for name in ["has space", "has=equals", "has,comma"] {
+            let error = one_axis(&format!(
+                r#"{{ name: "{name}", options: {{ real: {{ deployments: [] }} }} }}"#
+            ))
+            .expect_err("an unwireable name must be refused");
+            assert!(error.contains(name), "got: {error}");
+        }
+    }
+
+    #[test]
+    fn an_axis_with_no_options_is_refused() {
+        let error = one_axis(r#"{ name: "robot", options: {} }"#)
+            .expect_err("an empty options map must be refused");
+        assert!(error.contains("declares no `options`"), "got: {error}");
+    }
+
+    #[test]
+    fn optional_with_a_default_is_refused() {
+        let error = one_axis(
+            r#"{ name: "robot", optional: true, default: "real",
+                 options: { real: { deployments: [] } } }"#,
+        )
+        .expect_err("optional and default are exclusive");
+        assert!(error.contains("both"), "got: {error}");
+    }
+
+    #[test]
+    fn a_default_naming_a_missing_option_is_refused() {
+        let error = one_axis(
+            r#"{ name: "robot", default: "sim", options: { real: { deployments: [] } } }"#,
+        )
+        .expect_err("a default must name a declared option");
+        assert!(error.contains("`sim`"), "got: {error}");
+        assert!(error.contains("`real`"), "got: {error}");
+    }
+
+    #[test]
+    fn a_duplicated_axis_name_is_refused() {
+        let error = one_axis(
+            r#"{ name: "robot", options: { a: { deployments: [] } } },
+                { name: "robot", options: { b: { deployments: [] } } }"#,
+        )
+        .expect_err("duplicate axis names must be refused");
+        assert!(error.contains("more than once"), "got: {error}");
+    }
+
+    #[test]
+    fn an_axis_may_share_a_name_with_its_own_option() {
+        one_axis(
+            r#"{ name: "cameras", optional: true, options: { cameras: { deployments: [] } } }"#,
+        )
+        .expect("a single-option optional axis is a feature toggle");
+    }
+
+    #[test]
+    fn an_axis_sharing_another_axis_option_name_is_refused() {
+        let error = one_axis(
+            r#"{ name: "robot", options: { real: { deployments: [] } } },
+                { name: "real", options: { x: { deployments: [] } } }"#,
+        )
+        .expect_err("a bare --with word must resolve to one thing");
+        assert!(error.contains("`robot`"), "got: {error}");
+        assert!(error.contains("`real`"), "got: {error}");
+    }
+
+    // -- validate_adjustment ------------------------------------------------
+
+    fn parse_adjustment(body: &str) -> Result<Adjustment, String> {
+        let adjustment: Adjustment = serde_json5::from_str(body).map_err(|e| e.to_string())?;
+        validate_adjustment(&adjustment, "a test fragment").map(|()| adjustment)
+    }
+
+    #[test]
+    fn a_complete_adjustment_parses() {
+        let adjustment = parse_adjustment(
+            r#"{
+                target: "backbone_inst",
+                when: { commander: "xr_commander" },
+                set_arguments: { upstream_mode: "pose" },
+                set_links: { collision_ctrl: { vacant: "no producer here" } },
+                add_links: { recorder: ["recorder_inst"] },
+                unset_links: ["leader_left_arm_pose"],
+            }"#,
+        )
+        .expect("a full adjustment parses");
+        assert_eq!(adjustment.target.as_str(), "backbone_inst");
+        assert_eq!(
+            adjustment.when.as_ref().and_then(|w| w.get("commander")).map(String::as_str),
+            Some("xr_commander")
+        );
+    }
+
+    #[test]
+    fn an_adjustment_with_no_operation_is_refused() {
+        let error = parse_adjustment(r#"{ target: "backbone_inst" }"#)
+            .expect_err("an adjustment must do something");
+        assert!(error.contains("names no operation"), "got: {error}");
+    }
+
+    #[test]
+    fn an_empty_guard_is_refused() {
+        let error = parse_adjustment(
+            r#"{ target: "backbone_inst", when: {}, set_arguments: { a: 1 } }"#,
+        )
+        .expect_err("an empty guard means nothing");
+        assert!(error.contains("empty `when`"), "got: {error}");
+    }
+
+    #[test]
+    fn add_links_targets_are_shape_checked() {
+        let error = parse_adjustment(
+            r#"{ target: "c", add_links: { cameras: [] } }"#,
+        )
+        .expect_err("an empty target list appends nothing");
+        assert!(error.contains("no target"), "got: {error}");
+
+        let error = parse_adjustment(
+            r#"{ target: "c", add_links: { cameras: ["a", "a"] } }"#,
+        )
+        .expect_err("a duplicate target is a mistake");
+        assert!(error.contains("more than once"), "got: {error}");
+
+        let error = parse_adjustment(
+            r#"{ target: "c", add_links: { cameras: ["a//b"] } }"#,
+        )
+        .expect_err("a malformed target is refused");
+        assert!(error.contains("malformed"), "got: {error}");
+    }
+
+    #[test]
+    fn a_guard_naming_an_unknown_axis_is_refused() {
+        let axes: Vec<ComponentAxis> = serde_json5::from_str(
+            r#"[{ name: "robot", options: { real: { deployments: [] } } }]"#,
+        )
+        .expect("axes parse");
+        let error = validate_guard(
+            &BTreeMap::from([("commander".to_owned(), "web".to_owned())]),
+            &axes,
+            "a test fragment",
+        )
+        .expect_err("an unknown axis is a dead reference");
+        assert!(error.contains("`commander`"), "got: {error}");
+        assert!(error.contains("`robot`"), "got: {error}");
+    }
+
+    #[test]
+    fn a_guard_naming_an_unknown_option_is_refused() {
+        let axes: Vec<ComponentAxis> = serde_json5::from_str(
+            r#"[{ name: "robot", options: { real: { deployments: [] } } }]"#,
+        )
+        .expect("axes parse");
+        let error = validate_guard(
+            &BTreeMap::from([("robot".to_owned(), "sim".to_owned())]),
+            &axes,
+            "a test fragment",
+        )
+        .expect_err("an unknown option is a dead reference");
+        assert!(error.contains("`sim`"), "got: {error}");
+    }
+}

--- a/crates/daemon-config-internal/src/launcher/flatten.rs
+++ b/crates/daemon-config-internal/src/launcher/flatten.rs
@@ -865,7 +865,7 @@ pub fn flatten(
     // not a second author fighting a fragment; it is the one author who
     // owns the file, and its later entries win over its earlier ones.
     let mut writers: HashMap<(&str, KeySpace, &str), (usize, String)> = HashMap::new();
-    let mut adders: HashMap<(&str, &str), (usize, String)> = HashMap::new();
+    let mut adders: HashMap<(&str, &str), String> = HashMap::new();
     for step in &running {
         if step.is_base {
             continue;
@@ -895,17 +895,15 @@ pub fn flatten(
             claim_write(&mut writers, target, space, key, step)?;
         }
         for key in step.adjustment.add_links.iter().flat_map(|links| links.keys()) {
-            let entry = adders
-                .entry((target, key.as_str()))
-                .or_insert((step.fragment_id, step.origin.clone()));
-            entry.1 = step.origin.clone();
+            adders.insert((target, key.as_str()), step.origin.clone());
         }
     }
-    for ((target, key), (adder_id, adder_origin)) in &adders {
-        if let Some((writer_id, writer_origin)) =
-            writers.get(&(target, KeySpace::Links, key))
-            && *writer_id != *adder_id
-        {
+    // Appending to a slot and replacing it are two claims on the same entry,
+    // from one fragment or two: whichever order they applied in, one verb
+    // would silently eat part of the other's effect, so the pair is refused
+    // outright.
+    for ((target, key), adder_origin) in &adders {
+        if let Some((_writer_id, writer_origin)) = writers.get(&(target, KeySpace::Links, key)) {
             return Err(CompositionError::AdjustmentsConflict {
                 target: (*target).to_owned(),
                 field: format!("links.{key}"),
@@ -1515,6 +1513,43 @@ mod tests {
         let parsed = parse_launcher(&fs::read_to_string(&launcher).unwrap());
         let err = compose(&parsed, &launcher, &["on".to_string()]).expect_err("duplicate add");
         assert!(err.to_string().contains("seed_inst"), "got: {err}");
+    }
+
+    #[test]
+    fn replacing_and_appending_to_one_slot_conflict_even_in_one_fragment() {
+        let dir = tempdir().unwrap();
+        write(
+            &dir.path().join("fragments/a.json5"),
+            &fragment_file(
+                r#"
+                adjustments: [
+                    { target: "panel", set_links: { observers: ["seed_inst"] } },
+                    { target: "panel", add_links: { observers: ["a_inst"] } },
+                ],
+            "#,
+            ),
+        );
+        let launcher = write(
+            &dir.path().join("l.json5"),
+            r#"{
+                peppy_schema: "launcher/v1",
+                components: [
+                    { name: "a", optional: true, options: { on: "fragments/a.json5" } },
+                ],
+                deployments: [
+                    { source: { name: "panel", tag: "v1" }, instances: [{ instance_id: "panel" }] },
+                    { source: { name: "seed", tag: "v1" }, instances: [{ instance_id: "seed_inst" }] },
+                    { source: { name: "a", tag: "v1" }, instances: [{ instance_id: "a_inst" }] },
+                ],
+            }"#,
+        );
+        let parsed = parse_launcher(&fs::read_to_string(&launcher).unwrap());
+        let err = compose(&parsed, &launcher, &words(&["on"]))
+            .expect_err("replace and append are two claims on one entry");
+        let CompositionError::AdjustmentsConflict { field, .. } = &err else {
+            panic!("expected AdjustmentsConflict, got: {err}");
+        };
+        assert_eq!(field, "links.observers");
     }
 
     #[test]

--- a/crates/daemon-config-internal/src/launcher/flatten.rs
+++ b/crates/daemon-config-internal/src/launcher/flatten.rs
@@ -16,6 +16,7 @@ use super::types::{Deployment, LinkTargets, LinkValue, PeppyLauncher, Selection}
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::{Component as PathComponent, Path, PathBuf};
 use thiserror::Error;
+use tracing::warn;
 
 /// Everything composition can refuse: bad `--with` words, unreadable or
 /// unsafe fragment paths, options that do not provide what their axis
@@ -208,48 +209,33 @@ pub fn resolve_selection(
     axes: &[ComponentAxis],
     words: &[String],
 ) -> Result<ComponentSelection, CompositionError> {
-    let menu = axes_menu(axes);
     let mut chosen: BTreeMap<String, String> = BTreeMap::new();
 
     for word in words {
-        let (axis_name, option_name) = match word.split_once('=') {
-            Some((axis, option)) => (Some(axis), option),
-            None => (None, word.as_str()),
-        };
-
-        let axis_name = match axis_name {
-            Some(explicit) => {
-                if !axes.iter().any(|axis| axis.name == explicit) {
-                    return Err(CompositionError::UnknownSelection {
-                        word: word.clone(),
-                        menu,
-                    });
-                }
-                explicit
+        let (axis, option_name) = match word.split_once('=') {
+            Some((axis_name, option)) => {
+                let Some(axis) = axes.iter().find(|axis| axis.name == axis_name) else {
+                    return Err(unknown_selection(word, axes));
+                };
+                (axis, option)
             }
             // A bare word resolves against option names across every axis;
             // matching more than one is ambiguous and asks for the explicit
             // form.
             None => {
-                let holders: Vec<&str> = axes
+                let holders: Vec<&ComponentAxis> = axes
                     .iter()
-                    .filter(|axis| axis.options.contains_key(option_name))
-                    .map(ComponentAxis::as_str)
+                    .filter(|axis| axis.options.contains_key(word.as_str()))
                     .collect();
                 match holders.as_slice() {
-                    [] => {
-                        return Err(CompositionError::UnknownSelection {
-                            word: word.clone(),
-                            menu,
-                        })
-                    }
-                    [axis] => *axis,
+                    [] => return Err(unknown_selection(word, axes)),
+                    [axis] => (*axis, word.as_str()),
                     many => {
                         return Err(CompositionError::AmbiguousSelection {
                             word: word.clone(),
                             axes: many
                                 .iter()
-                                .map(|axis| format!("`{axis}`"))
+                                .map(|axis| format!("`{}`", axis.as_str()))
                                 .collect::<Vec<_>>()
                                 .join(", "),
                         })
@@ -258,26 +244,19 @@ pub fn resolve_selection(
             }
         };
 
-        let axis = axes
-            .iter()
-            .find(|axis| axis.name == axis_name)
-            .expect("axis existence checked above");
         if !axis.options.contains_key(option_name) {
-            return Err(CompositionError::UnknownSelection {
-                word: word.clone(),
-                menu,
-            });
+            return Err(unknown_selection(word, axes));
         }
-        if let Some(first) = chosen.get(axis_name)
+        if let Some(first) = chosen.get(axis.name.as_str())
             && first != option_name
         {
             return Err(CompositionError::ConflictingSelection {
-                axis: axis_name.to_owned(),
+                axis: axis.name.clone(),
                 first: first.clone(),
                 second: option_name.to_owned(),
             });
         }
-        chosen.insert(axis_name.to_owned(), option_name.to_owned());
+        chosen.insert(axis.name.clone(), option_name.to_owned());
     }
 
     let mut entries = Vec::with_capacity(axes.len());
@@ -313,6 +292,16 @@ pub fn resolve_selection(
     }
 
     Ok(ComponentSelection { entries })
+}
+
+/// The refusal for a `--with` word that names no axis or option, with the
+/// menu the fix picks from. Built here, on the error path, so a resolving
+/// selection never pays for the menu.
+fn unknown_selection(word: &str, axes: &[ComponentAxis]) -> CompositionError {
+    CompositionError::UnknownSelection {
+        word: word.to_owned(),
+        menu: axes_menu(axes),
+    }
 }
 
 /// One line per axis naming its options, for the "names no option of this
@@ -401,6 +390,20 @@ pub fn load_composition(
     let axes = &launcher.components;
     let mut options: BTreeMap<String, BTreeMap<String, Vec<LoadedFragment>>> = BTreeMap::new();
     let launcher_label = launcher_file_label(launcher_dir);
+    // The symlink-escape check compares each fragment's canonical path
+    // against the launcher's canonical directory, resolved once here rather
+    // than once per fragment reference.
+    let canonical_dir = launcher_dir.canonicalize().map_err(|e| {
+        CompositionError::FragmentUnreadable {
+            path: launcher_dir.display().to_string(),
+            origin: launcher_label.clone(),
+            detail: format!("the launcher's directory cannot be resolved: {e}"),
+        }
+    })?;
+    // Sharing one fragment file between several options is the designed
+    // pattern (the relay fragment under both simulators), so each file is
+    // read and parsed once per composition, keyed by the path as written.
+    let mut file_bodies: HashMap<&str, super::composition::Fragment> = HashMap::new();
 
     for axis in axes {
         let mut loaded_axis = BTreeMap::new();
@@ -413,8 +416,23 @@ pub fn load_composition(
                         origin: format!("inline option `{}.{}`", axis.name, option_name),
                     }),
                     FragmentPart::File(raw) => {
-                        let origin = format!("{launcher_label}, option `{}.{}`", axis.name, option_name);
-                        loaded.push(load_fragment_file(launcher_dir, raw, &origin)?);
+                        let origin = format!(
+                            "{launcher_label}, option `{}.{}`",
+                            axis.name, option_name
+                        );
+                        let body = match file_bodies.get(raw.as_str()) {
+                            Some(cached) => cached.clone(),
+                            None => {
+                                let body =
+                                    read_fragment_file(&canonical_dir, raw, &origin, axes)?;
+                                file_bodies.insert(raw.as_str(), body.clone());
+                                body
+                            }
+                        };
+                        loaded.push(LoadedFragment {
+                            fragment: body,
+                            origin: raw.to_owned(),
+                        });
                     }
                 }
             }
@@ -446,39 +464,21 @@ pub fn load_composition(
         }
     }
 
-    // Guards of file fragments reference the launcher's axes; the inline ones
-    // were checked when the launcher parsed.
-    for axis in axes {
-        for loaded in options[axis.name.as_str()].values() {
-            for fragment in loaded {
-                for adjustment in &fragment.fragment.adjustments {
-                    if let Some(when) = &adjustment.when {
-                        validate_guard(when, axes, &fragment.origin)
-                            .map_err(|reason| CompositionError::FragmentInvalid {
-                                path: fragment.origin.clone(),
-                                origin: launcher_label.clone(),
-                                detail: reason,
-                            })?;
-                    }
-                }
-            }
-        }
-    }
-
     // An adjustment target the selection does not define is skipped; a
     // target NOTHING can define is a dead reference, and refusing it here
     // catches it once for every selection.
+    let all_fragments: Vec<&LoadedFragment> = options
+        .values()
+        .flat_map(|axis| axis.values())
+        .flat_map(|fragments| fragments.iter())
+        .collect();
     let mut definable: HashSet<&str> = launcher
         .deployments
         .iter()
         .flat_map(|d| d.instances.iter())
         .map(|i| i.instance_id.as_str())
         .collect();
-    for fragment in options
-        .values()
-        .flat_map(|axis| axis.values())
-        .flat_map(|fragments| fragments.iter())
-    {
+    for fragment in &all_fragments {
         for deployment in &fragment.fragment.deployments {
             for instance in &deployment.instances {
                 definable.insert(instance.instance_id.as_str());
@@ -493,11 +493,7 @@ pub fn load_composition(
             });
         }
     }
-    for fragment in options
-        .values()
-        .flat_map(|axis| axis.values())
-        .flat_map(|fragments| fragments.iter())
-    {
+    for fragment in &all_fragments {
         for adjustment in &fragment.fragment.adjustments {
             if !definable.contains(adjustment.target.as_str()) {
                 return Err(CompositionError::TargetDefinedNowhere {
@@ -520,50 +516,49 @@ fn launcher_file_label(launcher_dir: &Path) -> String {
         .unwrap_or_else(|| launcher_dir.display().to_string())
 }
 
-fn load_fragment_file(
-    launcher_dir: &Path,
+/// Reads, parses, and shape-checks one `launcher_fragment/v1` file through
+/// the shared fragment parser (which owns the read-and-refuse-empty half).
+/// The adjustment checks — shape and guard — run wherever a fragment is
+/// read: here for files, at launcher parse for inline bodies.
+fn read_fragment_file(
+    canonical_dir: &Path,
     raw: &str,
     origin: &str,
-) -> Result<LoadedFragment, CompositionError> {
-    let path = resolve_fragment_path(launcher_dir, raw, origin)?;
-    let content = std::fs::read_to_string(&path).map_err(|e| CompositionError::FragmentUnreadable {
+    axes: &[ComponentAxis],
+) -> Result<super::composition::Fragment, CompositionError> {
+    let invalid = |detail: String| CompositionError::FragmentInvalid {
         path: raw.to_owned(),
         origin: origin.to_owned(),
-        detail: e.to_string(),
-    })?;
-    if content.trim().is_empty() {
-        return Err(CompositionError::FragmentUnreadable {
-            path: raw.to_owned(),
-            origin: origin.to_owned(),
-            detail: "the file is empty".to_owned(),
-        });
-    }
-    let parsed = LauncherFragmentParser::from_content(&content).map_err(|e| {
-        CompositionError::FragmentInvalid {
+        detail,
+    };
+    let path = resolve_fragment_path(canonical_dir, raw, origin)?;
+    let parsed = LauncherFragmentParser::from_path(&path).map_err(|e| match &e {
+        crate::error::Error::Parsing(
+            crate::error::ParsingError::CannotRead(..) | crate::error::ParsingError::EmptyContent(..),
+        ) => CompositionError::FragmentUnreadable {
             path: raw.to_owned(),
             origin: origin.to_owned(),
             detail: e.to_string(),
-        }
+        },
+        other => invalid(other.to_string()),
     })?;
     for adjustment in &parsed.body.adjustments {
-        validate_adjustment(adjustment, raw).map_err(|reason| CompositionError::FragmentInvalid {
-            path: raw.to_owned(),
-            origin: origin.to_owned(),
-            detail: reason,
-        })?;
+        validate_adjustment(adjustment, raw).map_err(&invalid)?;
+        if let Some(when) = &adjustment.when {
+            validate_guard(when, axes, raw).map_err(&invalid)?;
+        }
     }
-    Ok(LoadedFragment {
-        fragment: parsed.body,
-        origin: raw.to_owned(),
-    })
+    Ok(parsed.body)
 }
 
 /// A fragment path must be relative, plain (no `.` or `..` segments), and
 /// must stay inside the launcher's directory even through symlinks: a
 /// repository launcher and a filesystem launcher resolve fragments
-/// identically, and neither reaches outside the tree it lives in.
+/// identically, and neither reaches outside the tree it lives in. The base
+/// arrives already canonicalized, once per composition rather than once per
+/// fragment.
 fn resolve_fragment_path(
-    launcher_dir: &Path,
+    canonical_dir: &Path,
     raw: &str,
     origin: &str,
 ) -> Result<PathBuf, CompositionError> {
@@ -592,14 +587,7 @@ fn resolve_fragment_path(
         return refuse("it is empty");
     }
 
-    let base = launcher_dir.canonicalize().map_err(|e| {
-        CompositionError::FragmentUnreadable {
-            path: raw.to_owned(),
-            origin: origin.to_owned(),
-            detail: format!("the launcher's directory cannot be resolved: {e}"),
-        }
-    })?;
-    let full = launcher_dir.join(&cleaned);
+    let full = canonical_dir.join(&cleaned);
     let canonical = full.canonicalize().map_err(|e| {
         CompositionError::FragmentUnreadable {
             path: raw.to_owned(),
@@ -607,7 +595,7 @@ fn resolve_fragment_path(
             detail: e.to_string(),
         }
     })?;
-    if !canonical.starts_with(&base) {
+    if !canonical.starts_with(canonical_dir) {
         return refuse("it escapes the launcher's directory (through a symlink)");
     }
     Ok(full)
@@ -728,9 +716,10 @@ struct PlannedAdjustment<'a> {
     origin: String,
     /// Identifies the fragment an adjustment belongs to for the conflict
     /// rules: two adjustments from one fragment are one author applying list
-    /// order, two from different fragments are two authors fighting.
-    fragment_id: usize,
-    is_base: bool,
+    /// order, two from different fragments are two authors fighting. `None`
+    /// marks the base, which is no second author but the one who owns the
+    /// file, so it joins no conflict at all.
+    fragment_id: Option<usize>,
 }
 
 /// Flattens a composed launcher with a resolved selection into the ordinary
@@ -825,8 +814,7 @@ pub fn flatten(
             planned.push(PlannedAdjustment {
                 adjustment,
                 origin: fragment.origin.clone(),
-                fragment_id,
-                is_base: false,
+                fragment_id: Some(fragment_id),
             });
         }
     }
@@ -834,8 +822,7 @@ pub fn flatten(
         planned.push(PlannedAdjustment {
             adjustment,
             origin: base_origin.clone(),
-            fragment_id: usize::MAX,
-            is_base: true,
+            fragment_id: None,
         });
     }
     let mut running: Vec<&PlannedAdjustment> = Vec::new();
@@ -864,10 +851,10 @@ pub fn flatten(
     // 6. Conflict rules among surviving FRAGMENT adjustments. The base is
     // not a second author fighting a fragment; it is the one author who
     // owns the file, and its later entries win over its earlier ones.
-    let mut writers: HashMap<(&str, KeySpace, &str), (usize, String)> = HashMap::new();
+    let mut writers: HashMap<(&str, KeySpace, &str), (Option<usize>, String)> = HashMap::new();
     let mut adders: HashMap<(&str, &str), String> = HashMap::new();
     for step in &running {
-        if step.is_base {
+        if step.fragment_id.is_none() {
             continue;
         }
         let target = step.adjustment.target.as_str();
@@ -938,9 +925,9 @@ pub fn flatten(
                         old: instance
                             .arguments
                             .get(key)
-                            .map(render_value)
+                            .map(render)
                             .or(Some(String::from("(absent)"))),
-                        new: render_value(value),
+                        new: render(value),
                     },
                     target: target.clone(),
                     origin: origin.clone(),
@@ -953,8 +940,8 @@ pub fn flatten(
                 applied.push(AppliedAdjustment {
                     field: format!("links.{slot}"),
                     change: AppliedChange::Set {
-                        old: instance.links.get(slot).map(render_link).or(Some(String::from("(absent)"))),
-                        new: render_link(value),
+                        old: instance.links.get(slot).map(render).or(Some(String::from("(absent)"))),
+                        new: render(value),
                     },
                     target: target.clone(),
                     origin: origin.clone(),
@@ -964,73 +951,52 @@ pub fn flatten(
         }
         if let Some(links) = &step.adjustment.add_links {
             for (slot, additions) in links {
-                match instance.links.get(slot) {
-                    None | Some(LinkValue::Bound(Selection::Array(_))) => {
-                        let mut targets = instance
-                            .links
-                            .get(slot)
-                            .and_then(|value| value.selection().cloned())
-                            .map(|selection| match selection {
-                                Selection::Array(targets) => targets.as_slice().to_vec(),
-                                _ => unreachable!("matched an array binding above"),
-                            })
-                            .unwrap_or_default();
-                        for addition in additions {
-                            if targets.contains(addition) {
-                                return Err(CompositionError::AddLinksDuplicateTarget {
-                                    origin: origin.clone(),
-                                    target: target.clone(),
-                                    slot: slot.clone(),
-                                    added: addition.clone(),
-                                });
-                            }
-                            applied.push(AppliedAdjustment {
-                                field: format!("links.{slot}"),
-                                change: AppliedChange::Added {
-                                    target: addition.clone(),
-                                },
-                                target: target.clone(),
-                                origin: origin.clone(),
-                            });
-                            targets.push(addition.clone());
-                        }
-                        let bound = LinkTargets::new(targets).map_err(|err| {
-                            CompositionError::AddLinksDuplicateTarget {
-                                origin: origin.clone(),
-                                target: target.clone(),
-                                slot: slot.clone(),
-                                added: err.target,
-                            }
-                        })?;
-                        instance
-                            .links
-                            .insert(slot.clone(), LinkValue::Bound(Selection::Array(bound)));
+                // Appending is for array bindings: an absent slot starts
+                // one, an existing array extends, anything else is refused.
+                let mut targets = match instance.links.get(slot) {
+                    None => Vec::new(),
+                    Some(LinkValue::Bound(Selection::Array(existing))) => {
+                        existing.as_slice().to_vec()
                     }
-                    Some(LinkValue::Bound(Selection::Scalar(_))) => {
+                    Some(other) => {
                         return Err(CompositionError::AddLinksOnNonArray {
                             origin: origin.clone(),
                             target: target.clone(),
                             slot: slot.clone(),
-                            holds: "a scalar binding",
+                            holds: non_array_holds(other),
                         })
                     }
-                    Some(LinkValue::Bound(Selection::Flags(_))) => {
-                        return Err(CompositionError::AddLinksOnNonArray {
+                };
+                for addition in additions {
+                    if targets.contains(addition) {
+                        return Err(CompositionError::AddLinksDuplicateTarget {
                             origin: origin.clone(),
                             target: target.clone(),
                             slot: slot.clone(),
-                            holds: "a flag-accumulated binding",
-                        })
+                            added: addition.clone(),
+                        });
                     }
-                    Some(LinkValue::Vacant(_)) => {
-                        return Err(CompositionError::AddLinksOnNonArray {
-                            origin: origin.clone(),
-                            target: target.clone(),
-                            slot: slot.clone(),
-                            holds: "a vacancy",
-                        })
-                    }
+                    applied.push(AppliedAdjustment {
+                        field: format!("links.{slot}"),
+                        change: AppliedChange::Added {
+                            target: addition.clone(),
+                        },
+                        target: target.clone(),
+                        origin: origin.clone(),
+                    });
+                    targets.push(addition.clone());
                 }
+                let bound = LinkTargets::new(targets).map_err(|err| {
+                    CompositionError::AddLinksDuplicateTarget {
+                        origin: origin.clone(),
+                        target: target.clone(),
+                        slot: slot.clone(),
+                        added: err.target,
+                    }
+                })?;
+                instance
+                    .links
+                    .insert(slot.clone(), LinkValue::Bound(Selection::Array(bound)));
             }
         }
         if let Some(slots) = &step.adjustment.unset_links {
@@ -1039,7 +1005,7 @@ pub fn flatten(
                     applied.push(AppliedAdjustment {
                         field: format!("links.{slot}"),
                         change: AppliedChange::Removed {
-                            old: render_link(&old),
+                            old: render(&old),
                         },
                         target: target.clone(),
                         origin: origin.clone(),
@@ -1099,7 +1065,7 @@ impl KeySpace {
 /// two authors, and no last-writer-wins between them is allowed to be
 /// silent.
 fn claim_write<'a>(
-    writers: &mut HashMap<(&'a str, KeySpace, &'a str), (usize, String)>,
+    writers: &mut HashMap<(&'a str, KeySpace, &'a str), (Option<usize>, String)>,
     target: &'a str,
     space: KeySpace,
     key: &'a str,
@@ -1135,11 +1101,19 @@ fn render_guard(when: &BTreeMap<String, String>) -> String {
         .join(" ")
 }
 
-fn render_value(value: &config::AnyType) -> String {
-    serde_json5::to_string(value).unwrap_or_else(|_| String::from("(unrenderable)"))
+/// What a slot holds, for the "appending is for array bindings" refusal.
+/// The array arm exists for totality; the caller matches it before this
+/// helper can see it.
+fn non_array_holds(value: &LinkValue) -> &'static str {
+    match value {
+        LinkValue::Bound(Selection::Scalar(_)) => "a scalar binding",
+        LinkValue::Bound(Selection::Flags(_)) => "a flag-accumulated binding",
+        LinkValue::Bound(Selection::Array(_)) => "an array binding",
+        LinkValue::Vacant(_) => "a vacancy",
+    }
 }
 
-fn render_link(value: &LinkValue) -> String {
+fn render<T: serde::Serialize>(value: &T) -> String {
     serde_json5::to_string(value).unwrap_or_else(|_| String::from("(unrenderable)"))
 }
 
@@ -1161,17 +1135,64 @@ pub fn compose(
         return Err(CompositionError::WithOnFlatLauncher);
     }
 
-    let launcher_dir = match launcher_file.parent() {
-        Some(parent) if !parent.as_os_str().is_empty() => parent.to_path_buf(),
-        _ => PathBuf::from("."),
-    };
+    let launcher_dir = launcher_dir_of(launcher_file);
     let loaded = load_composition(launcher, &launcher_dir)?;
     let selection = resolve_selection(&launcher.components, words)?;
-    let base_label = launcher_file
-        .file_name()
-        .map(|name| name.to_string_lossy().into_owned())
-        .unwrap_or_else(|| launcher_file.display().to_string());
+    let base_label = launcher_file_label(launcher_file);
     flatten(launcher, &loaded, &selection, &base_label)
+}
+
+/// The ceiling on the selection space [`check_composition`] enumerates.
+/// Above it the check degrades to per-axis validation (every fragment
+/// exists, parses, provides, and guards cleanly) and says so, because a
+/// check that skips combinations must say so or it looks like it checked
+/// them all.
+const COMBINATION_CEILING: usize = 512;
+
+/// The directory fragment paths resolve against: the launcher's own, or the
+/// working directory when the launcher path itself was elided.
+fn launcher_dir_of(launcher_file: &Path) -> PathBuf {
+    match launcher_file.parent() {
+        Some(parent) if !parent.as_os_str().is_empty() => parent.to_path_buf(),
+        _ => PathBuf::from("."),
+    }
+}
+
+/// Holds a composed launcher to the same checks a launch would run, across
+/// every legal selection of its axes: the wholesale validation
+/// `repo index --check` performs per launcher. All of it is launcher-local
+/// (no node manifests, no daemon), which is what lets it run on a
+/// contributor's branch: the commit that adds an option whose shape
+/// contradicts an existing adjustment is the commit whose check fails,
+/// rather than the first launch that selects it.
+///
+/// Returns the rendered problems, each prefixed with the launcher's file
+/// name; an empty vec means every selection flattens.
+pub fn check_composition(launcher: &PeppyLauncher, launcher_file: &Path) -> Vec<String> {
+    let label = launcher_file_label(launcher_file);
+    let loaded = match load_composition(launcher, &launcher_dir_of(launcher_file)) {
+        Ok(loaded) => loaded,
+        Err(e) => return vec![format!("{label}: {e}")],
+    };
+    let space = selection_space_size(&launcher.components);
+    if space > COMBINATION_CEILING {
+        // Per-axis validation above (fragments, provides, guards, targets)
+        // still ran; what is skipped is every CROSS-axial combination, and
+        // the count of those is the space itself.
+        warn!(
+            "skipped all {space} cross-combination checks for {label}: the selection space \
+             exceeds the {COMBINATION_CEILING}-combination ceiling, so each axis was \
+             validated on its own instead"
+        );
+        return Vec::new();
+    }
+    let mut problems = Vec::new();
+    for selection in enumerate_selections(&launcher.components) {
+        if let Err(e) = flatten(launcher, &loaded, &selection, &label) {
+            problems.push(format!("{label} ({}): {e}", selection.echo()));
+        }
+    }
+    problems
 }
 
 #[cfg(test)]
@@ -1774,14 +1795,13 @@ mod tests {
             let spec = FragmentSpec(vec![super::super::composition::FragmentPart::File(
                 raw.to_owned(),
             )]);
-            let mut axis = ComponentAxis {
+            let axis = ComponentAxis {
                 name: "robot".to_owned(),
                 options: BTreeMap::from([("sim".to_owned(), spec)]),
                 default: None,
                 optional: false,
                 provides: Vec::new(),
             };
-            axis.default = None;
             let launcher = PeppyLauncher {
                 peppy_schema: config::schema::PeppySchema::LauncherV1,
                 core_nodes: Vec::new(),

--- a/crates/daemon-config-internal/src/launcher/flatten.rs
+++ b/crates/daemon-config-internal/src/launcher/flatten.rs
@@ -16,7 +16,6 @@ use super::types::{Deployment, LinkTargets, LinkValue, PeppyLauncher, Selection}
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::{Component as PathComponent, Path, PathBuf};
 use thiserror::Error;
-use tracing::warn;
 
 /// Everything composition can refuse: bad `--with` words, unreadable or
 /// unsafe fragment paths, options that do not provide what their axis
@@ -97,10 +96,7 @@ pub enum CompositionError {
         "adjustment on `{target}` in {origin} names a target no option of this launcher defines \
          anywhere; that is a dead reference or a typo"
     )]
-    TargetDefinedNowhere {
-        target: String,
-        origin: String,
-    },
+    TargetDefinedNowhere { target: String, origin: String },
 
     #[error(
         "instance `{id}` is defined by both {first} and {second}; each instance id belongs to \
@@ -192,7 +188,9 @@ impl ComponentSelection {
         self.entries
             .iter()
             .map(|entry| match (&entry.option, entry.source) {
-                (Some(option), SelectionSource::Default) => format!("{}={option} (default)", entry.axis),
+                (Some(option), SelectionSource::Default) => {
+                    format!("{}={option} (default)", entry.axis)
+                }
                 (Some(option), _) => format!("{}={option}", entry.axis),
                 (None, _) => format!("{}=(off)", entry.axis),
             })
@@ -205,7 +203,7 @@ impl ComponentSelection {
 /// `axis=option`. At most one option per axis (repeating the same option is
 /// the same choice); unselected axes take their default, and a required axis
 /// with neither refuses.
-pub fn resolve_selection(
+fn resolve_selection(
     axes: &[ComponentAxis],
     words: &[String],
 ) -> Result<ComponentSelection, CompositionError> {
@@ -238,7 +236,7 @@ pub fn resolve_selection(
                                 .map(|axis| format!("`{}`", axis.as_str()))
                                 .collect::<Vec<_>>()
                                 .join(", "),
-                        })
+                        });
                     }
                 }
             }
@@ -285,7 +283,7 @@ pub fn resolve_selection(
                             "; its options are {}",
                             crate::error::format_quoted_list(axis.options.keys())
                         ),
-                    })
+                    });
                 }
             },
         }
@@ -323,7 +321,7 @@ fn axes_menu(axes: &[ComponentAxis]) -> String {
 /// declaration order, option by option in declaration order, an unfilled
 /// entry last on optional axes. Used by `repo index --check` to hold the
 /// whole selection space to the same structural checks a launch would run.
-pub fn enumerate_selections(axes: &[ComponentAxis]) -> Vec<ComponentSelection> {
+fn enumerate_selections(axes: &[ComponentAxis]) -> Vec<ComponentSelection> {
     let mut selections = vec![ComponentSelection::default()];
     for axis in axes {
         let mut next = Vec::with_capacity(selections.len() * (axis.options.len() + 1));
@@ -355,7 +353,7 @@ pub fn enumerate_selections(axes: &[ComponentAxis]) -> Vec<ComponentSelection> {
 /// The size of the selection space, saturating rather than multiplying out:
 /// callers use it to decide whether enumerating is reasonable, which it must
 /// answer without doing the enumeration.
-pub fn selection_space_size(axes: &[ComponentAxis]) -> usize {
+fn selection_space_size(axes: &[ComponentAxis]) -> usize {
     axes.iter()
         .map(|axis| axis.options.len() + usize::from(axis.optional))
         .fold(1usize, |acc, per_axis| acc.saturating_mul(per_axis))
@@ -364,9 +362,9 @@ pub fn selection_space_size(axes: &[ComponentAxis]) -> usize {
 /// One fragment of one option, loaded and paired with the label the resolve
 /// report and the error messages name it by: the path as written for a file,
 /// `inline option `axis.option`` for a body written in the launcher.
-pub struct LoadedFragment {
-    pub fragment: super::composition::Fragment,
-    pub origin: String,
+struct LoadedFragment {
+    fragment: super::composition::Fragment,
+    origin: String,
 }
 
 /// Every option's fragments, loaded: file fragments read and validated,
@@ -375,31 +373,28 @@ pub struct LoadedFragment {
 /// `repo index --check` refuses (an option that does not provide its axis's
 /// interface, a guard naming an unknown axis) instead of discovering them
 /// one selection at a time.
-pub struct LoadedComposition {
-    pub options: BTreeMap<String, BTreeMap<String, Vec<LoadedFragment>>>,
+struct LoadedComposition {
+    options: BTreeMap<String, BTreeMap<String, Vec<LoadedFragment>>>,
 }
 
 /// Reads every file fragment the launcher references and runs the
 /// selection-independent checks: path safety, fragment parse, `provides`
 /// satisfaction, guard references, and that every adjustment target is
 /// defined by some option of the launcher.
-pub fn load_composition(
+fn load_composition(
     launcher: &PeppyLauncher,
-    launcher_dir: &Path,
+    launcher_file: &Path,
 ) -> Result<LoadedComposition, CompositionError> {
     let axes = &launcher.components;
     let mut options: BTreeMap<String, BTreeMap<String, Vec<LoadedFragment>>> = BTreeMap::new();
-    let launcher_label = launcher_file_label(launcher_dir);
+    let launcher_label = launcher_file_label(launcher_file);
     // The symlink-escape check compares each fragment's canonical path
-    // against the launcher's canonical directory, resolved once here rather
-    // than once per fragment reference.
-    let canonical_dir = launcher_dir.canonicalize().map_err(|e| {
-        CompositionError::FragmentUnreadable {
-            path: launcher_dir.display().to_string(),
-            origin: launcher_label.clone(),
-            detail: format!("the launcher's directory cannot be resolved: {e}"),
-        }
-    })?;
+    // against the launcher's canonical directory, resolved once at the first
+    // file reference rather than once per fragment. Resolving lazily is what
+    // lets an inline-only composition flatten without touching the
+    // filesystem at all: its launcher directory need not even exist.
+    let launcher_dir = launcher_dir_of(launcher_file);
+    let mut canonical_dir: Option<PathBuf> = None;
     // Sharing one fragment file between several options is the designed
     // pattern (the relay fragment under both simulators), so each file is
     // read and parsed once per composition, keyed by the path as written.
@@ -416,15 +411,24 @@ pub fn load_composition(
                         origin: format!("inline option `{}.{}`", axis.name, option_name),
                     }),
                     FragmentPart::File(raw) => {
-                        let origin = format!(
-                            "{launcher_label}, option `{}.{}`",
-                            axis.name, option_name
-                        );
+                        let origin =
+                            format!("{launcher_label}, option `{}.{}`", axis.name, option_name);
+                        if canonical_dir.is_none() {
+                            canonical_dir = Some(launcher_dir.canonicalize().map_err(|e| {
+                                CompositionError::FragmentUnreadable {
+                                    path: launcher_dir.display().to_string(),
+                                    origin: launcher_label.clone(),
+                                    detail: format!(
+                                        "the launcher's directory cannot be resolved: {e}"
+                                    ),
+                                }
+                            })?);
+                        }
+                        let canonical = canonical_dir.as_deref().expect("resolved just above");
                         let body = match file_bodies.get(raw.as_str()) {
                             Some(cached) => cached.clone(),
                             None => {
-                                let body =
-                                    read_fragment_file(&canonical_dir, raw, &origin, axes)?;
+                                let body = read_fragment_file(canonical, raw, &origin, axes)?;
                                 file_bodies.insert(raw.as_str(), body.clone());
                                 body
                             }
@@ -508,17 +512,17 @@ pub fn load_composition(
 }
 
 /// The label error messages and reports name a launcher by: its file name,
-/// or the directory's name when the launcher path itself was elided.
-fn launcher_file_label(launcher_dir: &Path) -> String {
-    launcher_dir
+/// or the path as written when it has no final component.
+fn launcher_file_label(launcher_file: &Path) -> String {
+    launcher_file
         .file_name()
         .map(|name| name.to_string_lossy().into_owned())
-        .unwrap_or_else(|| launcher_dir.display().to_string())
+        .unwrap_or_else(|| launcher_file.display().to_string())
 }
 
 /// Reads, parses, and shape-checks one `launcher_fragment/v1` file through
 /// the shared fragment parser (which owns the read-and-refuse-empty half).
-/// The adjustment checks — shape and guard — run wherever a fragment is
+/// The adjustment checks (shape and guard) run wherever a fragment is
 /// read: here for files, at launcher parse for inline bodies.
 fn read_fragment_file(
     canonical_dir: &Path,
@@ -534,7 +538,8 @@ fn read_fragment_file(
     let path = resolve_fragment_path(canonical_dir, raw, origin)?;
     let parsed = LauncherFragmentParser::from_path(&path).map_err(|e| match &e {
         crate::error::Error::Parsing(
-            crate::error::ParsingError::CannotRead(..) | crate::error::ParsingError::EmptyContent(..),
+            crate::error::ParsingError::CannotRead(..)
+            | crate::error::ParsingError::EmptyContent(..),
         ) => CompositionError::FragmentUnreadable {
             path: raw.to_owned(),
             origin: origin.to_owned(),
@@ -588,17 +593,20 @@ fn resolve_fragment_path(
     }
 
     let full = canonical_dir.join(&cleaned);
-    let canonical = full.canonicalize().map_err(|e| {
-        CompositionError::FragmentUnreadable {
+    let canonical = full
+        .canonicalize()
+        .map_err(|e| CompositionError::FragmentUnreadable {
             path: raw.to_owned(),
             origin: origin.to_owned(),
             detail: e.to_string(),
-        }
-    })?;
+        })?;
     if !canonical.starts_with(canonical_dir) {
         return refuse("it escapes the launcher's directory (through a symlink)");
     }
-    Ok(full)
+    // The canonical path is the one that was validated, so it is the one the
+    // caller opens: no symlink swapped in after the check can redirect the
+    // read.
+    Ok(canonical)
 }
 
 /// What one applied adjustment did, for the resolve report: the target and
@@ -615,16 +623,9 @@ pub struct AppliedAdjustment {
 
 #[derive(Debug, Clone)]
 pub enum AppliedChange {
-    Set {
-        old: Option<String>,
-        new: String,
-    },
-    Added {
-        target: String,
-    },
-    Removed {
-        old: String,
-    },
+    Set { old: Option<String>, new: String },
+    Added { target: String },
+    Removed { old: String },
 }
 
 impl AppliedChange {
@@ -689,7 +690,10 @@ impl FlattenReport {
             for entry in &self.applied {
                 lines.push(format!(
                     "  {}.{}: {}  ({})",
-                    entry.target, entry.field, entry.change.render(), entry.origin
+                    entry.target,
+                    entry.field,
+                    entry.change.render(),
+                    entry.origin
                 ));
             }
         }
@@ -729,7 +733,7 @@ struct PlannedAdjustment<'a> {
 /// The flattened document goes back through the flat launcher's own
 /// validation (serialize, re-parse), so every whole-document check a
 /// hand-written file gets runs on the composed result too.
-pub fn flatten(
+fn flatten(
     launcher: &PeppyLauncher,
     loaded: &LoadedComposition,
     selection: &ComponentSelection,
@@ -744,7 +748,9 @@ pub fn flatten(
         .collect();
     let mut selected_fragments: Vec<&LoadedFragment> = Vec::new();
     for entry in &selection.entries {
-        let Some(option) = &entry.option else { continue };
+        let Some(option) = &entry.option else {
+            continue;
+        };
         let Some(fragments) = loaded
             .options
             .get(entry.axis.as_str())
@@ -850,9 +856,11 @@ pub fn flatten(
 
     // 6. Conflict rules among surviving FRAGMENT adjustments. The base is
     // not a second author fighting a fragment; it is the one author who
-    // owns the file, and its later entries win over its earlier ones.
-    let mut writers: HashMap<(&str, KeySpace, &str), (Option<usize>, String)> = HashMap::new();
-    let mut adders: HashMap<(&str, &str), String> = HashMap::new();
+    // owns the file, and its later entries win over its earlier ones. Both
+    // maps are ordered so when several pairs fight, the one reported is the
+    // same on every run.
+    let mut writers: BTreeMap<(&str, KeySpace, &str), (Option<usize>, String)> = BTreeMap::new();
+    let mut adders: BTreeMap<(&str, &str), String> = BTreeMap::new();
     for step in &running {
         if step.fragment_id.is_none() {
             continue;
@@ -881,7 +889,12 @@ pub fn flatten(
         for (space, key) in written_keys {
             claim_write(&mut writers, target, space, key, step)?;
         }
-        for key in step.adjustment.add_links.iter().flat_map(|links| links.keys()) {
+        for key in step
+            .adjustment
+            .add_links
+            .iter()
+            .flat_map(|links| links.keys())
+        {
             adders.insert((target, key.as_str()), step.origin.clone());
         }
     }
@@ -906,7 +919,10 @@ pub fn flatten(
     let mut index: HashMap<String, (usize, usize)> = HashMap::new();
     for (deployment_idx, deployment) in merged.iter().enumerate() {
         for (instance_idx, instance) in deployment.instances.iter().enumerate() {
-            index.insert(instance.instance_id.to_string(), (deployment_idx, instance_idx));
+            index.insert(
+                instance.instance_id.to_string(),
+                (deployment_idx, instance_idx),
+            );
         }
     }
     let mut applied: Vec<AppliedAdjustment> = Vec::new();
@@ -940,7 +956,11 @@ pub fn flatten(
                 applied.push(AppliedAdjustment {
                     field: format!("links.{slot}"),
                     change: AppliedChange::Set {
-                        old: instance.links.get(slot).map(render).or(Some(String::from("(absent)"))),
+                        old: instance
+                            .links
+                            .get(slot)
+                            .map(render)
+                            .or(Some(String::from("(absent)"))),
                         new: render(value),
                     },
                     target: target.clone(),
@@ -964,7 +984,7 @@ pub fn flatten(
                             target: target.clone(),
                             slot: slot.clone(),
                             holds: non_array_holds(other),
-                        })
+                        });
                     }
                 };
                 for addition in additions {
@@ -1004,9 +1024,7 @@ pub fn flatten(
                 if let Some(old) = instance.links.remove(slot) {
                     applied.push(AppliedAdjustment {
                         field: format!("links.{slot}"),
-                        change: AppliedChange::Removed {
-                            old: render(&old),
-                        },
+                        change: AppliedChange::Removed { old: render(&old) },
                         target: target.clone(),
                         origin: origin.clone(),
                     });
@@ -1025,9 +1043,9 @@ pub fn flatten(
         components: Vec::new(),
         adjustments: Vec::new(),
     };
-    let text = serde_json5::to_string(&flat).map_err(|e| CompositionError::FlatValidation(
-        crate::error::Error::Serialize(e.to_string()),
-    ))?;
+    let text = serde_json5::to_string(&flat).map_err(|e| {
+        CompositionError::FlatValidation(crate::error::Error::Serialize(e.to_string()))
+    })?;
     let validated = PeppyLauncherParser::from_content(&text)?;
 
     Ok((
@@ -1043,7 +1061,7 @@ pub fn flatten(
 /// The two key spaces an adjustment can write in. `add_links` shares the
 /// links space with `set_links` and `unset_links`: appending to a slot and
 /// replacing it are two claims on the same entry.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 enum KeySpace {
     Arguments,
     Links,
@@ -1065,7 +1083,7 @@ impl KeySpace {
 /// two authors, and no last-writer-wins between them is allowed to be
 /// silent.
 fn claim_write<'a>(
-    writers: &mut HashMap<(&'a str, KeySpace, &'a str), (Option<usize>, String)>,
+    writers: &mut BTreeMap<(&'a str, KeySpace, &'a str), (Option<usize>, String)>,
     target: &'a str,
     space: KeySpace,
     key: &'a str,
@@ -1135,18 +1153,17 @@ pub fn compose(
         return Err(CompositionError::WithOnFlatLauncher);
     }
 
-    let launcher_dir = launcher_dir_of(launcher_file);
-    let loaded = load_composition(launcher, &launcher_dir)?;
+    let loaded = load_composition(launcher, launcher_file)?;
     let selection = resolve_selection(&launcher.components, words)?;
     let base_label = launcher_file_label(launcher_file);
     flatten(launcher, &loaded, &selection, &base_label)
 }
 
 /// The ceiling on the selection space [`check_composition`] enumerates.
-/// Above it the check degrades to per-axis validation (every fragment
-/// exists, parses, provides, and guards cleanly) and says so, because a
-/// check that skips combinations must say so or it looks like it checked
-/// them all.
+/// Above it only per-axis validation runs (every fragment exists, parses,
+/// provides, and guards cleanly), and the skipped cross-combination checks
+/// are reported as a problem: a check that skips combinations must fail or
+/// it looks like it checked them all.
 const COMBINATION_CEILING: usize = 512;
 
 /// The directory fragment paths resolve against: the launcher's own, or the
@@ -1170,7 +1187,7 @@ fn launcher_dir_of(launcher_file: &Path) -> PathBuf {
 /// name; an empty vec means every selection flattens.
 pub fn check_composition(launcher: &PeppyLauncher, launcher_file: &Path) -> Vec<String> {
     let label = launcher_file_label(launcher_file);
-    let loaded = match load_composition(launcher, &launcher_dir_of(launcher_file)) {
+    let loaded = match load_composition(launcher, launcher_file) {
         Ok(loaded) => loaded,
         Err(e) => return vec![format!("{label}: {e}")],
     };
@@ -1178,13 +1195,13 @@ pub fn check_composition(launcher: &PeppyLauncher, launcher_file: &Path) -> Vec<
     if space > COMBINATION_CEILING {
         // Per-axis validation above (fragments, provides, guards, targets)
         // still ran; what is skipped is every CROSS-axial combination, and
-        // the count of those is the space itself.
-        warn!(
-            "skipped all {space} cross-combination checks for {label}: the selection space \
-             exceeds the {COMBINATION_CEILING}-combination ceiling, so each axis was \
-             validated on its own instead"
-        );
-        return Vec::new();
+        // an incomplete check reported as success would read as a pass.
+        return vec![format!(
+            "{label}: the selection space has {space} combinations, more than the \
+             {COMBINATION_CEILING} this check enumerates, so the cross-combination checks \
+             did not run (each axis was validated on its own). Split the launcher or \
+             reduce its axes' options"
+        )];
     }
     let mut problems = Vec::new();
     for selection in enumerate_selections(&launcher.components) {
@@ -1226,7 +1243,8 @@ mod tests {
     fn composed_fixture(dir: &Path) -> (PathBuf, PeppyLauncher) {
         write(
             &dir.join("fragments/sim_relays.json5"),
-            &fragment_file(r#"
+            &fragment_file(
+                r#"
                 deployments: [
                     { source: { name: "arm_sim", tag: "v1" },
                       instances: [{ instance_id: "arm_inst", links: { engine: "sim_inst/arm" } }] },
@@ -1234,11 +1252,13 @@ mod tests {
                 adjustments: [
                     { target: "backbone_inst", set_arguments: { max_ee_velocity_m_s: 0.5 } },
                 ],
-            "#),
+            "#,
+            ),
         );
         write(
             &dir.join("fragments/mujoco_engine.json5"),
-            &fragment_file(r#"
+            &fragment_file(
+                r#"
                 deployments: [
                     { source: { name: "sim_mujoco", tag: "v1" },
                       instances: [{ instance_id: "sim_inst", arguments: { state_rate_hz: 100 } }] },
@@ -1247,11 +1267,13 @@ mod tests {
                     { target: "recorder_inst",
                       set_arguments: { robot_type: "openarm_mujoco" } },
                 ],
-            "#),
+            "#,
+            ),
         );
         write(
             &dir.join("fragments/recorder.json5"),
-            &fragment_file(r#"
+            &fragment_file(
+                r#"
                 deployments: [
                     { source: { name: "recorder", tag: "v1" },
                       instances: [{ instance_id: "recorder_inst",
@@ -1260,7 +1282,8 @@ mod tests {
                 adjustments: [
                     { target: "commander_inst", add_links: { recorder: ["recorder_inst"] } },
                 ],
-            "#),
+            "#,
+            ),
         );
         let launcher = write(
             &dir.join("teleop.json5"),
@@ -1317,12 +1340,17 @@ mod tests {
             .map(|d| format!("{}:{}", d.source.name, d.source.tag))
             .collect();
         assert_eq!(sources, ["backbone:v1", "commander:v1", "can_arm:v1"]);
-        assert_eq!(report.selection.echo(), "robot=real (default)  recorder=(off)");
+        assert_eq!(
+            report.selection.echo(),
+            "robot=real (default)  recorder=(off)"
+        );
         // The base's sim specialization sleeps when the robot is real.
-        assert!(report
-            .skipped
-            .iter()
-            .any(|s| s.target == "sim_inst" && matches!(s.reason, SkipReason::TargetAbsent)));
+        assert!(
+            report
+                .skipped
+                .iter()
+                .any(|s| s.target == "sim_inst" && matches!(s.reason, SkipReason::TargetAbsent))
+        );
     }
 
     #[test]
@@ -1341,7 +1369,6 @@ mod tests {
             sources,
             ["backbone:v1", "commander:v1", "arm_sim:v1", "sim_mujoco:v1"]
         );
-        let _ = report;
         // The base adjustment reached the engine instance.
         let sim = flat
             .deployments
@@ -1368,13 +1395,20 @@ mod tests {
     #[test]
     fn fragments_merge_into_a_base_deployment_of_the_same_source() {
         let dir = tempdir().unwrap();
-        write(&dir.path().join("fragments/cam.json5"), &fragment_file(r#"
+        write(
+            &dir.path().join("fragments/cam.json5"),
+            &fragment_file(
+                r#"
             deployments: [
                 { source: { name: "camera", tag: "v1" },
                   instances: [{ instance_id: "wrist" }] },
             ],
-        "#));
-        let launcher = write(&dir.path().join("l.json5"), r#"{
+        "#,
+            ),
+        );
+        let launcher = write(
+            &dir.path().join("l.json5"),
+            r#"{
             peppy_schema: "launcher/v1",
             components: [
                 { name: "cams", optional: true, provides: ["wrist"],
@@ -1384,7 +1418,8 @@ mod tests {
                 { source: { name: "camera", tag: "v1" },
                   instances: [{ instance_id: "chest" }] },
             ],
-        }"#);
+        }"#,
+        );
         let parsed = parse_launcher(&fs::read_to_string(&launcher).unwrap());
         let (flat, _) = compose(&parsed, &launcher, &["on".to_string()]).expect("composes");
         assert_eq!(flat.deployments.len(), 1);
@@ -1400,13 +1435,20 @@ mod tests {
     #[test]
     fn a_duplicate_instance_id_names_both_origins() {
         let dir = tempdir().unwrap();
-        write(&dir.path().join("fragments/dup.json5"), &fragment_file(r#"
+        write(
+            &dir.path().join("fragments/dup.json5"),
+            &fragment_file(
+                r#"
             deployments: [
                 { source: { name: "other", tag: "v1" },
                   instances: [{ instance_id: "arm_inst" }] },
             ],
-        "#));
-        let launcher = write(&dir.path().join("l.json5"), r#"{
+        "#,
+            ),
+        );
+        let launcher = write(
+            &dir.path().join("l.json5"),
+            r#"{
             peppy_schema: "launcher/v1",
             components: [
                 { name: "robot", optional: true, provides: ["arm_inst"],
@@ -1416,30 +1458,46 @@ mod tests {
                 { source: { name: "can_arm", tag: "v1" },
                   instances: [{ instance_id: "arm_inst" }] },
             ],
-        }"#);
+        }"#,
+        );
         let parsed = parse_launcher(&fs::read_to_string(&launcher).unwrap());
         let err = compose(&parsed, &launcher, &["sim".to_string()]).expect_err("duplicate id");
         assert!(err.to_string().contains("arm_inst"), "got: {err}");
         assert!(err.to_string().contains("l.json5"), "got: {err}");
-        assert!(err.to_string().contains("fragments/dup.json5"), "got: {err}");
+        assert!(
+            err.to_string().contains("fragments/dup.json5"),
+            "got: {err}"
+        );
     }
 
     #[test]
     fn add_links_appends_across_fragments_in_order() {
         let dir = tempdir().unwrap();
-        write(&dir.path().join("fragments/a.json5"), &fragment_file(r#"
+        write(
+            &dir.path().join("fragments/a.json5"),
+            &fragment_file(
+                r#"
             deployments: [],
             adjustments: [
                 { target: "panel", add_links: { observers: ["a_inst"] } },
             ],
-        "#));
-        write(&dir.path().join("fragments/b.json5"), &fragment_file(r#"
+        "#,
+            ),
+        );
+        write(
+            &dir.path().join("fragments/b.json5"),
+            &fragment_file(
+                r#"
             deployments: [],
             adjustments: [
                 { target: "panel", add_links: { observers: ["b_inst"] } },
             ],
-        "#));
-        let launcher = write(&dir.path().join("l.json5"), r#"{
+        "#,
+            ),
+        );
+        let launcher = write(
+            &dir.path().join("l.json5"),
+            r#"{
             peppy_schema: "launcher/v1",
             components: [
                 { name: "a", optional: true, options: { on: "fragments/a.json5" } },
@@ -1453,10 +1511,15 @@ mod tests {
                 { source: { name: "a", tag: "v1" }, instances: [{ instance_id: "a_inst" }] },
                 { source: { name: "b", tag: "v1" }, instances: [{ instance_id: "b_inst" }] },
             ],
-        }"#);
+        }"#,
+        );
         let parsed = parse_launcher(&fs::read_to_string(&launcher).unwrap());
-        let (flat, report) = compose(&parsed, &launcher, &["a=on".to_string(), "b=on".to_string()])
-            .expect("composes");
+        let (flat, report) = compose(
+            &parsed,
+            &launcher,
+            &["a=on".to_string(), "b=on".to_string()],
+        )
+        .expect("composes");
         let panel = &flat.deployments[0].instances[0];
         let LinkValue::Bound(Selection::Array(targets)) = &panel.links["observers"] else {
             panic!("observers stays an array binding");
@@ -1517,10 +1580,17 @@ mod tests {
     #[test]
     fn add_links_refuses_a_target_already_bound() {
         let dir = tempdir().unwrap();
-        write(&dir.path().join("fragments/a.json5"), &fragment_file(r#"
+        write(
+            &dir.path().join("fragments/a.json5"),
+            &fragment_file(
+                r#"
             adjustments: [ { target: "panel", add_links: { observers: ["seed_inst"] } } ],
-        "#));
-        let launcher = write(&dir.path().join("l.json5"), r#"{
+        "#,
+            ),
+        );
+        let launcher = write(
+            &dir.path().join("l.json5"),
+            r#"{
             peppy_schema: "launcher/v1",
             components: [
                 { name: "a", optional: true, options: { on: "fragments/a.json5" } },
@@ -1530,7 +1600,8 @@ mod tests {
                   instances: [{ instance_id: "panel",
                                 links: { observers: ["seed_inst"] } }] },
             ],
-        }"#);
+        }"#,
+        );
         let parsed = parse_launcher(&fs::read_to_string(&launcher).unwrap());
         let err = compose(&parsed, &launcher, &["on".to_string()]).expect_err("duplicate add");
         assert!(err.to_string().contains("seed_inst"), "got: {err}");
@@ -1576,13 +1647,25 @@ mod tests {
     #[test]
     fn two_fragments_writing_one_key_are_refused() {
         let dir = tempdir().unwrap();
-        write(&dir.path().join("fragments/a.json5"), &fragment_file(r#"
+        write(
+            &dir.path().join("fragments/a.json5"),
+            &fragment_file(
+                r#"
             adjustments: [ { target: "panel", set_arguments: { rate: 10 } } ],
-        "#));
-        write(&dir.path().join("fragments/b.json5"), &fragment_file(r#"
+        "#,
+            ),
+        );
+        write(
+            &dir.path().join("fragments/b.json5"),
+            &fragment_file(
+                r#"
             adjustments: [ { target: "panel", set_arguments: { rate: 20 } } ],
-        "#));
-        let launcher = write(&dir.path().join("l.json5"), r#"{
+        "#,
+            ),
+        );
+        let launcher = write(
+            &dir.path().join("l.json5"),
+            r#"{
             peppy_schema: "launcher/v1",
             components: [
                 { name: "a", optional: true, options: { on: "fragments/a.json5" } },
@@ -1591,24 +1674,45 @@ mod tests {
             deployments: [
                 { source: { name: "panel", tag: "v1" }, instances: [{ instance_id: "panel" }] },
             ],
-        }"#);
+        }"#,
+        );
         let parsed = parse_launcher(&fs::read_to_string(&launcher).unwrap());
-        let err = compose(&parsed, &launcher, &["a=on".to_string(), "b=on".to_string()])
-            .expect_err("fragments must not fight");
-        let CompositionError::AdjustmentsConflict { field, first, second, .. } = &err else {
+        let err = compose(
+            &parsed,
+            &launcher,
+            &["a=on".to_string(), "b=on".to_string()],
+        )
+        .expect_err("fragments must not fight");
+        let CompositionError::AdjustmentsConflict {
+            field,
+            first,
+            second,
+            ..
+        } = &err
+        else {
             panic!("expected AdjustmentsConflict, got: {err}");
         };
         assert_eq!(field, "arguments.rate");
-        assert!(first.contains("a.json5") && second.contains("b.json5"), "got: {first} / {second}");
+        assert!(
+            first.contains("a.json5") && second.contains("b.json5"),
+            "got: {first} / {second}"
+        );
     }
 
     #[test]
     fn the_base_overrides_a_fragment_and_a_later_base_entry_wins() {
         let dir = tempdir().unwrap();
-        write(&dir.path().join("fragments/a.json5"), &fragment_file(r#"
+        write(
+            &dir.path().join("fragments/a.json5"),
+            &fragment_file(
+                r#"
             adjustments: [ { target: "panel", set_arguments: { rate: 10 } } ],
-        "#));
-        let launcher = write(&dir.path().join("l.json5"), r#"{
+        "#,
+            ),
+        );
+        let launcher = write(
+            &dir.path().join("l.json5"),
+            r#"{
             peppy_schema: "launcher/v1",
             components: [
                 { name: "a", optional: true, options: { on: "fragments/a.json5" } },
@@ -1620,7 +1724,8 @@ mod tests {
             deployments: [
                 { source: { name: "panel", tag: "v1" }, instances: [{ instance_id: "panel" }] },
             ],
-        }"#);
+        }"#,
+        );
         let parsed = parse_launcher(&fs::read_to_string(&launcher).unwrap());
         let (flat, report) = compose(&parsed, &launcher, &["on".to_string()]).expect("composes");
         assert_eq!(
@@ -1633,7 +1738,9 @@ mod tests {
             .iter()
             .filter(|a| a.field == "arguments.rate")
             .map(|a| match &a.change {
-                AppliedChange::Set { old, new } => format!("{}->{}", old.clone().unwrap_or_default(), new),
+                AppliedChange::Set { old, new } => {
+                    format!("{}->{}", old.clone().unwrap_or_default(), new)
+                }
                 _ => String::new(),
             })
             .collect();
@@ -1643,7 +1750,10 @@ mod tests {
     #[test]
     fn guards_skip_and_absent_targets_skip() {
         let dir = tempdir().unwrap();
-        write(&dir.path().join("fragments/xr.json5"), &fragment_file(r#"
+        write(
+            &dir.path().join("fragments/xr.json5"),
+            &fragment_file(
+                r#"
             deployments: [
                 { source: { name: "xr", tag: "v1" },
                   instances: [{ instance_id: "leader_inst" }] },
@@ -1652,8 +1762,13 @@ mod tests {
                 { target: "backbone_inst",
                   set_arguments: { upstream_mode: "pose" } },
             ],
-        "#));
-        write(&dir.path().join("fragments/rec.json5"), &fragment_file(r#"
+        "#,
+            ),
+        );
+        write(
+            &dir.path().join("fragments/rec.json5"),
+            &fragment_file(
+                r#"
             deployments: [
                 { source: { name: "rec", tag: "v1" },
                   instances: [{ instance_id: "recorder_inst" }] },
@@ -1668,8 +1783,12 @@ mod tests {
                 { target: "sim_inst",
                   set_arguments: { state_rate_hz: 50 } },
             ],
-        "#));
-        let launcher = write(&dir.path().join("l.json5"), r#"{
+        "#,
+            ),
+        );
+        let launcher = write(
+            &dir.path().join("l.json5"),
+            r#"{
             peppy_schema: "launcher/v1",
             components: [
                 { name: "commander", default: "web",
@@ -1688,41 +1807,46 @@ mod tests {
                 { source: { name: "backbone", tag: "v1" },
                   instances: [{ instance_id: "backbone_inst" }] },
             ],
-        }"#);
+        }"#,
+        );
         let parsed = parse_launcher(&fs::read_to_string(&launcher).unwrap());
 
         // web + recorder: the guard is not met and sim_inst is absent, so
         // both of the recorder fragment's adjustments skip.
-        let (flat, report) = compose(&parsed, &launcher, &words(&["recorder=on"]))
-            .expect("composes");
+        let (flat, report) =
+            compose(&parsed, &launcher, &words(&["recorder=on"])).expect("composes");
         assert_eq!(report.skipped.len(), 2);
         assert!(report.skipped.iter().any(|s| matches!(
             s.reason,
             SkipReason::GuardNotMet(ref g) if g == "commander=xr"
         )));
-        assert!(report.skipped.iter().any(|s| matches!(
-            s.reason,
-            SkipReason::TargetAbsent
-        )));
+        assert!(
+            report
+                .skipped
+                .iter()
+                .any(|s| matches!(s.reason, SkipReason::TargetAbsent))
+        );
         let backbone = flat
             .deployments
             .iter()
             .find(|d| d.source.name == "backbone")
             .unwrap();
-        assert!(!backbone.instances[0].arguments.contains_key("record_backbone"));
+        assert!(
+            !backbone.instances[0]
+                .arguments
+                .contains_key("record_backbone")
+        );
 
         // xr + recorder: the guard holds and its target exists, so it
         // applies; sim_inst is still absent and still skips.
-        let (flat, report) = compose(
-            &parsed,
-            &launcher,
-            &words(&["commander=xr", "recorder=on"]),
-        )
-        .expect("composes");
-        assert!(report
-            .skipped
-            .iter()
-            .all(|s| matches!(s.reason, SkipReason::TargetAbsent)));
+        let (flat, report) = compose(&parsed, &launcher, &words(&["commander=xr", "recorder=on"]))
+            .expect("composes");
+        assert!(
+            report
+                .skipped
+                .iter()
+                .all(|s| matches!(s.reason, SkipReason::TargetAbsent))
+        );
         let backbone = flat
             .deployments
             .iter()
@@ -1746,40 +1870,59 @@ mod tests {
     #[test]
     fn an_option_missing_a_provides_id_is_refused() {
         let dir = tempdir().unwrap();
-        write(&dir.path().join("fragments/bad.json5"), &fragment_file(r#"
+        write(
+            &dir.path().join("fragments/bad.json5"),
+            &fragment_file(
+                r#"
             deployments: [
                 { source: { name: "other", tag: "v1" }, instances: [{ instance_id: "wrong_inst" }] },
             ],
-        "#));
-        let launcher = write(&dir.path().join("l.json5"), r#"{
+        "#,
+            ),
+        );
+        let launcher = write(
+            &dir.path().join("l.json5"),
+            r#"{
             peppy_schema: "launcher/v1",
             components: [
                 { name: "robot", provides: ["arm_inst"],
                   options: { sim: "fragments/bad.json5" } },
             ],
             deployments: [],
-        }"#);
+        }"#,
+        );
         let parsed = parse_launcher(&fs::read_to_string(&launcher).unwrap());
         let err = compose(&parsed, &launcher, &["sim".to_string()]).expect_err("provides unmet");
         let CompositionError::ProvidesUnmet { axis, option, id } = &err else {
             panic!("expected ProvidesUnmet, got: {err}");
         };
-        assert_eq!((axis.as_str(), option.as_str(), id.as_str()), ("robot", "sim", "arm_inst"));
+        assert_eq!(
+            (axis.as_str(), option.as_str(), id.as_str()),
+            ("robot", "sim", "arm_inst")
+        );
     }
 
     #[test]
     fn an_adjustment_target_defined_nowhere_is_refused() {
         let dir = tempdir().unwrap();
-        write(&dir.path().join("fragments/a.json5"), &fragment_file(r#"
+        write(
+            &dir.path().join("fragments/a.json5"),
+            &fragment_file(
+                r#"
             adjustments: [ { target: "ghost_inst", set_arguments: { x: 1 } } ],
-        "#));
-        let launcher = write(&dir.path().join("l.json5"), r#"{
+        "#,
+            ),
+        );
+        let launcher = write(
+            &dir.path().join("l.json5"),
+            r#"{
             peppy_schema: "launcher/v1",
             components: [
                 { name: "a", optional: true, options: { on: "fragments/a.json5" } },
             ],
             deployments: [],
-        }"#);
+        }"#,
+        );
         let parsed = parse_launcher(&fs::read_to_string(&launcher).unwrap());
         let err = compose(&parsed, &launcher, &["on".to_string()]).expect_err("dead target");
         let CompositionError::TargetDefinedNowhere { target, .. } = &err else {
@@ -1812,31 +1955,70 @@ mod tests {
             let err = compose(&launcher, &dir.path().join("l.json5"), &["sim".to_string()])
                 .expect_err("unsafe path must be refused");
             assert!(
-                err.to_string().contains("not usable") || err.to_string().contains("cannot be read"),
+                err.to_string().contains("not usable")
+                    || err.to_string().contains("cannot be read"),
+                "raw path {raw:?}: got: {err}"
+            );
+            // The origin names the launcher FILE, exactly as the flatten
+            // report and the duplicate-id refusal do.
+            assert!(
+                err.to_string().contains("l.json5"),
                 "raw path {raw:?}: got: {err}"
             );
         }
     }
 
     #[test]
+    fn an_inline_only_composition_needs_no_launcher_directory() {
+        let launcher = parse_launcher(
+            r#"{
+            peppy_schema: "launcher/v1",
+            components: [
+                { name: "robot", default: "real",
+                  options: { real: { deployments: [
+                      { source: { name: "can_arm", tag: "v1" },
+                        instances: [{ instance_id: "arm_inst" }] } ] } } },
+            ],
+            deployments: [],
+        }"#,
+        );
+        // Inline fragments do no I/O, so the launcher's directory is never
+        // resolved and need not exist.
+        let (flat, _) = compose(
+            &launcher,
+            Path::new("/nonexistent-peppy-launcher-dir/l.json5"),
+            &[],
+        )
+        .expect("an inline-only composition reads no files");
+        assert_eq!(flat.deployments.len(), 1);
+        assert_eq!(flat.deployments[0].source.name, "can_arm");
+    }
+
+    #[test]
     fn a_symlink_escaping_the_launcher_directory_is_refused() {
         let dir = tempdir().unwrap();
         let outside = tempdir().unwrap();
-        write(&outside.path().join("escape.json5"), &fragment_file("deployments: []"));
+        write(
+            &outside.path().join("escape.json5"),
+            &fragment_file("deployments: []"),
+        );
         fs::create_dir_all(dir.path().join("fragments")).unwrap();
         std::os::unix::fs::symlink(
             outside.path().join("escape.json5"),
             dir.path().join("fragments/escape.json5"),
         )
         .unwrap();
-        let launcher = write(&dir.path().join("l.json5"), r#"{
+        let launcher = write(
+            &dir.path().join("l.json5"),
+            r#"{
             peppy_schema: "launcher/v1",
             components: [
                 { name: "robot", optional: true,
                   options: { sim: "fragments/escape.json5" } },
             ],
             deployments: [],
-        }"#);
+        }"#,
+        );
         let parsed = parse_launcher(&fs::read_to_string(&launcher).unwrap());
         let err = compose(&parsed, &launcher, &["sim".to_string()]).expect_err("escape refused");
         assert!(err.to_string().contains("escapes"), "got: {err}");
@@ -1845,17 +2027,25 @@ mod tests {
     #[test]
     fn core_nodes_union_base_first() {
         let dir = tempdir().unwrap();
-        write(&dir.path().join("fragments/a.json5"), &fragment_file(r#"
+        write(
+            &dir.path().join("fragments/a.json5"),
+            &fragment_file(
+                r#"
             core_nodes: ["edge", "cloud"],
-        "#));
-        let launcher = write(&dir.path().join("l.json5"), r#"{
+        "#,
+            ),
+        );
+        let launcher = write(
+            &dir.path().join("l.json5"),
+            r#"{
             peppy_schema: "launcher/v1",
             components: [
                 { name: "a", optional: true, options: { on: "fragments/a.json5" } },
             ],
             core_nodes: ["cloud", "base"],
             deployments: [],
-        }"#);
+        }"#,
+        );
         let parsed = parse_launcher(&fs::read_to_string(&launcher).unwrap());
         let (flat, _) = compose(&parsed, &launcher, &["on".to_string()]).expect("composes");
         assert_eq!(flat.core_nodes, ["cloud", "base", "edge"]);
@@ -1892,7 +2082,10 @@ mod tests {
         let CompositionError::AmbiguousSelection { axes: named, .. } = &err else {
             panic!("expected AmbiguousSelection, got: {err}");
         };
-        assert!(named.contains("`robot`") && named.contains("`recorder`"), "got: {named}");
+        assert!(
+            named.contains("`robot`") && named.contains("`recorder`"),
+            "got: {named}"
+        );
         // The explicit form resolves.
         resolve_selection(&axes, &["robot=none".to_string()]).expect("explicit form");
     }
@@ -1902,21 +2095,23 @@ mod tests {
         let axes = axes_from(
             r#"[{ name: "robot", options: { real: { deployments: [] }, mujoco: { deployments: [] } } }]"#,
         );
-        let err = resolve_selection(
-            &axes,
-            &["mujoco".to_string(), "robot=real".to_string()],
-        )
-        .expect_err("conflicting selection");
-        let CompositionError::ConflictingSelection { axis, first, second } = &err else {
+        let err = resolve_selection(&axes, &["mujoco".to_string(), "robot=real".to_string()])
+            .expect_err("conflicting selection");
+        let CompositionError::ConflictingSelection {
+            axis,
+            first,
+            second,
+        } = &err
+        else {
             panic!("expected ConflictingSelection, got: {err}");
         };
-        assert_eq!((axis.as_str(), first.as_str(), second.as_str()), ("robot", "mujoco", "real"));
+        assert_eq!(
+            (axis.as_str(), first.as_str(), second.as_str()),
+            ("robot", "mujoco", "real")
+        );
         // Repeating the same option is the same choice, not a conflict.
-        resolve_selection(
-            &axes,
-            &["mujoco".to_string(), "robot=mujoco".to_string()],
-        )
-        .expect("same option twice is one choice");
+        resolve_selection(&axes, &["mujoco".to_string(), "robot=mujoco".to_string()])
+            .expect("same option twice is one choice");
     }
 
     #[test]
@@ -1951,11 +2146,13 @@ mod tests {
 
     #[test]
     fn with_on_a_flat_launcher_is_refused() {
-        let launcher = parse_launcher(
-            r#"{ peppy_schema: "launcher/v1", deployments: [] }"#,
-        );
-        let err = compose(&launcher, Path::new("/tmp/x.json5"), &["mujoco".to_string()])
-            .expect_err("flat launcher has nothing to select");
+        let launcher = parse_launcher(r#"{ peppy_schema: "launcher/v1", deployments: [] }"#);
+        let err = compose(
+            &launcher,
+            Path::new("/tmp/x.json5"),
+            &["mujoco".to_string()],
+        )
+        .expect_err("flat launcher has nothing to select");
         assert!(matches!(err, CompositionError::WithOnFlatLauncher));
     }
 }

--- a/crates/daemon-config-internal/src/launcher/flatten.rs
+++ b/crates/daemon-config-internal/src/launcher/flatten.rs
@@ -1,0 +1,1906 @@
+//! Selection resolution and flattening: turning a composed launcher plus a
+//! `--with` selection into the ordinary flat launcher the rest of the
+//! pipeline consumes.
+//!
+//! Composition is a pure function of the launcher, its fragments, and the
+//! selection; the only I/O is reading fragment files, all of them resolved
+//! relative to the launcher's own directory so a repository launcher and a
+//! filesystem launcher compose identically.
+
+use super::composition::{
+    Adjustment, ComponentAxis, FragmentPart, LauncherFragmentParser, validate_adjustment,
+    validate_guard,
+};
+use super::parse::PeppyLauncherParser;
+use super::types::{Deployment, LinkTargets, LinkValue, PeppyLauncher, Selection};
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::path::{Component as PathComponent, Path, PathBuf};
+use thiserror::Error;
+
+/// Everything composition can refuse: bad `--with` words, unreadable or
+/// unsafe fragment paths, options that do not provide what their axis
+/// promises, and adjustments that fight.
+///
+/// The `--with` refusals are launch refusals (the words are caller input);
+/// the rest surface wherever the launcher or its fragments are read, which
+/// for `repo index --check` is authoring time and for a launch is before
+/// anything is pinned or started.
+#[derive(Debug, Error)]
+pub enum CompositionError {
+    #[error(
+        "`--with` was given but this launcher declares no `components`; it is a flat stack with \
+         nothing to select"
+    )]
+    WithOnFlatLauncher,
+
+    #[error("`--with {word}` names no axis or option of this launcher.{menu}")]
+    UnknownSelection { word: String, menu: String },
+
+    #[error(
+        "`--with {word}` matches an option of more than one axis ({axes}); say which you mean \
+         with the `axis=option` form"
+    )]
+    AmbiguousSelection { word: String, axes: String },
+
+    #[error(
+        "axis `{axis}` is selected twice with different options (`{first}`, `{second}`); an axis \
+         takes one option, never two"
+    )]
+    ConflictingSelection {
+        axis: String,
+        first: String,
+        second: String,
+    },
+
+    #[error(
+        "axis `{axis}` is neither selected nor defaulted and is not `optional`; choose one of \
+         its options with `--with`{options}"
+    )]
+    UnresolvedAxis { axis: String, options: String },
+
+    #[error(
+        "fragment path `{path}` in {origin} is not usable: {reason}. A fragment path is \
+         relative to the launcher's own directory and stays inside it"
+    )]
+    FragmentPath {
+        path: String,
+        origin: String,
+        reason: String,
+    },
+
+    #[error("fragment `{path}` referenced by {origin} cannot be read: {detail}")]
+    FragmentUnreadable {
+        path: String,
+        origin: String,
+        detail: String,
+    },
+
+    #[error("fragment `{path}` referenced by {origin} does not parse: {detail}")]
+    FragmentInvalid {
+        path: String,
+        origin: String,
+        detail: String,
+    },
+
+    #[error(
+        "option `{option}` of axis `{axis}` does not define `{id}`, which the axis's `provides` \
+         promises; every option defines the axis's interface ids"
+    )]
+    ProvidesUnmet {
+        axis: String,
+        option: String,
+        id: String,
+    },
+
+    #[error(
+        "adjustment on `{target}` in {origin} names a target no option of this launcher defines \
+         anywhere; that is a dead reference or a typo"
+    )]
+    TargetDefinedNowhere {
+        target: String,
+        origin: String,
+    },
+
+    #[error(
+        "instance `{id}` is defined by both {first} and {second}; each instance id belongs to \
+         one origin"
+    )]
+    DuplicateInstanceId {
+        id: String,
+        first: String,
+        second: String,
+    },
+
+    #[error(
+        "two fragments adjust the same thing: {first} and {second} both write \
+         `{target}.{field}`. Fragments refuse to fight over one value; the base specializes \
+         fragments, not the other way around"
+    )]
+    AdjustmentsConflict {
+        target: String,
+        field: String,
+        first: String,
+        second: String,
+    },
+
+    #[error(
+        "adjustment in {origin} cannot append to slot `{slot}` on `{target}`: the slot holds \
+         {holds}. Appending is for array bindings; replacing is `set_links`'s job"
+    )]
+    AddLinksOnNonArray {
+        origin: String,
+        target: String,
+        slot: String,
+        holds: &'static str,
+    },
+
+    #[error(
+        "adjustment in {origin} adds `{added}` to slot `{slot}` on `{target}`, which already \
+         binds it: a slot's bound set lists each producer once"
+    )]
+    AddLinksDuplicateTarget {
+        origin: String,
+        target: String,
+        slot: String,
+        added: String,
+    },
+
+    #[error("the flattened launcher does not validate: {0}")]
+    FlatValidation(#[from] crate::error::Error),
+}
+
+/// How one axis of a resolved selection came to be filled.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SelectionSource {
+    /// Named by `--with`.
+    Explicit,
+    /// Filled from the axis's `default`.
+    Default,
+    /// An `optional` axis left unfilled; contributes nothing.
+    Unfilled,
+}
+
+/// One axis's fate in a resolved selection.
+#[derive(Debug, Clone)]
+pub struct SelectionEntry {
+    pub axis: String,
+    pub option: Option<String>,
+    pub source: SelectionSource,
+}
+
+/// A `--with` selection resolved against a launcher's axes: one entry per
+/// axis, in declaration order.
+#[derive(Debug, Clone, Default)]
+pub struct ComponentSelection {
+    pub entries: Vec<SelectionEntry>,
+}
+
+impl ComponentSelection {
+    /// The option selected on `axis`, or `None` when the axis is unfilled.
+    pub fn option_on(&self, axis: &str) -> Option<&str> {
+        self.entries
+            .iter()
+            .find(|entry| entry.axis == axis)
+            .and_then(|entry| entry.option.as_deref())
+    }
+
+    /// The one-line echo of the full resolution, as launch feedback prints
+    /// it before anything runs: `robot=mujoco  commander=web (default)
+    /// recorder=(off)`.
+    pub fn echo(&self) -> String {
+        self.entries
+            .iter()
+            .map(|entry| match (&entry.option, entry.source) {
+                (Some(option), SelectionSource::Default) => format!("{}={option} (default)", entry.axis),
+                (Some(option), _) => format!("{}={option}", entry.axis),
+                (None, _) => format!("{}=(off)", entry.axis),
+            })
+            .collect::<Vec<_>>()
+            .join("  ")
+    }
+}
+
+/// The `--with` words against the axes: each entry is `option` or
+/// `axis=option`. At most one option per axis (repeating the same option is
+/// the same choice); unselected axes take their default, and a required axis
+/// with neither refuses.
+pub fn resolve_selection(
+    axes: &[ComponentAxis],
+    words: &[String],
+) -> Result<ComponentSelection, CompositionError> {
+    let menu = axes_menu(axes);
+    let mut chosen: BTreeMap<String, String> = BTreeMap::new();
+
+    for word in words {
+        let (axis_name, option_name) = match word.split_once('=') {
+            Some((axis, option)) => (Some(axis), option),
+            None => (None, word.as_str()),
+        };
+
+        let axis_name = match axis_name {
+            Some(explicit) => {
+                if !axes.iter().any(|axis| axis.name == explicit) {
+                    return Err(CompositionError::UnknownSelection {
+                        word: word.clone(),
+                        menu,
+                    });
+                }
+                explicit
+            }
+            // A bare word resolves against option names across every axis;
+            // matching more than one is ambiguous and asks for the explicit
+            // form.
+            None => {
+                let holders: Vec<&str> = axes
+                    .iter()
+                    .filter(|axis| axis.options.contains_key(option_name))
+                    .map(ComponentAxis::as_str)
+                    .collect();
+                match holders.as_slice() {
+                    [] => {
+                        return Err(CompositionError::UnknownSelection {
+                            word: word.clone(),
+                            menu,
+                        })
+                    }
+                    [axis] => *axis,
+                    many => {
+                        return Err(CompositionError::AmbiguousSelection {
+                            word: word.clone(),
+                            axes: many
+                                .iter()
+                                .map(|axis| format!("`{axis}`"))
+                                .collect::<Vec<_>>()
+                                .join(", "),
+                        })
+                    }
+                }
+            }
+        };
+
+        let axis = axes
+            .iter()
+            .find(|axis| axis.name == axis_name)
+            .expect("axis existence checked above");
+        if !axis.options.contains_key(option_name) {
+            return Err(CompositionError::UnknownSelection {
+                word: word.clone(),
+                menu,
+            });
+        }
+        if let Some(first) = chosen.get(axis_name)
+            && first != option_name
+        {
+            return Err(CompositionError::ConflictingSelection {
+                axis: axis_name.to_owned(),
+                first: first.clone(),
+                second: option_name.to_owned(),
+            });
+        }
+        chosen.insert(axis_name.to_owned(), option_name.to_owned());
+    }
+
+    let mut entries = Vec::with_capacity(axes.len());
+    for axis in axes {
+        match chosen.get(axis.name.as_str()) {
+            Some(option) => entries.push(SelectionEntry {
+                axis: axis.name.clone(),
+                option: Some(option.clone()),
+                source: SelectionSource::Explicit,
+            }),
+            None => match &axis.default {
+                Some(default) => entries.push(SelectionEntry {
+                    axis: axis.name.clone(),
+                    option: Some(default.clone()),
+                    source: SelectionSource::Default,
+                }),
+                None if axis.optional => entries.push(SelectionEntry {
+                    axis: axis.name.clone(),
+                    option: None,
+                    source: SelectionSource::Unfilled,
+                }),
+                None => {
+                    return Err(CompositionError::UnresolvedAxis {
+                        axis: axis.name.clone(),
+                        options: format!(
+                            "; its options are {}",
+                            crate::error::format_quoted_list(axis.options.keys())
+                        ),
+                    })
+                }
+            },
+        }
+    }
+
+    Ok(ComponentSelection { entries })
+}
+
+/// One line per axis naming its options, for the "names no option of this
+/// launcher" refusals: the fix is picking from the list, so the list is the
+/// error.
+fn axes_menu(axes: &[ComponentAxis]) -> String {
+    axes.iter()
+        .map(|axis| {
+            format!(
+                "\n  - {}: {}",
+                axis.name,
+                crate::error::format_quoted_list(axis.options.keys())
+            )
+        })
+        .collect()
+}
+
+/// Every legal selection of these axes, in a fixed order: axis by axis in
+/// declaration order, option by option in declaration order, an unfilled
+/// entry last on optional axes. Used by `repo index --check` to hold the
+/// whole selection space to the same structural checks a launch would run.
+pub fn enumerate_selections(axes: &[ComponentAxis]) -> Vec<ComponentSelection> {
+    let mut selections = vec![ComponentSelection::default()];
+    for axis in axes {
+        let mut next = Vec::with_capacity(selections.len() * (axis.options.len() + 1));
+        for selection in &selections {
+            for option in axis.options.keys() {
+                let mut extended = selection.clone();
+                extended.entries.push(SelectionEntry {
+                    axis: axis.name.clone(),
+                    option: Some(option.clone()),
+                    source: SelectionSource::Explicit,
+                });
+                next.push(extended);
+            }
+            if axis.optional {
+                let mut extended = selection.clone();
+                extended.entries.push(SelectionEntry {
+                    axis: axis.name.clone(),
+                    option: None,
+                    source: SelectionSource::Unfilled,
+                });
+                next.push(extended);
+            }
+        }
+        selections = next;
+    }
+    selections
+}
+
+/// The size of the selection space, saturating rather than multiplying out:
+/// callers use it to decide whether enumerating is reasonable, which it must
+/// answer without doing the enumeration.
+pub fn selection_space_size(axes: &[ComponentAxis]) -> usize {
+    axes.iter()
+        .map(|axis| axis.options.len() + usize::from(axis.optional))
+        .fold(1usize, |acc, per_axis| acc.saturating_mul(per_axis))
+}
+
+/// One fragment of one option, loaded and paired with the label the resolve
+/// report and the error messages name it by: the path as written for a file,
+/// `inline option `axis.option`` for a body written in the launcher.
+pub struct LoadedFragment {
+    pub fragment: super::composition::Fragment,
+    pub origin: String,
+}
+
+/// Every option's fragments, loaded: file fragments read and validated,
+/// inline fragments taken from the launcher document. Loading ALL options,
+/// not just the selected ones, is what lets a launch refuse the same things
+/// `repo index --check` refuses (an option that does not provide its axis's
+/// interface, a guard naming an unknown axis) instead of discovering them
+/// one selection at a time.
+pub struct LoadedComposition {
+    pub options: BTreeMap<String, BTreeMap<String, Vec<LoadedFragment>>>,
+}
+
+/// Reads every file fragment the launcher references and runs the
+/// selection-independent checks: path safety, fragment parse, `provides`
+/// satisfaction, guard references, and that every adjustment target is
+/// defined by some option of the launcher.
+pub fn load_composition(
+    launcher: &PeppyLauncher,
+    launcher_dir: &Path,
+) -> Result<LoadedComposition, CompositionError> {
+    let axes = &launcher.components;
+    let mut options: BTreeMap<String, BTreeMap<String, Vec<LoadedFragment>>> = BTreeMap::new();
+    let launcher_label = launcher_file_label(launcher_dir);
+
+    for axis in axes {
+        let mut loaded_axis = BTreeMap::new();
+        for (option_name, spec) in &axis.options {
+            let mut loaded = Vec::with_capacity(spec.0.len());
+            for part in &spec.0 {
+                match part {
+                    FragmentPart::Inline(fragment) => loaded.push(LoadedFragment {
+                        fragment: fragment.clone(),
+                        origin: format!("inline option `{}.{}`", axis.name, option_name),
+                    }),
+                    FragmentPart::File(raw) => {
+                        let origin = format!("{launcher_label}, option `{}.{}`", axis.name, option_name);
+                        loaded.push(load_fragment_file(launcher_dir, raw, &origin)?);
+                    }
+                }
+            }
+            loaded_axis.insert(option_name.clone(), loaded);
+        }
+        options.insert(axis.name.clone(), loaded_axis);
+    }
+
+    // Every option defines its axis's interface, whatever else it privately
+    // defines: that is the promise a link or adjustment against a `provides`
+    // id rests on.
+    for axis in axes {
+        for (option_name, loaded) in &options[axis.name.as_str()] {
+            let defined: HashSet<&str> = loaded
+                .iter()
+                .flat_map(|fragment| fragment.fragment.deployments.iter())
+                .flat_map(|deployment| deployment.instances.iter())
+                .map(|instance| instance.instance_id.as_str())
+                .collect();
+            for id in &axis.provides {
+                if !defined.contains(id.as_str()) {
+                    return Err(CompositionError::ProvidesUnmet {
+                        axis: axis.name.clone(),
+                        option: option_name.clone(),
+                        id: id.to_string(),
+                    });
+                }
+            }
+        }
+    }
+
+    // Guards of file fragments reference the launcher's axes; the inline ones
+    // were checked when the launcher parsed.
+    for axis in axes {
+        for loaded in options[axis.name.as_str()].values() {
+            for fragment in loaded {
+                for adjustment in &fragment.fragment.adjustments {
+                    if let Some(when) = &adjustment.when {
+                        validate_guard(when, axes, &fragment.origin)
+                            .map_err(|reason| CompositionError::FragmentInvalid {
+                                path: fragment.origin.clone(),
+                                origin: launcher_label.clone(),
+                                detail: reason,
+                            })?;
+                    }
+                }
+            }
+        }
+    }
+
+    // An adjustment target the selection does not define is skipped; a
+    // target NOTHING can define is a dead reference, and refusing it here
+    // catches it once for every selection.
+    let mut definable: HashSet<&str> = launcher
+        .deployments
+        .iter()
+        .flat_map(|d| d.instances.iter())
+        .map(|i| i.instance_id.as_str())
+        .collect();
+    for fragment in options
+        .values()
+        .flat_map(|axis| axis.values())
+        .flat_map(|fragments| fragments.iter())
+    {
+        for deployment in &fragment.fragment.deployments {
+            for instance in &deployment.instances {
+                definable.insert(instance.instance_id.as_str());
+            }
+        }
+    }
+    for adjustment in &launcher.adjustments {
+        if !definable.contains(adjustment.target.as_str()) {
+            return Err(CompositionError::TargetDefinedNowhere {
+                target: adjustment.target.to_string(),
+                origin: format!("{launcher_label} (base)"),
+            });
+        }
+    }
+    for fragment in options
+        .values()
+        .flat_map(|axis| axis.values())
+        .flat_map(|fragments| fragments.iter())
+    {
+        for adjustment in &fragment.fragment.adjustments {
+            if !definable.contains(adjustment.target.as_str()) {
+                return Err(CompositionError::TargetDefinedNowhere {
+                    target: adjustment.target.to_string(),
+                    origin: fragment.origin.clone(),
+                });
+            }
+        }
+    }
+
+    Ok(LoadedComposition { options })
+}
+
+/// The label error messages and reports name a launcher by: its file name,
+/// or the directory's name when the launcher path itself was elided.
+fn launcher_file_label(launcher_dir: &Path) -> String {
+    launcher_dir
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_else(|| launcher_dir.display().to_string())
+}
+
+fn load_fragment_file(
+    launcher_dir: &Path,
+    raw: &str,
+    origin: &str,
+) -> Result<LoadedFragment, CompositionError> {
+    let path = resolve_fragment_path(launcher_dir, raw, origin)?;
+    let content = std::fs::read_to_string(&path).map_err(|e| CompositionError::FragmentUnreadable {
+        path: raw.to_owned(),
+        origin: origin.to_owned(),
+        detail: e.to_string(),
+    })?;
+    if content.trim().is_empty() {
+        return Err(CompositionError::FragmentUnreadable {
+            path: raw.to_owned(),
+            origin: origin.to_owned(),
+            detail: "the file is empty".to_owned(),
+        });
+    }
+    let parsed = LauncherFragmentParser::from_content(&content).map_err(|e| {
+        CompositionError::FragmentInvalid {
+            path: raw.to_owned(),
+            origin: origin.to_owned(),
+            detail: e.to_string(),
+        }
+    })?;
+    for adjustment in &parsed.body.adjustments {
+        validate_adjustment(adjustment, raw).map_err(|reason| CompositionError::FragmentInvalid {
+            path: raw.to_owned(),
+            origin: origin.to_owned(),
+            detail: reason,
+        })?;
+    }
+    Ok(LoadedFragment {
+        fragment: parsed.body,
+        origin: raw.to_owned(),
+    })
+}
+
+/// A fragment path must be relative, plain (no `.` or `..` segments), and
+/// must stay inside the launcher's directory even through symlinks: a
+/// repository launcher and a filesystem launcher resolve fragments
+/// identically, and neither reaches outside the tree it lives in.
+fn resolve_fragment_path(
+    launcher_dir: &Path,
+    raw: &str,
+    origin: &str,
+) -> Result<PathBuf, CompositionError> {
+    let refuse = |reason: &str| {
+        Err(CompositionError::FragmentPath {
+            path: raw.to_owned(),
+            origin: origin.to_owned(),
+            reason: reason.to_owned(),
+        })
+    };
+
+    let relative = Path::new(raw);
+    if relative.is_absolute() {
+        return refuse("it is absolute");
+    }
+    let mut cleaned = PathBuf::new();
+    for component in relative.components() {
+        match component {
+            PathComponent::Normal(segment) => cleaned.push(segment),
+            PathComponent::CurDir => return refuse("it contains a `.` segment"),
+            PathComponent::ParentDir => return refuse("it contains a `..` segment"),
+            _ => return refuse("it is not a plain relative path"),
+        }
+    }
+    if cleaned.as_os_str().is_empty() {
+        return refuse("it is empty");
+    }
+
+    let base = launcher_dir.canonicalize().map_err(|e| {
+        CompositionError::FragmentUnreadable {
+            path: raw.to_owned(),
+            origin: origin.to_owned(),
+            detail: format!("the launcher's directory cannot be resolved: {e}"),
+        }
+    })?;
+    let full = launcher_dir.join(&cleaned);
+    let canonical = full.canonicalize().map_err(|e| {
+        CompositionError::FragmentUnreadable {
+            path: raw.to_owned(),
+            origin: origin.to_owned(),
+            detail: e.to_string(),
+        }
+    })?;
+    if !canonical.starts_with(&base) {
+        return refuse("it escapes the launcher's directory (through a symlink)");
+    }
+    Ok(full)
+}
+
+/// What one applied adjustment did, for the resolve report: the target and
+/// field it touched, the before and after, and the fragment (or base) it
+/// came from.
+#[derive(Debug, Clone)]
+pub struct AppliedAdjustment {
+    pub target: String,
+    /// `arguments.<key>` or `links.<slot>`.
+    pub field: String,
+    pub change: AppliedChange,
+    pub origin: String,
+}
+
+#[derive(Debug, Clone)]
+pub enum AppliedChange {
+    Set {
+        old: Option<String>,
+        new: String,
+    },
+    Added {
+        target: String,
+    },
+    Removed {
+        old: String,
+    },
+}
+
+impl AppliedChange {
+    fn render(&self) -> String {
+        match self {
+            AppliedChange::Set {
+                old: Some(old),
+                new,
+            } => format!("{old} -> {new}"),
+            AppliedChange::Set { old: None, new } => format!("(absent) -> {new}"),
+            AppliedChange::Added { target } => format!("+ {target}"),
+            AppliedChange::Removed { old } => format!("removed (was {old})"),
+        }
+    }
+}
+
+/// Why an adjustment did not run.
+#[derive(Debug, Clone)]
+pub enum SkipReason {
+    /// The target the selection resolved to does not define this instance:
+    /// the recorder's attach simply does not run when no recorder was
+    /// selected.
+    TargetAbsent,
+    /// The `when` guard named an axis whose selected option is not the one
+    /// the guard requires.
+    GuardNotMet(String),
+}
+
+impl SkipReason {
+    fn render(&self) -> String {
+        match self {
+            SkipReason::TargetAbsent => "target is not in this selection".to_owned(),
+            SkipReason::GuardNotMet(guard) => format!("guard {guard} is not met"),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SkippedAdjustment {
+    pub target: String,
+    pub reason: SkipReason,
+    pub origin: String,
+}
+
+/// The audit trail of one flattening: what was selected, which adjustments
+/// applied (with the values they replaced), and which were skipped (and
+/// why). `peppy stack resolve` prints it; a launch holds it for the echo.
+#[derive(Debug, Clone, Default)]
+pub struct FlattenReport {
+    pub selection: ComponentSelection,
+    pub applied: Vec<AppliedAdjustment>,
+    pub skipped: Vec<SkippedAdjustment>,
+}
+
+impl FlattenReport {
+    /// The report body `peppy stack resolve` writes to stderr, one entry per
+    /// line, applied before skipped.
+    pub fn render_lines(&self) -> Vec<String> {
+        let mut lines = vec![format!("components: {}", self.selection.echo())];
+        if !self.applied.is_empty() {
+            lines.push(String::from("adjustments applied:"));
+            for entry in &self.applied {
+                lines.push(format!(
+                    "  {}.{}: {}  ({})",
+                    entry.target, entry.field, entry.change.render(), entry.origin
+                ));
+            }
+        }
+        if !self.skipped.is_empty() {
+            lines.push(String::from("adjustments skipped:"));
+            for entry in &self.skipped {
+                lines.push(format!(
+                    "  {}: {}  ({})",
+                    entry.target,
+                    entry.reason.render(),
+                    entry.origin
+                ));
+            }
+        }
+        lines
+    }
+}
+
+/// One adjustment paired with where it came from and whether it speaks for
+/// a fragment (bound by the no-fighting rules) or for the base (which may
+/// override anything a fragment set).
+struct PlannedAdjustment<'a> {
+    adjustment: &'a Adjustment,
+    origin: String,
+    /// Identifies the fragment an adjustment belongs to for the conflict
+    /// rules: two adjustments from one fragment are one author applying list
+    /// order, two from different fragments are two authors fighting.
+    fragment_id: usize,
+    is_base: bool,
+}
+
+/// Flattens a composed launcher with a resolved selection into the ordinary
+/// flat launcher the existing pipeline consumes, exactly as if the author
+/// had written it by hand.
+///
+/// The flattened document goes back through the flat launcher's own
+/// validation (serialize, re-parse), so every whole-document check a
+/// hand-written file gets runs on the composed result too.
+pub fn flatten(
+    launcher: &PeppyLauncher,
+    loaded: &LoadedComposition,
+    selection: &ComponentSelection,
+    base_label: &str,
+) -> Result<(PeppyLauncher, FlattenReport), CompositionError> {
+    // 1-2. Collect: base deployments first, then each selected option's
+    // fragments in axis declaration order and fragment list order.
+    let mut collected: Vec<(&Deployment, String)> = launcher
+        .deployments
+        .iter()
+        .map(|deployment| (deployment, base_label.to_owned()))
+        .collect();
+    let mut selected_fragments: Vec<&LoadedFragment> = Vec::new();
+    for entry in &selection.entries {
+        let Some(option) = &entry.option else { continue };
+        let Some(fragments) = loaded
+            .options
+            .get(entry.axis.as_str())
+            .and_then(|axis| axis.get(option.as_str()))
+        else {
+            continue;
+        };
+        selected_fragments.extend(fragments.iter());
+    }
+    for fragment in &selected_fragments {
+        for deployment in &fragment.fragment.deployments {
+            collected.push((deployment, fragment.origin.clone()));
+        }
+    }
+
+    // 3. Instance-id uniqueness across the collected set, naming both
+    // origins. Distinct options of one axis may share ids by design, but
+    // only one option per axis is ever selected.
+    let mut first_origin: HashMap<&str, &str> = HashMap::new();
+    for (deployment, origin) in &collected {
+        for instance in &deployment.instances {
+            let id = instance.instance_id.as_str();
+            if let Some(first) = first_origin.insert(id, origin) {
+                return Err(CompositionError::DuplicateInstanceId {
+                    id: id.to_owned(),
+                    first: first.to_owned(),
+                    second: origin.clone(),
+                });
+            }
+        }
+    }
+
+    // 2 (again, structurally): merge entries sharing a source into one
+    // entry whose instance list is the union, in collection order. The
+    // daemon resolves one deployment per name:tag, so this merge is what
+    // lets a base and a fragment both deploy `uvc_camera_linux`.
+    let mut merged: Vec<Deployment> = Vec::with_capacity(collected.len());
+    for &(deployment, _) in &collected {
+        match merged
+            .iter_mut()
+            .find(|entry| entry.source == deployment.source)
+        {
+            Some(entry) => entry.instances.extend(deployment.instances.iter().cloned()),
+            None => merged.push(deployment.clone()),
+        }
+    }
+
+    // 4. Union core node links: base first, then fragments in collection
+    // order; a link declared by both is one link.
+    let mut core_nodes: Vec<String> = launcher.core_nodes.clone();
+    for fragment in &selected_fragments {
+        for link in &fragment.fragment.core_nodes {
+            if !core_nodes.contains(link) {
+                core_nodes.push(link.clone());
+            }
+        }
+    }
+
+    // 5. Plan the adjustments: fragments in collection order, then the base
+    // in list order. A plan step runs only if its guard holds and its
+    // target is in this selection; each skip is recorded.
+    let base_origin = format!("{base_label} (base)");
+    let mut planned: Vec<PlannedAdjustment> = Vec::new();
+    let mut skipped: Vec<SkippedAdjustment> = Vec::new();
+    for (fragment_id, fragment) in selected_fragments.iter().enumerate() {
+        for adjustment in &fragment.fragment.adjustments {
+            planned.push(PlannedAdjustment {
+                adjustment,
+                origin: fragment.origin.clone(),
+                fragment_id,
+                is_base: false,
+            });
+        }
+    }
+    for adjustment in &launcher.adjustments {
+        planned.push(PlannedAdjustment {
+            adjustment,
+            origin: base_origin.clone(),
+            fragment_id: usize::MAX,
+            is_base: true,
+        });
+    }
+    let mut running: Vec<&PlannedAdjustment> = Vec::new();
+    for step in &planned {
+        if let Some(when) = &step.adjustment.when
+            && !guard_holds(selection, when)
+        {
+            skipped.push(SkippedAdjustment {
+                target: step.adjustment.target.to_string(),
+                reason: SkipReason::GuardNotMet(render_guard(when)),
+                origin: step.origin.clone(),
+            });
+            continue;
+        }
+        if !first_origin.contains_key(step.adjustment.target.as_str()) {
+            skipped.push(SkippedAdjustment {
+                target: step.adjustment.target.to_string(),
+                reason: SkipReason::TargetAbsent,
+                origin: step.origin.clone(),
+            });
+            continue;
+        }
+        running.push(step);
+    }
+
+    // 6. Conflict rules among surviving FRAGMENT adjustments. The base is
+    // not a second author fighting a fragment; it is the one author who
+    // owns the file, and its later entries win over its earlier ones.
+    let mut writers: HashMap<(&str, KeySpace, &str), (usize, String)> = HashMap::new();
+    let mut adders: HashMap<(&str, &str), (usize, String)> = HashMap::new();
+    for step in &running {
+        if step.is_base {
+            continue;
+        }
+        let target = step.adjustment.target.as_str();
+        let written_keys = step
+            .adjustment
+            .set_arguments
+            .iter()
+            .flat_map(|arguments| arguments.keys())
+            .map(|key| (KeySpace::Arguments, key.as_str()))
+            .chain(
+                step.adjustment
+                    .set_links
+                    .iter()
+                    .flat_map(|links| links.keys())
+                    .map(|key| (KeySpace::Links, key.as_str())),
+            )
+            .chain(
+                step.adjustment
+                    .unset_links
+                    .iter()
+                    .flatten()
+                    .map(|key| (KeySpace::Links, key.as_str())),
+            );
+        for (space, key) in written_keys {
+            claim_write(&mut writers, target, space, key, step)?;
+        }
+        for key in step.adjustment.add_links.iter().flat_map(|links| links.keys()) {
+            let entry = adders
+                .entry((target, key.as_str()))
+                .or_insert((step.fragment_id, step.origin.clone()));
+            entry.1 = step.origin.clone();
+        }
+    }
+    for ((target, key), (adder_id, adder_origin)) in &adders {
+        if let Some((writer_id, writer_origin)) =
+            writers.get(&(target, KeySpace::Links, key))
+            && *writer_id != *adder_id
+        {
+            return Err(CompositionError::AdjustmentsConflict {
+                target: (*target).to_owned(),
+                field: format!("links.{key}"),
+                first: writer_origin.clone(),
+                second: adder_origin.clone(),
+            });
+        }
+    }
+
+    // 7. Apply. Instances are located by id across the merged deployments.
+    // The map is keyed by owned ids: the apply loop mutates `merged` while
+    // looking targets up in it.
+    let mut index: HashMap<String, (usize, usize)> = HashMap::new();
+    for (deployment_idx, deployment) in merged.iter().enumerate() {
+        for (instance_idx, instance) in deployment.instances.iter().enumerate() {
+            index.insert(instance.instance_id.to_string(), (deployment_idx, instance_idx));
+        }
+    }
+    let mut applied: Vec<AppliedAdjustment> = Vec::new();
+    for step in &running {
+        let &(deployment_idx, instance_idx) = index
+            .get(step.adjustment.target.as_str())
+            .expect("target presence checked when the plan was built");
+        let instance = &mut merged[deployment_idx].instances[instance_idx];
+        let origin = step.origin.clone();
+        let target = step.adjustment.target.to_string();
+        if let Some(arguments) = &step.adjustment.set_arguments {
+            for (key, value) in arguments {
+                applied.push(AppliedAdjustment {
+                    field: format!("arguments.{key}"),
+                    change: AppliedChange::Set {
+                        old: instance
+                            .arguments
+                            .get(key)
+                            .map(render_value)
+                            .or(Some(String::from("(absent)"))),
+                        new: render_value(value),
+                    },
+                    target: target.clone(),
+                    origin: origin.clone(),
+                });
+                instance.arguments.insert(key.clone(), value.clone());
+            }
+        }
+        if let Some(links) = &step.adjustment.set_links {
+            for (slot, value) in links {
+                applied.push(AppliedAdjustment {
+                    field: format!("links.{slot}"),
+                    change: AppliedChange::Set {
+                        old: instance.links.get(slot).map(render_link).or(Some(String::from("(absent)"))),
+                        new: render_link(value),
+                    },
+                    target: target.clone(),
+                    origin: origin.clone(),
+                });
+                instance.links.insert(slot.clone(), value.clone());
+            }
+        }
+        if let Some(links) = &step.adjustment.add_links {
+            for (slot, additions) in links {
+                match instance.links.get(slot) {
+                    None | Some(LinkValue::Bound(Selection::Array(_))) => {
+                        let mut targets = instance
+                            .links
+                            .get(slot)
+                            .and_then(|value| value.selection().cloned())
+                            .map(|selection| match selection {
+                                Selection::Array(targets) => targets.as_slice().to_vec(),
+                                _ => unreachable!("matched an array binding above"),
+                            })
+                            .unwrap_or_default();
+                        for addition in additions {
+                            if targets.contains(addition) {
+                                return Err(CompositionError::AddLinksDuplicateTarget {
+                                    origin: origin.clone(),
+                                    target: target.clone(),
+                                    slot: slot.clone(),
+                                    added: addition.clone(),
+                                });
+                            }
+                            applied.push(AppliedAdjustment {
+                                field: format!("links.{slot}"),
+                                change: AppliedChange::Added {
+                                    target: addition.clone(),
+                                },
+                                target: target.clone(),
+                                origin: origin.clone(),
+                            });
+                            targets.push(addition.clone());
+                        }
+                        let bound = LinkTargets::new(targets).map_err(|err| {
+                            CompositionError::AddLinksDuplicateTarget {
+                                origin: origin.clone(),
+                                target: target.clone(),
+                                slot: slot.clone(),
+                                added: err.target,
+                            }
+                        })?;
+                        instance
+                            .links
+                            .insert(slot.clone(), LinkValue::Bound(Selection::Array(bound)));
+                    }
+                    Some(LinkValue::Bound(Selection::Scalar(_))) => {
+                        return Err(CompositionError::AddLinksOnNonArray {
+                            origin: origin.clone(),
+                            target: target.clone(),
+                            slot: slot.clone(),
+                            holds: "a scalar binding",
+                        })
+                    }
+                    Some(LinkValue::Bound(Selection::Flags(_))) => {
+                        return Err(CompositionError::AddLinksOnNonArray {
+                            origin: origin.clone(),
+                            target: target.clone(),
+                            slot: slot.clone(),
+                            holds: "a flag-accumulated binding",
+                        })
+                    }
+                    Some(LinkValue::Vacant(_)) => {
+                        return Err(CompositionError::AddLinksOnNonArray {
+                            origin: origin.clone(),
+                            target: target.clone(),
+                            slot: slot.clone(),
+                            holds: "a vacancy",
+                        })
+                    }
+                }
+            }
+        }
+        if let Some(slots) = &step.adjustment.unset_links {
+            for slot in slots {
+                if let Some(old) = instance.links.remove(slot) {
+                    applied.push(AppliedAdjustment {
+                        field: format!("links.{slot}"),
+                        change: AppliedChange::Removed {
+                            old: render_link(&old),
+                        },
+                        target: target.clone(),
+                        origin: origin.clone(),
+                    });
+                }
+            }
+        }
+    }
+
+    // 8. The flat document is validated by the same parse a hand-written
+    // launcher goes through, so link-target resolution, sentinel keys, and
+    // the core-node checks all run on the composed result.
+    let flat = PeppyLauncher {
+        peppy_schema: launcher.peppy_schema,
+        core_nodes,
+        deployments: merged,
+        components: Vec::new(),
+        adjustments: Vec::new(),
+    };
+    let text = serde_json5::to_string(&flat).map_err(|e| CompositionError::FlatValidation(
+        crate::error::Error::Serialize(e.to_string()),
+    ))?;
+    let validated = PeppyLauncherParser::from_content(&text)?;
+
+    Ok((
+        validated,
+        FlattenReport {
+            selection: selection.clone(),
+            applied,
+            skipped,
+        },
+    ))
+}
+
+/// The two key spaces an adjustment can write in. `add_links` shares the
+/// links space with `set_links` and `unset_links`: appending to a slot and
+/// replacing it are two claims on the same entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum KeySpace {
+    Arguments,
+    Links,
+}
+
+impl KeySpace {
+    fn label(self) -> &'static str {
+        match self {
+            KeySpace::Arguments => "arguments",
+            KeySpace::Links => "links",
+        }
+    }
+}
+
+/// Records one fragment's claim on a `(target, key)` write slot, refusing
+/// when a DIFFERENT fragment already claimed it. Two adjustments from one
+/// fragment are one author applying list order (the later wins, the
+/// earlier's claim is simply superseded); two from different fragments are
+/// two authors, and no last-writer-wins between them is allowed to be
+/// silent.
+fn claim_write<'a>(
+    writers: &mut HashMap<(&'a str, KeySpace, &'a str), (usize, String)>,
+    target: &'a str,
+    space: KeySpace,
+    key: &'a str,
+    step: &PlannedAdjustment<'_>,
+) -> Result<(), CompositionError> {
+    let entry = writers
+        .entry((target, space, key))
+        .or_insert((step.fragment_id, step.origin.clone()));
+    if entry.0 != step.fragment_id {
+        return Err(CompositionError::AdjustmentsConflict {
+            target: target.to_owned(),
+            field: format!("{}.{key}", space.label()),
+            first: entry.1.clone(),
+            second: step.origin.clone(),
+        });
+    }
+    entry.1 = step.origin.clone();
+    Ok(())
+}
+
+/// Every guard entry must match the selection: naming several axes is an
+/// AND, which is how a base writes "only when the headset leads the real
+/// robot".
+fn guard_holds(selection: &ComponentSelection, when: &BTreeMap<String, String>) -> bool {
+    when.iter()
+        .all(|(axis, option)| selection.option_on(axis) == Some(option.as_str()))
+}
+
+fn render_guard(when: &BTreeMap<String, String>) -> String {
+    when.iter()
+        .map(|(axis, option)| format!("{axis}={option}"))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn render_value(value: &config::AnyType) -> String {
+    serde_json5::to_string(value).unwrap_or_else(|_| String::from("(unrenderable)"))
+}
+
+fn render_link(value: &LinkValue) -> String {
+    serde_json5::to_string(value).unwrap_or_else(|_| String::from("(unrenderable)"))
+}
+
+/// Resolve the `--with` words against a launcher and flatten the result.
+///
+/// The one entry point the launch paths and `peppy stack resolve` share: a
+/// flat launcher with no words passes through unchanged, a flat launcher
+/// with words is refused, and a composed launcher is loaded, resolved, and
+/// flattened into an ordinary `launcher/v1` document.
+pub fn compose(
+    launcher: &PeppyLauncher,
+    launcher_file: &Path,
+    words: &[String],
+) -> Result<(PeppyLauncher, FlattenReport), CompositionError> {
+    if launcher.components.is_empty() {
+        if words.is_empty() {
+            return Ok((launcher.clone(), FlattenReport::default()));
+        }
+        return Err(CompositionError::WithOnFlatLauncher);
+    }
+
+    let launcher_dir = match launcher_file.parent() {
+        Some(parent) if !parent.as_os_str().is_empty() => parent.to_path_buf(),
+        _ => PathBuf::from("."),
+    };
+    let loaded = load_composition(launcher, &launcher_dir)?;
+    let selection = resolve_selection(&launcher.components, words)?;
+    let base_label = launcher_file
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_else(|| launcher_file.display().to_string());
+    flatten(launcher, &loaded, &selection, &base_label)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::composition::FragmentSpec;
+    use super::*;
+    use crate::launcher::{ComponentAxis, PeppyLauncherParser};
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn write(path: &Path, content: &str) -> PathBuf {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(path, content).unwrap();
+        path.to_path_buf()
+    }
+
+    fn parse_launcher(content: &str) -> PeppyLauncher {
+        PeppyLauncherParser::from_content(content).expect("launcher parses")
+    }
+
+    fn fragment_file(body: &str) -> String {
+        format!("{{ peppy_schema: \"launcher_fragment/v1\", {body} }}")
+    }
+
+    /// The worked micro-example: one base, a robot axis with an inline real
+    /// option and a file-backed sim option sharing a relay fragment, an
+    /// optional recorder axis whose attach adjustment reaches whichever
+    /// commander was selected.
+    fn composed_fixture(dir: &Path) -> (PathBuf, PeppyLauncher) {
+        write(
+            &dir.join("fragments/sim_relays.json5"),
+            &fragment_file(r#"
+                deployments: [
+                    { source: { name: "arm_sim", tag: "v1" },
+                      instances: [{ instance_id: "arm_inst", links: { engine: "sim_inst/arm" } }] },
+                ],
+                adjustments: [
+                    { target: "backbone_inst", set_arguments: { max_ee_velocity_m_s: 0.5 } },
+                ],
+            "#),
+        );
+        write(
+            &dir.join("fragments/mujoco_engine.json5"),
+            &fragment_file(r#"
+                deployments: [
+                    { source: { name: "sim_mujoco", tag: "v1" },
+                      instances: [{ instance_id: "sim_inst", arguments: { state_rate_hz: 100 } }] },
+                ],
+                adjustments: [
+                    { target: "recorder_inst",
+                      set_arguments: { robot_type: "openarm_mujoco" } },
+                ],
+            "#),
+        );
+        write(
+            &dir.join("fragments/recorder.json5"),
+            &fragment_file(r#"
+                deployments: [
+                    { source: { name: "recorder", tag: "v1" },
+                      instances: [{ instance_id: "recorder_inst",
+                                    links: { observed: ["arm_inst"] } }] },
+                ],
+                adjustments: [
+                    { target: "commander_inst", add_links: { recorder: ["recorder_inst"] } },
+                ],
+            "#),
+        );
+        let launcher = write(
+            &dir.join("teleop.json5"),
+            r#"{
+                peppy_schema: "launcher/v1",
+                components: [
+                    { name: "robot",
+                      provides: ["arm_inst"],
+                      default: "real",
+                      options: {
+                          real: { deployments: [
+                              { source: { name: "can_arm", tag: "v1" },
+                                instances: [{ instance_id: "arm_inst" }] } ] },
+                          mujoco: ["fragments/sim_relays.json5", "fragments/mujoco_engine.json5"],
+                      } },
+                    { name: "recorder",
+                      optional: true,
+                      provides: ["recorder_inst"],
+                      options: { on: "fragments/recorder.json5" } },
+                ],
+                adjustments: [
+                    { target: "sim_inst", set_arguments: { hardware_version: "v2" } },
+                ],
+                deployments: [
+                    { source: { name: "backbone", tag: "v1" },
+                      instances: [{ instance_id: "backbone_inst",
+                                    links: { arm: "arm_inst" } }] },
+                    { source: { name: "commander", tag: "v1" },
+                      instances: [{ instance_id: "commander_inst",
+                                    links: { backbone: "backbone_inst" } }] },
+                ],
+            }"#,
+        );
+        let parsed = parse_launcher(&fs::read_to_string(&launcher).unwrap());
+        (launcher, parsed)
+    }
+
+    fn words(entries: &[&str]) -> Vec<String> {
+        entries.iter().map(|entry| entry.to_string()).collect()
+    }
+
+    #[test]
+    fn defaults_produce_the_flat_document() {
+        let dir = tempdir().unwrap();
+        let (file, launcher) = composed_fixture(dir.path());
+        let (flat, report) = compose(&launcher, &file, &[]).expect("composes");
+
+        assert!(flat.components.is_empty());
+        assert!(flat.adjustments.is_empty());
+        // Base deployments first, then the real option's deployment.
+        let sources: Vec<String> = flat
+            .deployments
+            .iter()
+            .map(|d| format!("{}:{}", d.source.name, d.source.tag))
+            .collect();
+        assert_eq!(sources, ["backbone:v1", "commander:v1", "can_arm:v1"]);
+        assert_eq!(report.selection.echo(), "robot=real (default)  recorder=(off)");
+        // The base's sim specialization sleeps when the robot is real.
+        assert!(report
+            .skipped
+            .iter()
+            .any(|s| s.target == "sim_inst" && matches!(s.reason, SkipReason::TargetAbsent)));
+    }
+
+    #[test]
+    fn a_selection_pulls_in_fragments_in_order() {
+        let dir = tempdir().unwrap();
+        let (file, launcher) = composed_fixture(dir.path());
+        let (flat, report) = compose(&launcher, &file, &words(&["mujoco"])).expect("composes");
+
+        // Base deployments first, then sim_relays, then the engine.
+        let sources: Vec<String> = flat
+            .deployments
+            .iter()
+            .map(|d| format!("{}:{}", d.source.name, d.source.tag))
+            .collect();
+        assert_eq!(
+            sources,
+            ["backbone:v1", "commander:v1", "arm_sim:v1", "sim_mujoco:v1"]
+        );
+        let _ = report;
+        // The base adjustment reached the engine instance.
+        let sim = flat
+            .deployments
+            .iter()
+            .find(|d| d.source.name == "sim_mujoco")
+            .unwrap();
+        assert_eq!(
+            sim.instances[0].arguments.get("hardware_version"),
+            Some(&config::AnyType::String("v2".to_owned()))
+        );
+        // And the relay fragment's adjustment reached the base's backbone.
+        let backbone = flat
+            .deployments
+            .iter()
+            .find(|d| d.source.name == "backbone")
+            .unwrap();
+        assert_eq!(
+            backbone.instances[0].arguments.get("max_ee_velocity_m_s"),
+            Some(&config::AnyType::Float(0.5))
+        );
+        assert_eq!(report.selection.echo(), "robot=mujoco  recorder=(off)");
+    }
+
+    #[test]
+    fn fragments_merge_into_a_base_deployment_of_the_same_source() {
+        let dir = tempdir().unwrap();
+        write(&dir.path().join("fragments/cam.json5"), &fragment_file(r#"
+            deployments: [
+                { source: { name: "camera", tag: "v1" },
+                  instances: [{ instance_id: "wrist" }] },
+            ],
+        "#));
+        let launcher = write(&dir.path().join("l.json5"), r#"{
+            peppy_schema: "launcher/v1",
+            components: [
+                { name: "cams", optional: true, provides: ["wrist"],
+                  options: { on: "fragments/cam.json5" } },
+            ],
+            deployments: [
+                { source: { name: "camera", tag: "v1" },
+                  instances: [{ instance_id: "chest" }] },
+            ],
+        }"#);
+        let parsed = parse_launcher(&fs::read_to_string(&launcher).unwrap());
+        let (flat, _) = compose(&parsed, &launcher, &["on".to_string()]).expect("composes");
+        assert_eq!(flat.deployments.len(), 1);
+        assert_eq!(flat.deployments[0].source.name, "camera");
+        let ids: Vec<&str> = flat.deployments[0]
+            .instances
+            .iter()
+            .map(|i| i.instance_id.as_str())
+            .collect();
+        assert_eq!(ids, ["chest", "wrist"]);
+    }
+
+    #[test]
+    fn a_duplicate_instance_id_names_both_origins() {
+        let dir = tempdir().unwrap();
+        write(&dir.path().join("fragments/dup.json5"), &fragment_file(r#"
+            deployments: [
+                { source: { name: "other", tag: "v1" },
+                  instances: [{ instance_id: "arm_inst" }] },
+            ],
+        "#));
+        let launcher = write(&dir.path().join("l.json5"), r#"{
+            peppy_schema: "launcher/v1",
+            components: [
+                { name: "robot", optional: true, provides: ["arm_inst"],
+                  options: { sim: "fragments/dup.json5" } },
+            ],
+            deployments: [
+                { source: { name: "can_arm", tag: "v1" },
+                  instances: [{ instance_id: "arm_inst" }] },
+            ],
+        }"#);
+        let parsed = parse_launcher(&fs::read_to_string(&launcher).unwrap());
+        let err = compose(&parsed, &launcher, &["sim".to_string()]).expect_err("duplicate id");
+        assert!(err.to_string().contains("arm_inst"), "got: {err}");
+        assert!(err.to_string().contains("l.json5"), "got: {err}");
+        assert!(err.to_string().contains("fragments/dup.json5"), "got: {err}");
+    }
+
+    #[test]
+    fn add_links_appends_across_fragments_in_order() {
+        let dir = tempdir().unwrap();
+        write(&dir.path().join("fragments/a.json5"), &fragment_file(r#"
+            deployments: [],
+            adjustments: [
+                { target: "panel", add_links: { observers: ["a_inst"] } },
+            ],
+        "#));
+        write(&dir.path().join("fragments/b.json5"), &fragment_file(r#"
+            deployments: [],
+            adjustments: [
+                { target: "panel", add_links: { observers: ["b_inst"] } },
+            ],
+        "#));
+        let launcher = write(&dir.path().join("l.json5"), r#"{
+            peppy_schema: "launcher/v1",
+            components: [
+                { name: "a", optional: true, options: { on: "fragments/a.json5" } },
+                { name: "b", optional: true, options: { on: "fragments/b.json5" } },
+            ],
+            deployments: [
+                { source: { name: "panel", tag: "v1" },
+                  instances: [{ instance_id: "panel",
+                                links: { observers: ["seed_inst"] } }] },
+                { source: { name: "seed", tag: "v1" }, instances: [{ instance_id: "seed_inst" }] },
+                { source: { name: "a", tag: "v1" }, instances: [{ instance_id: "a_inst" }] },
+                { source: { name: "b", tag: "v1" }, instances: [{ instance_id: "b_inst" }] },
+            ],
+        }"#);
+        let parsed = parse_launcher(&fs::read_to_string(&launcher).unwrap());
+        let (flat, report) = compose(&parsed, &launcher, &["a=on".to_string(), "b=on".to_string()])
+            .expect("composes");
+        let panel = &flat.deployments[0].instances[0];
+        let LinkValue::Bound(Selection::Array(targets)) = &panel.links["observers"] else {
+            panic!("observers stays an array binding");
+        };
+        assert_eq!(targets.as_slice(), ["seed_inst", "a_inst", "b_inst"]);
+        let added: Vec<&str> = report
+            .applied
+            .iter()
+            .filter(|a| a.field == "links.observers")
+            .map(|a| match &a.change {
+                AppliedChange::Added { target } => target.as_str(),
+                _ => "",
+            })
+            .collect();
+        assert_eq!(added, ["a_inst", "b_inst"]);
+    }
+
+    #[test]
+    fn add_links_refuses_a_scalar_and_a_vacancy() {
+        for (slot_value, holds) in [
+            ("\"x_inst\"", "a scalar binding"),
+            ("{ vacant: \"nothing here\" }", "a vacancy"),
+        ] {
+            let dir = tempdir().unwrap();
+            write(
+                &dir.path().join("fragments/a.json5"),
+                &fragment_file(
+                    r#"adjustments: [ { target: "panel", add_links: { observers: ["a_inst"] } } ],"#,
+                ),
+            );
+            let launcher = write(
+                &dir.path().join("l.json5"),
+                &format!(
+                    r#"{{
+                        peppy_schema: "launcher/v1",
+                        components: [
+                            {{ name: "a", optional: true, options: {{ on: "fragments/a.json5" }} }},
+                        ],
+                        deployments: [
+                            {{ source: {{ name: "panel", tag: "v1" }},
+                              instances: [{{ instance_id: "panel",
+                                            links: {{ observers: {slot_value} }} }}] }},
+                            {{ source: {{ name: "a", tag: "v1" }}, instances: [{{ instance_id: "a_inst" }}] }},
+                        ],
+                    }}"#
+                ),
+            );
+            let parsed = parse_launcher(&fs::read_to_string(&launcher).unwrap());
+            let err = compose(&parsed, &launcher, &words(&["on"]))
+                .expect_err("appending past a non-array must be refused");
+            let CompositionError::AddLinksOnNonArray { holds: actual, .. } = &err else {
+                panic!("expected AddLinksOnNonArray, got: {err}");
+            };
+            assert_eq!(*actual, holds);
+        }
+    }
+
+    #[test]
+    fn add_links_refuses_a_target_already_bound() {
+        let dir = tempdir().unwrap();
+        write(&dir.path().join("fragments/a.json5"), &fragment_file(r#"
+            adjustments: [ { target: "panel", add_links: { observers: ["seed_inst"] } } ],
+        "#));
+        let launcher = write(&dir.path().join("l.json5"), r#"{
+            peppy_schema: "launcher/v1",
+            components: [
+                { name: "a", optional: true, options: { on: "fragments/a.json5" } },
+            ],
+            deployments: [
+                { source: { name: "panel", tag: "v1" },
+                  instances: [{ instance_id: "panel",
+                                links: { observers: ["seed_inst"] } }] },
+            ],
+        }"#);
+        let parsed = parse_launcher(&fs::read_to_string(&launcher).unwrap());
+        let err = compose(&parsed, &launcher, &["on".to_string()]).expect_err("duplicate add");
+        assert!(err.to_string().contains("seed_inst"), "got: {err}");
+    }
+
+    #[test]
+    fn two_fragments_writing_one_key_are_refused() {
+        let dir = tempdir().unwrap();
+        write(&dir.path().join("fragments/a.json5"), &fragment_file(r#"
+            adjustments: [ { target: "panel", set_arguments: { rate: 10 } } ],
+        "#));
+        write(&dir.path().join("fragments/b.json5"), &fragment_file(r#"
+            adjustments: [ { target: "panel", set_arguments: { rate: 20 } } ],
+        "#));
+        let launcher = write(&dir.path().join("l.json5"), r#"{
+            peppy_schema: "launcher/v1",
+            components: [
+                { name: "a", optional: true, options: { on: "fragments/a.json5" } },
+                { name: "b", optional: true, options: { on: "fragments/b.json5" } },
+            ],
+            deployments: [
+                { source: { name: "panel", tag: "v1" }, instances: [{ instance_id: "panel" }] },
+            ],
+        }"#);
+        let parsed = parse_launcher(&fs::read_to_string(&launcher).unwrap());
+        let err = compose(&parsed, &launcher, &["a=on".to_string(), "b=on".to_string()])
+            .expect_err("fragments must not fight");
+        let CompositionError::AdjustmentsConflict { field, first, second, .. } = &err else {
+            panic!("expected AdjustmentsConflict, got: {err}");
+        };
+        assert_eq!(field, "arguments.rate");
+        assert!(first.contains("a.json5") && second.contains("b.json5"), "got: {first} / {second}");
+    }
+
+    #[test]
+    fn the_base_overrides_a_fragment_and_a_later_base_entry_wins() {
+        let dir = tempdir().unwrap();
+        write(&dir.path().join("fragments/a.json5"), &fragment_file(r#"
+            adjustments: [ { target: "panel", set_arguments: { rate: 10 } } ],
+        "#));
+        let launcher = write(&dir.path().join("l.json5"), r#"{
+            peppy_schema: "launcher/v1",
+            components: [
+                { name: "a", optional: true, options: { on: "fragments/a.json5" } },
+            ],
+            adjustments: [
+                { target: "panel", set_arguments: { rate: 20 } },
+                { target: "panel", set_arguments: { rate: 30 } },
+            ],
+            deployments: [
+                { source: { name: "panel", tag: "v1" }, instances: [{ instance_id: "panel" }] },
+            ],
+        }"#);
+        let parsed = parse_launcher(&fs::read_to_string(&launcher).unwrap());
+        let (flat, report) = compose(&parsed, &launcher, &["on".to_string()]).expect("composes");
+        assert_eq!(
+            flat.deployments[0].instances[0].arguments.get("rate"),
+            Some(&config::AnyType::Int(30))
+        );
+        // Both base entries and the fragment's contribution are visible.
+        let rates: Vec<String> = report
+            .applied
+            .iter()
+            .filter(|a| a.field == "arguments.rate")
+            .map(|a| match &a.change {
+                AppliedChange::Set { old, new } => format!("{}->{}", old.clone().unwrap_or_default(), new),
+                _ => String::new(),
+            })
+            .collect();
+        assert_eq!(rates, ["(absent)->10", "10->20", "20->30"]);
+    }
+
+    #[test]
+    fn guards_skip_and_absent_targets_skip() {
+        let dir = tempdir().unwrap();
+        write(&dir.path().join("fragments/xr.json5"), &fragment_file(r#"
+            deployments: [
+                { source: { name: "xr", tag: "v1" },
+                  instances: [{ instance_id: "leader_inst" }] },
+            ],
+            adjustments: [
+                { target: "backbone_inst",
+                  set_arguments: { upstream_mode: "pose" } },
+            ],
+        "#));
+        write(&dir.path().join("fragments/rec.json5"), &fragment_file(r#"
+            deployments: [
+                { source: { name: "rec", tag: "v1" },
+                  instances: [{ instance_id: "recorder_inst" }] },
+            ],
+            adjustments: [
+                // A shape condition: only the XR leader pairs with the
+                // backbone this way.
+                { target: "backbone_inst", when: { commander: "xr" },
+                  set_arguments: { record_backbone: true } },
+                // Reaches into whichever robot was selected; skipped when the
+                // robot is real and no sim_inst exists.
+                { target: "sim_inst",
+                  set_arguments: { state_rate_hz: 50 } },
+            ],
+        "#));
+        let launcher = write(&dir.path().join("l.json5"), r#"{
+            peppy_schema: "launcher/v1",
+            components: [
+                { name: "commander", default: "web",
+                  options: { web: { deployments: [] }, xr: "fragments/xr.json5" } },
+                { name: "recorder", optional: true,
+                  options: { on: "fragments/rec.json5" } },
+                { name: "robot", default: "real",
+                  options: {
+                      real: { deployments: [] },
+                      mujoco: { deployments: [
+                          { source: { name: "sim_mujoco", tag: "v1" },
+                            instances: [{ instance_id: "sim_inst" }] } ] },
+                  } },
+            ],
+            deployments: [
+                { source: { name: "backbone", tag: "v1" },
+                  instances: [{ instance_id: "backbone_inst" }] },
+            ],
+        }"#);
+        let parsed = parse_launcher(&fs::read_to_string(&launcher).unwrap());
+
+        // web + recorder: the guard is not met and sim_inst is absent, so
+        // both of the recorder fragment's adjustments skip.
+        let (flat, report) = compose(&parsed, &launcher, &words(&["recorder=on"]))
+            .expect("composes");
+        assert_eq!(report.skipped.len(), 2);
+        assert!(report.skipped.iter().any(|s| matches!(
+            s.reason,
+            SkipReason::GuardNotMet(ref g) if g == "commander=xr"
+        )));
+        assert!(report.skipped.iter().any(|s| matches!(
+            s.reason,
+            SkipReason::TargetAbsent
+        )));
+        let backbone = flat
+            .deployments
+            .iter()
+            .find(|d| d.source.name == "backbone")
+            .unwrap();
+        assert!(!backbone.instances[0].arguments.contains_key("record_backbone"));
+
+        // xr + recorder: the guard holds and its target exists, so it
+        // applies; sim_inst is still absent and still skips.
+        let (flat, report) = compose(
+            &parsed,
+            &launcher,
+            &words(&["commander=xr", "recorder=on"]),
+        )
+        .expect("composes");
+        assert!(report
+            .skipped
+            .iter()
+            .all(|s| matches!(s.reason, SkipReason::TargetAbsent)));
+        let backbone = flat
+            .deployments
+            .iter()
+            .find(|d| d.source.name == "backbone")
+            .unwrap();
+        assert_eq!(
+            backbone.instances[0].arguments.get("record_backbone"),
+            Some(&config::AnyType::Bool(true))
+        );
+
+        // xr + recorder + mujoco: every target exists, nothing skips.
+        let (_, report) = compose(
+            &parsed,
+            &launcher,
+            &words(&["commander=xr", "recorder=on", "robot=mujoco"]),
+        )
+        .expect("composes");
+        assert!(report.skipped.is_empty());
+    }
+
+    #[test]
+    fn an_option_missing_a_provides_id_is_refused() {
+        let dir = tempdir().unwrap();
+        write(&dir.path().join("fragments/bad.json5"), &fragment_file(r#"
+            deployments: [
+                { source: { name: "other", tag: "v1" }, instances: [{ instance_id: "wrong_inst" }] },
+            ],
+        "#));
+        let launcher = write(&dir.path().join("l.json5"), r#"{
+            peppy_schema: "launcher/v1",
+            components: [
+                { name: "robot", provides: ["arm_inst"],
+                  options: { sim: "fragments/bad.json5" } },
+            ],
+            deployments: [],
+        }"#);
+        let parsed = parse_launcher(&fs::read_to_string(&launcher).unwrap());
+        let err = compose(&parsed, &launcher, &["sim".to_string()]).expect_err("provides unmet");
+        let CompositionError::ProvidesUnmet { axis, option, id } = &err else {
+            panic!("expected ProvidesUnmet, got: {err}");
+        };
+        assert_eq!((axis.as_str(), option.as_str(), id.as_str()), ("robot", "sim", "arm_inst"));
+    }
+
+    #[test]
+    fn an_adjustment_target_defined_nowhere_is_refused() {
+        let dir = tempdir().unwrap();
+        write(&dir.path().join("fragments/a.json5"), &fragment_file(r#"
+            adjustments: [ { target: "ghost_inst", set_arguments: { x: 1 } } ],
+        "#));
+        let launcher = write(&dir.path().join("l.json5"), r#"{
+            peppy_schema: "launcher/v1",
+            components: [
+                { name: "a", optional: true, options: { on: "fragments/a.json5" } },
+            ],
+            deployments: [],
+        }"#);
+        let parsed = parse_launcher(&fs::read_to_string(&launcher).unwrap());
+        let err = compose(&parsed, &launcher, &["on".to_string()]).expect_err("dead target");
+        let CompositionError::TargetDefinedNowhere { target, .. } = &err else {
+            panic!("expected TargetDefinedNowhere, got: {err}");
+        };
+        assert_eq!(target, "ghost_inst");
+    }
+
+    #[test]
+    fn unsafe_fragment_paths_are_refused() {
+        for raw in ["/etc/passwd", "../outside.json5", "./here.json5", ""] {
+            let dir = tempdir().unwrap();
+            let spec = FragmentSpec(vec![super::super::composition::FragmentPart::File(
+                raw.to_owned(),
+            )]);
+            let mut axis = ComponentAxis {
+                name: "robot".to_owned(),
+                options: BTreeMap::from([("sim".to_owned(), spec)]),
+                default: None,
+                optional: false,
+                provides: Vec::new(),
+            };
+            axis.default = None;
+            let launcher = PeppyLauncher {
+                peppy_schema: config::schema::PeppySchema::LauncherV1,
+                core_nodes: Vec::new(),
+                deployments: Vec::new(),
+                components: vec![axis],
+                adjustments: Vec::new(),
+            };
+            let err = compose(&launcher, &dir.path().join("l.json5"), &["sim".to_string()])
+                .expect_err("unsafe path must be refused");
+            assert!(
+                err.to_string().contains("not usable") || err.to_string().contains("cannot be read"),
+                "raw path {raw:?}: got: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_symlink_escaping_the_launcher_directory_is_refused() {
+        let dir = tempdir().unwrap();
+        let outside = tempdir().unwrap();
+        write(&outside.path().join("escape.json5"), &fragment_file("deployments: []"));
+        fs::create_dir_all(dir.path().join("fragments")).unwrap();
+        std::os::unix::fs::symlink(
+            outside.path().join("escape.json5"),
+            dir.path().join("fragments/escape.json5"),
+        )
+        .unwrap();
+        let launcher = write(&dir.path().join("l.json5"), r#"{
+            peppy_schema: "launcher/v1",
+            components: [
+                { name: "robot", optional: true,
+                  options: { sim: "fragments/escape.json5" } },
+            ],
+            deployments: [],
+        }"#);
+        let parsed = parse_launcher(&fs::read_to_string(&launcher).unwrap());
+        let err = compose(&parsed, &launcher, &["sim".to_string()]).expect_err("escape refused");
+        assert!(err.to_string().contains("escapes"), "got: {err}");
+    }
+
+    #[test]
+    fn core_nodes_union_base_first() {
+        let dir = tempdir().unwrap();
+        write(&dir.path().join("fragments/a.json5"), &fragment_file(r#"
+            core_nodes: ["edge", "cloud"],
+        "#));
+        let launcher = write(&dir.path().join("l.json5"), r#"{
+            peppy_schema: "launcher/v1",
+            components: [
+                { name: "a", optional: true, options: { on: "fragments/a.json5" } },
+            ],
+            core_nodes: ["cloud", "base"],
+            deployments: [],
+        }"#);
+        let parsed = parse_launcher(&fs::read_to_string(&launcher).unwrap());
+        let (flat, _) = compose(&parsed, &launcher, &["on".to_string()]).expect("composes");
+        assert_eq!(flat.core_nodes, ["cloud", "base", "edge"]);
+    }
+
+    // -- selection resolution ------------------------------------------------
+
+    fn axes_from(body: &str) -> Vec<ComponentAxis> {
+        serde_json5::from_str(body).expect("axes parse")
+    }
+
+    #[test]
+    fn an_unknown_word_lists_every_axis_with_its_options() {
+        let axes = axes_from(
+            r#"[{ name: "robot", options: { real: { deployments: [] }, mujoco: { deployments: [] } } },
+                { name: "commander", options: { web: { deployments: [] } } }]"#,
+        );
+        let err = resolve_selection(&axes, &["isaac".to_string()]).expect_err("unknown word");
+        let CompositionError::UnknownSelection { menu, .. } = &err else {
+            panic!("expected UnknownSelection, got: {err}");
+        };
+        assert!(menu.contains("robot"), "got: {menu}");
+        assert!(menu.contains("`mujoco`, `real`"), "got: {menu}");
+        assert!(menu.contains("commander"), "got: {menu}");
+    }
+
+    #[test]
+    fn an_ambiguous_bare_word_names_the_axes() {
+        let axes = axes_from(
+            r#"[{ name: "robot", default: "none", options: { none: { deployments: [] } } },
+                { name: "recorder", default: "none", options: { none: { deployments: [] } } }]"#,
+        );
+        let err = resolve_selection(&axes, &["none".to_string()]).expect_err("ambiguous word");
+        let CompositionError::AmbiguousSelection { axes: named, .. } = &err else {
+            panic!("expected AmbiguousSelection, got: {err}");
+        };
+        assert!(named.contains("`robot`") && named.contains("`recorder`"), "got: {named}");
+        // The explicit form resolves.
+        resolve_selection(&axes, &["robot=none".to_string()]).expect("explicit form");
+    }
+
+    #[test]
+    fn two_different_options_on_one_axis_are_refused() {
+        let axes = axes_from(
+            r#"[{ name: "robot", options: { real: { deployments: [] }, mujoco: { deployments: [] } } }]"#,
+        );
+        let err = resolve_selection(
+            &axes,
+            &["mujoco".to_string(), "robot=real".to_string()],
+        )
+        .expect_err("conflicting selection");
+        let CompositionError::ConflictingSelection { axis, first, second } = &err else {
+            panic!("expected ConflictingSelection, got: {err}");
+        };
+        assert_eq!((axis.as_str(), first.as_str(), second.as_str()), ("robot", "mujoco", "real"));
+        // Repeating the same option is the same choice, not a conflict.
+        resolve_selection(
+            &axes,
+            &["mujoco".to_string(), "robot=mujoco".to_string()],
+        )
+        .expect("same option twice is one choice");
+    }
+
+    #[test]
+    fn a_required_axis_with_no_default_refuses() {
+        let axes = axes_from(
+            r#"[{ name: "robot", options: { real: { deployments: [] }, mujoco: { deployments: [] } } }]"#,
+        );
+        let err = resolve_selection(&axes, &[]).expect_err("unresolved axis");
+        let CompositionError::UnresolvedAxis { axis, options, .. } = &err else {
+            panic!("expected UnresolvedAxis, got: {err}");
+        };
+        assert_eq!(axis, "robot");
+        assert!(options.contains("`real`"), "got: {options}");
+    }
+
+    #[test]
+    fn the_selection_space_enumerates_options_then_unfilled() {
+        let axes = axes_from(
+            r#"[
+                { name: "robot", options: { real: {}, sim: {} } },
+                { name: "recorder", optional: true, options: { on: {} } },
+            ]"#,
+        );
+        let selections = enumerate_selections(&axes);
+        assert_eq!(selections.len(), 4);
+        assert_eq!(selection_space_size(&axes), 4);
+        // Fixed order: options in name order, unfilled last on each axis.
+        assert_eq!(selections[0].echo(), "robot=real  recorder=on");
+        assert_eq!(selections[1].echo(), "robot=real  recorder=(off)");
+        assert_eq!(selections[3].echo(), "robot=sim  recorder=(off)");
+    }
+
+    #[test]
+    fn with_on_a_flat_launcher_is_refused() {
+        let launcher = parse_launcher(
+            r#"{ peppy_schema: "launcher/v1", deployments: [] }"#,
+        );
+        let err = compose(&launcher, Path::new("/tmp/x.json5"), &["mujoco".to_string()])
+            .expect_err("flat launcher has nothing to select");
+        assert!(matches!(err, CompositionError::WithOnFlatLauncher));
+    }
+}

--- a/crates/daemon-config-internal/src/launcher/types.rs
+++ b/crates/daemon-config-internal/src/launcher/types.rs
@@ -1,3 +1,4 @@
+use super::composition::{Adjustment, ComponentAxis};
 use crate::error::StructuredError;
 use crate::internal::contract::validate_named_items;
 use crate::internal::core_node_name::{CoreNodeName, SELF_CORE_NODE};
@@ -29,6 +30,24 @@ pub struct PeppyLauncher {
     pub core_nodes: Vec<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub deployments: Vec<Deployment>,
+    /// The component axes of a composed launcher: what `--with` selects
+    /// between. Empty for a flat stack, which is the ordinary way to write a
+    /// one-off and parses with today's exact semantics.
+    ///
+    /// A launcher that declares axes is a FAMILY of stacks, not one: its base
+    /// `deployments` may link instance ids only an option defines, so the
+    /// whole-document cross-checks a flat launcher gets below (every link
+    /// target names a known instance, every `core_node` names a declared
+    /// link) are deferred to the flattened result, where the selected
+    /// options' deployments are part of the document.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub components: Vec<ComponentAxis>,
+    /// The base's changes to instances defined elsewhere, applied after all
+    /// fragment adjustments. How a base specializes fragments shared between
+    /// launchers. Requires `components`: with nothing to specialize, an
+    /// adjustment is indirection around a file the author can edit directly.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub adjustments: Vec<Adjustment>,
 }
 
 /// Custom deserialization for [`PeppyLauncher`] that, after the default
@@ -37,6 +56,11 @@ pub struct PeppyLauncher {
 /// points at an unknown instance is rejected with a structured
 /// [`StructuredError::UnknownInstanceId`] so callers see a path-aware
 /// message instead of a generic serde error.
+///
+/// A COMPOSED launcher (one declaring `components`) gets the same shape
+/// checks per fragment but not the cross-instance ones: its base links may
+/// name ids only a selected option defines, so those checks run once, on
+/// the flattened document.
 impl<'de> Deserialize<'de> for PeppyLauncher {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -51,78 +75,110 @@ impl<'de> Deserialize<'de> for PeppyLauncher {
             core_nodes: Vec<String>,
             #[serde(default)]
             deployments: Vec<Deployment>,
+            #[serde(default)]
+            components: Vec<ComponentAxis>,
+            #[serde(default)]
+            adjustments: Vec<Adjustment>,
         }
 
         let raw = RawPeppyLauncher::deserialize(deserializer)?;
 
         validate_core_node_links(&raw.core_nodes).map_err(de::Error::custom)?;
-
-        // A `core_node` must name a declared link. Checking it here, once the
-        // whole document is parsed, is what lets the error say WHICH links
-        // were available instead of just that this one was not one of them.
-        let declared: HashSet<&str> = raw.core_nodes.iter().map(String::as_str).collect();
-        for deployment in &raw.deployments {
-            for instance in &deployment.instances {
-                let Some(core_node) = &instance.core_node else {
-                    continue;
-                };
-                if declared.contains(core_node.as_str()) {
-                    continue;
-                }
-                return Err(de::Error::custom(undeclared_core_node_message(
-                    instance.instance_id.as_str(),
-                    core_node,
-                    &raw.core_nodes,
-                )));
-            }
+        super::composition::validate_axes(&raw.components).map_err(de::Error::custom)?;
+        super::composition::validate_launcher_adjustments(&raw.adjustments, &raw.components)
+            .map_err(de::Error::custom)?;
+        if raw.components.is_empty() && !raw.adjustments.is_empty() {
+            return Err(de::Error::custom(
+                "this launcher declares `adjustments` but no `components`: with nothing to \
+                 specialize, an adjustment is indirection around a file the author can edit \
+                 directly. Move the values into the instances themselves, or declare the axes \
+                 the adjustments specialize",
+            ));
         }
 
-        let known_ids: HashSet<&str> = raw
-            .deployments
-            .iter()
-            .flat_map(|d| d.instances.iter())
-            .map(|i| i.instance_id.as_str())
-            .collect();
-
-        for deployment in &raw.deployments {
-            for instance in &deployment.instances {
-                for (link, value) in &instance.links {
-                    if link == DEFAULT_LINK_ID_SENTINEL {
-                        let err = StructuredError::LinkSentinelKey {
-                            owner_instance_id: instance.instance_id.to_string(),
-                            link: link.clone(),
-                        };
-                        return Err(de::Error::custom(err.json5_message()));
-                    }
-                    // Only the instance part of a target names a deployed
-                    // instance; a pairing/observer target's optional
-                    // `/<link_id>` suffix selects a slot on that instance and
-                    // is resolved (against the manifest) at plan time. A vacant
-                    // slot selects nothing, so it names no instance to check.
-                    let Some(selection) = value.selection() else {
-                        continue;
-                    };
-                    for target in selection.targets() {
-                        let (target_instance, _link_suffix) = split_link_target(target);
-                        if !known_ids.contains(target_instance) {
-                            let err = StructuredError::UnknownInstanceId {
-                                owner_instance_id: instance.instance_id.to_string(),
-                                link: link.clone(),
-                                instance_id: target_instance.to_string(),
-                            };
-                            return Err(de::Error::custom(err.json5_message()));
-                        }
-                    }
-                }
-            }
+        if raw.components.is_empty() {
+            cross_check_flat_document(&raw.deployments, &raw.core_nodes).map_err(de::Error::custom)?;
         }
 
         Ok(PeppyLauncher {
             peppy_schema: raw.peppy_schema,
             core_nodes: raw.core_nodes,
             deployments: raw.deployments,
+            components: raw.components,
+            adjustments: raw.adjustments,
         })
     }
+}
+
+/// The whole-document cross-checks of a flat launcher: every `core_node`
+/// names a declared link, no link key is the reserved producer-default
+/// sentinel, and every link target names a known instance. Extracted from
+/// [`PeppyLauncher`]'s deserializer so the composed arm of that deserializer
+/// can defer exactly these checks to the flattened document.
+fn cross_check_flat_document(
+    deployments: &[Deployment],
+    core_nodes: &[String],
+) -> Result<(), String> {
+    // A `core_node` must name a declared link. Checking it here, once the
+    // whole document is parsed, is what lets the error say WHICH links
+    // were available instead of just that this one was not one of them.
+    let declared: HashSet<&str> = core_nodes.iter().map(String::as_str).collect();
+    for deployment in deployments {
+        for instance in &deployment.instances {
+            let Some(core_node) = &instance.core_node else {
+                continue;
+            };
+            if declared.contains(core_node.as_str()) {
+                continue;
+            }
+            return Err(undeclared_core_node_message(
+                instance.instance_id.as_str(),
+                core_node,
+                core_nodes,
+            ));
+        }
+    }
+
+    let known_ids: HashSet<&str> = deployments
+        .iter()
+        .flat_map(|d| d.instances.iter())
+        .map(|i| i.instance_id.as_str())
+        .collect();
+
+    for deployment in deployments {
+        for instance in &deployment.instances {
+            for (link, value) in &instance.links {
+                if link == DEFAULT_LINK_ID_SENTINEL {
+                    let err = StructuredError::LinkSentinelKey {
+                        owner_instance_id: instance.instance_id.to_string(),
+                        link: link.clone(),
+                    };
+                    return Err(err.json5_message());
+                }
+                // Only the instance part of a target names a deployed
+                // instance; a pairing/observer target's optional
+                // `/<link_id>` suffix selects a slot on that instance and
+                // is resolved (against the manifest) at plan time. A vacant
+                // slot selects nothing, so it names no instance to check.
+                let Some(selection) = value.selection() else {
+                    continue;
+                };
+                for target in selection.targets() {
+                    let (target_instance, _link_suffix) = split_link_target(target);
+                    if !known_ids.contains(target_instance) {
+                        let err = StructuredError::UnknownInstanceId {
+                            owner_instance_id: instance.instance_id.to_string(),
+                            link: link.clone(),
+                            instance_id: target_instance.to_string(),
+                        };
+                        return Err(err.json5_message());
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
 }
 
 /// Core node link ids are unique, never the reserved `self`, and spelled like

--- a/crates/daemon-config-internal/src/launcher/types.rs
+++ b/crates/daemon-config-internal/src/launcher/types.rs
@@ -32,7 +32,7 @@ pub struct PeppyLauncher {
     pub deployments: Vec<Deployment>,
     /// The component axes of a composed launcher: what `--with` selects
     /// between. Empty for a flat stack, which is the ordinary way to write a
-    /// one-off and parses with today's exact semantics.
+    /// one-off.
     ///
     /// A launcher that declares axes is a FAMILY of stacks, not one: its base
     /// `deployments` may link instance ids only an option defines, so the
@@ -85,8 +85,10 @@ impl<'de> Deserialize<'de> for PeppyLauncher {
 
         validate_core_node_links(&raw.core_nodes).map_err(de::Error::custom)?;
         super::composition::validate_axes(&raw.components).map_err(de::Error::custom)?;
-        super::composition::validate_launcher_adjustments(&raw.adjustments, &raw.components)
-            .map_err(de::Error::custom)?;
+        // Checked before the per-adjustment validation: a flat launcher with
+        // adjustments should hear that adjustments do not belong here, not
+        // that one of its guards names an axis the (empty) `components` list
+        // does not declare.
         if raw.components.is_empty() && !raw.adjustments.is_empty() {
             return Err(de::Error::custom(
                 "this launcher declares `adjustments` but no `components`: with nothing to \
@@ -95,9 +97,12 @@ impl<'de> Deserialize<'de> for PeppyLauncher {
                  the adjustments specialize",
             ));
         }
+        super::composition::validate_launcher_adjustments(&raw.adjustments, &raw.components)
+            .map_err(de::Error::custom)?;
 
         if raw.components.is_empty() {
-            cross_check_flat_document(&raw.deployments, &raw.core_nodes).map_err(de::Error::custom)?;
+            cross_check_flat_document(&raw.deployments, &raw.core_nodes)
+                .map_err(de::Error::custom)?;
         }
 
         Ok(PeppyLauncher {

--- a/crates/daemon-config-internal/src/lib.rs
+++ b/crates/daemon-config-internal/src/lib.rs
@@ -91,13 +91,17 @@ pub mod peppy_config {
 // -- launcher --
 pub mod launcher {
     pub use crate::internal::launcher::{
-        AlreadyPairedSlots, BindingValidationItem, Deployment, DeploymentInstance,
+        Adjustment, AlreadyPairedSlots, AppliedAdjustment, AppliedChange, BindingValidationItem,
+        ComponentAxis, ComponentSelection, CompositionError, Deployment, DeploymentInstance,
         DeploymentSource, DuplicateLinkTarget, EmptyVacantReason, ExternallyCoveredSlots,
-        FrameworkOverrides, LinkTargets, LinkValue, PairingValidationItem, PeppyLauncher,
+        FlattenReport, Fragment, FragmentPart, FragmentSpec, FrameworkOverrides, LauncherFragment,
+        LauncherFragmentParser, LinkTargets, LinkValue, PairingValidationItem, PeppyLauncher,
         PeppyLauncherParser, Placements, PlannedObservation, PlannedPairEndpoint, PlannedPairing,
-        Selection, VacantReason, ValidatedBindings, ValidatedLinkPlan, ValidatedObservations,
-        ValidatedPairings, participant_vacancies, split_link_target, validate_bindings,
-        validate_link_plan, validate_link_slots, validate_observations, validate_pairings,
+        Selection, SelectionEntry, SelectionSource, SkipReason, SkippedAdjustment, VacantReason,
+        ValidatedBindings, ValidatedLinkPlan, ValidatedObservations, ValidatedPairings, compose,
+        enumerate_selections, flatten, load_composition, participant_vacancies, resolve_selection,
+        selection_space_size, split_link_target, validate_bindings, validate_link_plan,
+        validate_link_slots, validate_observations, validate_pairings,
     };
 }
 

--- a/crates/daemon-config-internal/src/lib.rs
+++ b/crates/daemon-config-internal/src/lib.rs
@@ -97,11 +97,10 @@ pub mod launcher {
         FlattenReport, Fragment, FragmentPart, FragmentSpec, FrameworkOverrides, LauncherFragment,
         LauncherFragmentParser, LinkTargets, LinkValue, PairingValidationItem, PeppyLauncher,
         PeppyLauncherParser, Placements, PlannedObservation, PlannedPairEndpoint, PlannedPairing,
-        Selection, SelectionEntry,
-        SelectionSource, SkipReason, SkippedAdjustment, VacantReason, ValidatedBindings,
-        ValidatedLinkPlan, ValidatedObservations, ValidatedPairings, check_composition, compose,
-        participant_vacancies, split_link_target, validate_bindings, validate_link_plan,
-        validate_link_slots, validate_observations, validate_pairings,
+        Selection, SelectionEntry, SelectionSource, SkipReason, SkippedAdjustment, VacantReason,
+        ValidatedBindings, ValidatedLinkPlan, ValidatedObservations, ValidatedPairings,
+        check_composition, compose, participant_vacancies, split_link_target, validate_bindings,
+        validate_link_plan, validate_link_slots, validate_observations, validate_pairings,
     };
 }
 

--- a/crates/daemon-config-internal/src/lib.rs
+++ b/crates/daemon-config-internal/src/lib.rs
@@ -97,10 +97,10 @@ pub mod launcher {
         FlattenReport, Fragment, FragmentPart, FragmentSpec, FrameworkOverrides, LauncherFragment,
         LauncherFragmentParser, LinkTargets, LinkValue, PairingValidationItem, PeppyLauncher,
         PeppyLauncherParser, Placements, PlannedObservation, PlannedPairEndpoint, PlannedPairing,
-        Selection, SelectionEntry, SelectionSource, SkipReason, SkippedAdjustment, VacantReason,
-        ValidatedBindings, ValidatedLinkPlan, ValidatedObservations, ValidatedPairings, compose,
-        enumerate_selections, flatten, load_composition, participant_vacancies, resolve_selection,
-        selection_space_size, split_link_target, validate_bindings, validate_link_plan,
+        Selection, SelectionEntry,
+        SelectionSource, SkipReason, SkippedAdjustment, VacantReason, ValidatedBindings,
+        ValidatedLinkPlan, ValidatedObservations, ValidatedPairings, check_composition, compose,
+        participant_vacancies, split_link_target, validate_bindings, validate_link_plan,
         validate_link_slots, validate_observations, validate_pairings,
     };
 }

--- a/crates/daemon-config-internal/src/repository/types.rs
+++ b/crates/daemon-config-internal/src/repository/types.rs
@@ -427,13 +427,6 @@ impl RepositoryIndex {
             RepoItemKind::Contract => &mut self.contracts,
             RepoItemKind::Pairing => &mut self.pairings,
             RepoItemKind::McpExposure => &mut self.mcp_exposures,
-            RepoItemKind::LauncherFragment => {
-                return Err(format!(
-                    "fragment `{name}` cannot be declared in a repository index: a fragment \
-                     is referenced by the launcher whose option names it, never listed \
-                     alongside the stacks"
-                ));
-            }
         };
         let Some(tag) = tag else {
             return Err(format!("{kind} `{name}` has no tag"));

--- a/crates/daemon-config-internal/src/repository/types.rs
+++ b/crates/daemon-config-internal/src/repository/types.rs
@@ -427,6 +427,13 @@ impl RepositoryIndex {
             RepoItemKind::Contract => &mut self.contracts,
             RepoItemKind::Pairing => &mut self.pairings,
             RepoItemKind::McpExposure => &mut self.mcp_exposures,
+            RepoItemKind::LauncherFragment => {
+                return Err(format!(
+                    "fragment `{name}` cannot be declared in a repository index: a fragment \
+                     is referenced by the launcher whose option names it, never listed \
+                     alongside the stacks"
+                ));
+            }
         };
         let Some(tag) = tag else {
             return Err(format!("{kind} `{name}` has no tag"));

--- a/crates/peppy/src/commands/stack.rs
+++ b/crates/peppy/src/commands/stack.rs
@@ -41,21 +41,8 @@ pub enum StackCommands {
         /// against a federated topology with no second machine.
         #[arg(long)]
         local: bool,
-        /// Select one option of the launcher's declared `components` axes:
-        /// `option` or `axis=option`. Repeatable and comma-separated; every
-        /// axis left unselected takes its default.
-        ///
-        /// The words travel to the coordinator verbatim, like `--local`:
-        /// only the daemon holds a repository launcher's document, so only
-        /// it knows which axes exist.
-        #[arg(
-            long = "with",
-            value_name = "option|axis=option",
-            value_delimiter = ',',
-            value_parser = parse_with_word,
-            action = clap::ArgAction::Append
-        )]
-        with: Vec<String>,
+        #[command(flatten)]
+        with: WithSelection,
         /// Idle timeout in seconds for the node add phase (resets on git/http progress or sub-process output)
         #[arg(long, default_value_t = DEFAULT_IDLE_TIMEOUT_SECS)]
         node_add_idle_timeout_secs: u64,
@@ -82,17 +69,8 @@ pub enum StackCommands {
     Resolve {
         /// Path to the peppy launcher configuration file
         launcher_config_path: PathBuf,
-        /// Select one option of the launcher's declared `components` axes:
-        /// `option` or `axis=option`. Repeatable and comma-separated; every
-        /// axis left unselected takes its default.
-        #[arg(
-            long = "with",
-            value_name = "option|axis=option",
-            value_delimiter = ',',
-            value_parser = parse_with_word,
-            action = clap::ArgAction::Append
-        )]
-        with: Vec<String>,
+        #[command(flatten)]
+        with: WithSelection,
     },
     /// Tear the node stack down to an empty state.
     ///
@@ -139,6 +117,28 @@ fn parse_place_kv(raw: &str) -> Result<(String, String), String> {
     crate::commands::node::parse_key_at_target(raw, "--place", "CORE_NODE_LINK@CORE_NODE")
 }
 
+/// The `--with` selection, stated once for every subcommand that takes one:
+/// `stack launch` and `stack resolve` must accept exactly the same words,
+/// because resolve's output is the advertised preview of a launch.
+#[derive(clap::Args, Default)]
+pub struct WithSelection {
+    /// Select one option of the launcher's declared `components` axes:
+    /// `option` or `axis=option`. Repeatable and comma-separated; every
+    /// axis left unselected takes its default.
+    ///
+    /// The words travel to the coordinator verbatim, like `--local`:
+    /// only the daemon holds a repository launcher's document, so only
+    /// it knows which axes exist.
+    #[arg(
+        long = "with",
+        value_name = "option|axis=option",
+        value_delimiter = ',',
+        value_parser = parse_with_word,
+        action = clap::ArgAction::Append
+    )]
+    pub words: Vec<String>,
+}
+
 /// One `--with` word: `option` or `axis=option`, never blank. Which axes and
 /// options exist is the coordinator's to say (it holds the document), so the
 /// CLI checks only that the word says something.
@@ -166,7 +166,7 @@ impl Command for StackCommand {
             StackCommands::Resolve {
                 launcher_config_path,
                 with,
-            } => resolve::resolve(ctx, launcher_config_path, with),
+            } => resolve::resolve(ctx, launcher_config_path, with.words),
             StackCommands::Launch {
                 launcher_config_path,
                 place,
@@ -185,7 +185,7 @@ impl Command for StackCommand {
                         places: place,
                         local,
                     },
-                    with,
+                    with.words,
                     node_add_idle_timeout_secs,
                     node_build_idle_timeout_secs,
                     node_run_idle_timeout_secs,

--- a/crates/peppy/src/commands/stack.rs
+++ b/crates/peppy/src/commands/stack.rs
@@ -3,9 +3,11 @@ mod colors;
 mod launch;
 mod list;
 mod reset;
+mod resolve;
 mod table;
 
 pub use list::{StackListReport, list_nodes_collecting};
+pub use resolve::resolve_rendered;
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -39,6 +41,21 @@ pub enum StackCommands {
         /// against a federated topology with no second machine.
         #[arg(long)]
         local: bool,
+        /// Select one option of the launcher's declared `components` axes:
+        /// `option` or `axis=option`. Repeatable and comma-separated; every
+        /// axis left unselected takes its default.
+        ///
+        /// The words travel to the coordinator verbatim, like `--local`:
+        /// only the daemon holds a repository launcher's document, so only
+        /// it knows which axes exist.
+        #[arg(
+            long = "with",
+            value_name = "option|axis=option",
+            value_delimiter = ',',
+            value_parser = parse_with_word,
+            action = clap::ArgAction::Append
+        )]
+        with: Vec<String>,
         /// Idle timeout in seconds for the node add phase (resets on git/http progress or sub-process output)
         #[arg(long, default_value_t = DEFAULT_IDLE_TIMEOUT_SECS)]
         node_add_idle_timeout_secs: u64,
@@ -55,6 +72,28 @@ pub enum StackCommands {
     },
     /// List the nodes in the current node stack
     List,
+    /// Print the flat launcher a composed launch would run, and the report
+    /// of what the selection did.
+    ///
+    /// Needs no running stack and touches nothing: the flattened
+    /// `launcher/v1` document goes to stdout, so it doubles as the escape
+    /// hatch (flatten, hand-edit, launch the flat file), while the
+    /// resolution report goes to stderr.
+    Resolve {
+        /// Path to the peppy launcher configuration file
+        launcher_config_path: PathBuf,
+        /// Select one option of the launcher's declared `components` axes:
+        /// `option` or `axis=option`. Repeatable and comma-separated; every
+        /// axis left unselected takes its default.
+        #[arg(
+            long = "with",
+            value_name = "option|axis=option",
+            value_delimiter = ',',
+            value_parser = parse_with_word,
+            action = clap::ArgAction::Append
+        )]
+        with: Vec<String>,
+    },
     /// Tear the node stack down to an empty state.
     ///
     /// Clears the targeted daemon alone: its stack slice, and any federated
@@ -100,6 +139,21 @@ fn parse_place_kv(raw: &str) -> Result<(String, String), String> {
     crate::commands::node::parse_key_at_target(raw, "--place", "CORE_NODE_LINK@CORE_NODE")
 }
 
+/// One `--with` word: `option` or `axis=option`, never blank. Which axes and
+/// options exist is the coordinator's to say (it holds the document), so the
+/// CLI checks only that the word says something.
+fn parse_with_word(raw: &str) -> Result<String, String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err(format!(
+            "a --with entry is `option` or `axis=option`, never blank (check for a stray comma \
+             in \"{}\")",
+            raw
+        ));
+    }
+    Ok(trimmed.to_owned())
+}
+
 pub struct StackCommand {
     pub command: StackCommands,
 }
@@ -109,10 +163,15 @@ impl Command for StackCommand {
         match self.command {
             StackCommands::List => list::list_nodes(ctx),
             StackCommands::Reset { federated } => reset::reset_stack(ctx, federated),
+            StackCommands::Resolve {
+                launcher_config_path,
+                with,
+            } => resolve::resolve(ctx, launcher_config_path, with),
             StackCommands::Launch {
                 launcher_config_path,
                 place,
                 local,
+                with,
                 node_add_idle_timeout_secs,
                 node_build_idle_timeout_secs,
                 node_run_idle_timeout_secs,
@@ -126,6 +185,7 @@ impl Command for StackCommand {
                         places: place,
                         local,
                     },
+                    with,
                     node_add_idle_timeout_secs,
                     node_build_idle_timeout_secs,
                     node_run_idle_timeout_secs,

--- a/crates/peppy/src/commands/stack/launch.rs
+++ b/crates/peppy/src/commands/stack/launch.rs
@@ -314,8 +314,7 @@ async fn launch_async(
     // COORDINATOR read, so that a repository launcher and a file one resolve identically.
     if let LauncherOrigin::Fs(path) = &launcher_origin {
         let parsed = PeppyLauncherParser::from_path(path).map_err(Error::DaemonConfig)?;
-        compose(&parsed, path, &with)
-            .map_err(|e| Error::ExecutionFailed(e.to_string()))?;
+        compose(&parsed, path, &with).map_err(|e| Error::ExecutionFailed(e.to_string()))?;
     }
 
     let conn = ctx.connect_to_daemon().await?;

--- a/crates/peppy/src/commands/stack/launch.rs
+++ b/crates/peppy/src/commands/stack/launch.rs
@@ -9,7 +9,7 @@ use core_node_api::encoding::{
     LauncherOrigin, NodeAddLogEntry, NodeBuildLogEntry, NodeRunLogEntry, PlacementSpec,
 };
 use daemon_config::core_node_name::CoreNodeName;
-use daemon_config::launcher::PeppyLauncherParser;
+use daemon_config::launcher::{PeppyLauncherParser, compose};
 use peppylib::ActionMessenger;
 use peppylib::messaging::ResultStatus;
 use tracing::info;
@@ -186,7 +186,7 @@ fn resolve_launcher_path(path: PathBuf) -> PathBuf {
 /// finds it regardless of its working directory. A bare name like `openarm01_sim_teleop` first
 /// tries the filesystem (sibling `.json5` shorthand from `resolve_launcher_path`) and only
 /// falls back to `Repository` when no file exists at that name.
-fn infer_launcher_origin(input: PathBuf) -> Result<LauncherOrigin> {
+pub(super) fn infer_launcher_origin(input: PathBuf) -> Result<LauncherOrigin> {
     if looks_like_fs_path(&input) {
         let resolved = resolve_launcher_path(input);
         let canonical = resolved.canonicalize().map_err(|e| {
@@ -275,6 +275,7 @@ pub fn launch(
     ctx: &Arc<AppContext>,
     launcher_config_path: PathBuf,
     placement: PlacementArgs,
+    with: Vec<String>,
     node_add_idle_timeout_secs: u64,
     node_build_idle_timeout_secs: u64,
     node_run_idle_timeout_secs: u64,
@@ -284,6 +285,7 @@ pub fn launch(
         ctx,
         launcher_config_path,
         placement,
+        with,
         node_add_idle_timeout_secs,
         node_build_idle_timeout_secs,
         node_run_idle_timeout_secs,
@@ -295,6 +297,7 @@ async fn launch_async(
     ctx: &Arc<AppContext>,
     launcher_config_path: PathBuf,
     placement: PlacementArgs,
+    with: Vec<String>,
     node_add_idle_timeout_secs: u64,
     node_build_idle_timeout_secs: u64,
     node_run_idle_timeout_secs: u64,
@@ -304,11 +307,13 @@ async fn launch_async(
 
     // Pre-validate the launcher config locally for `Fs` so the user gets a fast, precise parse
     // error before the daemon round-trip. `Repository` resolution lives daemon-side, so we
-    // skip the local check rather than duplicate the lookup here. Only the parse verdict is
-    // used: placement is resolved against the document the COORDINATOR read, so that a
-    // repository launcher and a file one place identically.
+    // skip the local check rather than duplicate the lookup here. Only the verdict is
+    // used: placement and the `--with` selection are resolved against the document the
+    // COORDINATOR read, so that a repository launcher and a file one resolve identically.
     if let LauncherOrigin::Fs(path) = &launcher_origin {
-        PeppyLauncherParser::from_path(path).map_err(Error::DaemonConfig)?;
+        let parsed = PeppyLauncherParser::from_path(path).map_err(Error::DaemonConfig)?;
+        compose(&parsed, path, &with)
+            .map_err(|e| Error::ExecutionFailed(e.to_string()))?;
     }
 
     let conn = ctx.connect_to_daemon().await?;
@@ -377,7 +382,8 @@ async fn launch_async(
         max_timeout_secs,
     )
     .with_env_vars(caller_env_overrides())
-    .with_placement(placement);
+    .with_placement(placement)
+    .with_selections(with);
 
     // CLI fallback ceiling: when the user opts into a max we grant the daemon a response-grace
     // window to surface its own error first, but never less than the absolute floor in case the

--- a/crates/peppy/src/commands/stack/launch.rs
+++ b/crates/peppy/src/commands/stack/launch.rs
@@ -271,6 +271,7 @@ impl PlacementArgs {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn launch(
     ctx: &Arc<AppContext>,
     launcher_config_path: PathBuf,
@@ -293,6 +294,7 @@ pub fn launch(
     ))
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn launch_async(
     ctx: &Arc<AppContext>,
     launcher_config_path: PathBuf,

--- a/crates/peppy/src/commands/stack/resolve.rs
+++ b/crates/peppy/src/commands/stack/resolve.rs
@@ -19,7 +19,11 @@ use crate::error::{Error, Result};
 /// `launcher/v1` document goes to stdout, so it doubles as the escape
 /// hatch: flatten, hand-edit, launch the flat file. The resolution report
 /// goes to stderr.
-pub fn resolve(_ctx: &Arc<AppContext>, launcher_config_path: PathBuf, with: Vec<String>) -> Result<()> {
+pub fn resolve(
+    _ctx: &Arc<AppContext>,
+    launcher_config_path: PathBuf,
+    with: Vec<String>,
+) -> Result<()> {
     let (document, report) = resolve_rendered(launcher_config_path, &with)?;
     for line in report {
         eprintln!("{line}");
@@ -37,12 +41,12 @@ pub fn resolve_rendered(
 ) -> Result<(String, Vec<String>)> {
     let path = match infer_launcher_origin(launcher_config_path)? {
         LauncherOrigin::Fs(path) => path,
-        LauncherOrigin::Repository { name } => core_node::resolve_repo_launcher_path(
-            &name,
-            &PeppyDirs::default(),
-            &|message: &str| info!("{message}"),
-        )
-        .map_err(Error::ExecutionFailed)?,
+        LauncherOrigin::Repository { name } => {
+            core_node::resolve_repo_launcher_path(&name, &PeppyDirs::default(), &|message: &str| {
+                info!("{message}")
+            })
+            .map_err(Error::ExecutionFailed)?
+        }
     };
 
     let parsed = PeppyLauncherParser::from_path(&path).map_err(Error::DaemonConfig)?;

--- a/crates/peppy/src/commands/stack/resolve.rs
+++ b/crates/peppy/src/commands/stack/resolve.rs
@@ -1,0 +1,55 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use core_node_api::encoding::LauncherOrigin;
+use daemon_config::consts::PeppyDirs;
+use daemon_config::launcher::{PeppyLauncherParser, compose};
+use tracing::info;
+
+use super::launch::infer_launcher_origin;
+use crate::context::AppContext;
+use crate::error::{Error, Result};
+
+/// `peppy stack resolve <name|path> [--with ...]`: print the flat launcher
+/// a composed launch would run, and the report of what the selection did.
+///
+/// Needs no running stack and touches nothing. A filesystem input is read
+/// where it stands; a repository name resolves through this machine's
+/// launcher cache, exactly as a launch would, minus the goal. The flattened
+/// `launcher/v1` document goes to stdout, so it doubles as the escape
+/// hatch: flatten, hand-edit, launch the flat file. The resolution report
+/// goes to stderr.
+pub fn resolve(_ctx: &Arc<AppContext>, launcher_config_path: PathBuf, with: Vec<String>) -> Result<()> {
+    let (document, report) = resolve_rendered(launcher_config_path, &with)?;
+    for line in report {
+        eprintln!("{line}");
+    }
+    println!("{document}");
+    Ok(())
+}
+
+/// The resolve command's whole verdict in printable form: the flattened
+/// document for stdout and the report lines for stderr. Split from
+/// [`resolve`] so a test can read the output instead of capturing stdout.
+pub fn resolve_rendered(
+    launcher_config_path: PathBuf,
+    with: &[String],
+) -> Result<(String, Vec<String>)> {
+    let path = match infer_launcher_origin(launcher_config_path)? {
+        LauncherOrigin::Fs(path) => path,
+        LauncherOrigin::Repository { name } => core_node::resolve_repo_launcher_path(
+            &name,
+            &PeppyDirs::default(),
+            &|message: &str| info!("{message}"),
+        )
+        .map_err(Error::ExecutionFailed)?,
+    };
+
+    let parsed = PeppyLauncherParser::from_path(&path).map_err(Error::DaemonConfig)?;
+    let (flat, report) =
+        compose(&parsed, &path, with).map_err(|e| Error::ExecutionFailed(e.to_string()))?;
+
+    let document = json5_pretty::to_string_pretty(&flat)
+        .map_err(|e| Error::ExecutionFailed(format!("cannot serialize the flat launcher: {e}")))?;
+    Ok((document, report.render_lines()))
+}

--- a/crates/peppy/tests/mcp_full_stack.rs
+++ b/crates/peppy/tests/mcp_full_stack.rs
@@ -561,6 +561,7 @@ async fn a_launcher_deploys_the_exposure_and_a_client_walks_it() {
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
+            with: Vec::new(),
             launcher_config_path: launcher_path,
             node_add_idle_timeout_secs: 120,
             node_build_idle_timeout_secs: 120,

--- a/crates/peppy/tests/mcp_full_stack.rs
+++ b/crates/peppy/tests/mcp_full_stack.rs
@@ -561,7 +561,7 @@ async fn a_launcher_deploys_the_exposure_and_a_client_walks_it() {
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
-            with: Vec::new(),
+            with: Default::default(),
             launcher_config_path: launcher_path,
             node_add_idle_timeout_secs: 120,
             node_build_idle_timeout_secs: 120,

--- a/crates/peppy/tests/stack_launch.rs
+++ b/crates/peppy/tests/stack_launch.rs
@@ -264,6 +264,7 @@ async fn node_launch_command_succeed() {
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
+            with: Vec::new(),
             launcher_config_path: launcher_path,
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
@@ -465,6 +466,7 @@ async fn node_launch_command_fails_when_node_never_becomes_healthy_and_clears_st
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
+            with: Vec::new(),
             launcher_config_path: launcher_path,
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
@@ -622,6 +624,7 @@ async fn node_launch_fails_when_node_build_idle_timeout_is_hit() {
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
+            with: Vec::new(),
             launcher_config_path: harness.launcher_path.clone(),
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 1,
@@ -662,6 +665,7 @@ async fn node_launch_fails_when_node_run_idle_timeout_is_hit() {
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
+            with: Vec::new(),
             launcher_config_path: harness.launcher_path.clone(),
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
@@ -710,6 +714,7 @@ async fn node_launch_fails_when_max_timeout_is_hit() {
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
+            with: Vec::new(),
             launcher_config_path: harness.launcher_path.clone(),
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
@@ -910,6 +915,7 @@ async fn stack_launch_populates_link_ids_from_launcher_bindings() {
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
+            with: Vec::new(),
             launcher_config_path: launcher_path,
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
@@ -1137,6 +1143,7 @@ async fn stack_launch_binds_multi_cardinality_slot_to_ordered_producer_set() {
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
+            with: Vec::new(),
             launcher_config_path: launcher_path,
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
@@ -1278,6 +1285,7 @@ async fn stack_launch_rejects_array_binding_on_a_one_slot() {
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
+            with: Vec::new(),
             launcher_config_path: launcher_path,
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
@@ -1375,6 +1383,7 @@ async fn stack_launch_rejects_stack_wide_duplicate_instance_id() {
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
+            with: Vec::new(),
             launcher_config_path: launcher_path,
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
@@ -1673,6 +1682,7 @@ async fn stack_launch_resolves_implements_binding_with_real_contract_doc() {
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
+            with: Vec::new(),
             launcher_config_path: launcher_path,
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
@@ -1825,6 +1835,7 @@ async fn stack_launch_rejects_binding_when_producer_omits_implements() {
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
+            with: Vec::new(),
             launcher_config_path: launcher_path,
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
@@ -1968,6 +1979,7 @@ async fn stack_launch_rejects_binding_with_wrong_tag_in_implements() {
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
+            with: Vec::new(),
             launcher_config_path: launcher_path,
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
@@ -2245,6 +2257,7 @@ async fn stack_launch_binds_contract_slots_in_both_directions() {
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
+            with: Vec::new(),
             launcher_config_path: launcher_path,
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
@@ -2504,6 +2517,7 @@ async fn stack_launch_binds_one_zero_or_one_instance_and_vacates_another() {
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
+            with: Vec::new(),
             launcher_config_path: launcher_path,
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
@@ -2654,6 +2668,7 @@ async fn stack_launch_rejects_unbound_slot() {
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
+            with: Vec::new(),
             launcher_config_path: launcher_path,
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
@@ -2850,6 +2865,7 @@ async fn stack_launch_establishes_launcher_pairings() {
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
+            with: Vec::new(),
             launcher_config_path: launcher_path,
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
@@ -3031,6 +3047,7 @@ async fn stack_launch_pairs_one_instance_and_vacates_another_of_the_same_node() 
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
+            with: Vec::new(),
             launcher_config_path: launcher_path,
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
@@ -3285,6 +3302,7 @@ async fn stack_launch_delivers_observer_member_sets() {
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
+            with: Vec::new(),
             launcher_config_path: launcher_path,
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
@@ -3451,6 +3469,7 @@ async fn stack_launch_rejects_uncovered_pairing_slot() {
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
+            with: Vec::new(),
             launcher_config_path: launcher_path,
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
@@ -3505,6 +3524,7 @@ async fn stack_launch_rejects_a_path_shaped_deployment_source() {
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
+            with: Vec::new(),
             launcher_config_path: launcher_path,
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
@@ -3768,6 +3788,7 @@ async fn stack_launch_serves_a_commander_panels_observer_slots() {
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
+            with: Vec::new(),
             launcher_config_path: launcher_path,
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
@@ -4022,6 +4043,7 @@ async fn stack_launch_allows_absent_node_dependency_on_an_empty_admitting_slot()
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
+            with: Vec::new(),
             launcher_config_path: launcher_path,
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
@@ -4178,6 +4200,7 @@ async fn stack_launch_still_requires_vacancy_for_an_absent_zero_or_one_dependenc
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
+            with: Vec::new(),
             launcher_config_path: launcher_path,
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
@@ -4195,5 +4218,370 @@ async fn stack_launch_still_requires_vacancy_for_an_absent_zero_or_one_dependenc
     assert!(
         !msg.contains("does not exist in the stack"),
         "the absent node itself is admitted; only the slot coverage is refused: {msg}"
+    );
+}
+
+/// A composed launch, end to end: the launcher declares a `backend` axis
+/// whose two options deploy the same registered node under different
+/// instance ids, and an optional `extras` axis whose fragment adjusts both
+/// candidates (one of which is absent in any given selection, so the launch
+/// also exercises the skip). `--with` picks beta and the extras; what runs
+/// is the flattened single deployment, and the coordinator echoes the full
+/// resolution before anything starts.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn stack_launch_flattens_a_composed_launcher() {
+    let serve = ServeCommandEmulation::with_mock()
+        .await
+        .expect("failed to create serve emulation");
+    let shared_messenger = serve.messenger();
+    let core_node_name = serve.core_node_name().to_string();
+
+    let nodes_dir = tempfile::tempdir().expect("failed to create temp nodes directory");
+    let node_name = "compose_flip_node";
+    let node_tag = "v1";
+    let instance_id = "beta_inst";
+    let git_hash = read_daemon_git_hash(serve.daemon_state_path());
+    let node_path = write_node_config(
+        nodes_dir.path(),
+        node_name,
+        node_tag,
+        &git_hash,
+        &["sh", "-c", "exit 0"],
+    );
+    // The launched instance must outlive the post-launch stack-list check,
+    // so tie it to the test instead of a fixed sleep.
+    let instances = peppy::test_support::InstanceLifetime::new();
+    peppy::test_support::override_run_cmd_while(
+        &node_path.join(NODE_CONFIG_FILE),
+        &instances.sentinel(),
+    );
+    // Model a node that releases its keep-alive when asked to shut down, so
+    // the teardown at the end of the test does not wait out a grace period.
+    let (_shutdown_handle, shutdown_rx) = peppylib::services::shutdown::listen_for_shutdown(
+        &MessengerHandle::from_shared(Arc::clone(&shared_messenger)),
+        &core_node_name,
+        instance_id,
+        test_node_target(node_name),
+    )
+    .await
+    .expect("node shutdown service should start");
+    tokio::spawn(async move {
+        let _ = shutdown_rx.await;
+        drop(instances);
+    });
+
+    let ctx = Arc::new(
+        AppContext::with_messenger(nodes_dir.path(), Arc::clone(&shared_messenger))
+            .with_daemon_state_file(serve.daemon_state_path()),
+    );
+
+    let log_capture = LogCapture::new();
+    let subscriber = tracing_subscriber::fmt()
+        .with_ansi(false)
+        .without_time()
+        .with_writer(log_capture.clone())
+        .finish();
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    register_repo_caches(serve.temp_dir(), &[(node_name, node_tag, &node_path)]);
+
+    let node_messenger = MessengerHandle::from_shared(Arc::clone(&shared_messenger));
+    let instance_id = "beta_inst";
+    let _node_ready_handle = listen_for_node_ready(
+        &node_messenger,
+        &core_node_name,
+        instance_id,
+        test_node_target(node_name),
+    )
+    .await
+    .expect("node ready service should start");
+    let _node_health_handle = listen_for_node_health(
+        &node_messenger,
+        &core_node_name,
+        instance_id,
+        test_node_target(node_name),
+    )
+    .await
+    .expect("node health service should start");
+
+    let launcher_path = nodes_dir.path().join("composed_launcher.json5");
+    let deployment = |instance_id: &str| {
+        format!(
+            r#"{{
+                source: {{ name: "{node_name}:{node_tag}" }},
+                instances: [{{ instance_id: "{instance_id}" }}]
+            }}"#
+        )
+    };
+    let launcher_json5 = format!(
+        r#"{{
+            peppy_schema: "launcher/v1",
+            components: [
+                {{
+                    name: "backend",
+                    default: "alpha",
+                    options: {{
+                        alpha: {{ deployments: [{}] }},
+                        beta: {{ deployments: [{}] }},
+                    }},
+                }},
+                {{
+                    name: "extras",
+                    optional: true,
+                    options: {{
+                        on: "fragments/extras.json5",
+                    }},
+                }},
+            ],
+            deployments: [],
+        }}"#,
+        deployment("alpha_inst"),
+        deployment("beta_inst"),
+    );
+    fs::write(&launcher_path, launcher_json5).expect("launcher config should be writable");
+    fs::create_dir_all(nodes_dir.path().join("fragments"))
+        .expect("fragments dir should be writable");
+    fs::write(
+        nodes_dir.path().join("fragments/extras.json5"),
+        r#"{
+            peppy_schema: "launcher_fragment/v1",
+            adjustments: [
+                { target: "alpha_inst", set_arguments: { tuned: true } },
+                { target: "beta_inst", set_arguments: { tuned: true } },
+            ],
+        }"#,
+    )
+    .expect("fragment should be writable");
+
+    StackCommand {
+        command: StackCommands::Launch {
+            place: Vec::new(),
+            local: false,
+            with: vec!["beta".to_owned(), "extras=on".to_owned()],
+            launcher_config_path: launcher_path,
+            node_add_idle_timeout_secs: 60,
+            node_build_idle_timeout_secs: 60,
+            node_run_idle_timeout_secs: 60,
+            max_timeout_secs: Some(120),
+        },
+    }
+    .execute(&ctx)
+    .expect("composed launch should succeed");
+
+    let logs = log_capture.logs();
+    assert!(
+        logs.contains("components: backend=beta  extras=on"),
+        "the coordinator's echo of the full resolution should reach the CLI: {logs}"
+    );
+
+    let messenger_handle = ctx
+        .messenger_handle()
+        .expect("messenger handle should be available");
+    let response = poll(
+        &StackListRequest::new(),
+        &messenger_handle,
+        &core_node_name,
+        CALLER_INSTANCE_ID,
+        &core_node_name,
+        Duration::from_secs(5),
+    )
+    .await
+    .expect("stack_list request should complete after launch");
+
+    let graph: SerializedNodeGraph =
+        serde_json::from_str(&response.graph_json).expect("graph_json should parse");
+    let running: Vec<String> = graph
+        .nodes
+        .iter()
+        .flat_map(|node| node.running_instance_ids())
+        .map(str::to_owned)
+        .collect();
+    assert!(
+        running.iter().any(|id| id == "beta_inst"),
+        "the selected option's instance should be running. Got: {running:?}"
+    );
+    assert!(
+        running.iter().all(|id| id != "alpha_inst"),
+        "the unselected option's instance must not exist. Got: {running:?}"
+    );
+}
+
+/// The words a `--with` sends are refused fast, caller-side, when the
+/// launcher on disk can already say they are wrong: a flat launcher has
+/// nothing to select, an unknown word names no option, and two options on
+/// one axis are two answers to one question. Each refusal happens before
+/// the daemon round-trip, naming what the operator should have typed.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn stack_launch_refuses_broken_selections_before_the_daemon_round_trip() {
+    let serve = ServeCommandEmulation::with_mock()
+        .await
+        .expect("failed to create serve emulation");
+
+    let nodes_dir = tempfile::tempdir().expect("failed to create temp nodes directory");
+    let ctx = Arc::new(
+        AppContext::with_messenger(nodes_dir.path(), Arc::clone(&serve.messenger()))
+            .with_daemon_state_file(serve.daemon_state_path()),
+    );
+
+    let flat_launcher = nodes_dir.path().join("flat.json5");
+    fs::write(
+        &flat_launcher,
+        r#"{ peppy_schema: "launcher/v1", deployments: [] }"#,
+    )
+    .expect("flat launcher should be writable");
+    let err = StackCommand {
+        command: StackCommands::Launch {
+            place: Vec::new(),
+            local: false,
+            with: vec!["mujoco".to_owned()],
+            launcher_config_path: flat_launcher,
+            node_add_idle_timeout_secs: 60,
+            node_build_idle_timeout_secs: 60,
+            node_run_idle_timeout_secs: 60,
+            max_timeout_secs: Some(60),
+        },
+    }
+    .execute(&ctx)
+    .expect_err("--with on a flat launcher must be refused");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("declares no `components`"),
+        "the refusal should say what is missing: {msg}"
+    );
+
+    let composed_launcher = nodes_dir.path().join("composed.json5");
+    fs::write(
+        &composed_launcher,
+        r#"{
+            peppy_schema: "launcher/v1",
+            components: [
+                { name: "robot", default: "real",
+                  options: { real: { deployments: [] }, mujoco: { deployments: [] } } },
+                { name: "recorder", optional: true,
+                  options: { on: { deployments: [] } } },
+            ],
+            deployments: [],
+        }"#,
+    )
+    .expect("composed launcher should be writable");
+
+    let launch_with = |with: Vec<String>, path: PathBuf| {
+        StackCommand {
+            command: StackCommands::Launch {
+                place: Vec::new(),
+                local: false,
+                with,
+                launcher_config_path: path,
+                node_add_idle_timeout_secs: 60,
+                node_build_idle_timeout_secs: 60,
+                node_run_idle_timeout_secs: 60,
+                max_timeout_secs: Some(60),
+            },
+        }
+        .execute(&ctx)
+    };
+
+    let msg = launch_with(vec!["isaac".to_owned()], composed_launcher.clone())
+        .expect_err("an unknown word must be refused")
+        .to_string();
+    assert!(
+        msg.contains("isaac") && msg.contains("`mujoco`, `real`") && msg.contains("`on`"),
+        "the refusal should list every axis with its options: {msg}"
+    );
+
+    let msg = launch_with(
+        vec!["mujoco".to_owned(), "robot=real".to_owned()],
+        composed_launcher.clone(),
+    )
+    .expect_err("two options on one axis must be refused")
+    .to_string();
+    assert!(
+        msg.contains("robot") && msg.contains("`mujoco`") && msg.contains("`real`"),
+        "the refusal should name the axis and both options: {msg}"
+    );
+}
+
+/// `peppy stack resolve` needs no daemon: for a filesystem launcher it reads
+/// the file where it stands, flattens the selection, and hands back the
+/// plain `launcher/v1` document plus the audit report. The document is what
+/// a launch would run; the report shows applied and skipped adjustments,
+/// each with its origin.
+#[test]
+fn stack_resolve_prints_the_flat_launcher_and_report() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    std::fs::create_dir_all(dir.path().join("fragments")).expect("fragments dir");
+    std::fs::write(
+        dir.path().join("fragments/recorder.json5"),
+        r#"{
+            peppy_schema: "launcher_fragment/v1",
+            deployments: [
+                { source: { name: "recorder", tag: "v1" },
+                  instances: [{ instance_id: "recorder_inst" }] },
+            ],
+            adjustments: [
+                { target: "panel_inst", add_links: { recorder: ["recorder_inst"] } },
+            ],
+        }"#,
+    )
+    .expect("fragment");
+    let launcher = dir.path().join("panel.json5");
+    std::fs::write(
+        &launcher,
+        r#"{
+            peppy_schema: "launcher/v1",
+            components: [
+                { name: "robot", default: "real",
+                  options: {
+                      real: { deployments: [] },
+                      mujoco: { deployments: [
+                          { source: { name: "sim", tag: "v1" },
+                            instances: [{ instance_id: "sim_inst" }] } ] },
+                  } },
+                { name: "recorder", optional: true,
+                  provides: ["recorder_inst"],
+                  options: { on: "fragments/recorder.json5" } },
+            ],
+            adjustments: [
+                { target: "sim_inst", set_arguments: { hardware_version: "v2" } },
+            ],
+            deployments: [
+                { source: { name: "panel", tag: "v1" },
+                  instances: [{ instance_id: "panel_inst",
+                                links: { recorder: [] } }] },
+            ],
+        }"#,
+    )
+    .expect("launcher");
+
+    let (document, report) =
+        peppy::commands::stack::resolve_rendered(launcher, &["recorder=on".to_owned()])
+            .expect("resolves");
+
+    assert!(
+        document.contains("recorder_inst") && document.contains("panel_inst"),
+        "the flat document carries the base and the selected fragment: {document}"
+    );
+    assert!(
+        !document.contains("components"),
+        "the flat document is an ordinary launcher with no composition keys: {document}"
+    );
+    assert!(
+        document.contains("\"launcher/v1\""),
+        "the document still declares the launcher schema: {document}"
+    );
+
+    let report_text = report.join("\\n");
+    assert!(
+        report_text.contains("components: robot=real (default)  recorder=on"),
+        "the report leads with the resolution: {report_text}"
+    );
+    assert!(
+        report_text.contains("panel_inst.links.recorder")
+            && report_text.contains("fragments/recorder.json5"),
+        "the applied attach is listed with its origin: {report_text}"
+    );
+    assert!(
+        report_text.contains("sim_inst") && report_text.contains("not in this selection"),
+        "the base's sleeping adjustment is listed as skipped: {report_text}"
     );
 }

--- a/crates/peppy/tests/stack_launch.rs
+++ b/crates/peppy/tests/stack_launch.rs
@@ -13,7 +13,7 @@ use core_node_api::SerializedNodeGraph;
 use core_node_api::encoding::StackListRequest;
 use peppy::commands::Command;
 use peppy::commands::node::{NodeCommand, NodeCommands};
-use peppy::commands::stack::{StackCommand, StackCommands};
+use peppy::commands::stack::{StackCommand, StackCommands, WithSelection};
 use peppy::context::AppContext;
 use peppylib::MessengerHandle;
 use peppylib::services::health::listen_for_node_health;
@@ -264,7 +264,7 @@ async fn node_launch_command_succeed() {
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
-            with: Vec::new(),
+            with: Default::default(),
             launcher_config_path: launcher_path,
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
@@ -466,7 +466,7 @@ async fn node_launch_command_fails_when_node_never_becomes_healthy_and_clears_st
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
-            with: Vec::new(),
+            with: Default::default(),
             launcher_config_path: launcher_path,
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
@@ -624,7 +624,7 @@ async fn node_launch_fails_when_node_build_idle_timeout_is_hit() {
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
-            with: Vec::new(),
+            with: Default::default(),
             launcher_config_path: harness.launcher_path.clone(),
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 1,
@@ -665,7 +665,7 @@ async fn node_launch_fails_when_node_run_idle_timeout_is_hit() {
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
-            with: Vec::new(),
+            with: Default::default(),
             launcher_config_path: harness.launcher_path.clone(),
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
@@ -714,7 +714,7 @@ async fn node_launch_fails_when_max_timeout_is_hit() {
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
-            with: Vec::new(),
+            with: Default::default(),
             launcher_config_path: harness.launcher_path.clone(),
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
@@ -915,7 +915,7 @@ async fn stack_launch_populates_link_ids_from_launcher_bindings() {
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
-            with: Vec::new(),
+            with: Default::default(),
             launcher_config_path: launcher_path,
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
@@ -1143,7 +1143,7 @@ async fn stack_launch_binds_multi_cardinality_slot_to_ordered_producer_set() {
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
-            with: Vec::new(),
+            with: Default::default(),
             launcher_config_path: launcher_path,
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
@@ -1285,7 +1285,7 @@ async fn stack_launch_rejects_array_binding_on_a_one_slot() {
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
-            with: Vec::new(),
+            with: Default::default(),
             launcher_config_path: launcher_path,
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
@@ -1383,7 +1383,7 @@ async fn stack_launch_rejects_stack_wide_duplicate_instance_id() {
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
-            with: Vec::new(),
+            with: Default::default(),
             launcher_config_path: launcher_path,
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
@@ -1682,7 +1682,7 @@ async fn stack_launch_resolves_implements_binding_with_real_contract_doc() {
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
-            with: Vec::new(),
+            with: Default::default(),
             launcher_config_path: launcher_path,
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
@@ -1835,7 +1835,7 @@ async fn stack_launch_rejects_binding_when_producer_omits_implements() {
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
-            with: Vec::new(),
+            with: Default::default(),
             launcher_config_path: launcher_path,
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
@@ -1979,7 +1979,7 @@ async fn stack_launch_rejects_binding_with_wrong_tag_in_implements() {
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
-            with: Vec::new(),
+            with: Default::default(),
             launcher_config_path: launcher_path,
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
@@ -2257,7 +2257,7 @@ async fn stack_launch_binds_contract_slots_in_both_directions() {
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
-            with: Vec::new(),
+            with: Default::default(),
             launcher_config_path: launcher_path,
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
@@ -2517,7 +2517,7 @@ async fn stack_launch_binds_one_zero_or_one_instance_and_vacates_another() {
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
-            with: Vec::new(),
+            with: Default::default(),
             launcher_config_path: launcher_path,
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
@@ -2668,7 +2668,7 @@ async fn stack_launch_rejects_unbound_slot() {
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
-            with: Vec::new(),
+            with: Default::default(),
             launcher_config_path: launcher_path,
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
@@ -2865,7 +2865,7 @@ async fn stack_launch_establishes_launcher_pairings() {
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
-            with: Vec::new(),
+            with: Default::default(),
             launcher_config_path: launcher_path,
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
@@ -3047,7 +3047,7 @@ async fn stack_launch_pairs_one_instance_and_vacates_another_of_the_same_node() 
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
-            with: Vec::new(),
+            with: Default::default(),
             launcher_config_path: launcher_path,
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
@@ -3302,7 +3302,7 @@ async fn stack_launch_delivers_observer_member_sets() {
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
-            with: Vec::new(),
+            with: Default::default(),
             launcher_config_path: launcher_path,
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
@@ -3469,7 +3469,7 @@ async fn stack_launch_rejects_uncovered_pairing_slot() {
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
-            with: Vec::new(),
+            with: Default::default(),
             launcher_config_path: launcher_path,
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
@@ -3524,7 +3524,7 @@ async fn stack_launch_rejects_a_path_shaped_deployment_source() {
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
-            with: Vec::new(),
+            with: Default::default(),
             launcher_config_path: launcher_path,
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
@@ -3788,7 +3788,7 @@ async fn stack_launch_serves_a_commander_panels_observer_slots() {
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
-            with: Vec::new(),
+            with: Default::default(),
             launcher_config_path: launcher_path,
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
@@ -4043,7 +4043,7 @@ async fn stack_launch_allows_absent_node_dependency_on_an_empty_admitting_slot()
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
-            with: Vec::new(),
+            with: Default::default(),
             launcher_config_path: launcher_path,
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
@@ -4200,7 +4200,7 @@ async fn stack_launch_still_requires_vacancy_for_an_absent_zero_or_one_dependenc
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
-            with: Vec::new(),
+            with: Default::default(),
             launcher_config_path: launcher_path,
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
@@ -4357,7 +4357,9 @@ async fn stack_launch_flattens_a_composed_launcher() {
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
-            with: vec!["beta".to_owned(), "extras=on".to_owned()],
+            with: WithSelection {
+                words: vec!["beta".to_owned(), "extras=on".to_owned()],
+            },
             launcher_config_path: launcher_path,
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
@@ -4431,7 +4433,9 @@ async fn stack_launch_refuses_broken_selections_before_the_daemon_round_trip() {
         command: StackCommands::Launch {
             place: Vec::new(),
             local: false,
-            with: vec!["mujoco".to_owned()],
+            with: WithSelection {
+                words: vec!["mujoco".to_owned()],
+            },
             launcher_config_path: flat_launcher,
             node_add_idle_timeout_secs: 60,
             node_build_idle_timeout_secs: 60,
@@ -4468,7 +4472,7 @@ async fn stack_launch_refuses_broken_selections_before_the_daemon_round_trip() {
             command: StackCommands::Launch {
                 place: Vec::new(),
                 local: false,
-                with,
+                with: WithSelection { words: with },
                 launcher_config_path: path,
                 node_add_idle_timeout_secs: 60,
                 node_build_idle_timeout_secs: 60,

--- a/crates/peppy/tests/stack_launch.rs
+++ b/crates/peppy/tests/stack_launch.rs
@@ -4374,12 +4374,10 @@ async fn stack_launch_flattens_a_composed_launcher() {
         "the coordinator's echo of the full resolution should reach the CLI: {logs}"
     );
 
-    let messenger_handle = ctx
-        .messenger_handle()
-        .expect("messenger handle should be available");
     let response = poll(
         &StackListRequest::new(),
-        &messenger_handle,
+        ctx.messenger_handle()
+            .expect("messenger handle should be available"),
         &core_node_name,
         CALLER_INSTANCE_ID,
         &core_node_name,

--- a/crates/peppy/tests/stack_launch.rs
+++ b/crates/peppy/tests/stack_launch.rs
@@ -4572,7 +4572,7 @@ fn stack_resolve_prints_the_flat_launcher_and_report() {
         "the document still declares the launcher schema: {document}"
     );
 
-    let report_text = report.join("\\n");
+    let report_text = report.join("\n");
     assert!(
         report_text.contains("components: robot=real (default)  recorder=on"),
         "the report leads with the resolution: {report_text}"

--- a/docs/src/content/docs/advanced_guides/repositories.mdx
+++ b/docs/src/content/docs/advanced_guides/repositories.mdx
@@ -241,6 +241,14 @@ Rules worth knowing before you hand-edit one:
 - **The file is generated.** Comments survive `--check`, but the next `peppy repo index` run
   discards them.
 
+A launcher fragment file (`peppy_schema: "launcher_fragment/v1"`) declares no item of its own: it
+is a piece of a composed launcher, referenced by the option that wants it (see
+[Launch files](/guides/launch_files/#fragments-splitting-a-launcher-across-files)), so it gets no
+entry here, takes no launcher name, and is never listed as a launchable stack. The indexer
+recognizes the kind, and `peppy repo index --check` validates every fragment a launcher references
+and flattens every legal selection of its component axes, so a broken combination is refused on
+the branch that introduced it rather than at the first launch that picks it.
+
 ### Index a repository
 
 ```sh

--- a/docs/src/content/docs/guides/launch_files.mdx
+++ b/docs/src/content/docs/guides/launch_files.mdx
@@ -5,6 +5,9 @@ sidebar:
   order: 9
 ---
 import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
+import { Code } from '@astrojs/starlight/components';
+import viewerLauncher from './snippets/launchers/viewer.json5?raw';
+import zedCameraFragment from './snippets/launchers/viewer_zed_camera.json5?raw';
 
 Launch files let you start multiple nodes simultaneously, including those with dependencies on each other. 
 With a single launch file, you or your team can recreate an entire node environment using just one command.
@@ -305,3 +308,124 @@ that leaves one unwired is refused. The escape hatch is
 `peppy stack launch --local`, which ignores the launcher's placements and runs
 every instance on the daemon you launched from. `--local` and `--place` are
 mutually exclusive.
+
+## Swapping parts at launch time
+
+A launcher file can describe a family of stacks whose members differ in which implementation fills a slot: a real robot or a simulator, a browser panel or a headset, with or without a recorder. The launcher declares **component axes**, and the launch command picks one option per axis with `--with`. A launcher without `components` is a plain flat stack, and that stays the ordinary way to write a one-off.
+
+The whole feature fits in one file. Here is a viewer stack with two swappable cameras:
+
+<Code code={viewerLauncher} lang="json5" title="viewer.json5" />
+
+```sh
+peppy stack launch ./viewer.json5              # runs the default camera (uvc)
+peppy stack launch ./viewer.json5 --with=zed   # runs the ZED camera instead
+```
+
+An axis entry has five fields:
+
+| Field | Meaning |
+|---|---|
+| `name` | The axis's name, unique in the launcher. Used in `--with axis=option` and in adjustment guards. |
+| `options` | The alternatives that fill this axis, at least one. Each option's body uses the same `deployments` grammar the launcher's own `deployments` use, so reading an option teaches nothing new. |
+| `default` | The option chosen when `--with` names nothing on this axis. |
+| `optional` | When true, the axis may be left unfilled; an unselected optional axis contributes nothing to the stack. Forbidden together with `default`. An axis with neither `default` nor `optional` must be selected. |
+| `provides` | The axis's interface: instance ids every option defines, so a link written against one is valid whichever option the operator picks. Options may define additional private ids. |
+
+Two cameras competing for one `cam_inst` is exactly what an axis is: the options of one axis are mutually exclusive alternatives, and a launch fills each axis with exactly one of them. `--with web_commander --with xr_commander` on a `commander` axis is refused, because the stack cannot have two commanders. Repeating the same option, or naming it once bare and once as `axis=option`, is the same choice and is fine.
+
+Each `--with` entry is either `option` (looked up across every axis) or `axis=option`. A bare word matching options on more than one axis is refused, naming the axes, so `axis=option` says which you mean. Several axes can each carry a `none` option, which is how an author writes a feature that is on by default and switchable off: declare the axis with a `none` option (its body can be empty) and make it the default.
+
+A launch with a `--with` selection echoes the full resolution before anything runs:
+
+```
+components: robot=mujoco  commander=web_commander (default)  recorder=(off)
+```
+
+`--with` is purely additive: unselected axes take their defaults, and there is no way to unselect a default other than naming a different option of that axis. Passing `--with` to a launcher that declares no `components` is refused.
+
+## Adjustments
+
+A family of stacks often needs more than swapped deployments: the recorder attaches itself to whichever commander was selected, and the headset flips a mode argument on the backbone. An **adjustment** names one instance defined elsewhere and one change to it, and every change names its operation:
+
+```json5
+adjustments: [
+  {
+    target: "backbone_inst",              // the instance to change
+    when: { commander: "xr_commander" },  // optional guard, see below
+
+    set_arguments: { upstream_mode: "pose" },
+    set_links: { collision_ctrl: { vacant: "the headset never produces governor_control" } },
+    add_links: { recorder: ["recorder_inst"] },
+    unset_links: ["leader_left_arm_pose"],
+  },
+]
+```
+
+| Operation | Effect |
+|---|---|
+| `set_arguments` | Replaces the target's value for each named argument key, creating it when absent. Nested objects replace wholesale. |
+| `set_links` | Replaces the target's whole entry for each named slot, creating it when absent. The value uses the ordinary [links](#links-optional) grammar, including vacancies. |
+| `add_links` | Appends targets to each named slot's array binding, creating the binding when the slot has no entry. Refused when the slot holds a scalar or a vacancy: replacing is `set_links`'s job. Appending is what lets independent fragments each contribute bindings to one multi-cardinality slot. |
+| `unset_links` | Drops each named slot's entry entirely, returning the slot to absent. |
+
+Fragments refuse to fight: two selected fragments writing the same argument key or the same slot on one target are refused, naming both. The launcher's own top-level `adjustments` apply after all fragment adjustments and may override anything a fragment set, which is how one launcher specializes fragments it shares with another. Within the launcher's own list, a later entry wins over an earlier one: both lines live in one file one author edits.
+
+An adjustment whose target the current selection does not define is **skipped**, not refused: the recorder's attach simply does not run when no recorder was selected. A target no option of the launcher defines anywhere is a dead reference and fails when the launcher is read. `when` guards are for conditions existence cannot express, mostly shape: two leaders may both provide `commander_inst`, but only one of them has camera slots. A guard names one option per axis, and every named axis must match; `when: { commander: "xr_commander", robot: "real" }` runs only for that pair.
+
+The ownership rule of thumb: if a value is something the operator genuinely decides, make it another option on the axis, visible in the command line. If it is a *consequence* of a choice already made, write the adjustment into that option's own fragment, where it needs no guard: it runs exactly when its fragment is selected and skips when its target is absent.
+
+## Fragments: splitting a launcher across files
+
+An option's body can live in its own file, called a **fragment**. This is an organizational choice, never a requirement: a launcher whose options are all inline is self-contained. Extract a fragment once a second launcher wants the same body, so the body is stated once.
+
+A fragment file carries the `launcher_fragment/v1` tag:
+
+<Code code={zedCameraFragment} lang="json5" title="fragments/zed_camera.json5" />
+
+The launcher references it by path, and the option value becomes that path string:
+
+```json5
+options: {
+  uvc: { deployments: [ /* inline, as above */ ] },
+  zed: "fragments/zed_camera.json5",
+}
+```
+
+Fragment paths are relative to the launcher's own directory. A path must be relative and plain: no `..`, no absolute paths, and nothing that escapes the launcher's directory through a symlink. A repository launcher and a filesystem launcher resolve their fragments identically.
+
+Two options can share one body with the list form, which merges its parts in order before the option contributes anything. This is how two simulator options share the relay deployments and differ only in the engine:
+
+```json5
+options: {
+  mujoco:    ["fragments/sim_relays.json5", "fragments/mujoco_engine.json5"],
+  isaac_sim: ["fragments/sim_relays.json5", "fragments/isaac_engine.json5"],
+}
+```
+
+Besides `deployments` and `adjustments`, a fragment may declare `core_nodes`: additional placement placeholders its instances need, unioned with the launcher's own, so selecting the option makes the matching `--place` bindings required exactly as if the launcher declared them.
+
+A fragment is not a stack. The repository indexer never lists a fragment as a launchable launcher, it needs no entry in `peppy_repository.json5`, and it cannot collide with a launcher name. `peppy repo index --check` validates every fragment a launcher references and flattens every legal selection of its axes, so a broken combination is refused on the branch that introduced it.
+
+## Auditing a composed launch
+
+Composition changes instances from a distance, so it ships with an audit command:
+
+```sh
+peppy stack resolve openarm_v2 --with=xr_commander,lerobot_recorder
+```
+
+`stack resolve` needs no running stack and touches nothing. It prints the flattened `launcher/v1` document to stdout and a resolution report to stderr:
+
+```
+components: robot=real (default)  commander=xr_commander  recorder=lerobot_recorder
+
+adjustments applied:
+  backbone_inst.arguments.upstream_mode      "joints" -> "pose"          fragments/xr_commander.json5
+  commander_inst.links.recorder              + "recorder_inst"           fragments/lerobot_recorder.json5
+
+adjustments skipped:
+  sim_inst.arguments.hardware_version        sim_inst is not in this selection  openarm_v2.json5 (base)
+```
+
+Every applied adjustment is listed with the value it replaced and the fragment it came from, and every skip says why. Because stdout is a plain launcher, it doubles as the escape hatch: flatten, hand-edit, launch the flat file.

--- a/docs/src/content/docs/guides/snippets/launchers/viewer.json5
+++ b/docs/src/content/docs/guides/snippets/launchers/viewer.json5
@@ -1,0 +1,62 @@
+// One file, two swappable cameras: the viewer stack declares a `camera`
+// axis whose options are written inline, so composition needs no second
+// file. `peppy stack launch ./viewer.json5` runs the default (`uvc`); the
+// same launcher with `--with=zed` swaps the camera.
+{
+  peppy_schema: "launcher/v1",
+
+  components: [
+    {
+      name: "camera",
+      provides: ["cam_inst"],
+      default: "uvc",
+      options: {
+        uvc: {
+          deployments: [
+            {
+              source: { name: "uvc_camera_linux", tag: "v1" },
+              instances: [
+                {
+                  instance_id: "cam_inst",
+                  arguments: {
+                    device_path: "/dev/video0",
+                    video: {
+                      frame_rate: 30,
+                      resolution: { width: 1280, height: 720 },
+                      camera_encoding: "mjpeg",
+                      topic_encoding: "rgb8",
+                    },
+                  },
+                },
+              ],
+            },
+          ],
+        },
+        zed: {
+          deployments: [
+            {
+              source: { name: "zed_camera", tag: "v1" },
+              instances: [
+                {
+                  instance_id: "cam_inst",
+                  arguments: {
+                    resolution: "hd720",
+                    frame_rate: 30,
+                    depth: { min_depth_m: 0.4, downscale: 2, block_size: 3 },
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      },
+    },
+  ],
+
+  deployments: [
+    {
+      source: { name: "web_viewer", tag: "v1" },
+      instances: [{ instance_id: "viewer_inst", links: { camera: "cam_inst" } }],
+    },
+  ],
+}

--- a/docs/src/content/docs/guides/snippets/launchers/viewer_zed_camera.json5
+++ b/docs/src/content/docs/guides/snippets/launchers/viewer_zed_camera.json5
@@ -1,0 +1,31 @@
+// The `zed` option of a viewer launcher, extracted into its own file: the
+// body is the same `deployments` grammar the launcher itself uses, and the
+// fragment tag is what keeps a fragment from ever being mistaken for a
+// launchable stack. Referenced from a launcher as
+// `zed: "fragments/zed_camera.json5"`.
+{
+  peppy_schema: "launcher_fragment/v1",
+
+  deployments: [
+    {
+      source: { name: "zed_camera", tag: "v1" },
+      instances: [
+        {
+          instance_id: "cam_inst",
+          arguments: {
+            resolution: "hd720",
+            frame_rate: 30,
+            depth: { min_depth_m: 0.4, downscale: 2, block_size: 3 },
+          },
+        },
+      ],
+    },
+  ],
+
+  adjustments: [
+    // A consequence of running this camera: the depth-aware viewer wants a
+    // denser mesh than the default. Lives here, with no guard, because it
+    // runs exactly when this fragment is selected.
+    { target: "viewer_inst", set_arguments: { mesh_density: "high" } },
+  ],
+}

--- a/docs/tests/integration/tests/snippet_configs.rs
+++ b/docs/tests/integration/tests/snippet_configs.rs
@@ -97,6 +97,15 @@ fn assert_parses_with_matching_schema(path: &Path) {
                 result.unwrap_err()
             );
         }
+        PeppySchema::LauncherFragmentV1 => {
+            let result = daemon_config::launcher::LauncherFragmentParser::from_path(path);
+            assert!(
+                result.is_ok(),
+                "failed to parse launcher fragment {}: {:?}",
+                path.display(),
+                result.unwrap_err()
+            );
+        }
         PeppySchema::RepositoryV1 => {
             let result = daemon_config::repository::PeppyRepositoryIndexParser::from_path(path);
             assert!(


### PR DESCRIPTION
## What

Composable launchers (FRAMEWORK-194): a launcher file can describe a family of stacks whose members differ in which implementation fills a slot group (real robot or a simulator, browser panel or XR headset, with or without a recorder), selected at launch time:

```sh
peppy stack launch openarm_v2 --with="mujoco,web_commander"
peppy stack launch openarm_v2 --with="isaac_sim,xr_commander,lerobot_recorder,cameras"
```

Composition is two optional top-level keys on `launcher/v1`: `components` (an ordered list of axes; an option's body is an inline fragment, a path relative to the launcher's directory, or a list mixing both) and `adjustments` (the four verbs `set_arguments`, `set_links`, `add_links`, `unset_links`, guarded by `when`). A launcher without them is a plain flat stack with today's exact semantics.

- `daemon-config-internal` parses the grammar (`launcher/composition.rs`) and flattens a selection into an ordinary flat launcher (`launcher/flatten.rs`): deployments collected base-first then in axis and fragment order, merged per `name:tag`, instance-id uniqueness with both origins named, `core_nodes` unioned, fragment adjustments before the base's with two fragments writing one key refused, guards and absent targets skipped into a report. The flat result is re-serialized and re-parsed, so it gets every whole-document check a hand-written file does. Fragment paths are relative, plain, and cannot escape the launcher's directory even through a symlink.
- The `--with` words travel on `LaunchGoal` verbatim and are resolved where the document is read (`stack/launch/resolve.rs`), the same intent-not-expansion rule `--local` follows; the coordinator echoes the full resolution (`components: robot=mujoco commander=web (default) recorder=(off)`) before anything runs. Filesystem launchers are still pre-parsed caller-side for a fast error.
- `peppy repo index --check` validates every referenced fragment and flattens every legal selection (512-combination ceiling, degrading to per-axis validation with a logged count of what it skipped). The indexer recognizes `launcher_fragment/v1` files as non-items.
- New `peppy stack resolve <name|path> [--with ...]`: flat document to stdout, adjustment report (applied with replaced values and origins, skipped with reasons) to stderr. Needs no running stack.
- The launch-files guide is restructured in learning order (plain launchers, inline `components`, adjustments, fragments last, resolve), with a `viewer.json5` snippet pinned by the existing snippet test (which gains the fragment arm). The repositories guide documents the fragment document kind.

Breaking by design (no fallbacks, no shims): the schema string stays `launcher/v1` but a pre-composition daemon rejects the new keys with its existing unknown-field error, and the goal carries selections with no compatibility path.

## Depends on

public-peppy-libs PR (same branch name) must merge first: this branch builds against its `launcher_fragment/v1` schema variant and `LaunchGoal.selections`. The `Cargo.lock` bump to the new shared-crate rev lands as a follow-up commit here once that merge is on `main` (same flow the MCP exposure work used); until then this branch's lock resolves the previous rev.

## Verification

- `cargo test --workspace` green (incl. new unit tests for the grammar and flattening, e2e composed launches through the daemon, selection refusals, resolve output, repo-index composition checks, docs snippet test).
- The rewritten launchers-hub (same branch name there) passes `peppy repo index --check` against this build: every legal selection of the two openarm bases (24 each) flattens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added composable launchers with selectable component options, reusable fragments, defaults, and conditional adjustments.
  * Added `peppy stack resolve` to preview flattened launcher configurations and resolution reports.
  * Added `--with` selections to `peppy stack launch`.
* **Bug Fixes**
  * Improved validation and error reporting for missing, malformed, conflicting, or incompatible launcher components.
  * Repository indexing now excludes launcher fragments from publishable and launchable entries.
* **Documentation**
  * Added guides and examples for composable launchers, fragments, selections, adjustments, and resolution reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->