### PR TITLE
[tuatini/FRAMEWORK-195] Add launcher `constraints`: selection refusals for the composition model

### DIFF
--- a/crates/daemon-config-internal/src/launcher.rs
+++ b/crates/daemon-config-internal/src/launcher.rs
@@ -14,7 +14,7 @@ mod types;
 pub use bindings::{BindingValidationItem, ValidatedBindings, validate_bindings};
 pub use composition::{
     Adjustment, ComponentAxis, Fragment, FragmentPart, FragmentSpec, LauncherFragment,
-    LauncherFragmentParser,
+    LauncherFragmentParser, SelectionConstraint,
 };
 pub use flatten::{
     AppliedAdjustment, AppliedChange, ComponentSelection, CompositionError, FlattenReport,

--- a/crates/daemon-config-internal/src/launcher/composition.rs
+++ b/crates/daemon-config-internal/src/launcher/composition.rs
@@ -139,6 +139,45 @@ where
     PeppySchema::deserialize_expecting(deserializer, PeppySchema::LauncherFragmentV1)
 }
 
+/// One rule about which selections this launcher refuses to be: `when` a
+/// guard holds, the selection must also satisfy at least one `requires`
+/// alternative, or the whole selection is refused before anything is pinned
+/// or started.
+///
+/// Constraints exist for the members of a family that FLATTEN cleanly into a
+/// stack nobody should run: a `when` guard on an adjustment can only decide
+/// whether that adjustment applies inside a legal selection, and `provides`
+/// only promises ids exist. Neither can say "this option needs another axis
+/// filled". A constraint can, and it only ever refuses: it never picks an
+/// option to satisfy itself, because a `--with` whose meaning shifts as
+/// constraints evolve would launch stacks the operator did not name.
+///
+/// Constraints live in the launcher, not in fragments: they speak in axis
+/// and option names, which are the launcher's vocabulary (fragments are
+/// deliberately reusable across launchers whose axes differ).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SelectionConstraint {
+    /// Guard: the selections this constraint speaks about, in the same
+    /// `axis: option` grammar as an adjustment's `when` (several pairs are an
+    /// AND). Absent means every selection; an unfilled optional axis matches
+    /// no pair, so a constraint guarded on its option stays quiet when the
+    /// axis is off.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub when: Option<BTreeMap<String, String>>,
+    /// The alternatives, at least one of which the selection must satisfy
+    /// wholly: each is an `axis: option` map (an AND), and listing several is
+    /// an OR. An unfilled optional axis satisfies no pair, which is exactly
+    /// how "this option needs a consumer" is written: require the axes that
+    /// can consume it.
+    pub requires: Vec<BTreeMap<String, String>>,
+    /// Why the refused selections must not launch, quoted verbatim in the
+    /// refusal. Required, like a vacancy's reason: the engine can render
+    /// what was required, but only the author knows what the dead
+    /// combination would have done.
+    pub reason: String,
+}
+
 /// One change to an instance defined elsewhere, in the base or in another
 /// selected fragment. Every change names its operation; nothing is inferred
 /// from a value's JSON type.
