### PR TITLE
Enforce the docs-gate verdict with a JSON schema and gate releases on blocking gaps only

### DIFF
--- a/.buildkite/README.md
+++ b/.buildkite/README.md
@@ -8,8 +8,11 @@ The docs freshness check used to be a third step here. It ran only on the
 `dev` → `main` release pull request, and releases are now cut straight from
 `dev`, so that pull request no longer exists. The check moved into the release
 script itself (`_verify_docs_up_to_date` in
-`scripts/functions/build_release.py`), which opens the follow-up docs pull
-request against `dev` and stops the release until it is merged.
+`scripts/functions/build_release.py`). When the check finds a blocking gap
+(docs stating something false, or a user-facing change with no documentation
+at all), it opens the follow-up docs pull request against `dev` and stops the
+release until it is merged; minor wording-level suggestions are printed and
+never block.
 
 ## One-time setup
 

--- a/scripts/functions/build_release.py
+++ b/scripts/functions/build_release.py
@@ -60,7 +60,12 @@ from .github import (
     replace_and_upload_asset,
 )
 from .lima import ensure_lima_vm, ensure_rust_in_vm, find_limactl, stop_lima_vm
-from .docs import RequiredChange, check_docs, update_docs
+from .docs import (
+    RequiredChange,
+    check_docs,
+    print_minor_changes,
+    update_docs,
+)
 from .verify_release import verify_all_releases
 from .release_notes import (
     ReleaseNotesInput,
@@ -549,12 +554,19 @@ def _verify_docs_up_to_date(
     commit exactly; `_verify_release_branch_state` has already fetched it and
     proved it is an ancestor of the release commit.
 
-    When the docs are stale, Claude regenerates them, the result is pushed to a
-    branch named after the release commit, a pull request against `dev` is
-    opened, and the release stops: the docs land through review like any other
-    change rather than being folded into a release nobody reads. A retry on the
-    same commit finds that pull request and stops on it, so nothing published is
-    ever rewritten.
+    Only blocking gaps stop the release: docs that now state something false,
+    or a user-facing change with no documentation at all. Minor suggestions
+    (wording, clarity, nice-to-haves) are printed and ignored, so a release is
+    never held hostage by how the model would phrase a sentence today.
+
+    When a blocking gap exists, Claude closes exactly the reported gaps, the
+    result is pushed to a branch named after the release commit, a pull
+    request against `dev` is opened, and the release stops: the docs land
+    through review like any other change rather than being folded into a
+    release nobody reads. A retry on the same commit finds that pull request
+    and stops on it, so nothing published is ever rewritten. When the updater
+    instead verifies every reported gap is already documented, the check's
+    findings were noise and the release continues.
     """
     docs_dir = repo_root / DOCS_DIR
     if has_changes_in_paths([docs_dir]):
@@ -570,12 +582,14 @@ def _verify_docs_up_to_date(
         f"Checking '{DOCS_DIR}/' covers the code changes since {base}..."
     )
     result = check_docs(base, release_commit)
-    if result.up_to_date:
+    print_minor_changes(result.minor)
+    blocking = result.blocking
+    if not blocking:
         console.print(f"[green]'{DOCS_DIR}/' is up to date.[/green]")
         return
 
     console.print(f"[yellow]'{DOCS_DIR}/' is out of date:[/yellow]")
-    for change in result.required_changes:
+    for change in blocking:
         console.print(f"  [bold]{change.file}[/bold]: {change.change}")
 
     # An earlier attempt on this same commit already did the work. Report that
@@ -591,19 +605,35 @@ def _verify_docs_up_to_date(
         _stop_for_docs_pr(pr_url)
 
     console.print("Asking Claude to update the docs...")
-    console.print(update_docs(base, release_commit))
+    update = update_docs(base, release_commit, blocking)
+    console.print(update.summary)
 
     if not has_changes_in_paths([docs_dir]):
+        if update.all_already_covered:
+            # The check and the updater disagree, and the updater had to Read
+            # the docs to say so: the reported gaps were noise, not real.
+            console.print(
+                "[yellow]The updater verified every reported gap is already "
+                "documented:[/yellow]"
+            )
+            for outcome in update.results:
+                console.print(f"  [bold]{outcome.file}[/bold]: {outcome.change}")
+            console.print(
+                f"[green]'{DOCS_DIR}/' already covers the release; "
+                f"continuing.[/green]"
+            )
+            return
         raise ReleaseError(
-            f"the check reported '{DOCS_DIR}/' as out of date but the update "
-            f"changed nothing there, so there is no pull request to open. "
-            f"Update the docs by hand and push them to '{RELEASE_BRANCH}', or "
-            f"re-run with --skip-docs-check if the report is wrong."
+            f"the check reported '{DOCS_DIR}/' as out of date and the update "
+            f"claimed to close gaps, but nothing changed there, so there is "
+            f"no pull request to open. Update the docs by hand and push them "
+            f"to '{RELEASE_BRANCH}', or re-run with --skip-docs-check if the "
+            f"report is wrong."
         )
 
     _push_docs_sync_branch(branch, docs_dir)
     pr_url = _open_docs_sync_pr(
-        client, slug, branch, release_commit, result.required_changes
+        client, slug, branch, release_commit, blocking
     )
     _stop_for_docs_pr(pr_url)
 

--- a/scripts/functions/claude.py
+++ b/scripts/functions/claude.py
@@ -2,9 +2,10 @@
 
 Both the docs freshness pipeline (``docs.py``) and the release-notes
 generator (``release_summary.py``) invoke Claude the same way: run
-``claude -p`` with a pinned model and effort, capture the JSON envelope, and
-return the final assistant text. This module is the single source of truth for
-that invocation so the model pin and response parsing live in one place.
+``claude -p`` with a pinned model and effort, a JSON Schema for the response,
+and capture the schema-validated structured output from the JSON envelope.
+This module is the single source of truth for that invocation so the model pin
+and response parsing live in one place.
 
 Requires ``claude`` on PATH, already authenticated in the invoking environment.
 """
@@ -41,10 +42,18 @@ def run_claude(
     allowed_tools: str,
     permission_mode: str,
     cwd: Path,
+    json_schema: dict,
     tools: str | None = None,
     effort: str = CLAUDE_EFFORT,
-) -> str:
-    """Run ``claude -p`` and return the final assistant text.
+) -> dict:
+    """Run ``claude -p`` and return its schema-validated structured output.
+
+    ``json_schema`` is passed to the CLI via ``--json-schema``, which forces
+    the final response through a validated structured-output tool call: a
+    prose-only answer cannot reach the caller, and the parsed object arrives
+    in the envelope's ``structured_output`` field. Callers still validate the
+    object's contents — the CLI is not pinned, so its enforcement is a
+    convenience, not a contract.
 
     ``tools`` controls which built-in tools exist for the run: pass "" to
     disable all tools (a pure text transformation), or a space/comma list to
@@ -67,6 +76,8 @@ def run_claude(
         "json",
         "--permission-mode",
         permission_mode,
+        "--json-schema",
+        json.dumps(json_schema),
     ]
     if tools is not None:
         cmd += ["--tools", tools]
@@ -86,20 +97,13 @@ def run_claude(
         raise ReleaseError(
             f"claude did not return valid JSON ({e}); stdout={result.stdout[:500]!r}"
         )
-    final_text = payload.get("result")
-    if not isinstance(final_text, str):
+    if not isinstance(payload, dict):
+        raise ReleaseError(f"claude response is not an object: {payload!r}")
+    structured = payload.get("structured_output")
+    if not isinstance(structured, dict):
+        text = payload.get("result")
         raise ReleaseError(
-            f"claude response missing 'result' string: {payload!r}"
+            f"claude response missing 'structured_output' object; "
+            f"result text={str(text)[:500]!r}"
         )
-    return final_text
-
-
-def strip_code_fence(text: str) -> str:
-    """Strip a leading/trailing Markdown code fence from a model response."""
-    text = text.strip()
-    if not text.startswith("```"):
-        return text
-    lines = text.splitlines()[1:]
-    if lines and lines[-1].strip().startswith("```"):
-        lines = lines[:-1]
-    return "\n".join(lines).strip()
+    return structured

--- a/scripts/functions/docs.py
+++ b/scripts/functions/docs.py
@@ -2,10 +2,16 @@
 
 Two entry points:
 
-- ``check_main``: diff two git refs, ask claude whether ``docs/`` is up to
-  date, and exit non-zero with a list of required edits if not.
-- ``update_main``: same diff, but let claude edit files under ``docs/``
-  in place.
+- ``check_main``: diff two git refs, ask claude whether ``docs/`` has any
+  blocking gap for the changes, and exit non-zero with the list if so.
+- ``update_main``: same diff, then let claude close exactly the blocking
+  gaps the check found by editing files under ``docs/`` in place.
+
+A gap is *blocking* only when the docs now state something false or a
+user-facing change is entirely undocumented. Wording, clarity, and other
+nice-to-haves are reported as *minor* and never fail the check or feed the
+updater: tooling must not generate wording churn, and a release must not
+hinge on how the model would phrase a sentence today.
 
 Both require ``claude`` and ``git`` on PATH. No special auth handling —
 the invoking environment must already have claude authenticated.
@@ -14,13 +20,12 @@ the invoking environment must already have claude authenticated.
 from __future__ import annotations
 
 import argparse
-import json
 import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
 
-from .claude import run_claude, strip_code_fence
+from .claude import run_claude
 from .cli import ReleaseError, console, need_cmd, run_with_error_handling
 from .repo import get_repo_root
 
@@ -39,17 +44,106 @@ _EXCLUDE_PREFIXES: tuple[str, ...] = (
 
 _MAX_DIFF_BYTES = 400_000
 
+SEVERITY_BLOCKING = "blocking"
+SEVERITY_MINOR = "minor"
+
+STATUS_IMPLEMENTED = "implemented"
+STATUS_ALREADY_COVERED = "already_covered"
+
+# Schema for the check verdict, enforced CLI-side via --json-schema. There is
+# deliberately no up-to-date boolean: pass/fail is derived from the list, so
+# the model cannot contradict itself, and the severity split gives it an
+# outlet for borderline observations without inflating them into blockers.
+_CHECK_SCHEMA: dict = {
+    "type": "object",
+    "properties": {
+        "required_changes": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "file": {"type": "string"},
+                    "change": {"type": "string"},
+                    "severity": {"enum": [SEVERITY_BLOCKING, SEVERITY_MINOR]},
+                },
+                "required": ["file", "change", "severity"],
+                "additionalProperties": False,
+            },
+        },
+    },
+    "required": ["required_changes"],
+    "additionalProperties": False,
+}
+
+# Schema for the update report: one entry per requested change, so the caller
+# can tell "nothing to do, docs already cover it" apart from a silent no-op.
+_UPDATE_SCHEMA: dict = {
+    "type": "object",
+    "properties": {
+        "results": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "file": {"type": "string"},
+                    "change": {"type": "string"},
+                    "status": {
+                        "enum": [STATUS_IMPLEMENTED, STATUS_ALREADY_COVERED]
+                    },
+                },
+                "required": ["file", "change", "status"],
+                "additionalProperties": False,
+            },
+        },
+        "summary": {"type": "string"},
+    },
+    "required": ["results", "summary"],
+    "additionalProperties": False,
+}
+
 
 @dataclass(frozen=True)
 class RequiredChange:
     file: str
     change: str
