### PR TITLE
docs: fix invalid `peppy node run` example in actions guide

### DIFF
--- a/docs/src/content/docs/advanced_guides/actions.mdx
+++ b/docs/src/content/docs/advanced_guides/actions.mdx
@@ -727,7 +727,7 @@ In a launcher / stack config:
 or, when launching a single node during development:
 
 ```sh
-peppy node run --link brain@left-arm-1 .
+peppy node run --link brain@left-arm-1 consumer:v1
 ```
 
 ### Worked example: `openarm01_backbone`


### PR DESCRIPTION
## What

A docs-vs-codebase audit of every command in `peppy/docs` found one stale invocation.

`advanced_guides/actions.mdx` showed:

```sh
peppy node run --link brain@left-arm-1 .
```

`peppy node run` takes a `<node_name>:<tag>` positional (`parse_node_ref` in `crates/peppy/src/commands/node.rs` rejects `.` at clap parse time with `expected node_name:tag format`); a directory source is `node add`'s grammar, not `node run`'s. Replaced with `consumer:v1`, matching the launcher example directly above the command and the pattern used in `topics.mdx` / `services.mdx`.

## Audit scope

Every `peppy` CLI invocation, installer/service-manager command, and env var across all doc pages was cross-checked against the clap definitions (`crates/peppy/src/main.rs`, `commands/*.rs`), `scripts/install.sh`, `commands/service/install.rs`, and the daemon-config env-var constants. This was the only mismatch; everything else (verbs, flags, defaults, name-based launcher/node resolution, installer env vars, systemd/launchd service names) is current.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Peppy-bot/codesmith/peppy/pr/393"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789769378&installation_model_id=433186&pr_number=393&repository=Peppy-bot%2Fpeppy&return_to=https%3A%2F%2Fgithub.com%2FPeppy-bot%2Fpeppy%2Fpull%2F393&signature=e25bc3ea94d6e290908f553daea8832b001e4f6c6032727ade1b925b622c6412"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->