@@ -537,19 +576,97 @@ pub(crate) fn validate_guard(
     axes: &[ComponentAxis],
     origin: &str,
 ) -> Result<(), String> {
-    for (axis_name, option_name) in when {
+    validate_selection_map(when, axes, "a `when` guard", origin)
+}
+
+/// The shared half of guard and constraint validation: every `axis: option`
+/// pair names an axis this launcher declares and an option that axis
+/// declares. `what` names the map's role in the error (a `when` guard, a
+/// `requires` alternative), which is all that differs between them.
+fn validate_selection_map(
+    map: &BTreeMap<String, String>,
+    axes: &[ComponentAxis],
+    what: &str,
+    origin: &str,
+) -> Result<(), String> {
+    for (axis_name, option_name) in map {
         let Some(axis) = axes.iter().find(|axis| axis.name == *axis_name) else {
             return Err(format!(
-                "a `when` guard in {origin} names axis `{axis_name}`, which this launcher does \
+                "{what} in {origin} names axis `{axis_name}`, which this launcher does \
                  not declare. Axes: {}",
                 crate::error::format_quoted_list(axes.iter().map(ComponentAxis::as_str))
             ));
         };
         if !axis.options.contains_key(option_name) {
             return Err(format!(
-                "a `when` guard in {origin} names option `{option_name}` on axis \
+                "{what} in {origin} names option `{option_name}` on axis \
                  `{axis_name}`, which the axis does not declare. Its options: {}",
                 crate::error::format_quoted_list(axis.options.keys())
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// The launcher-local checks on a `constraints` list: shapes that say
+/// something and references that resolve. Selection-independent, so it runs
+/// while the launcher document parses; whether a given selection violates a
+/// constraint is [`super::flatten`]'s question.
+pub(crate) fn validate_constraints(
+    constraints: &[SelectionConstraint],
+    axes: &[ComponentAxis],
+) -> Result<(), String> {
+    for (index, constraint) in constraints.iter().enumerate() {
+        let origin = format!("the launcher's `constraints` entry {}", index + 1);
+        if let Some(when) = &constraint.when {
+            if when.is_empty() {
+                return Err(format!(
+                    "{origin} declares an empty `when`: a guard names at least one \
+                     `axis: option` pair, or omits `when` entirely to speak about every \
+                     selection"
+                ));
+            }
+            validate_selection_map(when, axes, "a `when` guard", &origin)?;
+        }
+        if constraint.requires.is_empty() {
+            return Err(format!(
+                "{origin} declares no `requires` alternative: a constraint states what the \
+                 guarded selections must also have, and with nothing to require it refuses \
+                 nothing"
+            ));
+        }
+        let mut seen: Vec<&BTreeMap<String, String>> = Vec::with_capacity(constraint.requires.len());
+        for alternative in &constraint.requires {
+            if alternative.is_empty() {
+                return Err(format!(
+                    "{origin} lists an empty `requires` alternative: an alternative names at \
+                     least one `axis: option` pair"
+                ));
+            }
+            validate_selection_map(alternative, axes, "a `requires` alternative", &origin)?;
+            if let Some(when) = &constraint.when {
+                for axis_name in alternative.keys() {
+                    if when.contains_key(axis_name) {
+                        return Err(format!(
+                            "{origin} requires axis `{axis_name}` inside a constraint whose \
+                             `when` already fixes that axis: under the guard the alternative \
+                             is decided before anything is selected. Restate the requirement \
+                             without it"
+                        ));
+                    }
+                }
+            }
+            if seen.contains(&alternative) {
+                return Err(format!(
+                    "{origin} lists the same `requires` alternative more than once"
+                ));
+            }
+            seen.push(alternative);
+        }
+        if constraint.reason.trim().is_empty() {
+            return Err(format!(
+                "{origin} has an empty `reason`: the refusal quotes it to the operator, and \
+                 only the author knows why the refused combinations must not launch"
             ));
         }
     }
@@ -787,6 +904,129 @@ mod tests {
         .expect_err("a bare --with word must resolve to one thing");
         assert!(error.contains("`robot`"), "got: {error}");
         assert!(error.contains("`real`"), "got: {error}");
+    }
+
+    // -- validate_constraints -----------------------------------------------
+
+    /// Two axes shaped like the cases constraints exist for: a defaulted
+    /// choice and an optional feature toggle.
+    fn constraint_axes() -> Vec<ComponentAxis> {
+        serde_json5::from_str(
+            r#"[
+                { name: "robot", default: "real",
+                  options: { real: { deployments: [] }, mujoco: { deployments: [] } } },
+                { name: "recorder", optional: true,
+                  options: { on: { deployments: [] } } },
+            ]"#,
+        )
+        .expect("axes parse")
+    }
+
+    fn one_constraint(body: &str) -> Result<(), String> {
+        let constraints: Vec<SelectionConstraint> =
+            serde_json5::from_str(&format!("[{body}]")).map_err(|e| e.to_string())?;
+        validate_constraints(&constraints, &constraint_axes())
+    }
+
+    #[test]
+    fn a_well_formed_constraint_passes() {
+        one_constraint(
+            r#"{ when: { recorder: "on" },
+                 requires: [{ robot: "real" }],
+                 reason: "the recorder films the physical rig" }"#,
+        )
+        .expect("valid constraint");
+    }
+
+    #[test]
+    fn an_unconditional_constraint_passes() {
+        one_constraint(
+            r#"{ requires: [{ robot: "real" }, { recorder: "on" }], reason: "why" }"#,
+        )
+        .expect("a constraint without `when` speaks about every selection");
+    }
+
+    #[test]
+    fn an_empty_constraint_guard_is_refused() {
+        let error = one_constraint(r#"{ when: {}, requires: [{ robot: "real" }], reason: "r" }"#)
+            .expect_err("an empty guard means nothing");
+        assert!(error.contains("empty `when`"), "got: {error}");
+    }
+
+    #[test]
+    fn a_constraint_requiring_nothing_is_refused() {
+        let error = one_constraint(r#"{ when: { recorder: "on" }, requires: [], reason: "r" }"#)
+            .expect_err("nothing to require refuses nothing");
+        assert!(error.contains("no `requires` alternative"), "got: {error}");
+    }
+
+    #[test]
+    fn an_empty_requires_alternative_is_refused() {
+        let error =
+            one_constraint(r#"{ when: { recorder: "on" }, requires: [{}], reason: "r" }"#)
+                .expect_err("an empty alternative says nothing");
+        assert!(error.contains("empty `requires` alternative"), "got: {error}");
+    }
+
+    #[test]
+    fn a_requires_alternative_on_a_guarded_axis_is_refused() {
+        let error = one_constraint(
+            r#"{ when: { robot: "mujoco" }, requires: [{ robot: "real" }], reason: "r" }"#,
+        )
+        .expect_err("under the guard the axis is already fixed");
+        assert!(error.contains("already fixes"), "got: {error}");
+    }
+
+    #[test]
+    fn a_duplicated_requires_alternative_is_refused() {
+        let error = one_constraint(
+            r#"{ when: { recorder: "on" },
+                 requires: [{ robot: "real" }, { robot: "real" }], reason: "r" }"#,
+        )
+        .expect_err("a duplicate alternative is a mistake");
+        assert!(error.contains("more than once"), "got: {error}");
+    }
+
+    #[test]
+    fn a_blank_constraint_reason_is_refused() {
+        let error = one_constraint(
+            r#"{ when: { recorder: "on" }, requires: [{ robot: "real" }], reason: "   " }"#,
+        )
+        .expect_err("the refusal quotes the reason");
+        assert!(error.contains("empty `reason`"), "got: {error}");
+    }
+
+    #[test]
+    fn a_constraint_without_a_reason_does_not_parse() {
+        let error =
+            one_constraint(r#"{ when: { recorder: "on" }, requires: [{ robot: "real" }] }"#)
+                .expect_err("reason is required");
+        assert!(error.contains("reason"), "got: {error}");
+    }
+
+    #[test]
+    fn a_constraint_naming_an_unknown_axis_or_option_is_refused() {
+        let error = one_constraint(
+            r#"{ when: { commander: "web" }, requires: [{ robot: "real" }], reason: "r" }"#,
+        )
+        .expect_err("an unknown axis is a dead reference");
+        assert!(error.contains("`commander`"), "got: {error}");
+
+        let error = one_constraint(
+            r#"{ when: { recorder: "on" }, requires: [{ robot: "sim" }], reason: "r" }"#,
+        )
+        .expect_err("an unknown option is a dead reference");
+        assert!(error.contains("`sim`"), "got: {error}");
+        assert!(error.contains("`requires` alternative"), "got: {error}");
+    }
+
+    #[test]
+    fn a_misspelled_constraint_field_is_refused() {
+        let error = one_constraint(
+            r#"{ when: { recorder: "on" }, requires: [{ robot: "real" }], reasn: "r" }"#,
+        )
+        .expect_err("a misspelled field must not silently vanish");
+        assert!(error.contains("reasn"), "got: {error}");
     }
 
     // -- validate_adjustment ------------------------------------------------

--- a/crates/daemon-config-internal/src/launcher/composition.rs
+++ b/crates/daemon-config-internal/src/launcher/composition.rs
@@ -141,8 +141,8 @@ where
 
 /// One rule about which selections this launcher refuses to be: `when` a
 /// guard holds, the selection must also satisfy at least one `requires`
-/// alternative, or the whole selection is refused before anything is pinned
-/// or started.
+/// alternative and match no `forbids` entry, or the whole selection is
+/// refused before anything is pinned or started.
 ///
 /// Constraints exist for the members of a family that FLATTEN cleanly into a
 /// stack nobody should run: a `when` guard on an adjustment can only decide
@@ -170,7 +170,20 @@ pub struct SelectionConstraint {
     /// an OR. An unfilled optional axis satisfies no pair, which is exactly
     /// how "this option needs a consumer" is written: require the axes that
     /// can consume it.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub requires: Vec<BTreeMap<String, String>>,
+    /// The combinations the guarded selections must not contain: each entry
+    /// is an `axis: option` map (an AND), and matching any entry refuses the
+    /// selection. The direct form of "these options never launch together",
+    /// which `requires` cannot say about an OPTIONAL axis's option (nothing
+    /// requirable means "that axis stays off"). Where the axis is required,
+    /// prefer requiring the wanted option instead: `requires` fails closed
+    /// for options added later, while a `forbids` list names today's options
+    /// and stays silent about tomorrow's.
+    ///
+    /// A constraint states at least one of `requires` and `forbids`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub forbids: Vec<BTreeMap<String, String>>,
     /// Why the refused selections must not launch, quoted verbatim in the
     /// refusal. Required, like a vacancy's reason: the engine can render
     /// what was required, but only the author knows what the dead
@@ -628,40 +641,52 @@ pub(crate) fn validate_constraints(
             }
             validate_selection_map(when, axes, "a `when` guard", &origin)?;
         }
-        if constraint.requires.is_empty() {
+        if constraint.requires.is_empty() && constraint.forbids.is_empty() {
             return Err(format!(
-                "{origin} declares no `requires` alternative: a constraint states what the \
-                 guarded selections must also have, and with nothing to require it refuses \
-                 nothing"
+                "{origin} declares neither `requires` nor `forbids`: a constraint states what \
+                 the guarded selections must also have, or must not combine with, and with \
+                 neither it refuses nothing"
             ));
         }
-        let mut seen: Vec<&BTreeMap<String, String>> = Vec::with_capacity(constraint.requires.len());
-        for alternative in &constraint.requires {
-            if alternative.is_empty() {
-                return Err(format!(
-                    "{origin} lists an empty `requires` alternative: an alternative names at \
-                     least one `axis: option` pair"
-                ));
-            }
-            validate_selection_map(alternative, axes, "a `requires` alternative", &origin)?;
-            if let Some(when) = &constraint.when {
-                for axis_name in alternative.keys() {
-                    if when.contains_key(axis_name) {
-                        return Err(format!(
-                            "{origin} requires axis `{axis_name}` inside a constraint whose \
-                             `when` already fixes that axis: under the guard the alternative \
-                             is decided before anything is selected. Restate the requirement \
-                             without it"
-                        ));
+        for (entries, kind, verb) in [
+            (&constraint.requires, "`requires` alternative", "requires"),
+            (&constraint.forbids, "`forbids` entry", "forbids"),
+        ] {
+            let mut seen: Vec<&BTreeMap<String, String>> = Vec::with_capacity(entries.len());
+            for entry in entries {
+                if entry.is_empty() {
+                    return Err(format!(
+                        "{origin} lists an empty {kind}: an entry names at least one \
+                         `axis: option` pair"
+                    ));
+                }
+                validate_selection_map(entry, axes, &format!("a {kind}"), &origin)?;
+                if let Some(when) = &constraint.when {
+                    for axis_name in entry.keys() {
+                        if when.contains_key(axis_name) {
+                            return Err(format!(
+                                "{origin} {verb} axis `{axis_name}` inside a constraint whose \
+                                 `when` already fixes that axis: under the guard the entry is \
+                                 decided before anything is selected. Restate it without the \
+                                 axis"
+                            ));
+                        }
                     }
                 }
+                if seen.contains(&entry) {
+                    return Err(format!("{origin} lists the same {kind} more than once"));
+                }
+                seen.push(entry);
             }
-            if seen.contains(&alternative) {
+        }
+        for alternative in &constraint.requires {
+            if constraint.forbids.contains(alternative) {
                 return Err(format!(
-                    "{origin} lists the same `requires` alternative more than once"
+                    "{origin} lists the same `axis: option` map in `requires` and `forbids`: \
+                     a combination cannot be both what satisfies the constraint and what it \
+                     refuses"
                 ));
             }
-            seen.push(alternative);
         }
         if constraint.reason.trim().is_empty() {
             return Err(format!(
@@ -954,10 +979,73 @@ mod tests {
     }
 
     #[test]
-    fn a_constraint_requiring_nothing_is_refused() {
+    fn a_constraint_enforcing_nothing_is_refused() {
         let error = one_constraint(r#"{ when: { recorder: "on" }, requires: [], reason: "r" }"#)
-            .expect_err("nothing to require refuses nothing");
-        assert!(error.contains("no `requires` alternative"), "got: {error}");
+            .expect_err("nothing to enforce refuses nothing");
+        assert!(
+            error.contains("neither `requires` nor `forbids`"),
+            "got: {error}"
+        );
+    }
+
+    #[test]
+    fn a_forbids_only_constraint_passes() {
+        one_constraint(
+            r#"{ when: { robot: "mujoco" }, forbids: [{ recorder: "on" }],
+                 reason: "the recorder films only the physical rig" }"#,
+        )
+        .expect("an exclusion needs no requires");
+        one_constraint(
+            r#"{ forbids: [{ robot: "mujoco", recorder: "on" }], reason: "why" }"#,
+        )
+        .expect("an unconditional exclusion of one combination");
+    }
+
+    #[test]
+    fn an_empty_forbids_entry_is_refused() {
+        let error = one_constraint(r#"{ when: { robot: "mujoco" }, forbids: [{}], reason: "r" }"#)
+            .expect_err("an empty entry says nothing");
+        assert!(error.contains("empty `forbids` entry"), "got: {error}");
+    }
+
+    #[test]
+    fn a_forbids_entry_on_a_guarded_axis_is_refused() {
+        let error = one_constraint(
+            r#"{ when: { robot: "mujoco" }, forbids: [{ robot: "real" }], reason: "r" }"#,
+        )
+        .expect_err("under the guard the axis is already fixed");
+        assert!(error.contains("already fixes"), "got: {error}");
+    }
+
+    #[test]
+    fn a_duplicated_forbids_entry_is_refused() {
+        let error = one_constraint(
+            r#"{ forbids: [{ recorder: "on" }, { recorder: "on" }], reason: "r" }"#,
+        )
+        .expect_err("a duplicate entry is a mistake");
+        assert!(error.contains("more than once"), "got: {error}");
+    }
+
+    #[test]
+    fn a_map_in_both_requires_and_forbids_is_refused() {
+        let error = one_constraint(
+            r#"{ requires: [{ recorder: "on" }], forbids: [{ recorder: "on" }], reason: "r" }"#,
+        )
+        .expect_err("one map cannot be both the satisfaction and the refusal");
+        assert!(
+            error.contains("both what satisfies"),
+            "got: {error}"
+        );
+    }
+
+    #[test]
+    fn a_forbids_entry_naming_an_unknown_option_is_refused() {
+        let error = one_constraint(
+            r#"{ forbids: [{ robot: "genesis" }], reason: "r" }"#,
+        )
+        .expect_err("an unknown option is a dead reference");
+        assert!(error.contains("`genesis`"), "got: {error}");
+        assert!(error.contains("`forbids` entry"), "got: {error}");
     }
 
     #[test]

--- a/crates/daemon-config-internal/src/launcher/composition.rs
+++ b/crates/daemon-config-internal/src/launcher/composition.rs
@@ -1038,6 +1038,17 @@ mod tests {
         );
     }
 
+    /// The conflict is the IDENTICAL map in both lists: different maps may
+    /// share one constraint, each list keeping its own meaning.
+    #[test]
+    fn requires_and_forbids_with_different_maps_coexist() {
+        one_constraint(
+            r#"{ requires: [{ robot: "real" }], forbids: [{ recorder: "on" }],
+                 reason: "the rig runs unrecorded" }"#,
+        )
+        .expect("only the identical map in both lists is a conflict");
+    }
+
     #[test]
     fn a_forbids_entry_naming_an_unknown_option_is_refused() {
         let error = one_constraint(

--- a/crates/daemon-config-internal/src/launcher/flatten.rs
+++ b/crates/daemon-config-internal/src/launcher/flatten.rs
@@ -1344,30 +1344,70 @@ pub fn check_composition(launcher: &PeppyLauncher, launcher_file: &Path) -> Vec<
         Ok(loaded) => loaded,
         Err(e) => return vec![format!("{label}: {e}")],
     };
+    let mut problems = Vec::new();
+
+    // The bare launch must stay a member of the family: when every axis
+    // defaults or is optional, the selection `--with` nothing produces has
+    // to satisfy the constraints too. (A launcher with a required,
+    // defaultless axis has no bare launch, and resolve refuses it before
+    // constraints are consulted.) The default selection is one member
+    // checked on its own, so this runs before the enumeration cut below
+    // and an oversized family still hears it.
+    if let Ok(default_selection) = resolve_selection(&launcher.components, &[])
+        && let Some((_, constraint)) = first_violated(&launcher.constraints, &default_selection)
+    {
+        problems.push(format!(
+            "{label}: the default selection ({}) violates constraint `{}`: a bare launch \
+             with no `--with` must start. Change the axes' defaults or the constraint",
+            default_selection.echo(),
+            render_constraint(constraint),
+        ));
+    }
+
     let space = selection_space_size(&launcher.components);
     if space > COMBINATION_CEILING {
         // Per-axis validation above (fragments, provides, guards, targets)
         // still ran; what is skipped is every CROSS-axial combination, and
         // an incomplete check reported as success would read as a pass.
-        return vec![format!(
+        problems.push(format!(
             "{label}: the selection space has {space} combinations, more than the \
              {COMBINATION_CEILING} this check enumerates, so the cross-combination checks \
              did not run (each axis was validated on its own). Split the launcher or \
              reduce its axes' options"
-        )];
+        ));
+        return problems;
     }
-    let mut problems = Vec::new();
 
     // Split the space into the selections the constraints admit and the ones
     // they refuse. A refused selection is refused by design, so it is not
     // required to flatten; what IS checked is that the refusals leave a
     // usable family behind (below).
     let mut refused_by: Vec<usize> = vec![0; launcher.constraints.len()];
+    // For each constraint, the first constraint seen refusing a selection it
+    // also speaks about: itself when it is the first violation, an earlier
+    // one when something in front of it refuses that selection first. A
+    // constraint that refuses nothing while this names an EARLIER constraint
+    // is dead because that constraint shadows it; None means no selection
+    // ever spoke about it at all, so the axes alone already satisfy it.
+    let mut first_refuser: Vec<Option<usize>> = vec![None; launcher.constraints.len()];
     let mut legal: Vec<ComponentSelection> = Vec::new();
     for selection in enumerate_selections(&launcher.components) {
-        match first_violated(&launcher.constraints, &selection) {
-            Some((index, _)) => refused_by[index] += 1,
-            None => legal.push(selection),
+        let first = first_violated(&launcher.constraints, &selection);
+        for (index, constraint) in launcher.constraints.iter().enumerate() {
+            if constraint_satisfied(&selection, constraint) {
+                continue;
+            }
+            // This selection violates `index`, so `first` is necessarily
+            // Some: it names who refuses the selection, this constraint or
+            // an earlier one standing in front of it.
+            let (first_index, _) = first.expect("a violated constraint is a violation");
+            if first_index == index {
+                refused_by[index] += 1;
+            }
+            first_refuser[index].get_or_insert(first_index);
+        }
+        if first.is_none() {
+            legal.push(selection);
         }
     }
     for selection in &legal {
@@ -1382,9 +1422,20 @@ pub fn check_composition(launcher: &PeppyLauncher, launcher_file: &Path) -> Vec<
     // reads as protection it does not give.
     for (index, refused) in refused_by.iter().enumerate() {
         if *refused == 0 {
+            // The shadowed case names the constraint in front; the other
+            // keeps the axes explanation, since nothing was ever refused.
+            let why = match first_refuser[index].filter(|first| *first != index) {
+                Some(first) => format!(
+                    "the selections it would refuse are already refused by earlier \
+                     constraints (constraint {} refuses them first)",
+                    first + 1
+                ),
+                None => String::from(
+                    "it is already guaranteed by the axes or by an earlier constraint",
+                ),
+            };
             problems.push(format!(
-                "{label}: constraint {} ({}) refuses no selection: it is already guaranteed \
-                 by the axes or by an earlier constraint. Tighten it or drop it",
+                "{label}: constraint {} ({}) refuses no selection: {why}. Tighten it or drop it",
                 index + 1,
                 render_constraint(&launcher.constraints[index]),
             ));
@@ -1423,22 +1474,6 @@ pub fn check_composition(launcher: &PeppyLauncher, launcher_file: &Path) -> Vec<
                 ),
             });
         }
-    }
-
-    // The bare launch must stay a member of the family: when every axis
-    // defaults or is optional, the selection `--with` nothing produces has
-    // to satisfy the constraints too. (A launcher with a required,
-    // defaultless axis has no bare launch, and resolve refuses it before
-    // constraints are consulted.)
-    if let Ok(default_selection) = resolve_selection(&launcher.components, &[])
-        && let Some((_, constraint)) = first_violated(&launcher.constraints, &default_selection)
-    {
-        problems.push(format!(
-            "{label}: the default selection ({}) violates constraint `{}`: a bare launch \
-             with no `--with` must start. Change the axes' defaults or the constraint",
-            default_selection.echo(),
-            render_constraint(constraint),
-        ));
     }
 
     problems
@@ -2616,6 +2651,36 @@ mod tests {
         );
     }
 
+    /// A dead constraint shadowed by an earlier one is reported with the
+    /// constraint in front named, so the author sees the rule that makes
+    /// the later one dead rather than hunting for it.
+    #[test]
+    fn check_composition_names_the_constraint_that_shadows_a_dead_one() {
+        let launcher = constrained_launcher(
+            r#"{ forbids: [{ robot: "mujoco" }], reason: "the sim is retired" },
+               { when: { recorder: "on" }, forbids: [{ robot: "mujoco" }],
+                 reason: "the recorder films only the physical rig" }"#,
+        );
+        let problems = check_composition(&launcher, Path::new("family.json5"));
+        // The broad first rule strangles `mujoco` outright (a dead option)
+        // and stands in front of the narrow second one (a dead constraint).
+        assert_eq!(problems.len(), 2, "got: {problems:?}");
+        assert!(
+            problems
+                .iter()
+                .any(|p| p.contains("fill axis `robot` with `mujoco`")),
+            "got: {problems:?}"
+        );
+        let dead = problems
+            .iter()
+            .find(|p| p.contains("refuses no selection"))
+            .expect("the shadowed constraint is dead");
+        assert!(
+            dead.contains("constraint 1 refuses them first"),
+            "got: {dead}"
+        );
+    }
+
     #[test]
     fn check_composition_flags_a_refused_default_selection() {
         let launcher = constrained_launcher(
@@ -2630,6 +2695,45 @@ mod tests {
         );
         assert!(
             problems[0].contains("robot=real (default)"),
+            "got: {problems:?}"
+        );
+    }
+
+    /// The default selection is one member checked on its own, so it is
+    /// still checked when the family is too big to enumerate: the ceiling
+    /// guard skips the cross-combination checks, not the bare launch.
+    #[test]
+    fn check_composition_flags_a_refused_default_selection_above_the_ceiling() {
+        // Ten binary axes: 1024 selections, past the 512 ceiling, with
+        // defaults that violate the rule.
+        let axes = (0..10)
+            .map(|i| {
+                format!(
+                    r#"{{ name: "a{i}", default: "one",
+                         options: {{ one: {{ deployments: [] }}, two: {{ deployments: [] }} }} }}"#
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        let launcher = parse_launcher(&format!(
+            r#"{{
+                peppy_schema: "launcher/v1",
+                components: [{axes}],
+                constraints: [
+                    {{ when: {{ a0: "one" }}, requires: [{{ a1: "two" }}],
+                       reason: "the all-defaults member is not one anyone may run" }} ],
+            }}"#
+        ));
+        let problems = check_composition(&launcher, Path::new("family.json5"));
+        assert_eq!(problems.len(), 2, "got: {problems:?}");
+        assert!(
+            problems.iter().any(|p| p.contains("default selection")),
+            "got: {problems:?}"
+        );
+        assert!(
+            problems
+                .iter()
+                .any(|p| p.contains("cross-combination checks")),
             "got: {problems:?}"
         );
     }

--- a/crates/daemon-config-internal/src/launcher/flatten.rs
+++ b/crates/daemon-config-internal/src/launcher/flatten.rs
@@ -8,8 +8,8 @@
 //! filesystem launcher compose identically.
 
 use super::composition::{
-    Adjustment, ComponentAxis, FragmentPart, LauncherFragmentParser, validate_adjustment,
-    validate_guard,
+    Adjustment, ComponentAxis, FragmentPart, LauncherFragmentParser, SelectionConstraint,
+    validate_adjustment, validate_guard,
 };
 use super::parse::PeppyLauncherParser;
 use super::types::{Deployment, LinkTargets, LinkValue, PeppyLauncher, Selection};
@@ -57,6 +57,23 @@ pub enum CompositionError {
          its options with `--with`{options}"
     )]
     UnresolvedAxis { axis: String, options: String },
+
+    #[error(
+        "this launcher refuses the selection ({selection}): {condition} requires \
+         {alternatives}, which this selection does not satisfy. {reason}"
+    )]
+    ConstraintViolated {
+        /// The full resolved selection, with its `(default)` markers: the
+        /// axes the operator did not name are usually the fix.
+        selection: String,
+        /// `selecting axis=option ...`, or `every selection` for an
+        /// unconditional constraint.
+        condition: String,
+        /// The rendered `requires` alternatives.
+        alternatives: String,
+        /// The author's `reason`, verbatim.
+        reason: String,
+    },
 
     #[error(
         "fragment path `{path}` in {origin} is not usable: {reason}. A fragment path is \
@@ -1042,6 +1059,7 @@ fn flatten(
         deployments: merged,
         components: Vec::new(),
         adjustments: Vec::new(),
+        constraints: Vec::new(),
     };
     let text = serde_json5::to_string(&flat).map_err(|e| {
         CompositionError::FlatValidation(crate::error::Error::Serialize(e.to_string()))
@@ -1119,6 +1137,68 @@ fn render_guard(when: &BTreeMap<String, String>) -> String {
         .join(" ")
 }
 
+/// Whether this selection satisfies one constraint: either the constraint's
+/// guard does not speak about it, or at least one `requires` alternative
+/// holds wholly. Alternatives use the same matching a guard does, so an
+/// unfilled optional axis satisfies no pair on either side.
+fn constraint_satisfied(selection: &ComponentSelection, constraint: &SelectionConstraint) -> bool {
+    if let Some(when) = &constraint.when
+        && !guard_holds(selection, when)
+    {
+        return true;
+    }
+    constraint
+        .requires
+        .iter()
+        .any(|alternative| guard_holds(selection, alternative))
+}
+
+/// The first declared constraint this selection violates, with its position.
+/// Declaration order, so overlapping constraints refuse deterministically
+/// and the launcher author controls which reason the operator reads first.
+fn first_violated<'a>(
+    constraints: &'a [SelectionConstraint],
+    selection: &ComponentSelection,
+) -> Option<(usize, &'a SelectionConstraint)> {
+    constraints
+        .iter()
+        .enumerate()
+        .find(|(_, constraint)| !constraint_satisfied(selection, constraint))
+}
+
+/// The refusal for a selection that violates a constraint, carrying the full
+/// resolved selection (whose `(default)` markers show the axes the operator
+/// did not name), what was required, and the author's reason.
+fn constraint_violation(
+    constraint: &SelectionConstraint,
+    selection: &ComponentSelection,
+) -> CompositionError {
+    CompositionError::ConstraintViolated {
+        selection: selection.echo(),
+        condition: render_condition(constraint),
+        alternatives: render_alternatives(&constraint.requires),
+        reason: constraint.reason.clone(),
+    }
+}
+
+fn render_condition(constraint: &SelectionConstraint) -> String {
+    match &constraint.when {
+        Some(when) => format!("selecting {}", render_guard(when)),
+        None => String::from("every selection"),
+    }
+}
+
+fn render_alternatives(alternatives: &[BTreeMap<String, String>]) -> String {
+    let rendered: Vec<String> = alternatives
+        .iter()
+        .map(|alternative| format!("`{}`", render_guard(alternative)))
+        .collect();
+    match rendered.as_slice() {
+        [single] => single.clone(),
+        many => format!("one of {}", many.join(", ")),
+    }
+}
+
 /// What a slot holds, for the "appending is for array bindings" refusal.
 /// The array arm exists for totality; the caller matches it before this
 /// helper can see it.
@@ -1155,6 +1235,13 @@ pub fn compose(
 
     let loaded = load_composition(launcher, launcher_file)?;
     let selection = resolve_selection(&launcher.components, words)?;
+    // Constraints judge the RESOLVED selection: a default fills an axis
+    // exactly as an explicit word does, and the refusal's echo marks which
+    // was which. Refusing (rather than picking a satisfying option) keeps
+    // `--with` deterministic as constraints evolve.
+    if let Some((_, constraint)) = first_violated(&launcher.constraints, &selection) {
+        return Err(constraint_violation(constraint, &selection));
+    }
     let base_label = launcher_file_label(launcher_file);
     flatten(launcher, &loaded, &selection, &base_label)
 }
@@ -1183,8 +1270,14 @@ fn launcher_dir_of(launcher_file: &Path) -> PathBuf {
 /// contradicts an existing adjustment is the commit whose check fails,
 /// rather than the first launch that selects it.
 ///
+/// A legal selection is one the launcher's `constraints` admit: refused
+/// selections are refused by design and are not required to flatten, but
+/// the constraints themselves are held to leaving a usable family behind
+/// (no dead option, no dead constraint, a bare launch that still starts).
+///
 /// Returns the rendered problems, each prefixed with the launcher's file
-/// name; an empty vec means every selection flattens.
+/// name; an empty vec means every legal selection flattens and the
+/// constraints refuse only what the author could mean to refuse.
 pub fn check_composition(launcher: &PeppyLauncher, launcher_file: &Path) -> Vec<String> {
     let label = launcher_file_label(launcher_file);
     let loaded = match load_composition(launcher, launcher_file) {
@@ -1204,11 +1297,93 @@ pub fn check_composition(launcher: &PeppyLauncher, launcher_file: &Path) -> Vec<
         )];
     }
     let mut problems = Vec::new();
+
+    // Split the space into the selections the constraints admit and the ones
+    // they refuse. A refused selection is refused by design, so it is not
+    // required to flatten; what IS checked is that the refusals leave a
+    // usable family behind (below).
+    let mut refused_by: Vec<usize> = vec![0; launcher.constraints.len()];
+    let mut legal: Vec<ComponentSelection> = Vec::new();
     for selection in enumerate_selections(&launcher.components) {
-        if let Err(e) = flatten(launcher, &loaded, &selection, &label) {
+        match first_violated(&launcher.constraints, &selection) {
+            Some((index, _)) => refused_by[index] += 1,
+            None => legal.push(selection),
+        }
+    }
+    for selection in &legal {
+        if let Err(e) = flatten(launcher, &loaded, selection, &label) {
             problems.push(format!("{label} ({}): {e}", selection.echo()));
         }
     }
+
+    // A constraint that refuses nothing is dead: every selection it speaks
+    // about already satisfies it, or an earlier constraint refuses those
+    // selections first. Either way its reason is never read, and a dead rule
+    // reads as protection it does not give.
+    for (index, refused) in refused_by.iter().enumerate() {
+        if *refused == 0 {
+            let constraint = &launcher.constraints[index];
+            problems.push(format!(
+                "{label}: constraint {} ({} requires {}) refuses no selection: it is already \
+                 guaranteed by the axes or by an earlier constraint. Tighten it or drop it",
+                index + 1,
+                render_condition(constraint),
+                render_alternatives(&constraint.requires),
+            ));
+        }
+    }
+
+    // Every state of every axis must survive the constraints somewhere: an
+    // option no legal selection can pick is dead weight behind a refusal,
+    // and an optional axis that can never stay off is `optional` in name
+    // only.
+    for axis in &launcher.components {
+        let mut states: Vec<Option<&str>> =
+            axis.options.keys().map(|option| Some(option.as_str())).collect();
+        if axis.optional {
+            states.push(None);
+        }
+        for state in states {
+            if legal
+                .iter()
+                .any(|selection| selection.option_on(&axis.name) == state)
+            {
+                continue;
+            }
+            problems.push(match state {
+                Some(option) => format!(
+                    "{label}: no selection may fill axis `{}` with `{option}`: the \
+                     `constraints` refuse every selection that picks it, so the option can \
+                     never launch. Loosen a constraint or drop the option",
+                    axis.name
+                ),
+                None => format!(
+                    "{label}: no selection may leave axis `{}` unfilled: the `constraints` \
+                     refuse every selection without it, so `optional` is a promise nothing \
+                     keeps. Make the axis required or loosen a constraint",
+                    axis.name
+                ),
+            });
+        }
+    }
+
+    // The bare launch must stay a member of the family: when every axis
+    // defaults or is optional, the selection `--with` nothing produces has
+    // to satisfy the constraints too. (A launcher with a required,
+    // defaultless axis has no bare launch, and resolve refuses it before
+    // constraints are consulted.)
+    if let Ok(default_selection) = resolve_selection(&launcher.components, &[])
+        && let Some((_, constraint)) = first_violated(&launcher.constraints, &default_selection)
+    {
+        problems.push(format!(
+            "{label}: the default selection ({}) violates constraint `{} requires {}`: a bare \
+             launch with no `--with` must start. Change the axes' defaults or the constraint",
+            default_selection.echo(),
+            render_condition(constraint),
+            render_alternatives(&constraint.requires),
+        ));
+    }
+
     problems
 }
 
@@ -1951,6 +2126,7 @@ mod tests {
                 deployments: Vec::new(),
                 components: vec![axis],
                 adjustments: Vec::new(),
+                constraints: Vec::new(),
             };
             let err = compose(&launcher, &dir.path().join("l.json5"), &["sim".to_string()])
                 .expect_err("unsafe path must be refused");
@@ -2154,5 +2330,237 @@ mod tests {
         )
         .expect_err("flat launcher has nothing to select");
         assert!(matches!(err, CompositionError::WithOnFlatLauncher));
+    }
+
+    // -- constraints ---------------------------------------------------------
+
+    /// A robot choice and an optional recorder toggle, all inline: the
+    /// smallest family the constraints have something to say about.
+    fn constrained_launcher(constraints: &str) -> PeppyLauncher {
+        parse_launcher(&format!(
+            r#"{{
+                peppy_schema: "launcher/v1",
+                components: [
+                    {{ name: "robot", default: "real",
+                       options: {{
+                           real: {{ deployments: [
+                               {{ source: {{ name: "can_arm", tag: "v1" }},
+                                  instances: [{{ instance_id: "arm_inst" }}] }} ] }},
+                           mujoco: {{ deployments: [
+                               {{ source: {{ name: "sim_arm", tag: "v1" }},
+                                  instances: [{{ instance_id: "arm_inst" }}] }} ] }},
+                       }} }},
+                    {{ name: "recorder", optional: true,
+                       options: {{ on: {{ deployments: [
+                           {{ source: {{ name: "recorder", tag: "v1" }},
+                              instances: [{{ instance_id: "recorder_inst" }}] }} ] }} }} }},
+                ],
+                constraints: [{constraints}],
+            }}"#
+        ))
+    }
+
+    #[test]
+    fn a_selection_the_constraints_refuse_does_not_launch() {
+        let launcher = constrained_launcher(
+            r#"{ when: { recorder: "on" }, requires: [{ robot: "real" }],
+                 reason: "the recorder films the physical rig" }"#,
+        );
+        let err = compose(
+            &launcher,
+            Path::new("family.json5"),
+            &words(&["mujoco", "on"]),
+        )
+        .expect_err("the constraint must refuse this member");
+        assert!(matches!(err, CompositionError::ConstraintViolated { .. }));
+        let message = err.to_string();
+        assert!(message.contains("robot=mujoco  recorder=on"), "got: {message}");
+        assert!(message.contains("selecting recorder=on"), "got: {message}");
+        assert!(message.contains("`robot=real`"), "got: {message}");
+        assert!(
+            message.contains("films the physical rig"),
+            "the author's reason must reach the operator, got: {message}"
+        );
+    }
+
+    /// A default fills an axis exactly as an explicit word does, and the
+    /// refusal's echo marks it, so the operator sees which axis they never
+    /// named.
+    #[test]
+    fn a_defaulted_axis_can_violate_a_constraint_and_the_echo_marks_it() {
+        let launcher = constrained_launcher(
+            r#"{ when: { recorder: "on" }, requires: [{ robot: "mujoco" }],
+                 reason: "this recorder observes only the simulated arm" }"#,
+        );
+        let err = compose(&launcher, Path::new("family.json5"), &words(&["on"]))
+            .expect_err("the defaulted robot violates the constraint");
+        assert!(
+            err.to_string().contains("robot=real (default)"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn a_selection_satisfying_the_constraints_flattens() {
+        let launcher = constrained_launcher(
+            r#"{ when: { recorder: "on" }, requires: [{ robot: "real" }],
+                 reason: "the recorder films the physical rig" }"#,
+        );
+        // The default satisfies the requirement...
+        compose(&launcher, Path::new("family.json5"), &words(&["on"]))
+            .expect("real (default) + recorder satisfies the constraint");
+        // ...and a selection the guard does not speak about is untouched.
+        compose(&launcher, Path::new("family.json5"), &words(&["mujoco"]))
+            .expect("with the recorder off the constraint is quiet");
+        // An alternative list is an OR: the second alternative carries it.
+        let either = constrained_launcher(
+            r#"{ when: { robot: "mujoco" }, requires: [{ recorder: "on" }],
+                 reason: "the sim exists to produce datasets" }"#,
+        );
+        compose(&either, Path::new("family.json5"), &words(&["mujoco", "on"]))
+            .expect("the required recorder is selected");
+    }
+
+    /// The gap `repo index --check` closes: a selection the constraints
+    /// refuse is not required to flatten. This family's refused member is
+    /// exactly its broken one (the recorder's append lands on a slot the
+    /// mujoco arm binds as a scalar), so without the constraint the check
+    /// fails and with it the check passes.
+    #[test]
+    fn check_composition_holds_only_legal_selections_to_flattening() {
+        let family = |constraints: &str| {
+            parse_launcher(&format!(
+                r#"{{
+                    peppy_schema: "launcher/v1",
+                    components: [
+                        {{ name: "robot", default: "real",
+                           options: {{
+                               real: {{ deployments: [
+                                   {{ source: {{ name: "can_arm", tag: "v1" }},
+                                      instances: [{{ instance_id: "arm_inst" }}] }} ] }},
+                               mujoco: {{ deployments: [
+                                   {{ source: {{ name: "sim_engine", tag: "v1" }},
+                                      instances: [{{ instance_id: "sim_inst" }}] }},
+                                   {{ source: {{ name: "sim_arm", tag: "v1" }},
+                                      instances: [{{ instance_id: "arm_inst",
+                                                    links: {{ observed: "sim_inst" }} }}] }} ] }},
+                           }} }},
+                        {{ name: "recorder", optional: true,
+                           options: {{ on: {{
+                               deployments: [
+                                   {{ source: {{ name: "recorder", tag: "v1" }},
+                                      instances: [{{ instance_id: "recorder_inst" }}] }} ],
+                               adjustments: [
+                                   {{ target: "arm_inst",
+                                      add_links: {{ observed: ["recorder_inst"] }} }} ],
+                           }} }} }},
+                    ],
+                    {constraints}
+                }}"#
+            ))
+        };
+
+        let unconstrained = family("");
+        let problems = check_composition(&unconstrained, Path::new("family.json5"));
+        assert_eq!(problems.len(), 1, "got: {problems:?}");
+        assert!(
+            problems[0].contains("robot=mujoco  recorder=on"),
+            "got: {problems:?}"
+        );
+
+        let constrained = family(
+            r#"constraints: [
+                { when: { recorder: "on" }, requires: [{ robot: "real" }],
+                  reason: "the recorder films the physical rig" } ],"#,
+        );
+        let problems = check_composition(&constrained, Path::new("family.json5"));
+        assert!(problems.is_empty(), "got: {problems:?}");
+    }
+
+    #[test]
+    fn check_composition_flags_an_option_nothing_may_select() {
+        let launcher = constrained_launcher(
+            r#"{ when: { robot: "mujoco" }, requires: [{ recorder: "on" }],
+                 reason: "the sim exists to produce datasets" },
+               { when: { recorder: "on" }, requires: [{ robot: "real" }],
+                 reason: "the recorder films the physical rig" }"#,
+        );
+        let problems = check_composition(&launcher, Path::new("family.json5"));
+        assert_eq!(problems.len(), 1, "got: {problems:?}");
+        assert!(
+            problems[0].contains("fill axis `robot` with `mujoco`"),
+            "got: {problems:?}"
+        );
+    }
+
+    #[test]
+    fn check_composition_flags_a_constraint_that_refuses_nothing() {
+        let launcher = constrained_launcher(
+            r#"{ when: { recorder: "on" }, requires: [{ robot: "real" }, { robot: "mujoco" }],
+                 reason: "some robot must be selected" }"#,
+        );
+        let problems = check_composition(&launcher, Path::new("family.json5"));
+        assert_eq!(problems.len(), 1, "got: {problems:?}");
+        assert!(
+            problems[0].contains("refuses no selection"),
+            "got: {problems:?}"
+        );
+    }
+
+    #[test]
+    fn check_composition_flags_a_refused_default_selection() {
+        let launcher = constrained_launcher(
+            r#"{ when: { robot: "real" }, requires: [{ recorder: "on" }],
+                 reason: "the rig is always recorded" }"#,
+        );
+        let problems = check_composition(&launcher, Path::new("family.json5"));
+        assert_eq!(problems.len(), 1, "got: {problems:?}");
+        assert!(
+            problems[0].contains("default selection"),
+            "got: {problems:?}"
+        );
+        assert!(
+            problems[0].contains("robot=real (default)"),
+            "got: {problems:?}"
+        );
+    }
+
+    #[test]
+    fn check_composition_flags_an_optional_axis_that_may_never_stay_off() {
+        let launcher = constrained_launcher(
+            r#"{ requires: [{ recorder: "on" }], reason: "every session is recorded" }"#,
+        );
+        let problems = check_composition(&launcher, Path::new("family.json5"));
+        // Two findings, one cause: `optional` is a promise nothing keeps,
+        // and the bare launch it implies is refused.
+        assert_eq!(problems.len(), 2, "got: {problems:?}");
+        assert!(
+            problems
+                .iter()
+                .any(|p| p.contains("leave axis `recorder` unfilled")),
+            "got: {problems:?}"
+        );
+        assert!(
+            problems.iter().any(|p| p.contains("default selection")),
+            "got: {problems:?}"
+        );
+    }
+
+    #[test]
+    fn constraints_without_components_are_refused() {
+        let err = PeppyLauncherParser::from_content(
+            r#"{
+                peppy_schema: "launcher/v1",
+                deployments: [],
+                constraints: [
+                    { requires: [{ robot: "real" }], reason: "r" } ],
+            }"#,
+        )
+        .expect_err("a flat launcher has no selection to refuse");
+        assert!(
+            err.to_string()
+                .contains("declares `constraints` but no `components`"),
+            "got: {err}"
+        );
     }
 }

--- a/crates/daemon-config-internal/src/launcher/flatten.rs
+++ b/crates/daemon-config-internal/src/launcher/flatten.rs
@@ -59,18 +59,33 @@ pub enum CompositionError {
     UnresolvedAxis { axis: String, options: String },
 
     #[error(
-        "this launcher refuses the selection ({selection}): {condition} requires \
-         {alternatives}, which this selection does not satisfy. {reason}"
+        "{condition} requires {alternatives}, which this selection ({selection}) does not \
+         satisfy. {reason}"
     )]