+    severity: str
 
 
 @dataclass(frozen=True)
 class CheckResult:
-    up_to_date: bool
-    required_changes: tuple[RequiredChange, ...]
+    changes: tuple[RequiredChange, ...]
+
+    @property
+    def blocking(self) -> tuple[RequiredChange, ...]:
+        return tuple(c for c in self.changes if c.severity == SEVERITY_BLOCKING)
+
+    @property
+    def minor(self) -> tuple[RequiredChange, ...]:
+        return tuple(c for c in self.changes if c.severity == SEVERITY_MINOR)
+
+
+@dataclass(frozen=True)
+class UpdateOutcome:
+    file: str
+    change: str
+    status: str
+
+
+@dataclass(frozen=True)
+class UpdateResult:
+    results: tuple[UpdateOutcome, ...]
+    summary: str
+
+    @property
+    def all_already_covered(self) -> bool:
+        """True when the updater accounted for every gap as already documented.
+
+        An empty report does not count: the updater must name what it checked,
+        otherwise a malfunctioning run would read as a clean verdict.
+        """
+        return bool(self.results) and all(
+            r.status == STATUS_ALREADY_COVERED for r in self.results
+        )
 
 
 def _run_git(args: list[str], cwd: Path) -> str:
@@ -97,23 +191,28 @@ def _truncate_diff(diff: str) -> str:
 
 
 _CHECK_PROMPT = """\
-You are validating whether the documentation in `docs/src/content/docs/` is up
-to date with a set of code changes. The project is "peppy" — an Astro Starlight
-documentation site paired with Rust crates under `crates/`.
+You are judging whether the documentation in `docs/src/content/docs/` covers a
+set of code changes. The project is "peppy" — an Astro Starlight documentation
+site paired with Rust crates under `crates/`.
 
 Your task:
-1. Use Read/Grep/Glob to explore `docs/src/content/docs/` and identify any
-   user-facing changes in the diff below that require doc updates — CLI
-   flags and subcommands, `peppy.json5` schema, message formats, guide
-   steps, concepts, container workflows, etc.
-2. Ignore purely internal changes: refactors, tests, private APIs, build/CI
+1. Use Read/Grep/Glob to explore `docs/src/content/docs/` and compare it
+   against the diff below. Judge only what this diff changes — this is not a
+   general documentation audit.
+2. Report every documentation gap the diff creates as an entry in
+   `required_changes` (the doc file path, a one-sentence description of the
+   edit needed, and a severity):
+   - "blocking": the docs now state something false, or a user-facing change
+     in the diff (a CLI flag or subcommand, a `peppy.json5` schema key, a
+     message format, a step in a guide or workflow) is entirely undocumented.
+   - "minor": everything else — wording, clarity, style, restructuring,
+     extra cross-references, nice-to-have examples, mentioning a feature in
+     more places. Docs being improvable is not the same as docs being out of
+     date. When unsure between the two severities, choose "minor".
+3. Ignore purely internal changes: refactors, tests, private APIs, build/CI
    changes, log strings, dependency bumps.
-3. Return a JSON verdict as your final assistant message. No prose, no
-   code fence, no explanation — exactly this shape:
 
-{{"up_to_date": <bool>, "required_changes": [{{"file": "<doc path>", "change": "<one-sentence description>"}}]}}
-
-If `up_to_date` is true, `required_changes` must be `[]`.
+An empty `required_changes` means the docs fully cover the diff.
 
 Changed paths:
 {paths}
@@ -124,21 +223,25 @@ Unified diff:
 
 
 _UPDATE_PROMPT = """\
-You are updating the documentation in `docs/src/content/docs/` to reflect a
-set of code changes. The project is "peppy" — an Astro Starlight
-documentation site paired with Rust crates under `crates/`.
+You are updating the documentation in `docs/src/content/docs/` to close a
+fixed list of gaps left by a set of code changes. The project is "peppy" — an
+Astro Starlight documentation site paired with Rust crates under `crates/`.
+
+Gaps to close — implement exactly these, nothing else:
+{changes}
 
 Your task:
-1. Use Read/Grep/Glob to explore `docs/src/content/docs/` and identify any
-   user-facing changes in the diff below that require doc updates — CLI
-   flags and subcommands, `peppy.json5` schema, message formats, guide
-   steps, concepts, container workflows, etc.
-2. Edit docs files directly using Edit/Write. Only touch files under
-   `docs/src/content/docs/`. Do not modify `.astro` config, `package.json`,
-   or anything outside `docs/`.
-3. Keep edits minimal and focused — do not rewrite prose that is still
-   accurate, and do not fabricate features.
-4. After editing, summarize the files you changed in a few bullet points.
+1. For each listed gap, Read the named doc file (and any closely related
+   pages) and make the smallest edit that closes it. The diff below is the
+   source of truth for the facts — never state behaviour it does not show.
+2. If on inspection the docs already cover a listed gap, skip it and edit
+   nothing for it.
+3. Only touch files under `docs/src/content/docs/`. Do not reword,
+   restructure, or "improve" prose that is still accurate, and do not modify
+   `.astro` config, `package.json`, or anything outside `docs/`.
+4. Report one `results` entry per listed gap — its file, its change text,
+   and a status of "implemented" or "already_covered" — plus a short overall
+   `summary`.
 
 Changed paths:
 {paths}
@@ -148,22 +251,14 @@ Unified diff:
 """
 
 
-def _parse_check_response(text: str) -> CheckResult:
-    stripped = strip_code_fence(text)
-    try:
-        payload = json.loads(stripped)
-    except json.JSONDecodeError as e:
-        raise ReleaseError(
-            f"claude verdict was not valid JSON ({e}); text={text[:500]!r}"
-        )
-    if not isinstance(payload, dict):
-        raise ReleaseError(f"claude verdict must be an object: {payload!r}")
-    up_to_date = payload.get("up_to_date")
-    if not isinstance(up_to_date, bool):
-        raise ReleaseError(
-            f"claude verdict missing boolean 'up_to_date': {payload!r}"
-        )
-    raw_changes = payload.get("required_changes", [])
+def _parse_check_response(payload: dict) -> CheckResult:
+    """Validate the check verdict object into a CheckResult.
+
+    The CLI already validated the payload against ``_CHECK_SCHEMA``, but that
+    enforcement lives in an unpinned external tool; re-checking here keeps a
+    drifted CLI surfacing as a ReleaseError instead of a stray KeyError.
+    """
+    raw_changes = payload.get("required_changes")
     if not isinstance(raw_changes, list):
         raise ReleaseError(
             f"claude verdict 'required_changes' must be a list: {payload!r}"
@@ -176,12 +271,52 @@ def _parse_check_response(text: str) -> CheckResult:
             )
         file = item.get("file")
         change = item.get("change")
+        severity = item.get("severity")
         if not isinstance(file, str) or not isinstance(change, str):
             raise ReleaseError(
                 f"claude verdict change entry missing file/change: {item!r}"
             )
-        changes.append(RequiredChange(file=file, change=change))
-    return CheckResult(up_to_date=up_to_date, required_changes=tuple(changes))
+        if severity not in (SEVERITY_BLOCKING, SEVERITY_MINOR):
+            raise ReleaseError(
+                f"claude verdict change entry has unknown severity: {item!r}"
+            )
+        changes.append(
+            RequiredChange(file=file, change=change, severity=severity)
+        )
+    return CheckResult(changes=tuple(changes))
+
+
+def _parse_update_response(payload: dict) -> UpdateResult:
+    """Validate the update report object into an UpdateResult."""
+    raw_results = payload.get("results")
+    if not isinstance(raw_results, list):
+        raise ReleaseError(
+            f"claude update report 'results' must be a list: {payload!r}"
+        )
+    summary = payload.get("summary")
+    if not isinstance(summary, str):
+        raise ReleaseError(
+            f"claude update report missing string 'summary': {payload!r}"
+        )
+    results: list[UpdateOutcome] = []
+    for item in raw_results:
+        if not isinstance(item, dict):
+            raise ReleaseError(
+                f"claude update report entry must be an object: {item!r}"
+            )
+        file = item.get("file")
+        change = item.get("change")
+        status = item.get("status")
+        if not isinstance(file, str) or not isinstance(change, str):
+            raise ReleaseError(
+                f"claude update report entry missing file/change: {item!r}"
+            )
+        if status not in (STATUS_IMPLEMENTED, STATUS_ALREADY_COVERED):
+            raise ReleaseError(
+                f"claude update report entry has unknown status: {item!r}"
+            )
+        results.append(UpdateOutcome(file=file, change=change, status=status))
+    return UpdateResult(results=tuple(results), summary=summary)
 
 
 def check_docs(base: str, head: str) -> CheckResult:
@@ -189,39 +324,64 @@ def check_docs(base: str, head: str) -> CheckResult:
     repo_root = get_repo_root()
     diff, paths = get_code_diff(base, head, repo_root)
     if not paths:
-        return CheckResult(up_to_date=True, required_changes=())
+        return CheckResult(changes=())
     prompt = _CHECK_PROMPT.format(
         paths="\n".join(paths),
         diff=_truncate_diff(diff),
     )
-    text = run_claude(
+    # tools (not just allowed_tools) is restricted: under bypassPermissions
+    # the allowlist approves rather than limits, and the check must stay
+    # read-only.
+    payload = run_claude(
         prompt,
         allowed_tools="Read Grep Glob",
         permission_mode="bypassPermissions",
         cwd=repo_root,
+        json_schema=_CHECK_SCHEMA,
+        tools="Read Grep Glob",
     )
-    return _parse_check_response(text)
+    return _parse_check_response(payload)
 
 
-def update_docs(base: str, head: str) -> str:
-    """Invoke claude to update ``docs/`` for code changes between base and head.
+def update_docs(
+    base: str, head: str, changes: tuple[RequiredChange, ...]
+) -> UpdateResult:
+    """Have claude close exactly *changes* in ``docs/`` for the base..head diff.
 
-    Returns the summary text claude produced.
+    The change list scopes the edits: the updater implements those gaps and
+    nothing else, so the resulting diff is derived from the verdict rather
+    than from a free-form re-audit of the docs.
     """
