### PR TITLE
Stop forwarding caller PYTHONPATH/PYTHONHOME into spawned nodes

### DIFF
--- a/crates/peppy/src/commands/node/env.rs
+++ b/crates/peppy/src/commands/node/env.rs
@@ -16,7 +16,27 @@ use daemon_config::env::{is_forbidden_env_name, is_safe_env_value, is_valid_env_
 /// strip. All three are listed because the Rust and Python lookups differ
 /// (`TMPDIR` alone, versus `TMPDIR`, `TEMP`, `TMP` in order) and this stack
 /// runs both kinds of node.
-const CALLER_ONLY_ENV_KEYS: [&str; 5] = ["PWD", "OLDPWD", "TMPDIR", "TEMP", "TMP"];
+///
+/// The Python pair is a third kind: worse than naming host paths the node
+/// cannot see, a forwarded value *displaces* the image's own. Apptainer
+/// gives `--env` precedence over the image's `%environment`, so a caller
+/// shell that exports `PYTHONPATH` (a ROS `setup.bash`, say) erases the
+/// vendored `peppylib`/`peppygen` entries a Python container node boots
+/// from: the node dies at import time with `No module named 'peppylib'`,
+/// and only on machines whose shell exports one, which is why it escapes
+/// local reproduction. `PYTHONHOME` fails harder still: it points the
+/// container's interpreter at a host prefix, and Python cannot even find
+/// its stdlib. A node that genuinely wants either var gets it deliberately,
+/// via the launcher's `env_vars`.
+const CALLER_ONLY_ENV_KEYS: [&str; 7] = [
+    "PWD",
+    "OLDPWD",
+    "TMPDIR",
+    "TEMP",
+    "TMP",
+    "PYTHONPATH",
+    "PYTHONHOME",
+];
 
 /// Whether a caller env var should be forwarded to a spawned node: it must
 /// carry a name and a value a node can receive intact (see [`daemon_config::env`],
@@ -72,12 +92,33 @@ mod tests {
         }
     }
 
+    /// The caller's Python vars describe the caller's interpreter, not the
+    /// node's. Forwarding them is not merely useless: apptainer's `--env`
+    /// outranks the image's `%environment`, so a forwarded `PYTHONPATH`
+    /// replaces the vendored peppylib/peppygen path a Python container node
+    /// imports from (this is how `openarm_sim_mujoco` died with
+    /// `No module named 'peppylib'` on a machine whose shell exported a ROS
+    /// `PYTHONPATH`), and a forwarded `PYTHONHOME` points the interpreter at
+    /// a prefix the guest does not have. Both filters accept the values
+    /// (valid identifiers, path-only values), so they have to be excluded
+    /// by name.
+    #[test]
+    fn drops_caller_python_env_vars() {
+        for key in ["PYTHONPATH", "PYTHONHOME", "pythonpath"] {
+            assert!(
+                !should_forward_env(key, "/opt/ros/jazzy/lib/python3.12/site-packages"),
+                "{key} describes the caller's Python installation and must not reach the node"
+            );
+        }
+    }
+
     /// The exclusion is by whole name, not prefix: a node's own configuration
     /// must survive.
     #[test]
-    fn keeps_env_vars_that_merely_mention_temp() {
+    fn keeps_env_vars_that_merely_mention_excluded_names() {
         assert!(should_forward_env("TMPDIR_OVERRIDE", "/opt/scratch"));
         assert!(should_forward_env("PEPPY_TMP", "/opt/scratch"));
+        assert!(should_forward_env("PYTHONPATH_EXTRA", "/opt/plugins"));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`peppy stack launch openarm_v2 --with=mujoco` crashed for a user with:

```
ModuleNotFoundError: No module named 'peppylib'
```

while the same launch worked fine on other machines, and the default (no `--with`) selection worked everywhere.

## Root cause

The CLI forwards the caller's entire shell environment to the daemon (`caller_env_overrides()`), and the daemon injects each var into containers as apptainer `--env` flags. Apptainer gives `--env` precedence over the image's `%environment` (verified empirically on the bundled apptainer 1.5.2: the image value is fully replaced, not prepended to, and `--cleanenv` does not protect against explicit flags).

Python node SIFs (e.g. `openarm_sim_mujoco`) rely on `%environment` `PYTHONPATH` to import the vendored `peppylib`/`peppygen` from `/opt/<node>/.peppy/libs/`. A caller shell that exports `PYTHONPATH` (ROS `setup.bash`, conda) therefore erases the module path the node boots from, and the node dies at import time. This explains the failure pattern: it only reproduces on machines whose shell exports `PYTHONPATH`, and only `--with=mujoco`/`--with=isaac_sim` select a Python node (every default-selection node is Rust).

## Fix

Add `PYTHONPATH` and `PYTHONHOME` to `CALLER_ONLY_ENV_KEYS`, the existing filter for caller vars that describe the caller's filesystem rather than the node's (same class as `TMPDIR`). `PYTHONHOME` is included because forwarding it fails even harder: the container's interpreter cannot find its own stdlib. The filter only affects ambient shell vars; a launcher file's explicit `env_vars` still passes either var deliberately. Nothing in peppy itself sets or reads `PYTHONPATH`, so no other path is affected.

## Tests

- `drops_caller_python_env_vars`: both vars dropped, case-insensitively
- `keeps_env_vars_that_merely_mention_excluded_names`: whole-name exclusion, `PYTHONPATH_EXTRA` still forwards
- Full `peppy` crate suite: 214/214 passing, `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Peppy-bot/codesmith/peppy/pr/394"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789770743&installation_model_id=433186&pr_number=394&repository=Peppy-bot%2Fpeppy&return_to=https%3A%2F%2Fgithub.com%2FPeppy-bot%2Fpeppy%2Fpull%2F394&signature=9b7578ba6aef59d84c81eee902f54d50375038a307849b227e07472639547ac4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->