-    ConstraintViolated {
-        /// The full resolved selection, with its `(default)` markers: the
-        /// axes the operator did not name are usually the fix.
-        selection: String,
-        /// `selecting axis=option ...`, or `every selection` for an
-        /// unconditional constraint.
+    ConstraintUnsatisfied {
+        /// `selecting axis=option ...`, or `this launcher` for an
+        /// unconditional constraint: the offending choice leads the message.
         condition: String,
         /// The rendered `requires` alternatives.
         alternatives: String,
+        /// The full resolved selection, with its `(default)` markers: the
+        /// axes the operator did not name are usually the fix.
+        selection: String,
+        /// The author's `reason`, verbatim.
+        reason: String,
+    },
+
+    #[error(
+        "{condition} forbids {matched}, which this selection ({selection}) has. {reason}"
+    )]
+    ConstraintForbidden {
+        /// `selecting axis=option ...`, or `this launcher` for an
+        /// unconditional constraint.
+        condition: String,
+        /// The rendered `forbids` entry the selection matched.
+        matched: String,
+        /// The full resolved selection, with its `(default)` markers.
+        selection: String,
         /// The author's `reason`, verbatim.
         reason: String,
     },
@@ -1138,19 +1153,28 @@ fn render_guard(when: &BTreeMap<String, String>) -> String {
 }
 
 /// Whether this selection satisfies one constraint: either the constraint's