+    if not changes:
+        raise ReleaseError("update_docs called with no changes to implement")
     repo_root = get_repo_root()
     diff, paths = get_code_diff(base, head, repo_root)
-    if not paths:
-        return "no code changes — nothing to update"
     prompt = _UPDATE_PROMPT.format(
+        changes="\n".join(f"- `{c.file}`: {c.change}" for c in changes),
         paths="\n".join(paths),
         diff=_truncate_diff(diff),
     )
-    return run_claude(
+    payload = run_claude(
         prompt,
         allowed_tools="Read Edit Write Grep Glob",
         permission_mode="acceptEdits",
         cwd=repo_root,
+        json_schema=_UPDATE_SCHEMA,
+        tools="Read Edit Write Grep Glob",
     )
+    return _parse_update_response(payload)
+
+
+def print_minor_changes(minor: tuple[RequiredChange, ...]) -> None:
+    """Print minor doc suggestions as information; they never gate anything."""
+    if not minor:
+        return
+    console.print(
+        f"[dim]{len(minor)} minor doc suggestion(s) noted "
+        f"(never block anything):[/dim]"
+    )
+    for change in minor:
+        console.print(f"  [dim]{change.file}: {change.change}[/dim]")
 
 
 def _parse_args(prog: str) -> argparse.Namespace:
@@ -236,11 +396,12 @@ def _run_check() -> None:
     need_cmd("claude")
     args = _parse_args("is-doc-up-to-date")
     result = check_docs(args.base, args.head)
-    if result.up_to_date:
+    print_minor_changes(result.minor)
+    if not result.blocking:
         console.print("[green]docs are up to date[/green]")
         return
-    console.print("[red]docs are out of date — required changes:[/red]")
-    for change in result.required_changes:
+    console.print("[red]docs are out of date — blocking changes:[/red]")
+    for change in result.blocking:
         console.print(f"  [bold]{change.file}[/bold]: {change.change}")
     sys.exit(1)
 
@@ -249,8 +410,17 @@ def _run_update() -> None:
     need_cmd("git")
     need_cmd("claude")
     args = _parse_args("update-docs")
-    summary = update_docs(args.base, args.head)
-    console.print(summary)
+    check = check_docs(args.base, args.head)
+    print_minor_changes(check.minor)
+    if not check.blocking:
+        console.print("[green]docs are up to date — nothing to update[/green]")
+        return
+    update = update_docs(args.base, args.head, check.blocking)
+    for outcome in update.results:
+        console.print(
+            f"  [bold]{outcome.file}[/bold] ({outcome.status}): {outcome.change}"
+        )
+    console.print(update.summary)
 
 
 def check_main() -> None:

--- a/scripts/functions/release_summary.py
+++ b/scripts/functions/release_summary.py
@@ -9,14 +9,27 @@ reorganization, dependency bumps, build and codegen changes) is left out.
 
 from __future__ import annotations
 
-import json
 from dataclasses import dataclass
 from pathlib import Path
 
-from .claude import run_claude, strip_code_fence
+from .claude import run_claude
 from .cli import ReleaseError
 
 _FIELDS: tuple[str, ...] = ("title", "description", "notes")
+
+# Enforced CLI-side via --json-schema. minLength keeps a blank field from
+# passing validation, but whitespace-only strings still need the Python-side
+# check in _parse_release_content.
+_CONTENT_SCHEMA: dict = {
+    "type": "object",
+    "properties": {
+        "title": {"type": "string", "minLength": 1},
+        "description": {"type": "string", "minLength": 1},
+        "notes": {"type": "string", "minLength": 1},
+    },
+    "required": ["title", "description", "notes"],
+    "additionalProperties": False,
+}
 
 _PROMPT = """\
 You are writing the public release notes for "peppy", a developer tool shipped
@@ -27,12 +40,8 @@ Below is the exhaustive list of commits merged since the previous release
 (commit subjects, one per line). It is the only source of truth. Do not invent
 changes that are not listed.
 
-Respond with a single JSON object and nothing else. Do not explain your
-reasoning, do not narrate, do not add any text before or after the object, and
-do not wrap it in a code fence. Your entire response must be valid JSON that a
-strict parser accepts, exactly this shape:
-
-{{"title": "<headline>", "description": "<one sentence>", "notes": "<markdown>"}}
+Respond with the three fields "title" (a headline), "description" (one
+sentence), and "notes" (Markdown).
 
 Write for a user of the peppy tool, and include only changes such a user would
 notice or care about: new or changed CLI commands and flags, the `peppy.json5`
@@ -109,22 +118,21 @@ def generate_release_content(
     prompt = _PROMPT.format(tag=tag, changes=changes)
     # No tools: this is a pure transformation of the commit list. Giving Claude
     # repository access leads it to explore git history and answer with an
-    # analysis narrative instead of the JSON object.
-    text = run_claude(
+    # analysis narrative instead of the release content.
+    payload = run_claude(
         prompt,
         allowed_tools="",
         permission_mode="bypassPermissions",
         cwd=repo_root,
+        json_schema=_CONTENT_SCHEMA,
         tools="",
         effort="xhigh",
     )
-    return _parse_release_content(text)
+    return _parse_release_content(payload)
 
 
-def _parse_release_content(text: str) -> ReleaseContent:
-    """Parse and validate Claude's JSON response into a ReleaseContent."""
-    payload = _decode_json_object(text)
-
+def _parse_release_content(payload: dict) -> ReleaseContent:
+    """Validate Claude's structured output into a ReleaseContent."""
     values: dict[str, str] = {}
     for field in _FIELDS:
         value = payload.get(field)
@@ -134,62 +142,3 @@ def _parse_release_content(text: str) -> ReleaseContent:
             )
         values[field] = value.strip()
     return ReleaseContent(**values)
-
-
-def _decode_json_object(text: str) -> dict:
-    """Decode Claude's response into a JSON object, tolerating a stray preamble.
-
-    Tries the whole (de-fenced) response first, then falls back to the first
-    balanced ``{...}`` substring. Raises ReleaseError if neither is a JSON
-    object.
-    """
-    stripped = strip_code_fence(text)
-    candidates = [stripped]
-    extracted = _first_json_object(stripped)
-    if extracted is not None and extracted != stripped:
-        candidates.append(extracted)
-
-    for candidate in candidates:
-        try:
-            payload = json.loads(candidate)
-        except json.JSONDecodeError:
-            continue
-        if isinstance(payload, dict):
-            return payload
-        raise ReleaseError(f"claude release notes must be a JSON object: {payload!r}")
-
-    raise ReleaseError(
-        f"claude release notes were not valid JSON; text={text[:500]!r}"
-    )
-
-
-def _first_json_object(text: str) -> str | None:
-    """Return the first balanced top-level ``{...}`` substring, or None.
-
-    String-aware, so braces inside JSON string values do not unbalance the scan.
-    """
-    start = text.find("{")
-    if start == -1:
-        return None
-    depth = 0
-    in_string = False
-    escaped = False
-    for index in range(start, len(text)):
-        char = text[index]
-        if in_string:
-            if escaped:
-                escaped = False
-            elif char == "\\":
-                escaped = True
-            elif char == '"':
-                in_string = False
-            continue
-        if char == '"':
-            in_string = True
-        elif char == "{":
-            depth += 1
-        elif char == "}":
-            depth -= 1
-            if depth == 0:
-                return text[start : index + 1]
-    return None

--- a/scripts/tests/test_build_release.py
+++ b/scripts/tests/test_build_release.py
@@ -26,7 +26,12 @@ from functions.build_release import (
     _verify_release_branch_state,
 )
 from functions.cli import ReleaseError
-from functions.docs import CheckResult, RequiredChange
+from functions.docs import (
+    CheckResult,
+    RequiredChange,
+    UpdateOutcome,
+    UpdateResult,
+)
 from functions.github import RepoSlug
 from functions.release_summary import ReleaseContent
 
