### PR TITLE
Check for fuse2fs on hosts that run rootless apptainer containers

### DIFF
--- a/crates/containers-internal/build.rs
+++ b/crates/containers-internal/build.rs
@@ -2175,6 +2175,29 @@ echo "=== Apptainer build complete ==="
             false
         };
 
+        // fuse2fs is the one userspace mount helper the bundled apptainer tree
+        // does not carry: squashfs (every SIF root filesystem) is handled by
+        // the compiled-in squashfuse_ll and encrypted images by the bundled
+        // gocryptfs, but EXT3 filesystem images can only be mounted by the
+        // rootless fuse2fs image driver — this apptainer is deliberately
+        // built `--without-suid`, so there is no privileged ext mount to fall
+        // back on. Apptainer searches its own libexec bin dir (where peppy
+        // drops squashfuse_ll and gocryptfs) ahead of `$PATH` and ships no
+        // fuse2fs binary itself, so the machines peppy runs containers on take
+        // it from their distro; `scripts/install.sh` installs it there. A
+        // warning, not a panic: peppy also builds on machines that never
+        // launch containers (CI, cross-compile hosts), and squashfs SIFs run
+        // fine without it.
+        if !use_lima && !binary_runs("fuse2fs") {
+            println!(
+                "cargo:warning=fuse2fs not found on this host. The bundled rootless apptainer \
+                 needs it to mount EXT3 filesystem images; without it every container start logs \
+                 `fuse2fs not found, will not be able to mount EXT3 filesystems` and EXT3 mounts \
+                 are unavailable. Install it with `sudo apt-get install fuse2fs` (Debian/Ubuntu), \
+                 `sudo dnf install fuse2fs` (Fedora/RHEL) or `sudo pacman -S fuse2fs` (Arch)."
+            );
+        }
+
         let arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_else(|_| "aarch64".to_string());
         let out_dir = env::var("OUT_DIR").unwrap();
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -360,8 +360,16 @@ EOF
         [ "$(loginctl show-user "$(id -un)" -p Linger --value 2>/dev/null || echo "no")" = "yes" ]
     }
 
+    # Returns 0 if the fuse2fs ext2/3/4 FUSE mount helper is installed. The
+    # bundled rootless apptainer needs it to mount EXT3 filesystem images —
+    # peppy ships squashfuse_ll and gocryptfs next to apptainer, but not this
+    # one, so it must come from the distro.
+    check_fuse2fs() {
+        command -v fuse2fs >/dev/null 2>&1
+    }
+
     # ---- Linux system dependency checks (pre-download) -------------------------
-    # Checks and installs pre-download dependencies (dbus, linger, curl).
+    # Checks and installs pre-download dependencies (dbus, linger, curl, fuse2fs).
     # Apptainer setup is handled post-install by `peppy container setup`.
     #
     # Inside containers (Docker/Podman), D-Bus and linger are irrelevant —
@@ -395,6 +403,18 @@ EOF
                     echo "" >&2
                     echo "error: loginctl linger is not enabled for user ${CURRENT_USER}." >&2
                     echo "       Enable it manually: sudo loginctl enable-linger ${CURRENT_USER}" >&2
+                    echo "" >&2
+                    exit 1
+                fi
+
+                if ! check_fuse2fs; then
+                    echo "" >&2
+                    echo "error: fuse2fs not found." >&2
+                    echo "       Rootless apptainer needs it to mount EXT3 filesystem images." >&2
+                    echo "       Install it manually:" >&2
+                    echo "         Debian/Ubuntu: sudo apt-get install fuse2fs" >&2
+                    echo "         Fedora/RHEL:   sudo dnf install fuse2fs" >&2
+                    echo "         Arch Linux:    sudo pacman -S fuse2fs" >&2
                     echo "" >&2
                     exit 1
                 fi
@@ -434,6 +454,29 @@ EOF
                 if ! check_linger_enabled; then
                     ENABLE_LINGER_USER="$(id -un)"
                     ALL_LABELS="${ALL_LABELS}  - Enable systemd linger for user ${ENABLE_LINGER_USER} (allows peppy daemon to run after SSH disconnect)\n"