-/// guard does not speak about it, or at least one `requires` alternative
-/// holds wholly. Alternatives use the same matching a guard does, so an
-/// unfilled optional axis satisfies no pair on either side.
+/// guard does not speak about it, or it matches no `forbids` entry and (when
+/// any are declared) at least one `requires` alternative holds wholly. Both
+/// lists use the same matching a guard does, so an unfilled optional axis
+/// satisfies no pair on either side.
 fn constraint_satisfied(selection: &ComponentSelection, constraint: &SelectionConstraint) -> bool {
     if let Some(when) = &constraint.when
         && !guard_holds(selection, when)
     {
         return true;
     }
-    constraint
-        .requires
+    if constraint
+        .forbids
         .iter()
-        .any(|alternative| guard_holds(selection, alternative))
+        .any(|entry| guard_holds(selection, entry))
+    {
+        return false;
+    }
+    constraint.requires.is_empty()
+        || constraint
+            .requires
+            .iter()
+            .any(|alternative| guard_holds(selection, alternative))
 }
 
 /// The first declared constraint this selection violates, with its position.
@@ -1168,15 +1192,29 @@ fn first_violated<'a>(
 
 /// The refusal for a selection that violates a constraint, carrying the full
 /// resolved selection (whose `(default)` markers show the axes the operator