@@ -716,6 +721,14 @@ def test_verify_release_branch_state_rejects_main_ahead_of_dev(
 # --- the docs freshness gate ---
 
 
+_BLOCKING_CHANGE = RequiredChange(
+    file="docs/x.mdx", change="document --verbose", severity="blocking"
+)
+_MINOR_CHANGE = RequiredChange(
+    file="docs/y.mdx", change="reword the intro", severity="minor"
+)
+
+
 def _docs_gate(
     client: MagicMock | None = None,
     slug: MagicMock | None = None,
@@ -733,7 +746,7 @@ def _docs_gate(
 @patch("functions.build_release.update_docs")
 @patch(
     "functions.build_release.check_docs",
-    return_value=CheckResult(up_to_date=True, required_changes=()),
+    return_value=CheckResult(changes=()),
 )
 @patch("functions.build_release.has_changes_in_paths", return_value=False)
 def test_docs_gate_passes_and_diffs_against_origin_main(
@@ -747,6 +760,31 @@ def test_docs_gate_passes_and_diffs_against_origin_main(
     # to cover; the head is the dev commit being released.
     mock_check.assert_called_once_with("origin/main", DEV_COMMIT)
     mock_update.assert_not_called()
+
+
+@patch("functions.build_release._find_open_docs_sync_pr")
+@patch("functions.build_release.update_docs")
+@patch(
+    "functions.build_release.check_docs",
+    return_value=CheckResult(changes=(_MINOR_CHANGE,)),
+)
+@patch("functions.build_release.has_changes_in_paths", return_value=False)
+def test_docs_gate_passes_on_minor_only_suggestions(
+    mock_has_changes: MagicMock,
+    mock_check: MagicMock,
+    mock_update: MagicMock,
+    mock_find_pr: MagicMock,
+    capfd: pytest.CaptureFixture[str],
+) -> None:
+    # Wording-level suggestions must never regenerate docs, open a pull
+    # request, or stop a release: they are printed and the release moves on.
+    _docs_gate(repo_root=Path("/repo"))
+
+    mock_update.assert_not_called()
+    mock_find_pr.assert_not_called()
+    err = capfd.readouterr().err
+    assert "reword the intro" in err
+    assert "up to date" in err
 
 
 @patch("functions.build_release.check_docs")
@@ -766,7 +804,7 @@ def test_docs_gate_rejects_a_dirty_docs_tree_before_asking_claude(
 @patch("functions.build_release._open_docs_sync_pr")
 @patch("functions.build_release._push_docs_sync_branch")
 @patch("functions.build_release._find_open_docs_sync_pr", return_value=None)
-@patch("functions.build_release.update_docs", return_value="edited 2 files")
+@patch("functions.build_release.update_docs")
 @patch("functions.build_release.check_docs")
 @patch("functions.build_release.has_changes_in_paths")
 def test_docs_gate_opens_a_pr_and_stops_the_release(
@@ -778,8 +816,17 @@ def test_docs_gate_opens_a_pr_and_stops_the_release(
     mock_open_pr: MagicMock,
     capfd: pytest.CaptureFixture[str],
 ) -> None:
-    changes = (RequiredChange(file="docs/x.mdx", change="document --verbose"),)
-    mock_check.return_value = CheckResult(up_to_date=False, required_changes=changes)
+    mock_check.return_value = CheckResult(changes=(_BLOCKING_CHANGE,))
+    mock_update.return_value = UpdateResult(
+        results=(
+            UpdateOutcome(
+                file="docs/x.mdx",
+                change="document --verbose",
+                status="implemented",
+            ),
+        ),
+        summary="edited 2 files",
+    )
     # Clean before the update, dirty after it: claude rewrote the docs.
     mock_has_changes.side_effect = [False, True]
     mock_open_pr.return_value = "https://github.com/test-owner/test-repo/pull/7"
@@ -788,7 +835,9 @@ def test_docs_gate_opens_a_pr_and_stops_the_release(
         _docs_gate(repo_root=Path("/repo"))
 
     assert excinfo.value.code == 1
-    mock_update.assert_called_once_with("origin/main", DEV_COMMIT)
+    mock_update.assert_called_once_with(
+        "origin/main", DEV_COMMIT, (_BLOCKING_CHANGE,)
+    )
     # The branch is named after the release commit, so a retry on that commit
     # finds the pull request instead of producing a second one.
     branch = f"auto/docs-update-{DEV_COMMIT[:12]}"
@@ -796,6 +845,49 @@ def test_docs_gate_opens_a_pr_and_stops_the_release(
     assert mock_open_pr.call_args.args[2] == branch
     # The user is pointed at the pull request that has to merge first.
     assert "pull/7" in capfd.readouterr().err
+
+
+@patch("functions.build_release._open_docs_sync_pr")
+@patch("functions.build_release._push_docs_sync_branch")
+@patch("functions.build_release._find_open_docs_sync_pr", return_value=None)
+@patch("functions.build_release.update_docs")
+@patch("functions.build_release.check_docs")
+@patch("functions.build_release.has_changes_in_paths")
+def test_docs_gate_feeds_only_blocking_changes_to_the_update_and_pr(
+    mock_has_changes: MagicMock,
+    mock_check: MagicMock,
+    mock_update: MagicMock,
+    mock_find_pr: MagicMock,
+    mock_push_branch: MagicMock,
+    mock_open_pr: MagicMock,
+    capfd: pytest.CaptureFixture[str],
+) -> None:
+    # A mixed verdict: the blocking gap drives the update and the pull
+    # request; the minor one is only printed.
+    mock_check.return_value = CheckResult(
+        changes=(_MINOR_CHANGE, _BLOCKING_CHANGE)
+    )
+    mock_update.return_value = UpdateResult(
+        results=(
+            UpdateOutcome(
+                file="docs/x.mdx",
+                change="document --verbose",
+                status="implemented",
+            ),
+        ),
+        summary="edited 1 file",
+    )
+    mock_has_changes.side_effect = [False, True]
+    mock_open_pr.return_value = "https://github.com/test-owner/test-repo/pull/7"
+
+    with pytest.raises(SystemExit):
+        _docs_gate(repo_root=Path("/repo"))
+
+    mock_update.assert_called_once_with(
+        "origin/main", DEV_COMMIT, (_BLOCKING_CHANGE,)
+    )
+    assert mock_open_pr.call_args.args[4] == (_BLOCKING_CHANGE,)
+    assert "reword the intro" in capfd.readouterr().err
 
 
 @patch("functions.build_release._push_docs_sync_branch")
@@ -817,10 +909,7 @@ def test_docs_gate_stops_on_the_pr_an_earlier_attempt_opened(
     # Re-running the release on a commit whose docs pull request is still open
     # must point at that pull request, not spend another Claude run deriving a
     # branch that would then have to replace the one under review.
-    mock_check.return_value = CheckResult(
-        up_to_date=False,
-        required_changes=(RequiredChange(file="docs/x.mdx", change="document it"),),
-    )
+    mock_check.return_value = CheckResult(changes=(_BLOCKING_CHANGE,))
 
     with pytest.raises(SystemExit) as excinfo:
         _docs_gate()
@@ -833,26 +922,71 @@ def test_docs_gate_stops_on_the_pr_an_earlier_attempt_opened(
     assert "pull/7" in capfd.readouterr().err
 
 
+@patch("functions.build_release._open_docs_sync_pr")
 @patch("functions.build_release._push_docs_sync_branch")
 @patch("functions.build_release._find_open_docs_sync_pr", return_value=None)
-@patch("functions.build_release.update_docs", return_value="nothing to do")
+@patch("functions.build_release.update_docs")
 @patch("functions.build_release.check_docs")
 @patch("functions.build_release.has_changes_in_paths", return_value=False)
-def test_docs_gate_raises_when_the_update_changes_nothing(
+def test_docs_gate_continues_when_the_updater_finds_gaps_already_covered(
+    mock_has_changes: MagicMock,
+    mock_check: MagicMock,
+    mock_update: MagicMock,
+    mock_find_pr: MagicMock,
+    mock_push_branch: MagicMock,
+    mock_open_pr: MagicMock,
+    capfd: pytest.CaptureFixture[str],
+) -> None:
+    # The check claimed a gap; the updater read the docs and verified each
+    # reported gap is already documented. That is the check being noisy, not
+    # the docs being stale, and it must not block the release.
+    mock_check.return_value = CheckResult(changes=(_BLOCKING_CHANGE,))
+    mock_update.return_value = UpdateResult(
+        results=(
+            UpdateOutcome(
+                file="docs/x.mdx",
+                change="document --verbose",
+                status="already_covered",
+            ),
+        ),
+        summary="everything already documented",
+    )
+
+    _docs_gate(repo_root=Path("/repo"))
+
+    mock_push_branch.assert_not_called()
+    mock_open_pr.assert_not_called()
+    assert "already" in capfd.readouterr().err
+
+
+@patch("functions.build_release._push_docs_sync_branch")
+@patch("functions.build_release._find_open_docs_sync_pr", return_value=None)
+@patch("functions.build_release.update_docs")
+@patch("functions.build_release.check_docs")
+@patch("functions.build_release.has_changes_in_paths", return_value=False)
+def test_docs_gate_raises_when_the_update_claims_edits_but_changed_nothing(
     mock_has_changes: MagicMock,
     mock_check: MagicMock,
     mock_update: MagicMock,
     mock_find_pr: MagicMock,
     mock_push_branch: MagicMock,
 ) -> None:
-    # Stale docs with no regenerated content leave nothing to put in a pull
-    # request, so the release stops with the manual route spelled out.
-    mock_check.return_value = CheckResult(
-        up_to_date=False,
-        required_changes=(RequiredChange(file="docs/x.mdx", change="document it"),),
+    # An "implemented" claim with a clean docs tree is a malfunctioning
+    # updater, not a noisy check; passing silently would make the gate
+    # unfalsifiable, so the release stops with the manual route spelled out.
+    mock_check.return_value = CheckResult(changes=(_BLOCKING_CHANGE,))
+    mock_update.return_value = UpdateResult(
+        results=(
+            UpdateOutcome(
+                file="docs/x.mdx",
+                change="document --verbose",
+                status="implemented",
+            ),
+        ),
+        summary="edited 1 file",
     )
 
-    with pytest.raises(ReleaseError, match="changed nothing there"):
+    with pytest.raises(ReleaseError, match="nothing changed there"):
         _docs_gate()
 
     mock_push_branch.assert_not_called()
@@ -916,7 +1050,11 @@ def test_open_docs_sync_pr_creates_a_pr_against_dev(mock_api: MagicMock) -> None
         slug,
         "auto/docs-update-abc",
         DEV_COMMIT,
-        (RequiredChange(file="docs/x.mdx", change="document --verbose"),),
+        (
+            RequiredChange(
+                file="docs/x.mdx", change="document --verbose", severity="blocking"
+            ),
+        ),
     )
 
     assert url == "https://github.com/test-owner/test-repo/pull/9"

--- a/scripts/tests/test_claude.py
+++ b/scripts/tests/test_claude.py
@@ -9,13 +9,14 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from functions.claude import (
-    CLAUDE_EFFORT,
-    CLAUDE_MODEL,
-    run_claude,
-    strip_code_fence,
-)
+from functions.claude import CLAUDE_EFFORT, CLAUDE_MODEL, run_claude
 from functions.cli import ReleaseError
+
+_SCHEMA: dict = {
+    "type": "object",
+    "properties": {"ok": {"type": "boolean"}},
+    "required": ["ok"],
+}
 
 
 def _flag_value(cmd: list[str], flag: str) -> str:
@@ -25,12 +26,12 @@ def _flag_value(cmd: list[str], flag: str) -> str:
 
 
 def _mock_run(
-    result_text: str,
+    structured: object,
     returncode: int = 0,
     *,
     capture: dict[str, Any] | None = None,
 ) -> Callable[..., MagicMock]:
-    """Build a subprocess.run replacement that mimics ``claude --output-format json``."""
+    """Build a subprocess.run replacement mimicking ``claude --json-schema``."""
 
     def _run(cmd: list[str], *args: object, **kwargs: object) -> MagicMock:
         if capture is not None:
@@ -38,44 +39,34 @@ def _mock_run(
             capture["input"] = kwargs.get("input")
         mock = MagicMock()
         mock.returncode = returncode
-        mock.stdout = json.dumps({"type": "result", "result": result_text})
+        mock.stdout = json.dumps(
+            {
+                "type": "result",
+                "result": json.dumps(structured),
+                "structured_output": structured,
+            }
+        )
         mock.stderr = ""
         return mock
 
     return _run
 
 
-# --- strip_code_fence ---
-
-
-def test_strip_code_fence_no_fence() -> None:
-    assert strip_code_fence('{"ok": true}') == '{"ok": true}'
-
-
-def test_strip_code_fence_with_lang() -> None:
-    assert strip_code_fence('```json\n{"ok": true}\n```') == '{"ok": true}'
-
-
-def test_strip_code_fence_bare() -> None:
-    assert strip_code_fence('```\n{"ok": true}\n```') == '{"ok": true}'
-
-
-def test_strip_code_fence_with_surrounding_whitespace() -> None:
-    assert strip_code_fence('  \n```json\n{"ok": true}\n```\n  ') == '{"ok": true}'
-
-
 # --- run_claude ---
 
 
-def test_run_claude_returns_result_text(tmp_path: Path) -> None:
-    with patch("functions.claude.subprocess.run", side_effect=_mock_run("hello")):
+def test_run_claude_returns_structured_output(tmp_path: Path) -> None:
+    with patch(
+        "functions.claude.subprocess.run", side_effect=_mock_run({"ok": True})
+    ):
         out = run_claude(
             "prompt",
             allowed_tools="Read",
             permission_mode="bypassPermissions",
             cwd=tmp_path,
+            json_schema=_SCHEMA,
         )
-    assert out == "hello"
+    assert out == {"ok": True}
 
 
 def test_run_claude_pins_model_effort_and_pipes_prompt_via_stdin(
@@ -84,13 +75,14 @@ def test_run_claude_pins_model_effort_and_pipes_prompt_via_stdin(
     capture: dict[str, Any] = {}
     with patch(
         "functions.claude.subprocess.run",
-        side_effect=_mock_run("ok", capture=capture),
+        side_effect=_mock_run({"ok": True}, capture=capture),
     ):
         run_claude(
             "the-prompt",
             allowed_tools="Read Grep Glob",
             permission_mode="bypassPermissions",
             cwd=tmp_path,
+            json_schema=_SCHEMA,
         )
     cmd = capture["cmd"]
     assert cmd[0] == "claude"
@@ -105,17 +97,35 @@ def test_run_claude_pins_model_effort_and_pipes_prompt_via_stdin(
     assert "the-prompt" not in cmd
 
 
+def test_run_claude_passes_schema_as_json(tmp_path: Path) -> None:
+    capture: dict[str, Any] = {}
+    with patch(
+        "functions.claude.subprocess.run",
+        side_effect=_mock_run({"ok": True}, capture=capture),
+    ):
+        run_claude(
+            "p",
+            allowed_tools="Read",
+            permission_mode="default",
+            cwd=tmp_path,
+            json_schema=_SCHEMA,
+        )
+    # The schema rides argv as serialized JSON the CLI can validate against.
+    assert json.loads(_flag_value(capture["cmd"], "--json-schema")) == _SCHEMA
+
+
 def test_run_claude_disables_tools_when_tools_empty(tmp_path: Path) -> None:
     capture: dict[str, Any] = {}
     with patch(
         "functions.claude.subprocess.run",
-        side_effect=_mock_run("ok", capture=capture),
+        side_effect=_mock_run({"ok": True}, capture=capture),
     ):
         run_claude(
             "p",
             allowed_tools="",
             permission_mode="bypassPermissions",
             cwd=tmp_path,
+            json_schema=_SCHEMA,
             tools="",
         )
     cmd = capture["cmd"]
@@ -128,13 +138,14 @@ def test_run_claude_effort_override(tmp_path: Path) -> None:
     capture: dict[str, Any] = {}
     with patch(
         "functions.claude.subprocess.run",
-        side_effect=_mock_run("ok", capture=capture),
+        side_effect=_mock_run({"ok": True}, capture=capture),
     ):
         run_claude(
             "p",
             allowed_tools="Read",
             permission_mode="default",
             cwd=tmp_path,
+            json_schema=_SCHEMA,
             effort="low",
         )
     assert _flag_value(capture["cmd"], "--effort") == "low"
@@ -144,10 +155,14 @@ def test_run_claude_defaults_to_pinned_effort(tmp_path: Path) -> None:
     capture: dict[str, Any] = {}
     with patch(
         "functions.claude.subprocess.run",
-        side_effect=_mock_run("ok", capture=capture),
+        side_effect=_mock_run({"ok": True}, capture=capture),
     ):
         run_claude(
-            "p", allowed_tools="Read", permission_mode="default", cwd=tmp_path
+            "p",
+            allowed_tools="Read",
+            permission_mode="default",
+            cwd=tmp_path,
+            json_schema=_SCHEMA,
         )
     assert _flag_value(capture["cmd"], "--effort") == CLAUDE_EFFORT
 
@@ -156,13 +171,14 @@ def test_run_claude_omits_tools_flag_by_default(tmp_path: Path) -> None:
     capture: dict[str, Any] = {}
     with patch(
         "functions.claude.subprocess.run",
-        side_effect=_mock_run("ok", capture=capture),
+        side_effect=_mock_run({"ok": True}, capture=capture),
     ):
         run_claude(
             "p",
             allowed_tools="Read",
             permission_mode="default",
             cwd=tmp_path,
+            json_schema=_SCHEMA,
         )
     cmd = capture["cmd"]
     assert "--tools" not in cmd
@@ -181,6 +197,7 @@ def test_run_claude_raises_on_nonzero_exit(tmp_path: Path) -> None:
                 allowed_tools="Read",
                 permission_mode="bypassPermissions",
                 cwd=tmp_path,
+                json_schema=_SCHEMA,
             )
 
 
@@ -196,21 +213,65 @@ def test_run_claude_raises_on_invalid_outer_json(tmp_path: Path) -> None:
                 allowed_tools="Read",
                 permission_mode="bypassPermissions",
                 cwd=tmp_path,
+                json_schema=_SCHEMA,
             )
 
 
-def test_run_claude_raises_on_missing_result(tmp_path: Path) -> None:
+def test_run_claude_raises_on_non_object_envelope(tmp_path: Path) -> None:
     mock = MagicMock()
     mock.returncode = 0
-    mock.stdout = json.dumps({"type": "result"})
+    mock.stdout = "[]"
     mock.stderr = ""
     with patch("functions.claude.subprocess.run", return_value=mock):
-        with pytest.raises(ReleaseError, match="missing 'result'"):
+        with pytest.raises(ReleaseError, match="not an object"):
             run_claude(
                 "p",
                 allowed_tools="Read",
                 permission_mode="bypassPermissions",
                 cwd=tmp_path,
+                json_schema=_SCHEMA,
+            )
+
+
+def test_run_claude_raises_on_missing_structured_output(tmp_path: Path) -> None:
+    # An envelope without structured_output means the CLI never forced the
+    # schema (an older CLI, or a run that died before the final answer); the
+    # prose result is surfaced so the failure is diagnosable.
+    mock = MagicMock()
+    mock.returncode = 0
+    mock.stdout = json.dumps({"type": "result", "result": "The docs are fine."})
+    mock.stderr = ""
+    with patch("functions.claude.subprocess.run", return_value=mock):
+        with pytest.raises(
+            ReleaseError, match="missing 'structured_output'"
+        ) as excinfo:
+            run_claude(
+                "p",
+                allowed_tools="Read",
+                permission_mode="bypassPermissions",
+                cwd=tmp_path,
+                json_schema=_SCHEMA,
+            )
+    assert "The docs are fine." in str(excinfo.value)
+
+
+def test_run_claude_raises_on_non_object_structured_output(
+    tmp_path: Path,
+) -> None:
+    mock = MagicMock()
+    mock.returncode = 0
+    mock.stdout = json.dumps(
+        {"type": "result", "result": "[]", "structured_output": []}
+    )
+    mock.stderr = ""
+    with patch("functions.claude.subprocess.run", return_value=mock):
+        with pytest.raises(ReleaseError, match="missing 'structured_output'"):
+            run_claude(
+                "p",
+                allowed_tools="Read",
+                permission_mode="bypassPermissions",
+                cwd=tmp_path,
+                json_schema=_SCHEMA,
             )
 
 

--- a/scripts/tests/test_docker.py
+++ b/scripts/tests/test_docker.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import base64
 import json
 from pathlib import Path
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -16,7 +16,6 @@ from functions.docker import (
     DOCKER_HUB_ACCOUNT,
     DOCKER_HUB_REGISTRY,
     DOCKER_PLATFORMS,
-    BaseImage,
     _ensure_buildx_builder,
     _get_docker_hub_username,
     _get_username_from_cred_store,

--- a/scripts/tests/test_docs.py
+++ b/scripts/tests/test_docs.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -11,10 +12,15 @@ import pytest
 from functions.claude import CLAUDE_EFFORT, CLAUDE_MODEL
 from functions.cli import ReleaseError
 from functions.docs import (
+    _CHECK_SCHEMA,
+    _UPDATE_SCHEMA,
     CheckResult,
     RequiredChange,
+    UpdateOutcome,
+    UpdateResult,
     _is_code_path,
     _parse_check_response,
+    _parse_update_response,
     _truncate_diff,
     check_docs,
     update_docs,
@@ -25,6 +31,14 @@ def _flag_value(cmd: list[str], flag: str) -> str:
     """Return the argv element following ``flag`` in ``cmd``."""
     assert flag in cmd, f"{flag} not in {cmd}"
     return cmd[cmd.index(flag) + 1]
+
+
+def _blocking(file: str = "docs/x.mdx", change: str = "add flag") -> RequiredChange:
+    return RequiredChange(file=file, change=change, severity="blocking")
+
+
+def _minor(file: str = "docs/y.mdx", change: str = "reword") -> RequiredChange:
+    return RequiredChange(file=file, change=change, severity="minor")
 
 
 # --- _is_code_path ---
@@ -65,89 +79,188 @@ def test_truncate_diff_long_truncated() -> None:
     assert "diff truncated" in out
 
 
+# --- the schemas the CLI enforces ---
+
+
+def test_check_schema_pins_required_fields_and_severity_enum() -> None:
+    # The Python validator and the CLI-side schema must not drift: a schema
+    # that stops requiring a field would let entries through that
+    # _parse_check_response rejects, turning verdicts into release-time
+    # crashes.
+    assert _CHECK_SCHEMA["required"] == ["required_changes"]
+    item = _CHECK_SCHEMA["properties"]["required_changes"]["items"]
+    assert item["required"] == ["file", "change", "severity"]
+    assert item["properties"]["severity"]["enum"] == ["blocking", "minor"]
+
+
+def test_update_schema_pins_required_fields_and_status_enum() -> None:
+    assert _UPDATE_SCHEMA["required"] == ["results", "summary"]
+    item = _UPDATE_SCHEMA["properties"]["results"]["items"]
+    assert item["required"] == ["file", "change", "status"]
+    assert item["properties"]["status"]["enum"] == [
+        "implemented",
+        "already_covered",
+    ]
+
+
+# --- CheckResult / UpdateResult ---
+
+
+def test_check_result_splits_blocking_and_minor() -> None:
+    result = CheckResult(changes=(_blocking(), _minor(), _blocking("docs/z.mdx")))
+    assert result.blocking == (_blocking(), _blocking("docs/z.mdx"))
+    assert result.minor == (_minor(),)
+
+
+def test_update_result_all_already_covered() -> None:
+    covered = UpdateOutcome(file="docs/x.mdx", change="c", status="already_covered")
+    implemented = UpdateOutcome(file="docs/x.mdx", change="c", status="implemented")
+    assert UpdateResult(results=(covered, covered), summary="s").all_already_covered
+    assert not UpdateResult(
+        results=(covered, implemented), summary="s"
+    ).all_already_covered
+    # An empty report is not a verdict: the updater must name what it checked.
+    assert not UpdateResult(results=(), summary="s").all_already_covered
+
+
 # --- _parse_check_response ---
 
 
-def test_parse_check_response_up_to_date() -> None:
-    result = _parse_check_response('{"up_to_date": true, "required_changes": []}')
-    assert result == CheckResult(up_to_date=True, required_changes=())
+def test_parse_check_response_empty_is_clean() -> None:
+    assert _parse_check_response({"required_changes": []}) == CheckResult(changes=())
 
 
-def test_parse_check_response_stale() -> None:
-    text = json.dumps(
-        {
-            "up_to_date": False,
-            "required_changes": [
-                {"file": "docs/src/content/docs/guides/installation.mdx",
-                 "change": "mention new --verbose flag"},
-            ],
-        }
-    )
-    result = _parse_check_response(text)
-    assert result.up_to_date is False
-    assert result.required_changes == (
+def test_parse_check_response_keeps_severities() -> None:
+    payload = {
+        "required_changes": [
+            {
+                "file": "docs/src/content/docs/guides/installation.mdx",
+                "change": "mention new --verbose flag",
+                "severity": "blocking",
+            },
+            {"file": "docs/a.mdx", "change": "reword intro", "severity": "minor"},
+        ]
+    }
+    result = _parse_check_response(payload)
+    assert result.blocking == (
         RequiredChange(
             file="docs/src/content/docs/guides/installation.mdx",
             change="mention new --verbose flag",
+            severity="blocking",
         ),
+    )
+    assert result.minor == (
+        RequiredChange(file="docs/a.mdx", change="reword intro", severity="minor"),
     )
 
 
-def test_parse_check_response_with_code_fence() -> None:
-    text = '```json\n{"up_to_date": true, "required_changes": []}\n```'
-    result = _parse_check_response(text)
-    assert result.up_to_date is True
-
-
-def test_parse_check_response_invalid_json() -> None:
-    with pytest.raises(ReleaseError, match="not valid JSON"):
-        _parse_check_response("not json at all")
-
-
-def test_parse_check_response_missing_up_to_date() -> None:
-    with pytest.raises(ReleaseError, match="up_to_date"):
-        _parse_check_response('{"required_changes": []}')
-
-
-def test_parse_check_response_up_to_date_not_bool() -> None:
-    with pytest.raises(ReleaseError, match="up_to_date"):
-        _parse_check_response('{"up_to_date": "yes", "required_changes": []}')
+def test_parse_check_response_missing_changes() -> None:
+    with pytest.raises(ReleaseError, match="required_changes"):
+        _parse_check_response({})
 
 
 def test_parse_check_response_changes_not_list() -> None:
     with pytest.raises(ReleaseError, match="required_changes"):
-        _parse_check_response('{"up_to_date": false, "required_changes": "foo"}')
+        _parse_check_response({"required_changes": "foo"})
+
+
+def test_parse_check_response_change_entry_not_object() -> None:
+    with pytest.raises(ReleaseError, match="must be an object"):
+        _parse_check_response({"required_changes": ["docs/a.mdx"]})
 
 
 def test_parse_check_response_change_entry_missing_fields() -> None:
-    text = '{"up_to_date": false, "required_changes": [{"file": "a.md"}]}'
     with pytest.raises(ReleaseError, match="file/change"):
-        _parse_check_response(text)
+        _parse_check_response(
+            {"required_changes": [{"file": "a.md", "severity": "minor"}]}
+        )
 
 
-def test_parse_check_response_not_object() -> None:
+def test_parse_check_response_unknown_severity() -> None:
+    with pytest.raises(ReleaseError, match="unknown severity"):
+        _parse_check_response(
+            {
+                "required_changes": [
+                    {"file": "a.md", "change": "c", "severity": "critical"}
+                ]
+            }
+        )
+
+
+# --- _parse_update_response ---
+
+
+def test_parse_update_response_valid() -> None:
+    payload = {
+        "results": [
+            {"file": "docs/x.mdx", "change": "add flag", "status": "implemented"},
+            {"file": "docs/y.mdx", "change": "fix", "status": "already_covered"},
+        ],
+        "summary": "closed one gap",
+    }
+    result = _parse_update_response(payload)
+    assert result == UpdateResult(
+        results=(
+            UpdateOutcome(file="docs/x.mdx", change="add flag", status="implemented"),
+            UpdateOutcome(file="docs/y.mdx", change="fix", status="already_covered"),
+        ),
+        summary="closed one gap",
+    )
+
+
+def test_parse_update_response_results_not_list() -> None:
+    with pytest.raises(ReleaseError, match="'results' must be a list"):
+        _parse_update_response({"results": {}, "summary": "s"})
+
+
+def test_parse_update_response_missing_summary() -> None:
+    with pytest.raises(ReleaseError, match="summary"):
+        _parse_update_response({"results": []})
+
+
+def test_parse_update_response_entry_not_object() -> None:
     with pytest.raises(ReleaseError, match="must be an object"):
-        _parse_check_response("[]")
+        _parse_update_response({"results": ["x"], "summary": "s"})
+
+
+def test_parse_update_response_unknown_status() -> None:
+    with pytest.raises(ReleaseError, match="unknown status"):
+        _parse_update_response(
+            {
+                "results": [{"file": "a", "change": "c", "status": "skipped"}],
+                "summary": "s",
+            }
+        )
 
 
 # --- check_docs / update_docs (mocked claude) ---
 
 
 def _mock_subprocess_run_for_claude(
-    result_text: str, returncode: int = 0
+    structured: object,
+    *,
+    capture: dict[str, Any] | None = None,
 ) -> MagicMock:
     """Build a MagicMock replacement for subprocess.run.
 
-    Returns a dummy for git calls (empty stdout, rc=0) and the provided
-    JSON payload for claude calls.
+    Returns the provided object as the envelope's structured output for
+    claude calls; git calls are not expected (get_code_diff is patched).
     """
 
     def _run(cmd: list[str], *args: object, **kwargs: object) -> MagicMock:
         if cmd and cmd[0] == "claude":
-            payload = json.dumps({"type": "result", "result": result_text})
+            if capture is not None:
+                capture["cmd"] = cmd
+                capture["input"] = kwargs.get("input")
             mock = MagicMock()
-            mock.returncode = returncode
-            mock.stdout = payload
+            mock.returncode = 0
+            mock.stdout = json.dumps(
+                {
+                    "type": "result",
+                    "result": json.dumps(structured),
+                    "structured_output": structured,
+                }
+            )
             mock.stderr = ""
             return mock
         raise AssertionError(f"unexpected command: {cmd}")
@@ -160,14 +273,16 @@ def test_check_docs_short_circuits_on_no_code_changes(tmp_path: Path) -> None:
          patch("functions.docs.get_code_diff", return_value=("", [])), \
          patch("functions.claude.subprocess.run") as mock_run:
         result = check_docs("BASE", "HEAD")
-    assert result.up_to_date is True
-    assert result.required_changes == ()
+    assert result == CheckResult(changes=())
     mock_run.assert_not_called()
 
 
 def test_check_docs_parses_claude_verdict(tmp_path: Path) -> None:
-    verdict = '{"up_to_date": false, "required_changes": [' \
-              '{"file": "docs/x.mdx", "change": "add flag"}]}'
+    verdict = {
+        "required_changes": [
+            {"file": "docs/x.mdx", "change": "add flag", "severity": "blocking"}
+        ]
+    }
     with patch("functions.docs.get_repo_root", return_value=tmp_path), \
          patch(
              "functions.docs.get_code_diff",
@@ -178,10 +293,32 @@ def test_check_docs_parses_claude_verdict(tmp_path: Path) -> None:
              _mock_subprocess_run_for_claude(verdict),
          ):
         result = check_docs("BASE", "HEAD")
-    assert result.up_to_date is False
-    assert result.required_changes == (
-        RequiredChange(file="docs/x.mdx", change="add flag"),
-    )
+    assert result.blocking == (_blocking(),)
+    assert result.minor == ()
+
+
+def test_check_docs_enforces_schema_and_readonly_tools(tmp_path: Path) -> None:
+    capture: dict[str, Any] = {}
+    verdict: dict = {"required_changes": []}
+    with patch("functions.docs.get_repo_root", return_value=tmp_path), \
+         patch(
+             "functions.docs.get_code_diff",
+             return_value=("diff", ["crates/foo.rs"]),
+         ), \
+         patch(
+             "functions.claude.subprocess.run",
+             _mock_subprocess_run_for_claude(verdict, capture=capture),
+         ):
+        check_docs("BASE", "HEAD")
+    cmd = capture["cmd"]
+    # The verdict shape is enforced CLI-side, so prose answers cannot crash
+    # the release.
+    assert json.loads(_flag_value(cmd, "--json-schema")) == _CHECK_SCHEMA
+    # tools (not just the allowlist) is restricted: under bypassPermissions
+    # the allowlist approves rather than limits, and the check must stay
+    # read-only.
+    assert _flag_value(cmd, "--tools") == "Read Grep Glob"
+    assert _flag_value(cmd, "--allowed-tools") == "Read Grep Glob"
 
 
 def test_check_docs_raises_on_claude_nonzero(tmp_path: Path) -> None:
@@ -199,10 +336,12 @@ def test_check_docs_raises_on_claude_nonzero(tmp_path: Path) -> None:
             check_docs("BASE", "HEAD")
 
 
-def test_check_docs_raises_on_invalid_outer_json(tmp_path: Path) -> None:
+def test_check_docs_raises_on_missing_structured_output(tmp_path: Path) -> None:
+    # The regression that motivated --json-schema: a prose answer must fail
+    # with a diagnosable error, never a JSON traceback.
     mock = MagicMock()
     mock.returncode = 0
-    mock.stdout = "not json"
+    mock.stdout = json.dumps({"type": "result", "result": "The docs are fine."})
     mock.stderr = ""
     with patch("functions.docs.get_repo_root", return_value=tmp_path), \
          patch(
@@ -210,45 +349,71 @@ def test_check_docs_raises_on_invalid_outer_json(tmp_path: Path) -> None:
              return_value=("diff", ["crates/foo.rs"]),
          ), \
          patch("functions.claude.subprocess.run", return_value=mock):
-        with pytest.raises(ReleaseError, match="not return valid JSON"):
+        with pytest.raises(ReleaseError, match="missing 'structured_output'"):
             check_docs("BASE", "HEAD")
 
 
-def test_update_docs_short_circuits_on_no_code_changes(tmp_path: Path) -> None:
+def test_update_docs_rejects_an_empty_change_list(tmp_path: Path) -> None:
     with patch("functions.docs.get_repo_root", return_value=tmp_path), \
-         patch("functions.docs.get_code_diff", return_value=("", [])), \
          patch("functions.claude.subprocess.run") as mock_run:
-        summary = update_docs("BASE", "HEAD")
-    assert "nothing to update" in summary
+        with pytest.raises(ReleaseError, match="no changes to implement"):
+            update_docs("BASE", "HEAD", ())
     mock_run.assert_not_called()
 
 
+def test_update_docs_scopes_the_prompt_to_the_requested_changes(
+    tmp_path: Path,
+) -> None:
+    capture: dict[str, Any] = {}
+    report = {
+        "results": [
+            {"file": "docs/x.mdx", "change": "add flag", "status": "implemented"}
+        ],
+        "summary": "edited 1 file",
+    }
+    changes = (_blocking(), _blocking("docs/z.mdx", "document subcommand"))
+    with patch("functions.docs.get_repo_root", return_value=tmp_path), \
+         patch(
+             "functions.docs.get_code_diff",
+             return_value=("THE-CODE-DIFF", ["crates/foo.rs"]),
+         ), \
+         patch(
+             "functions.claude.subprocess.run",
+             _mock_subprocess_run_for_claude(report, capture=capture),
+         ):
+        result = update_docs("BASE", "HEAD", changes)
+
+    assert result.summary == "edited 1 file"
+    prompt = capture["input"]
+    # The updater implements the check's verdict, nothing else: every
+    # requested change is enumerated, and the diff stays in as the source of
+    # truth for the facts.
+    assert "- `docs/x.mdx`: add flag" in prompt
+    assert "- `docs/z.mdx`: document subcommand" in prompt
+    assert "THE-CODE-DIFF" in prompt
+    assert json.loads(_flag_value(capture["cmd"], "--json-schema")) == _UPDATE_SCHEMA
+
+
 def test_update_docs_invokes_claude_with_edit_permissions(tmp_path: Path) -> None:
-    captured: dict[str, list[str]] = {}
-
-    def _run(cmd: list[str], *args: object, **kwargs: object) -> MagicMock:
-        captured["cmd"] = cmd
-        mock = MagicMock()
-        mock.returncode = 0
-        mock.stdout = json.dumps({"type": "result", "result": "edited 3 files"})
-        mock.stderr = ""
-        return mock
-
+    capture: dict[str, Any] = {}
+    report: dict = {"results": [], "summary": "edited 3 files"}
     with patch("functions.docs.get_repo_root", return_value=tmp_path), \
          patch(
              "functions.docs.get_code_diff",
              return_value=("diff", ["crates/foo.rs"]),
          ), \
-         patch("functions.claude.subprocess.run", side_effect=_run):
-        summary = update_docs("BASE", "HEAD")
+         patch(
+             "functions.claude.subprocess.run",
+             _mock_subprocess_run_for_claude(report, capture=capture),
+         ):
+        result = update_docs("BASE", "HEAD", (_blocking(),))
 
-    assert summary == "edited 3 files"
-    cmd = captured["cmd"]
+    assert result.summary == "edited 3 files"
+    cmd = capture["cmd"]
     assert cmd[0] == "claude"
-    assert "--permission-mode" in cmd
-    assert cmd[cmd.index("--permission-mode") + 1] == "acceptEdits"
-    assert "--allowed-tools" in cmd
-    allowed = cmd[cmd.index("--allowed-tools") + 1]
+    assert _flag_value(cmd, "--permission-mode") == "acceptEdits"
+    assert _flag_value(cmd, "--tools") == "Read Edit Write Grep Glob"
+    allowed = _flag_value(cmd, "--allowed-tools")
     assert "Edit" in allowed
     assert "Write" in allowed
 
@@ -257,34 +422,28 @@ def test_update_docs_invokes_claude_with_edit_permissions(tmp_path: Path) -> Non
 
 
 def _capture_claude_cmd(
-    fn, base: str, head: str, tmp_path: Path, result_text: str
+    fn, tmp_path: Path, structured: object
 ) -> list[str]:
-    """Invoke ``fn(base, head)`` with claude mocked and return its argv."""
-    captured: dict[str, list[str]] = {}
-
-    def _run(cmd: list[str], *args: object, **kwargs: object) -> MagicMock:
-        if cmd and cmd[0] == "claude":
-            captured["cmd"] = cmd
-        mock = MagicMock()
-        mock.returncode = 0
-        mock.stdout = json.dumps({"type": "result", "result": result_text})
-        mock.stderr = ""
-        return mock
-
+    """Invoke ``fn()`` with claude mocked and return its argv."""
+    capture: dict[str, Any] = {}
     with patch("functions.docs.get_repo_root", return_value=tmp_path), \
          patch(
              "functions.docs.get_code_diff",
              return_value=("diff", ["crates/foo.rs"]),
          ), \
-         patch("functions.claude.subprocess.run", side_effect=_run):
-        fn(base, head)
-    return captured["cmd"]
+         patch(
+             "functions.claude.subprocess.run",
+             _mock_subprocess_run_for_claude(structured, capture=capture),
+         ):
+        fn()
+    return capture["cmd"]
 
 
 def test_check_docs_pins_model_and_effort(tmp_path: Path) -> None:
     cmd = _capture_claude_cmd(
-        check_docs, "BASE", "HEAD", tmp_path,
-        '{"up_to_date": true, "required_changes": []}',
+        lambda: check_docs("BASE", "HEAD"),
+        tmp_path,
+        {"required_changes": []},
     )
     assert _flag_value(cmd, "--model") == CLAUDE_MODEL
     assert _flag_value(cmd, "--effort") == CLAUDE_EFFORT
@@ -292,7 +451,9 @@ def test_check_docs_pins_model_and_effort(tmp_path: Path) -> None:
 
 def test_update_docs_pins_model_and_effort(tmp_path: Path) -> None:
     cmd = _capture_claude_cmd(
-        update_docs, "BASE", "HEAD", tmp_path, "edited 1 file",
+        lambda: update_docs("BASE", "HEAD", (_blocking(),)),
+        tmp_path,
+        {"results": [], "summary": "edited 1 file"},
     )
     assert _flag_value(cmd, "--model") == CLAUDE_MODEL
     assert _flag_value(cmd, "--effort") == CLAUDE_EFFORT

--- a/scripts/tests/test_release_summary.py
+++ b/scripts/tests/test_release_summary.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 from unittest.mock import patch
 
@@ -10,48 +9,42 @@ import pytest
 
 from functions.cli import ReleaseError
 from functions.release_summary import (
+    _CONTENT_SCHEMA,
     ReleaseContent,
     _parse_release_content,
     generate_release_content,
 )
 
 
+# --- _CONTENT_SCHEMA ---
+
+
+def test_content_schema_requires_all_fields_non_empty() -> None:
+    # The Python validator and the CLI-side schema must not drift.
+    assert _CONTENT_SCHEMA["required"] == ["title", "description", "notes"]
+    for field in ("title", "description", "notes"):
+        assert _CONTENT_SCHEMA["properties"][field]["minLength"] == 1
+
+
 # --- _parse_release_content ---
 
 
 def test_parse_release_content_valid() -> None:
-    text = json.dumps(
-        {
-            "title": "Topics hardening",
-            "description": "Fixed deadlocks.",
-            "notes": "## What's Changed\n- x",
-        }
-    )
-    assert _parse_release_content(text) == ReleaseContent(
+    payload = {
+        "title": "Topics hardening",
+        "description": "Fixed deadlocks.",
+        "notes": "## What's Changed\n- x",
+    }
+    assert _parse_release_content(payload) == ReleaseContent(
         title="Topics hardening",
         description="Fixed deadlocks.",
         notes="## What's Changed\n- x",
     )
 
 
-def test_parse_release_content_strips_code_fence() -> None:
-    text = '```json\n{"title": "T", "description": "D", "notes": "N"}\n```'
-    assert _parse_release_content(text) == ReleaseContent("T", "D", "N")
-
-
 def test_parse_release_content_strips_whitespace() -> None:
     payload = {"title": "  T  ", "description": " D ", "notes": " N "}
-    assert _parse_release_content(json.dumps(payload)) == ReleaseContent("T", "D", "N")
-
-
-def test_parse_release_content_invalid_json() -> None:
-    with pytest.raises(ReleaseError, match="not valid JSON"):
-        _parse_release_content("not json at all")
-
-
-def test_parse_release_content_not_object() -> None:
-    with pytest.raises(ReleaseError, match="must be a JSON object"):
-        _parse_release_content("[]")
+    assert _parse_release_content(payload) == ReleaseContent("T", "D", "N")
 
 
 @pytest.mark.parametrize("missing", ["title", "description", "notes"])
@@ -59,36 +52,23 @@ def test_parse_release_content_missing_field(missing: str) -> None:
     payload = {"title": "T", "description": "D", "notes": "N"}
     del payload[missing]
     with pytest.raises(ReleaseError, match=f"missing non-empty '{missing}'"):
-        _parse_release_content(json.dumps(payload))
+        _parse_release_content(payload)
 
 
 @pytest.mark.parametrize("field", ["title", "description", "notes"])
 def test_parse_release_content_blank_field(field: str) -> None:
+    # minLength in the schema cannot catch whitespace-only strings; the
+    # Python-side check must.
     payload = {"title": "T", "description": "D", "notes": "N"}
     payload[field] = "   "
     with pytest.raises(ReleaseError, match=f"missing non-empty '{field}'"):
-        _parse_release_content(json.dumps(payload))
+        _parse_release_content(payload)
 
 
 def test_parse_release_content_non_string_field() -> None:
     payload: dict[str, object] = {"title": "T", "description": "D", "notes": 123}
     with pytest.raises(ReleaseError, match="missing non-empty 'notes'"):
-        _parse_release_content(json.dumps(payload))
-
-
-def test_parse_release_content_tolerates_preamble() -> None:
-    # Claude occasionally prefixes the object with a sentence; extract anyway.
-    text = 'Here are the notes:\n{"title": "T", "description": "D", "notes": "N"}'
-    assert _parse_release_content(text) == ReleaseContent("T", "D", "N")
-
-
-def test_parse_release_content_extracts_object_with_braces_in_notes() -> None:
-    # Braces inside the notes string must not unbalance the extraction.
-    notes = "Use `cfg{}` blocks"
-    text = "noise " + json.dumps(
-        {"title": "T", "description": "D", "notes": notes}
-    )
-    assert _parse_release_content(text) == ReleaseContent("T", "D", notes)
+        _parse_release_content(payload)
 
 
 # --- generate_release_content (mocked run_claude) ---
@@ -103,16 +83,18 @@ def test_generate_release_content_runs_claude_without_tools(tmp_path: Path) -> N
         allowed_tools: str,
         permission_mode: str,
         cwd: Path,
+        json_schema: dict,
         tools: str | None = None,
         effort: str = "max",
-    ) -> str:
+    ) -> dict:
         captured["prompt"] = prompt
         captured["allowed_tools"] = allowed_tools
         captured["permission_mode"] = permission_mode
         captured["cwd"] = cwd
+        captured["json_schema"] = json_schema
         captured["tools"] = tools
         captured["effort"] = effort
-        return json.dumps({"title": "T", "description": "D", "notes": "N"})
+        return {"title": "T", "description": "D", "notes": "N"}
 
     with patch("functions.release_summary.run_claude", side_effect=_fake_run_claude):
         result = generate_release_content(
@@ -127,6 +109,8 @@ def test_generate_release_content_runs_claude_without_tools(tmp_path: Path) -> N
     assert captured["allowed_tools"] == ""
     assert captured["effort"] == "xhigh"
     assert captured["cwd"] == tmp_path
+    # The response shape is enforced CLI-side.
+    assert captured["json_schema"] == _CONTENT_SCHEMA
     # The commit subjects and tag are interpolated into the prompt.
     assert "- fix(apptainer): pre-flight bind mounts" in captured["prompt"]
     assert "v0.12.0" in captured["prompt"]
@@ -135,9 +119,9 @@ def test_generate_release_content_runs_claude_without_tools(tmp_path: Path) -> N
 def test_generate_release_content_handles_no_commits(tmp_path: Path) -> None:
     captured: dict[str, str] = {}
 
-    def _fake_run_claude(prompt: str, **kwargs: object) -> str:
+    def _fake_run_claude(prompt: str, **kwargs: object) -> dict:
         captured["prompt"] = prompt
-        return json.dumps({"title": "T", "description": "D", "notes": "N"})
+        return {"title": "T", "description": "D", "notes": "N"}
 
     with patch("functions.release_summary.run_claude", side_effect=_fake_run_claude):
         generate_release_content([], "v0.1.0", tmp_path)


### PR DESCRIPTION
## Problem

A release run crashed with `claude verdict was not valid JSON`: the docs freshness check asked for a JSON verdict mid-prompt, appended a huge diff, and the model answered in prose. Separately, the check treated any imaginable doc improvement as "out of date", so a wording-level nitpick could regenerate docs, open a PR, and block the release non-deterministically.

## Changes

- `run_claude` always passes the CLI's `--json-schema` flag and returns the envelope's `structured_output`: the final answer is forced through a validated structured-output tool call, so a prose answer cannot reach the parser. Verified live, including a multi-turn agentic run with Read/Grep/Glob.
- Verdict entries carry `severity: blocking | minor`; the `up_to_date` boolean is gone (derived from the list, which also fixes `up_to_date: true` with a non-empty change list silently passing). Only blocking gaps — docs stating something false, or a user-facing change entirely undocumented — regenerate docs, open a PR, and stop the release. Minor suggestions are printed and never block.
- The updater no longer free-edits: it receives the exact blocking-change list and must account for each gap as `implemented` or `already_covered` (structured output as well), so the PR diff derives from the verdict instead of a fresh audit.
- When the updater verifies every reported gap is already documented, the release warns and continues instead of dying; it still hard-fails when the updater claims edits but the docs tree is unchanged.
- The check runs with `--tools "Read Grep Glob"` (under `bypassPermissions` the allowlist approves rather than restricts, so the read-only check could previously Bash/Edit/Write).
- `release_summary.py` migrated to the same mechanism, deleting ~70 lines of prose-salvage JSON extraction plus `strip_code_fence`.

## Testing

- Full scripts suite: 282 passed; the four touched test files (110 tests) cover the new schemas, severity filtering, the mixed blocking+minor verdict, both empty-diff outcomes, and the prose-regression case.
- Live smoke: `pixi run is-doc-up-to-date HEAD~1 HEAD` ran the real pinned-model check end to end and printed `docs are up to date`, exit 0 — the exact path that crashed before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)