### PR TITLE
Offer an optional docs-polish pull request for minor-only doc verdicts

### DIFF
--- a/.buildkite/README.md
+++ b/.buildkite/README.md
@@ -11,8 +11,8 @@ script itself (`_verify_docs_up_to_date` in
 `scripts/functions/build_release.py`). When the check finds a blocking gap
 (docs stating something false, or a user-facing change with no documentation
 at all), it opens the follow-up docs pull request against `dev` and stops the
-release until it is merged; minor wording-level suggestions are printed and
-never block.
+release until it is merged; minor wording-level suggestions are printed, at
+most offered as an optional side pull request, and never block.
 
 ## One-time setup
 

--- a/scripts/functions/build_release.py
+++ b/scripts/functions/build_release.py
@@ -107,6 +107,11 @@ DOCS_DIR = "docs"
 # branch (and its open pull request) rather than piling up new ones.
 DOCS_SYNC_BRANCH_PREFIX = "auto/docs-update-"
 
+# Prefix of the branch carrying optional minor doc polish the user asked for.
+# Separate from the sync prefix so a rerun that finds a blocking gap never
+# mistakes an open wording-level pull request for the fix it has to wait on.
+DOCS_POLISH_BRANCH_PREFIX = "auto/docs-polish-"
+
 
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
@@ -447,6 +452,32 @@ def _docs_sync_pr_body(
     return "\n".join(lines)
 
 
+def _docs_polish_pr_body(
+    release_commit: str,
+    changes: tuple[RequiredChange, ...],
+) -> str:
+    """Render the body of the optional docs-polish pull request."""
+    lines = [
+        (
+            "Optional docs polish produced by the release script "
+            + "(`scripts/functions/docs.py`): the docs check reported only minor "
+            + "suggestions, and the user chose to apply them anyway."
+        ),
+        "",
+        f"Release commit: {release_commit}",
+        "",
+        "Suggestions applied:",
+        "",
+    ]
+    lines += [f"- `{c.file}`: {c.change}" for c in changes]
+    lines += [
+        "",
+        "This pull request does not block the release it was cut from; merge "
+        "or close it on its own schedule.",
+    ]
+    return "\n".join(lines)
+
+
 def _find_open_docs_sync_pr(
     client: httpx.Client,
     slug: RepoSlug,
@@ -473,8 +504,8 @@ def _find_open_docs_sync_pr(
     return None
 
 
-def _push_docs_sync_branch(branch: str, docs_dir: Path) -> None:
-    """Commit the regenerated docs onto *branch* and push it.
+def _push_docs_sync_branch(branch: str, docs_dir: Path, message: str) -> None:
+    """Commit the regenerated docs onto *branch* as *message* and push it.
 
     The branch is cut from the release commit and carries the working-tree edits
     over, so its single commit holds the docs changes and nothing else. The
@@ -489,7 +520,7 @@ def _push_docs_sync_branch(branch: str, docs_dir: Path) -> None:
     """
     switch_to_new_branch(branch)
     try:
-        commit_paths([docs_dir], "docs: sync with the code being released")
+        commit_paths([docs_dir], message)
         console.print(f"Pushing '{branch}' to {GIT_REMOTE}...")
         try:
             push_branch(GIT_REMOTE, branch, branch)
@@ -505,14 +536,14 @@ def _push_docs_sync_branch(branch: str, docs_dir: Path) -> None:
         switch_branch(RELEASE_BRANCH)
 
 
-def _open_docs_sync_pr(
+def _open_docs_pr(
     client: httpx.Client,
     slug: RepoSlug,
     branch: str,
-    release_commit: str,
-    changes: tuple[RequiredChange, ...],
+    title: str,
+    body: str,
 ) -> str:
-    """Open the pull request carrying the regenerated docs.
+    """Open a docs pull request from *branch* into the release branch.
 
     Returns the pull request URL.
     """
@@ -521,10 +552,10 @@ def _open_docs_sync_pr(
         "POST",
         f"https://api.github.com/repos/{slug.full}/pulls",
         json_data={
-            "title": f"docs: sync with the code being released ({release_commit[:12]})",
+            "title": title,
             "head": branch,
             "base": RELEASE_BRANCH,
-            "body": _docs_sync_pr_body(release_commit, changes),
+            "body": body,
         },
     )
     if not isinstance(response, dict) or not response.get("html_url"):
@@ -533,6 +564,59 @@ def _open_docs_sync_pr(
             f"request: {response!r}"
         )
     return str(response["html_url"])
+
+
+def _offer_minor_docs_pr(
+    client: httpx.Client,
+    slug: RepoSlug,
+    release_commit: str,
+    repo_root: Path,
+    minor: tuple[RequiredChange, ...],
+) -> None:
+    """Offer to apply minor doc suggestions in an optional pull request.
+
+    Minor suggestions never gate anything, so nothing on this path stops the
+    release: when the user wants the pull request it is opened on the side and
+    the flow continues to the tag prompt. An earlier polish pull request for
+    this commit is reported instead of re-derived, and an update that ends up
+    changing nothing simply leaves nothing to open.
+    """
+    branch = f"{DOCS_POLISH_BRANCH_PREFIX}{release_commit[:12]}"
+    pr_url = _find_open_docs_sync_pr(client, slug, branch)
+    if pr_url:
+        console.print(
+            f"[yellow]A docs-polish pull request is already open for this "
+            f"commit: {pr_url}[/yellow]"
+        )
+        return
+    if not prompt_yn(
+        "Open a pull request applying these minor suggestions anyway? "
+        "The release continues either way."
+    ):
+        return
+
+    console.print("Asking Claude to apply the minor suggestions...")
+    base = f"{GIT_REMOTE}/{ALIGNED_BRANCH}"
+    update = update_docs(base, release_commit, minor)
+    console.print(update.summary)
+
+    docs_dir = repo_root / DOCS_DIR
+    if not has_changes_in_paths([docs_dir]):
+        console.print(
+            f"[yellow]The update changed nothing under '{DOCS_DIR}/'; there "
+            f"is no pull request to open.[/yellow]"
+        )
+        return
+
+    _push_docs_sync_branch(branch, docs_dir, "docs: minor polish")
+    pr_url = _open_docs_pr(
+        client,
+        slug,
+        branch,
+        f"docs: minor polish ({release_commit[:12]})",
+        _docs_polish_pr_body(release_commit, minor),
+    )
+    console.print(f"Opened {pr_url}; it does not block this release.")
 
 
 def _verify_docs_up_to_date(
@@ -556,8 +640,10 @@ def _verify_docs_up_to_date(
 
     Only blocking gaps stop the release: docs that now state something false,
     or a user-facing change with no documentation at all. Minor suggestions
-    (wording, clarity, nice-to-haves) are printed and ignored, so a release is
-    never held hostage by how the model would phrase a sentence today.
+    (wording, clarity, nice-to-haves) are printed, and the user is offered an
+    optional side pull request applying them; the release continues either
+    way, so it is never held hostage by how the model would phrase a sentence
+    today.
 
     When a blocking gap exists, Claude closes exactly the reported gaps, the
     result is pushed to a branch named after the release commit, a pull
@@ -585,6 +671,10 @@ def _verify_docs_up_to_date(
     print_minor_changes(result.minor)
     blocking = result.blocking
     if not blocking:
+        if result.minor:
+            _offer_minor_docs_pr(
+                client, slug, release_commit, repo_root, result.minor
+            )
         console.print(f"[green]'{DOCS_DIR}/' is up to date.[/green]")
         return
 
@@ -631,9 +721,15 @@ def _verify_docs_up_to_date(
             f"report is wrong."
         )
 
-    _push_docs_sync_branch(branch, docs_dir)
-    pr_url = _open_docs_sync_pr(
-        client, slug, branch, release_commit, blocking
+    _push_docs_sync_branch(
+        branch, docs_dir, "docs: sync with the code being released"
+    )
+    pr_url = _open_docs_pr(
+        client,
+        slug,
+        branch,
+        f"docs: sync with the code being released ({release_commit[:12]})",
+        _docs_sync_pr_body(release_commit, blocking),
     )
     _stop_for_docs_pr(pr_url)
 

--- a/scripts/functions/build_release.py
+++ b/scripts/functions/build_release.py
@@ -473,7 +473,7 @@ def _docs_polish_pr_body(
     lines += [
         "",
         "This pull request does not block the release it was cut from; merge "
-        "or close it on its own schedule.",
+        + "or close it on its own schedule.",
     ]
     return "\n".join(lines)
 

--- a/scripts/tests/test_build_release.py
+++ b/scripts/tests/test_build_release.py
@@ -14,7 +14,7 @@ from functions.build_release import (
     _commit_notes_and_align_main,
     _confirm_release_content,
     _find_open_docs_sync_pr,
-    _open_docs_sync_pr,
+    _open_docs_pr,
     _open_editor,
     _parse_editable,
     _prepare_release_content,
@@ -762,28 +762,159 @@ def test_docs_gate_passes_and_diffs_against_origin_main(
     mock_update.assert_not_called()
 
 
-@patch("functions.build_release._find_open_docs_sync_pr")
+@patch("functions.build_release.prompt_yn", return_value=False)
+@patch("functions.build_release._find_open_docs_sync_pr", return_value=None)
 @patch("functions.build_release.update_docs")
 @patch(
     "functions.build_release.check_docs",
     return_value=CheckResult(changes=(_MINOR_CHANGE,)),
 )
 @patch("functions.build_release.has_changes_in_paths", return_value=False)
-def test_docs_gate_passes_on_minor_only_suggestions(
+def test_docs_gate_passes_on_minor_only_suggestions_when_declined(
     mock_has_changes: MagicMock,
     mock_check: MagicMock,
     mock_update: MagicMock,
     mock_find_pr: MagicMock,
+    mock_prompt_yn: MagicMock,
     capfd: pytest.CaptureFixture[str],
 ) -> None:
-    # Wording-level suggestions must never regenerate docs, open a pull
-    # request, or stop a release: they are printed and the release moves on.
+    # Wording-level suggestions never stop a release: they are printed, the
+    # user is offered an optional pull request, and declining it leaves no
+    # trace — no update run, no branch, and the release moves on.
     _docs_gate(repo_root=Path("/repo"))
 
+    mock_prompt_yn.assert_called_once()
+    assert (
+        mock_find_pr.call_args.args[2] == f"auto/docs-polish-{DEV_COMMIT[:12]}"
+    )
     mock_update.assert_not_called()
-    mock_find_pr.assert_not_called()
     err = capfd.readouterr().err
     assert "reword the intro" in err
+    assert "up to date" in err
+
+
+@patch("functions.build_release._open_docs_pr")
+@patch("functions.build_release._push_docs_sync_branch")
+@patch("functions.build_release.prompt_yn", return_value=True)
+@patch("functions.build_release._find_open_docs_sync_pr", return_value=None)
+@patch("functions.build_release.update_docs")
+@patch(
+    "functions.build_release.check_docs",
+    return_value=CheckResult(changes=(_MINOR_CHANGE,)),
+)
+@patch("functions.build_release.has_changes_in_paths")
+def test_docs_gate_opens_an_optional_polish_pr_and_continues(
+    mock_has_changes: MagicMock,
+    mock_check: MagicMock,
+    mock_update: MagicMock,
+    mock_find_pr: MagicMock,
+    mock_prompt_yn: MagicMock,
+    mock_push_branch: MagicMock,
+    mock_open_pr: MagicMock,
+    capfd: pytest.CaptureFixture[str],
+) -> None:
+    # Accepting the offer opens the pull request on the side; the gate still
+    # returns normally so the release flows on to the tag prompt.
+    mock_update.return_value = UpdateResult(
+        results=(
+            UpdateOutcome(
+                file="docs/y.mdx",
+                change="reword the intro",
+                status="implemented",
+            ),
+        ),
+        summary="polished 1 file",
+    )
+    # Clean at the gate's dirty check, dirty after the polish update.
+    mock_has_changes.side_effect = [False, True]
+    mock_open_pr.return_value = "https://github.com/test-owner/test-repo/pull/8"
+
+    _docs_gate(repo_root=Path("/repo"))
+
+    mock_update.assert_called_once_with(
+        "origin/main", DEV_COMMIT, (_MINOR_CHANGE,)
+    )
+    branch = f"auto/docs-polish-{DEV_COMMIT[:12]}"
+    mock_push_branch.assert_called_once_with(
+        branch, Path("/repo/docs"), "docs: minor polish"
+    )
+    assert mock_open_pr.call_args.args[2] == branch
+    assert "minor polish" in mock_open_pr.call_args.args[3]
+    assert "reword the intro" in mock_open_pr.call_args.args[4]
+    err = capfd.readouterr().err
+    assert "pull/8" in err
+    assert "does not block" in err
+
+
+@patch("functions.build_release._open_docs_pr")
+@patch("functions.build_release._push_docs_sync_branch")
+@patch("functions.build_release.prompt_yn", return_value=True)
+@patch("functions.build_release._find_open_docs_sync_pr", return_value=None)
+@patch("functions.build_release.update_docs")
+@patch(
+    "functions.build_release.check_docs",
+    return_value=CheckResult(changes=(_MINOR_CHANGE,)),
+)
+@patch("functions.build_release.has_changes_in_paths", return_value=False)
+def test_docs_gate_skips_the_polish_pr_when_the_update_changes_nothing(
+    mock_has_changes: MagicMock,
+    mock_check: MagicMock,
+    mock_update: MagicMock,
+    mock_find_pr: MagicMock,
+    mock_prompt_yn: MagicMock,
+    mock_push_branch: MagicMock,
+    mock_open_pr: MagicMock,
+    capfd: pytest.CaptureFixture[str],
+) -> None:
+    # An accepted offer whose update produces no docs edits leaves nothing to
+    # open; the release just moves on — this path never hard-fails.
+    mock_update.return_value = UpdateResult(
+        results=(
+            UpdateOutcome(
+                file="docs/y.mdx",
+                change="reword the intro",
+                status="already_covered",
+            ),
+        ),
+        summary="nothing to polish",
+    )
+
+    _docs_gate(repo_root=Path("/repo"))
+
+    mock_push_branch.assert_not_called()
+    mock_open_pr.assert_not_called()
+    err = capfd.readouterr().err
+    assert "no pull request to open" in err
+    assert "up to date" in err
+
+
+@patch("functions.build_release.prompt_yn")
+@patch("functions.build_release.update_docs")
+@patch(
+    "functions.build_release._find_open_docs_sync_pr",
+    return_value="https://github.com/test-owner/test-repo/pull/8",
+)
+@patch(
+    "functions.build_release.check_docs",
+    return_value=CheckResult(changes=(_MINOR_CHANGE,)),
+)
+@patch("functions.build_release.has_changes_in_paths", return_value=False)
+def test_docs_gate_reports_an_open_polish_pr_without_prompting(
+    mock_has_changes: MagicMock,
+    mock_check: MagicMock,
+    mock_find_pr: MagicMock,
+    mock_update: MagicMock,
+    mock_prompt_yn: MagicMock,
+    capfd: pytest.CaptureFixture[str],
+) -> None:
+    # A polish pull request from an earlier attempt on this commit is
+    # reported, not re-derived — and there is nothing to ask the user.
+    _docs_gate(repo_root=Path("/repo"))
+
+    mock_prompt_yn.assert_not_called()
+    mock_update.assert_not_called()
+    err = capfd.readouterr().err
+    assert "pull/8" in err
     assert "up to date" in err
 
 
@@ -801,7 +932,7 @@ def test_docs_gate_rejects_a_dirty_docs_tree_before_asking_claude(
     mock_check.assert_not_called()
 
 
-@patch("functions.build_release._open_docs_sync_pr")
+@patch("functions.build_release._open_docs_pr")
 @patch("functions.build_release._push_docs_sync_branch")
 @patch("functions.build_release._find_open_docs_sync_pr", return_value=None)
 @patch("functions.build_release.update_docs")
@@ -841,13 +972,16 @@ def test_docs_gate_opens_a_pr_and_stops_the_release(
     # The branch is named after the release commit, so a retry on that commit
     # finds the pull request instead of producing a second one.
     branch = f"auto/docs-update-{DEV_COMMIT[:12]}"
-    mock_push_branch.assert_called_once_with(branch, Path("/repo/docs"))
+    mock_push_branch.assert_called_once_with(
+        branch, Path("/repo/docs"), "docs: sync with the code being released"
+    )
     assert mock_open_pr.call_args.args[2] == branch
     # The user is pointed at the pull request that has to merge first.
     assert "pull/7" in capfd.readouterr().err
 
 
-@patch("functions.build_release._open_docs_sync_pr")
+@patch("functions.build_release.prompt_yn")
+@patch("functions.build_release._open_docs_pr")
 @patch("functions.build_release._push_docs_sync_branch")
 @patch("functions.build_release._find_open_docs_sync_pr", return_value=None)
 @patch("functions.build_release.update_docs")
@@ -860,10 +994,12 @@ def test_docs_gate_feeds_only_blocking_changes_to_the_update_and_pr(
     mock_find_pr: MagicMock,
     mock_push_branch: MagicMock,
     mock_open_pr: MagicMock,
+    mock_prompt_yn: MagicMock,
     capfd: pytest.CaptureFixture[str],
 ) -> None:
     # A mixed verdict: the blocking gap drives the update and the pull
-    # request; the minor one is only printed.
+    # request; the minor one is only printed — the optional-polish offer
+    # belongs to minor-only verdicts, so nothing is asked here.
     mock_check.return_value = CheckResult(
         changes=(_MINOR_CHANGE, _BLOCKING_CHANGE)
     )
@@ -886,7 +1022,10 @@ def test_docs_gate_feeds_only_blocking_changes_to_the_update_and_pr(
     mock_update.assert_called_once_with(
         "origin/main", DEV_COMMIT, (_BLOCKING_CHANGE,)
     )
-    assert mock_open_pr.call_args.args[4] == (_BLOCKING_CHANGE,)
+    body = mock_open_pr.call_args.args[4]
+    assert "docs/x.mdx" in body
+    assert "reword the intro" not in body
+    mock_prompt_yn.assert_not_called()
     assert "reword the intro" in capfd.readouterr().err
 
 
@@ -922,7 +1061,7 @@ def test_docs_gate_stops_on_the_pr_an_earlier_attempt_opened(
     assert "pull/7" in capfd.readouterr().err
 
 
-@patch("functions.build_release._open_docs_sync_pr")
+@patch("functions.build_release._open_docs_pr")
 @patch("functions.build_release._push_docs_sync_branch")
 @patch("functions.build_release._find_open_docs_sync_pr", return_value=None)
 @patch("functions.build_release.update_docs")
@@ -1002,7 +1141,11 @@ def test_push_docs_sync_branch_pushes_without_force_and_returns_to_dev(
     mock_push: MagicMock,
     mock_switch: MagicMock,
 ) -> None:
-    _push_docs_sync_branch("auto/docs-update-abc", Path("/repo/docs"))
+    _push_docs_sync_branch(
+        "auto/docs-update-abc",
+        Path("/repo/docs"),
+        "docs: sync with the code being released",
+    )
 
     mock_switch_new.assert_called_once_with("auto/docs-update-abc")
     mock_commit.assert_called_once_with(
@@ -1030,7 +1173,9 @@ def test_push_docs_sync_branch_explains_a_rejected_push_and_returns_to_dev(
     # request is gone; say how to clear it instead of overwriting it. And a
     # failed push must never strand the working tree on the throwaway branch.
     with pytest.raises(ReleaseError) as excinfo:
-        _push_docs_sync_branch("auto/docs-update-abc", Path("/repo/docs"))
+        _push_docs_sync_branch(
+            "auto/docs-update-abc", Path("/repo/docs"), "docs: minor polish"
+        )
 
     message = str(excinfo.value)
     assert "non-fast-forward" in message
@@ -1039,28 +1184,25 @@ def test_push_docs_sync_branch_explains_a_rejected_push_and_returns_to_dev(
 
 
 @patch("functions.build_release.github_api")
-def test_open_docs_sync_pr_creates_a_pr_against_dev(mock_api: MagicMock) -> None:
+def test_open_docs_pr_creates_a_pr_against_dev(mock_api: MagicMock) -> None:
     slug = RepoSlug(owner="test-owner", repo="test-repo")
     mock_api.return_value = {
         "html_url": "https://github.com/test-owner/test-repo/pull/9"
     }
 
-    url = _open_docs_sync_pr(
+    url = _open_docs_pr(
         MagicMock(),
         slug,
         "auto/docs-update-abc",
-        DEV_COMMIT,
-        (
-            RequiredChange(
-                file="docs/x.mdx", change="document --verbose", severity="blocking"
-            ),
-        ),
+        "docs: sync with the code being released (abc)",
+        f"body mentioning docs/x.mdx at {DEV_COMMIT}",
     )
 
     assert url == "https://github.com/test-owner/test-repo/pull/9"
     payload = mock_api.call_args.kwargs["json_data"]
     assert payload["head"] == "auto/docs-update-abc"
     assert payload["base"] == "dev"
+    assert payload["title"] == "docs: sync with the code being released (abc)"
     assert "docs/x.mdx" in payload["body"]
     assert DEV_COMMIT in payload["body"]
 


### PR DESCRIPTION
Follow-up to #387. When the release docs check reports only minor suggestions, the release script now asks (before the tag prompt) whether to open a pull request applying them anyway:

- **Declined** (default): nothing happens, the release continues as before.
- **Accepted**: the scoped updater applies exactly the minor list, the result is pushed to `auto/docs-polish-<commit12>` and a pull request is opened — and the release still continues to the tag prompt. Only blocking gaps stop a release.
- The polish branch uses a separate prefix from the blocking `auto/docs-update-` sync branch, so a rerun that finds a blocking gap never mistakes an open wording-level pull request for the fix it has to wait on.
- An already-open polish pull request for the same commit is reported instead of re-derived (no prompt), and an accepted update that changes nothing under `docs/` simply skips the pull request — this path never hard-fails.

## Testing

- 113 tests pass across the touched files; new coverage: decline leaves no trace, accept opens the PR and returns normally (no exit), no-op update skips the PR, existing polish PR short-circuits the prompt, and blocking verdicts never trigger the offer.
- ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)