-/// did not name), what was required, and the author's reason.
+/// did not name), what was required or forbidden, and the author's reason.
+/// A matched `forbids` entry is the sharper claim, so it is the one
+/// reported when a selection fails on both counts.
 fn constraint_violation(
     constraint: &SelectionConstraint,
     selection: &ComponentSelection,
 ) -> CompositionError {
-    CompositionError::ConstraintViolated {
-        selection: selection.echo(),
+    if let Some(matched) = constraint
+        .forbids
+        .iter()
+        .find(|entry| guard_holds(selection, entry))
+    {
+        return CompositionError::ConstraintForbidden {
+            condition: render_condition(constraint),
+            matched: format!("`{}`", render_guard(matched)),
+            selection: selection.echo(),
+            reason: constraint.reason.clone(),
+        };
+    }
+    CompositionError::ConstraintUnsatisfied {
         condition: render_condition(constraint),
         alternatives: render_alternatives(&constraint.requires),
+        selection: selection.echo(),
         reason: constraint.reason.clone(),
     }
 }
@@ -1184,7 +1222,7 @@ fn constraint_violation(
 fn render_condition(constraint: &SelectionConstraint) -> String {
     match &constraint.when {
         Some(when) => format!("selecting {}", render_guard(when)),
-        None => String::from("every selection"),
+        None => String::from("this launcher"),
     }
 }
 
@@ -1197,6 +1235,28 @@ fn render_alternatives(alternatives: &[BTreeMap<String, String>]) -> String {
         [single] => single.clone(),
         many => format!("one of {}", many.join(", ")),
     }
+}
+
+/// One constraint in a line, for the check-time problems that name a whole
+/// rule rather than one refusal: "selecting cameras=cameras requires
+/// `robot=real`", "this launcher forbids `robot=mujoco recorder=on`".
+fn render_constraint(constraint: &SelectionConstraint) -> String {
+    let mut clauses = Vec::with_capacity(2);
+    if !constraint.requires.is_empty() {
+        clauses.push(format!(
+            "requires {}",
+            render_alternatives(&constraint.requires)
+        ));
+    }
+    if !constraint.forbids.is_empty() {
+        let entries: Vec<String> = constraint
+            .forbids
+            .iter()
+            .map(|entry| format!("`{}`", render_guard(entry)))
+            .collect();
+        clauses.push(format!("forbids {}", entries.join(", ")));
+    }
+    format!("{} {}", render_condition(constraint), clauses.join(" and "))
 }
 
 /// What a slot holds, for the "appending is for array bindings" refusal.
@@ -1322,13 +1382,11 @@ pub fn check_composition(launcher: &PeppyLauncher, launcher_file: &Path) -> Vec<
     // reads as protection it does not give.
     for (index, refused) in refused_by.iter().enumerate() {
         if *refused == 0 {
-            let constraint = &launcher.constraints[index];
             problems.push(format!(
-                "{label}: constraint {} ({} requires {}) refuses no selection: it is already \
-                 guaranteed by the axes or by an earlier constraint. Tighten it or drop it",
+                "{label}: constraint {} ({}) refuses no selection: it is already guaranteed \
+                 by the axes or by an earlier constraint. Tighten it or drop it",
                 index + 1,
-                render_condition(constraint),
-                render_alternatives(&constraint.requires),
+                render_constraint(&launcher.constraints[index]),
             ));
         }
     }
@@ -1376,11 +1434,10 @@ pub fn check_composition(launcher: &PeppyLauncher, launcher_file: &Path) -> Vec<
         && let Some((_, constraint)) = first_violated(&launcher.constraints, &default_selection)
     {
         problems.push(format!(
-            "{label}: the default selection ({}) violates constraint `{} requires {}`: a bare \
-             launch with no `--with` must start. Change the axes' defaults or the constraint",
+            "{label}: the default selection ({}) violates constraint `{}`: a bare launch \
+             with no `--with` must start. Change the axes' defaults or the constraint",
             default_selection.echo(),
-            render_condition(constraint),
-            render_alternatives(&constraint.requires),
+            render_constraint(constraint),
         ));
     }
 
@@ -2372,7 +2429,7 @@ mod tests {
             &words(&["mujoco", "on"]),
         )
         .expect_err("the constraint must refuse this member");
-        assert!(matches!(err, CompositionError::ConstraintViolated { .. }));
+        assert!(matches!(err, CompositionError::ConstraintUnsatisfied { .. }));
         let message = err.to_string();
         assert!(message.contains("robot=mujoco  recorder=on"), "got: {message}");
         assert!(message.contains("selecting recorder=on"), "got: {message}");
@@ -2419,6 +2476,58 @@ mod tests {
         );
         compose(&either, Path::new("family.json5"), &words(&["mujoco", "on"]))
             .expect("the required recorder is selected");
+    }
+
+    #[test]
+    fn a_forbidden_combination_is_refused_and_names_the_matched_entry() {
+        let launcher = constrained_launcher(
+            r#"{ when: { robot: "mujoco" }, forbids: [{ recorder: "on" }],
+                 reason: "the recorder films only the physical rig" }"#,
+        );
+        let err = compose(
+            &launcher,
+            Path::new("family.json5"),
+            &words(&["mujoco", "on"]),
+        )
+        .expect_err("the exclusion must refuse this member");
+        assert!(matches!(err, CompositionError::ConstraintForbidden { .. }));
+        let message = err.to_string();
+        assert!(message.contains("selecting robot=mujoco"), "got: {message}");
+        assert!(message.contains("forbids `recorder=on`"), "got: {message}");
+        assert!(
+            message.contains("films only the physical rig"),
+            "got: {message}"
+        );
+        // Either side alone is untouched.
+        compose(&launcher, Path::new("family.json5"), &words(&["mujoco"]))
+            .expect("the sim without the recorder is fine");
+        compose(&launcher, Path::new("family.json5"), &words(&["on"]))
+            .expect("the recorder on the real (default) robot is fine");
+    }
+
+    /// The unconditional form: one entry naming the whole combination, with
+    /// no `when` at all.
+    #[test]
+    fn an_unconditional_forbid_refuses_exactly_its_combination() {
+        let launcher = constrained_launcher(
+            r#"{ forbids: [{ robot: "mujoco", recorder: "on" }],
+                 reason: "the recorder films only the physical rig" }"#,
+        );
+        let err = compose(
+            &launcher,
+            Path::new("family.json5"),
+            &words(&["mujoco", "on"]),
+        )
+        .expect_err("the combination is forbidden");
+        assert!(
+            err.to_string()
+                .contains("this launcher forbids `recorder=on robot=mujoco`"),
+            "got: {err}"
+        );
+        compose(&launcher, Path::new("family.json5"), &words(&["mujoco"]))
+            .expect("half the combination is not the combination");
+        let problems = check_composition(&launcher, Path::new("family.json5"));
+        assert!(problems.is_empty(), "got: {problems:?}");
     }
 
     /// The gap `repo index --check` closes: a selection the constraints