+                fi
+
+                # fuse2fs: the ext2/3/4 FUSE mounter the bundled rootless
+                # apptainer uses for EXT3 filesystem images. Unlike
+                # squashfuse_ll and gocryptfs it is not bundled with peppy,
+                # so it comes from the distro.
+                if ! check_fuse2fs; then
+                    FUSE2FS_FIX=""
+                    if command -v apt-get >/dev/null 2>&1; then
+                        FUSE2FS_FIX="apt-get update -qq && apt-get install -y -qq fuse2fs"
+                    elif command -v dnf >/dev/null 2>&1; then
+                        FUSE2FS_FIX="dnf install -y fuse2fs"
+                    elif command -v pacman >/dev/null 2>&1; then
+                        FUSE2FS_FIX="pacman -Sy --noconfirm fuse2fs"
+                    fi
+                    if [ -n "$FUSE2FS_FIX" ]; then
+                        PREDOWNLOAD_FIXES="${PREDOWNLOAD_FIXES}${FUSE2FS_FIX} && "
+                        ALL_LABELS="${ALL_LABELS}  - Install fuse2fs (needed to mount EXT3 filesystems in rootless containers)\n"
+                    else
+                        echo "warning: fuse2fs not found and no supported package manager detected (apt-get, dnf, pacman)." >&2
+                        echo "         Rootless containers cannot mount EXT3 filesystems without it." >&2
+                        echo "         Debian/Ubuntu: sudo apt-get install fuse2fs; Fedora/RHEL: sudo dnf install fuse2fs; Arch Linux: sudo pacman -S fuse2fs" >&2
+                    fi
                 fi
             fi
 


### PR DESCRIPTION
## Why

peppy builds apptainer from source `--without-suid`, so EXT3 filesystem images can only be mounted through the userspace `fuse2fs` FUSE driver. peppy bundles `squashfuse_ll` (squashfs/SIF root filesystems) and `gocryptfs` (encrypted images) next to apptainer, but not `fuse2fs` — that one has to come from the distro. When it is missing, every container start logs:

```
INFO:    fuse2fs not found, will not be able to mount EXT3 filesystems
```

and EXT3 mounts are unavailable (squashfs SIFs still run fine). This showed up on every node start in a stack launch on `cn-sweet-edison`, so hosts should get fuse2fs installed and peppy should notice when it is not.

## What

- `scripts/install.sh`: new `check_fuse2fs()` alongside the dbus/linger checks.
  - Normal mode: sudo-installs `fuse2fs` through the detected package manager (apt-get / dnf / pacman — same package name on all three) via the existing consolidated consent + fix flow.
  - `PEPPY_NO_ROOT_INSTALL`: hard error with per-distro manual instructions, matching how dbus/linger are handled.
  - No supported package manager: warning + manual instructions, install continues.
  - Skipped in-container (Docker/Podman/`PEPPY_NO_CONTAINER_SETUP`) and on macOS, like the other container-runtime checks.
- `crates/containers-internal/build.rs`: on Linux native builds, a `$PATH` probe emits a `cargo:warning` when `fuse2fs` is absent, naming the consequence and the per-distro install command. Deliberately a warning, not a panic: peppy also builds on machines that never launch containers (CI, cross-compile hosts).

## Verification

- `sh -n` on the modified installer; each new branch exercised in a harness (missing+apt → fix queued with label, missing+no-pm → warning only, present → skipped, no-root mode → exit 1).
- `cargo check -p containers`: the warning fires on a host without fuse2fs and disappears with a stub `fuse2fs` on `$PATH`; apptainer cache resolution unaffected; `cargo fmt --check` clean.

Note: the stack-launch failure that surfaced this (`openarm_arm`/`left_arm_inst` exiting with `ENODEV` opening CAN interface `left_arm`) was **not** caused by fuse2fs — that is the missing/unbrought-up CAN interface on the host. This PR only addresses the fuse2fs gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)