--- a/crates/daemon-config-internal/src/launcher/types.rs
+++ b/crates/daemon-config-internal/src/launcher/types.rs
@@ -1,4 +1,4 @@
-use super::composition::{Adjustment, ComponentAxis};
+use super::composition::{Adjustment, ComponentAxis, SelectionConstraint};
 use crate::error::StructuredError;
 use crate::internal::contract::validate_named_items;
 use crate::internal::core_node_name::{CoreNodeName, SELF_CORE_NODE};
@@ -48,6 +48,13 @@ pub struct PeppyLauncher {
     /// adjustment is indirection around a file the author can edit directly.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub adjustments: Vec<Adjustment>,
+    /// The selections this family refuses to be: rules that a resolved
+    /// selection must satisfy or the launch is refused before anything is
+    /// pinned or started. How a family excludes members that would flatten
+    /// cleanly into a stack nobody should run. Requires `components`: with
+    /// nothing to select there is no selection to refuse.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub constraints: Vec<SelectionConstraint>,
 }
 
 /// Custom deserialization for [`PeppyLauncher`] that, after the default
@@ -79,6 +86,8 @@ impl<'de> Deserialize<'de> for PeppyLauncher {
             components: Vec<ComponentAxis>,
             #[serde(default)]
             adjustments: Vec<Adjustment>,
+            #[serde(default)]
+            constraints: Vec<SelectionConstraint>,
         }
 
         let raw = RawPeppyLauncher::deserialize(deserializer)?;
@@ -99,6 +108,18 @@ impl<'de> Deserialize<'de> for PeppyLauncher {
         }
         super::composition::validate_launcher_adjustments(&raw.adjustments, &raw.components)
             .map_err(de::Error::custom)?;
+        // Same shape of refusal as the adjustments one above: a constraint
+        // speaks in axis and option names, so without axes it refers to
+        // nothing.
+        if raw.components.is_empty() && !raw.constraints.is_empty() {
+            return Err(de::Error::custom(
+                "this launcher declares `constraints` but no `components`: with nothing to \
+                 select there is no selection to refuse. Declare the axes the constraints \
+                 speak about, or drop them",
+            ));
+        }
+        super::composition::validate_constraints(&raw.constraints, &raw.components)
+            .map_err(de::Error::custom)?;
 
         if raw.components.is_empty() {
             cross_check_flat_document(&raw.deployments, &raw.core_nodes)
@@ -111,6 +132,7 @@ impl<'de> Deserialize<'de> for PeppyLauncher {
             deployments: raw.deployments,
             components: raw.components,
             adjustments: raw.adjustments,
+            constraints: raw.constraints,
         })
     }
 }

--- a/crates/daemon-config-internal/src/lib.rs
+++ b/crates/daemon-config-internal/src/lib.rs
@@ -97,8 +97,9 @@ pub mod launcher {
         FlattenReport, Fragment, FragmentPart, FragmentSpec, FrameworkOverrides, LauncherFragment,
         LauncherFragmentParser, LinkTargets, LinkValue, PairingValidationItem, PeppyLauncher,
         PeppyLauncherParser, Placements, PlannedObservation, PlannedPairEndpoint, PlannedPairing,
-        Selection, SelectionEntry, SelectionSource, SkipReason, SkippedAdjustment, VacantReason,
-        ValidatedBindings, ValidatedLinkPlan, ValidatedObservations, ValidatedPairings,
+        Selection, SelectionConstraint, SelectionEntry, SelectionSource, SkipReason,
+        SkippedAdjustment, VacantReason, ValidatedBindings, ValidatedLinkPlan,
+        ValidatedObservations, ValidatedPairings,
         check_composition, compose, participant_vacancies, split_link_target, validate_bindings,
         validate_link_plan, validate_link_slots, validate_observations, validate_pairings,
     };

--- a/crates/peppy/tests/repo_index.rs
+++ b/crates/peppy/tests/repo_index.rs
@@ -67,6 +67,111 @@ fn repo_index_check_passes_on_a_generated_index() {
     repo_index(Some(repo), true).expect("the index it just wrote should check out");
 }
 
+/// Helper: a composed family whose one structurally broken member is the
+/// one the given `constraints` refuse. The mujoco arm binds `observed` to
+/// its engine as a scalar, so the recorder's append onto that slot cannot
+/// flatten: without constraints the check must fail on `mujoco` + recorder,
+/// with them it must pass, because a refused selection is refused by
+/// design rather than required to flatten.
+fn write_constrained_family(repo: &Path, constraints: &str) {
+    std::fs::create_dir_all(repo.join("launchers")).unwrap();
+    std::fs::write(
+        repo.join("launchers/family.json5"),
+        format!(
+            r#"{{
+  peppy_schema: "launcher/v1",
+  components: [
+    {{ name: "robot", default: "real",
+       options: {{
+           real: {{ deployments: [
+               {{ source: {{ name: "arm", tag: "v1" }},
+                  instances: [{{ instance_id: "arm_inst" }}] }} ] }},
+           mujoco: {{ deployments: [
+               {{ source: {{ name: "engine", tag: "v1" }},
+                  instances: [{{ instance_id: "sim_inst" }}] }},
+               {{ source: {{ name: "arm", tag: "v1" }},
+                  instances: [{{ instance_id: "arm_inst",
+                                links: {{ observed: "sim_inst" }} }}] }} ] }},
+       }} }},
+    {{ name: "recorder", optional: true,
+       options: {{ on: {{
+           deployments: [
+               {{ source: {{ name: "recorder", tag: "v1" }},
+                  instances: [{{ instance_id: "recorder_inst" }}] }} ],
+           adjustments: [
+               {{ target: "arm_inst",
+                  add_links: {{ observed: ["recorder_inst"] }} }} ],
+       }} }} }},
+  ],
+  {constraints}
+  deployments: [],
+}}"#
+        ),
+    )
+    .unwrap();
+}
+
+/// The end-to-end shape of the whole feature: a family with a member that
+/// flattens into nonsense is refused by its `constraints`, and
+/// `repo index --check` holds only the legal members to flattening. The
+/// same family without the constraints fails the same check on the same
+/// member.
+#[test]
+fn repo_index_check_skips_selections_the_constraints_refuse() {
+    let tmp = TempDir::new().unwrap();
+
+    let unconstrained = tmp.path().join("unconstrained");
+    write_node(&unconstrained.join("nodes/a"), "a", "v1");
+    write_constrained_family(&unconstrained, "");
+    repo_index(Some(unconstrained.clone()), false).expect("indexing should succeed");
+    let err = repo_index(Some(unconstrained), true)
+        .expect_err("the broken member must fail the unconstrained check");
+    let message = err.to_string();
+    assert!(message.contains("family.json5"), "{message}");
+    assert!(
+        message.contains("robot=mujoco  recorder=on"),
+        "the check names the selection that cannot flatten: {message}"
+    );
+
+    let constrained = tmp.path().join("constrained");
+    write_node(&constrained.join("nodes/a"), "a", "v1");
+    write_constrained_family(
+        &constrained,
+        r#"constraints: [
+    { when: { recorder: "on" }, requires: [{ robot: "real" }],
+      reason: "the recorder films the physical rig" } ],"#,
+    );
+    repo_index(Some(constrained.clone()), false).expect("indexing should succeed");
+    repo_index(Some(constrained), true)
+        .expect("the constrained family should check out: its refused member need not flatten");
+}
+
+/// The guardrail on the guardrail: constraints that strangle an option out
+/// of the family entirely fail the check, naming the dead option, so a
+/// typo'd rule cannot silently shrink what a launcher offers.
+#[test]
+fn repo_index_check_flags_an_option_the_constraints_strangle() {
+    let tmp = TempDir::new().unwrap();
+    let repo = tmp.path().join("hub");
+    write_node(&repo.join("nodes/a"), "a", "v1");
+    write_constrained_family(
+        &repo,
+        r#"constraints: [
+    { when: { robot: "mujoco" }, requires: [{ recorder: "on" }],
+      reason: "the sim exists to produce datasets" },
+    { when: { recorder: "on" }, requires: [{ robot: "real" }],
+      reason: "the recorder films the physical rig" } ],"#,
+    );
+    repo_index(Some(repo.clone()), false).expect("indexing should succeed");
+
+    let err = repo_index(Some(repo), true).expect_err("a dead option must fail the check");
+    let message = err.to_string();
+    assert!(
+        message.contains("fill axis `robot` with `mujoco`"),
+        "the check names the option nothing can select: {message}"
+    );
+}
+
 /// Writing twice produces the same file, so re-running generation after an
 /// unrelated change never shows up as a spurious diff in a pull request.
 #[test]

--- a/crates/peppy/tests/stack_launch.rs
+++ b/crates/peppy/tests/stack_launch.rs
@@ -4227,7 +4227,9 @@ async fn stack_launch_still_requires_vacancy_for_an_absent_zero_or_one_dependenc
 /// candidates (one of which is absent in any given selection, so the launch
 /// also exercises the skip). `--with` picks beta and the extras; what runs
 /// is the flattened single deployment, and the coordinator echoes the full
-/// resolution before anything starts.
+/// resolution before anything starts. The launcher also declares a
+/// constraint this selection satisfies, so a satisfied constraint is shown
+/// not to stand in a real launch's way.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn stack_launch_flattens_a_composed_launcher() {
     let serve = ServeCommandEmulation::with_mock()
@@ -4332,6 +4334,10 @@ async fn stack_launch_flattens_a_composed_launcher() {
                         on: "fragments/extras.json5",
                     }},
                 }},
+            ],
+            constraints: [
+                {{ when: {{ extras: "on" }}, requires: [{{ backend: "beta" }}],
+                   reason: "the extras tune only the beta backend" }},
             ],
             deployments: [],
         }}"#,
@@ -4501,6 +4507,79 @@ async fn stack_launch_refuses_broken_selections_before_the_daemon_round_trip() {
         msg.contains("robot") && msg.contains("`mujoco`") && msg.contains("`real`"),
         "the refusal should name the axis and both options: {msg}"
     );
+
+    // A selection the launcher's `constraints` refuse is caught by the same
+    // caller-side preflight: the message opens with the choice that brought
+    // the rule in, marks the axes the operator never named, and quotes the
+    // author's reason. Here the violating axis is a DEFAULT: the operator
+    // only typed `on`.
+    let requires_launcher = nodes_dir.path().join("requires.json5");
+    fs::write(
+        &requires_launcher,
+        r#"{
+            peppy_schema: "launcher/v1",
+            components: [
+                { name: "robot", default: "real",
+                  options: { real: { deployments: [] }, mujoco: { deployments: [] } } },
+                { name: "recorder", optional: true,
+                  options: { on: { deployments: [] } } },
+            ],
+            constraints: [
+                { when: { recorder: "on" }, requires: [{ robot: "mujoco" }],
+                  reason: "this recorder observes only the simulated arm" },
+            ],
+            deployments: [],
+        }"#,
+    )
+    .expect("constrained launcher should be writable");
+    let msg = launch_with(vec!["on".to_owned()], requires_launcher)
+        .expect_err("a constraint-violating selection must be refused")
+        .to_string();
+    assert!(
+        msg.contains("selecting recorder=on") && msg.contains("`robot=mujoco`"),
+        "the refusal should name the guard and the requirement: {msg}"
+    );
+    assert!(
+        msg.contains("robot=real (default)"),
+        "the echo should mark the defaulted axis the operator never typed: {msg}"
+    );
+    assert!(
+        msg.contains("observes only the simulated arm"),
+        "the author's reason should reach the operator: {msg}"
+    );
+
+    // The `forbids` form refuses a combination directly.
+    let forbids_launcher = nodes_dir.path().join("forbids.json5");
+    fs::write(
+        &forbids_launcher,
+        r#"{
+            peppy_schema: "launcher/v1",
+            components: [
+                { name: "robot", default: "real",
+                  options: { real: { deployments: [] }, mujoco: { deployments: [] } } },
+                { name: "recorder", optional: true,
+                  options: { on: { deployments: [] } } },
+            ],
+            constraints: [
+                { when: { robot: "mujoco" }, forbids: [{ recorder: "on" }],
+                  reason: "the recorder films only the physical rig" },
+            ],
+            deployments: [],
+        }"#,
+    )
+    .expect("constrained launcher should be writable");
+    let msg = launch_with(
+        vec!["mujoco".to_owned(), "on".to_owned()],
+        forbids_launcher,
+    )
+    .expect_err("a forbidden combination must be refused")
+    .to_string();
+    assert!(
+        msg.contains("selecting robot=mujoco")
+            && msg.contains("forbids `recorder=on`")
+            && msg.contains("films only the physical rig"),
+        "the refusal should name the guard, the matched entry, and the reason: {msg}"
+    );
 }
 
 /// `peppy stack resolve` needs no daemon: for a filesystem launcher it reads
@@ -4585,5 +4664,66 @@ fn stack_resolve_prints_the_flat_launcher_and_report() {
     assert!(
         report_text.contains("sim_inst") && report_text.contains("not in this selection"),
         "the base's sleeping adjustment is listed as skipped: {report_text}"
+    );
+}
+
+/// A constraint refusal reaches `stack resolve` through the same `compose`
+/// a launch runs, with no daemon involved; a legal sibling still flattens,
+/// and the flat document carries no composition keys.
+#[test]
+fn stack_resolve_refuses_a_selection_the_constraints_exclude() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let launcher = dir.path().join("family.json5");
+    std::fs::write(
+        &launcher,
+        r#"{
+            peppy_schema: "launcher/v1",
+            components: [
+                { name: "robot", default: "real",
+                  options: {
+                      real: { deployments: [
+                          { source: { name: "arm", tag: "v1" },
+                            instances: [{ instance_id: "arm_inst" }] } ] },
+                      mujoco: { deployments: [
+                          { source: { name: "sim", tag: "v1" },
+                            instances: [{ instance_id: "arm_inst" }] } ] },
+                  } },
+                { name: "cameras", optional: true,
+                  options: { cameras: { deployments: [
+                      { source: { name: "cam", tag: "v1" },
+                        instances: [{ instance_id: "cam_inst" }] } ] } } },
+            ],
+            constraints: [
+                { when: { cameras: "cameras" }, requires: [{ robot: "real" }],
+                  reason: "the cameras film the physical rig" },
+            ],
+            deployments: [],
+        }"#,
+    )
+    .expect("launcher");
+
+    let err = peppy::commands::stack::resolve_rendered(
+        launcher.clone(),
+        &["mujoco".to_owned(), "cameras".to_owned()],
+    )
+    .expect_err("the refused member must not resolve");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("selecting cameras=cameras")
+            && msg.contains("`robot=real`")
+            && msg.contains("film the physical rig"),
+        "the refusal names the guard, the requirement, and the reason: {msg}"
+    );
+
+    let (document, _report) =
+        peppy::commands::stack::resolve_rendered(launcher, &["cameras".to_owned()])
+            .expect("the legal sibling resolves");
+    assert!(
+        document.contains("cam_inst") && document.contains("arm_inst"),
+        "the flat document carries the selected options: {document}"
+    );
+    assert!(
+        !document.contains("constraints"),
+        "the flat document is an ordinary launcher with no composition keys: {document}"
     );
 }

--- a/docs/src/content/docs/guides/launch_files.mdx
+++ b/docs/src/content/docs/guides/launch_files.mdx
@@ -377,17 +377,17 @@ The ownership rule of thumb: if a value is something the operator genuinely deci
 
 ## Constraints
 
-Adjustments change what a selection builds; a **constraint** refuses selections nobody should run. Some members of a family are stacks no operator should be able to name: the recorder that films only the physical rig must not launch against the simulator. Those members flatten cleanly, so neither `provides` (which only promises ids exist) nor an adjustment's `when` guard (which only decides whether one adjustment applies inside a legal selection) can say it. A constraint can, and it only ever refuses: a violating selection is rejected before anything is pinned or started. It never picks an option to satisfy itself, because a `--with` whose meaning shifted as constraints evolve would launch stacks the operator did not name.
+Adjustments change what a selection builds; a **constraint** refuses selections nobody should run. Some members of a family are stacks no operator should be able to name: the ZED camera that films only the physical rig must not launch against the simulator. Those members flatten cleanly, so neither `provides` (which only promises ids exist) nor an adjustment's `when` guard (which only decides whether one adjustment applies inside a legal selection) can say it. A constraint can, and it only ever refuses: a violating selection is rejected before anything is pinned or started. It never picks an option to satisfy itself, because a `--with` whose meaning shifted as constraints evolve would launch stacks the operator did not name.
 
 ```json5
 constraints: [
-  // With the recorder selected, the robot must be the real one.
-  { when: { recorder: "lerobot_recorder" }, requires: [{ robot: "real" }],
-    reason: "the recorder films the physical rig" },
+  // With the ZED camera selected, the robot must be the real one.
+  { when: { camera: "zed" }, requires: [{ robot: "real" }],
+    reason: "the ZED films the physical rig" },
 
   // The whole combination is refused, no guard needed.
-  { forbids: [{ robot: "mujoco", recorder: "lerobot_recorder" }],
-    reason: "the dataset recorder pairs with the real rig only" },
+  { forbids: [{ robot: "mujoco", camera: "zed" }],
+    reason: "the stereo camera pairs with the real rig only" },
 ]
 ```
 
@@ -400,7 +400,7 @@ constraints: [
 
 A constraint states at least one of `requires` and `forbids`; with neither it refuses nothing, and the launcher is refused when it is read. The rest of the shape is held to the same standard: `when` and every entry name at least one `axis: option` pair, an entry may not repeat an axis the guard already fixes (under the guard that axis is decided before anything is selected), the same map may not be listed twice in one list, and one map may not appear in both lists.
 
-Matching treats an unfilled optional axis as matching no pair, on either side: a guard on `recorder: "lerobot_recorder"` stays quiet when the recorder axis is off, and a `requires` alternative naming that option is satisfied only by selecting it, never by leaving the axis unfilled. That asymmetry is the tool for optional features: `requires` is how an option demands company, while `forbids` is the only way to say an optional option never launches with another one (nothing requirable means "that axis stays off"). Where the axis is required, prefer `requires` of the wanted option instead: `requires` fails closed for options added later, while a `forbids` list names today's options and stays silent about tomorrow's.
+Matching treats an unfilled optional axis as matching no pair, on either side: a guard on `camera: "zed"` stays quiet when the camera axis is off, and a `requires` alternative naming that option is satisfied only by selecting it, never by leaving the axis unfilled. That asymmetry is the tool for optional features: `requires` is how an option demands company, while `forbids` is the only way to say an optional option never launches with another one (nothing requirable means "that axis stays off"). Where the axis is required, prefer `requires` of the wanted option instead: `requires` fails closed for options added later, while a `forbids` list names today's options and stays silent about tomorrow's.
 
 The refusal happens at selection time and names the full resolution (with its `(default)` markers showing the axes the operator never named), what was required or forbidden, and the author's `reason`. When several constraints overlap, the first declared one refuses, so the author controls which reason the operator reads.
 

--- a/docs/src/content/docs/guides/launch_files.mdx
+++ b/docs/src/content/docs/guides/launch_files.mdx
@@ -375,6 +375,37 @@ An adjustment whose target the current selection does not define is **skipped**,
 
 The ownership rule of thumb: if a value is something the operator genuinely decides, make it another option on the axis, visible in the command line. If it is a *consequence* of a choice already made, write the adjustment into that option's own fragment, where it needs no guard: it runs exactly when its fragment is selected and skips when its target is absent.
 
+## Constraints
+
+Adjustments change what a selection builds; a **constraint** refuses selections nobody should run. Some members of a family are stacks no operator should be able to name: the recorder that films only the physical rig must not launch against the simulator. Those members flatten cleanly, so neither `provides` (which only promises ids exist) nor an adjustment's `when` guard (which only decides whether one adjustment applies inside a legal selection) can say it. A constraint can, and it only ever refuses: a violating selection is rejected before anything is pinned or started. It never picks an option to satisfy itself, because a `--with` whose meaning shifted as constraints evolve would launch stacks the operator did not name.
+
+```json5
+constraints: [
+  // With the recorder selected, the robot must be the real one.
+  { when: { recorder: "lerobot_recorder" }, requires: [{ robot: "real" }],
+    reason: "the recorder films the physical rig" },
+
+  // The whole combination is refused, no guard needed.
+  { forbids: [{ robot: "mujoco", recorder: "lerobot_recorder" }],
+    reason: "the dataset recorder pairs with the real rig only" },
+]
+```
+
+| Field | Meaning |
+|---|---|
+| `when` | The guard: the selections this constraint speaks about, in the same `axis: option` grammar as an adjustment's `when`, every named axis matching (an AND). Omit it to speak about every selection. |
+| `requires` | What the guarded selections must also contain: a list of alternatives, at least one of which must match wholly. Each alternative is an `axis: option` map where every pair must match (an AND); listing several alternatives is an OR. |
+| `forbids` | What the guarded selections must not contain: a list of `axis: option` maps, and matching any one of them (each an AND of its pairs) refuses the selection outright. |
+| `reason` | Why the refused selections must not run. Required, and quoted verbatim in the refusal: peppy can render what was required or forbidden, but only the author knows what the dead combination would have done. |
+
+A constraint states at least one of `requires` and `forbids`; with neither it refuses nothing, and the launcher is refused when it is read. The rest of the shape is held to the same standard: `when` and every entry name at least one `axis: option` pair, an entry may not repeat an axis the guard already fixes (under the guard that axis is decided before anything is selected), the same map may not be listed twice in one list, and one map may not appear in both lists.
+
+Matching treats an unfilled optional axis as matching no pair, on either side: a guard on `recorder: "lerobot_recorder"` stays quiet when the recorder axis is off, and a `requires` alternative naming that option is satisfied only by selecting it, never by leaving the axis unfilled. That asymmetry is the tool for optional features: `requires` is how an option demands company, while `forbids` is the only way to say an optional option never launches with another one (nothing requirable means "that axis stays off"). Where the axis is required, prefer `requires` of the wanted option instead: `requires` fails closed for options added later, while a `forbids` list names today's options and stays silent about tomorrow's.
+
+The refusal happens at selection time and names the full resolution (with its `(default)` markers showing the axes the operator never named), what was required or forbidden, and the author's `reason`. When several constraints overlap, the first declared one refuses, so the author controls which reason the operator reads.
+
+Constraints live in the launcher, not in fragments: they speak in axis and option names, the launcher's vocabulary, while fragments are deliberately reusable across launchers whose axes differ. `peppy repo index --check` holds them to leaving a usable family behind: a constraint that refuses no selection, an option no legal selection can pick, and a default selection that violates a constraint are each reported when the launcher is indexed.
+
 ## Fragments: splitting a launcher across files
 
 An option's body can live in its own file, called a **fragment**. This is an organizational choice, never a requirement: a launcher whose options are all inline is self-contained. Extract a fragment once a second launcher wants the same body, so the body is stated once.


### PR DESCRIPTION
A composed launcher can now refuse selections that flatten cleanly into a stack nobody should run. `--with` was already refused for conflicting or unknown words, but nothing could say "this option needs another axis filled" or "these options never go together". In the openarm family that meant cameras with no consumer launched three producers publishing to nobody, and a simulated robot with recorder + cameras silently recorded poisoned datasets.

## The `constraints` block

A launcher that declares `components` may now also declare:

```json5
constraints: [
  // "cameras need a consumer": when the guard holds, at least one
  // `requires` alternative must hold too.
  { when: { cameras: "cameras" },
    requires: [{ recorder: "lerobot_recorder" }, { commander: "xr_commander" }],
    reason: "nothing in this selection consumes a camera stream" },

  // "these never launch together": `forbids` refuses a combination
  // directly — the form `requires` cannot express against an optional axis.
  { when: { robot: "mujoco" },
    forbids: [{ recorder: "lerobot_recorder" }],
    reason: "the recorder observes only the physical rig" },
]
```

- All three keys use the `axis: option` map grammar that `when` guards already use. Pairs in one map are an AND; several `requires` maps are an OR; matching any `forbids` map refuses.
- Constraints judge the **resolved** selection — defaults count — and they only ever refuse. They never pick an option to satisfy themselves, so the same `--with` keeps meaning the same stack as constraints evolve.
- `reason` is required and quoted verbatim in the refusal: the engine can render what was required, but only the author knows why the dead combination must not run.
- Constraints live in the launcher, not in fragments: they speak the launcher's axis vocabulary, and the base stays the single authority on which family members exist.

## What a refusal looks like

```
$ peppy stack launch openarm_v2 --with=cameras
Cannot resolve the launcher's components: selecting cameras=cameras requires
one of `recorder=lerobot_recorder`, `commander=xr_commander`, which this
selection (robot=real (default)  commander=web_commander (default)
recorder=(off)  cameras=cameras) does not satisfy. nothing in this selection
consumes a camera stream: only the recorder and the XR leader have camera slots
```

The message opens with the choice that brought the rule in, and the echo marks the axes the operator never named, so the fix is readable from the error. A `forbids` refusal reads the same way:

```
selecting robot=mujoco forbids `recorder=lerobot_recorder`, which this
selection (robot=mujoco  recorder=lerobot_recorder) has. the recorder
observes only the physical rig
```

## `repo index --check`

The checker now enumerates only constraint-legal selections and holds those to flattening (a refused selection is refused by design, not broken). It also fails when the constraints themselves rot:

- an option — or an optional axis's "off" state — that no legal selection can reach
- a constraint that refuses nothing (a dead rule reads as protection it does not give)
- a default selection the constraints refuse (the bare launch must start)

Dead references (unknown axis or option in `when` / `requires` / `forbids`), empty guards or entries, duplicate or guard-contradicted entries, and blank reasons are refused where the launcher parses.

## Testing

- 28 unit tests in `daemon-config` (418 total, all passing) covering the grammar validation, both refusal shapes, and every new `--check` rule; clippy clean; workspace check passes.
- End-to-end tests in the `peppy` integration suite, alongside the existing composition e2e tests:
  - the caller-side preflight refuses a constraint-violating `stack launch` for both verbs, quoting the reason and marking the defaulted axis the operator never typed;
  - the full composed-launch test (daemon emulation, real instance running) now declares a constraint its selection satisfies, proving a satisfied constraint does not stand in a launch's way;
  - `stack resolve` refuses a refused member and still flattens a legal sibling into a document with no composition keys;
  - `repo index --check` fails a family whose broken member flattens into nonsense, passes the same family once a constraint refuses that member (the exact gap this PR closes), and flags a constraint set that strangles an option out of the family.
- Run against the real openarm bases: all 9 bad selections per base refuse (including both incident commands), the 3 legal camera selections and every sim/recording session still flatten, and `check_composition` is clean.

Companion: Peppy-bot/launchers-hub#30 declares the openarm rules. It merges only after this ships in a release — a launcher declaring `constraints` does not parse on older daemons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added conditional launcher selection constraints that can require or forbid specific component combinations.
  - Added clear refusal reasons and detailed validation errors for invalid selections.
  - Constraints now support serialized configuration and are checked during launcher composition and repository indexing.
- **Bug Fixes**
  - Invalid, unreachable, conflicting, or dead selections are now detected before launch.
  - Valid selections continue to resolve into launchable configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->