### PR TITLE
release: draft the notes from the code and docs diffs, not commit subjects alone

### DIFF
--- a/scripts/functions/build_release.py
+++ b/scripts/functions/build_release.py
@@ -72,13 +72,16 @@ from .release_notes import (
     fetch_release_body_html,
     generate_release_notes_file,
 )
-from .release_summary import ReleaseContent, generate_release_content
+from .release_summary import (
+    ReleaseContent,
+    collect_release_changes,
+    generate_release_content,
+)
 from .docker import main as build_base_images_main
 from .repo import (
     commit_paths,
     fetch_remote_branches,
     get_commit,
-    get_commit_subjects,
     get_current_branch,
     get_repo_root,
     has_changes_in_paths,
@@ -281,14 +284,16 @@ def _prepare_release_content(
     client: httpx.Client,
     slug: RepoSlug,
     tag: str,
+    release_commit: str,
     repo_root: Path,
 ) -> ReleaseContent:
     """Derive the release content from the changes since the last release.
 
-    Collects the commit subjects since the previous published release, asks
-    Claude to draft the title/description/notes as a self-contained list of
-    changes (no external links), then lets the user review, edit, or abort
-    before anything is built or published.
+    Collects everything merged between the previous published release and the
+    release commit (the commit subjects, the code diff, and the user
+    documentation diff), asks Claude to draft the title/description/notes as a
+    self-contained list of user-facing changes (no external links), then lets
+    the user review, edit, or abort before anything is built or published.
     """
     latest = get_latest_release(client, slug)
     previous_tag = latest.get("tag_name") if latest else None
@@ -300,9 +305,9 @@ def _prepare_release_content(
             "listing the full history.[/yellow]"
         )
 
-    commits = get_commit_subjects(previous_tag)
+    changes = collect_release_changes(previous_tag, release_commit, repo_root)
     console.print("Asking Claude to write the release notes...")
-    content = generate_release_content(commits, tag, repo_root)
+    content = generate_release_content(changes, tag, repo_root)
     return _confirm_release_content(content)
 
 
@@ -854,7 +859,9 @@ def _run_full(
     if not tag:
         raise ReleaseError("release tag cannot be empty")
 
-    content = _prepare_release_content(client, slug, tag, repo_root)
+    content = _prepare_release_content(
+        client, slug, tag, release_commit, repo_root
+    )
 
     # Build and package all targets
     targets = get_targets_for_platform()

--- a/scripts/functions/docs.py
+++ b/scripts/functions/docs.py
@@ -13,6 +13,10 @@ nice-to-haves are reported as *minor* and never fail the check or feed the
 updater: tooling must not generate wording churn, and a release must not
 hinge on how the model would phrase a sentence today.
 
+The diff helpers (``get_code_diff``, ``get_docs_diff``, ``truncate_diff``)
+are shared with the release-notes generator (``release_summary.py``), so the
+notes are drafted from the same changes the docs check judged.
+
 Both require ``claude`` and ``git`` on PATH. No special auth handling —
 the invoking environment must already have claude authenticated.
 """
@@ -22,6 +26,7 @@ from __future__ import annotations
 import argparse
 import subprocess
 import sys
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -40,6 +45,17 @@ _EXCLUDE_PREFIXES: tuple[str, ...] = (
     "scripts/functions/docs.py",
     "scripts/tests/test_docs.py",
 )
+
+# Files excluded from the code diff outright. The lock file only records
+# dependency versions, which neither the docs nor the release notes report, and
+# it sorts first in `git diff` output, so a large bump would spend the diff
+# budget before any code is reached.
+_EXCLUDE_PATHS: tuple[str, ...] = ("Cargo.lock",)
+
+# The user documentation: the pages the docs site renders, including the
+# snippets they embed. Release notes under `docs/src/content/releases/` and the
+# site's own configuration are not part of it.
+USER_DOCS_PREFIX = "docs/src/content/docs/"
 
 _MAX_DIFF_BYTES = 400_000
 
@@ -160,27 +176,49 @@ def _run_git(args: list[str], cwd: Path) -> str:
 
 
 def _is_code_path(path: str) -> bool:
+    if path in _EXCLUDE_PATHS:
+        return False
     return not any(path.startswith(p) for p in _EXCLUDE_PREFIXES)
 
 
-def get_code_diff(base: str, head: str, repo_root: Path) -> tuple[str, list[str]]:
-    """Return (diff_text, changed_paths) for code-only changes between refs."""
+def _is_user_docs_path(path: str) -> bool:
+    return path.startswith(USER_DOCS_PREFIX)
+
+
+def _diff_matching(
+    base: str, head: str, repo_root: Path, keep: Callable[[str], bool]
+) -> tuple[str, list[str]]:
+    """Return (diff_text, changed_paths) between refs for the paths *keep* accepts.
+
+    The changed paths are listed first so the diff itself is only read for the
+    paths that matter; when none match, git is not asked for a diff at all.
+    """
     names_raw = _run_git(
         ["diff", "--name-only", f"{base}..{head}"],
         cwd=repo_root,
     )
     changed = [line for line in names_raw.splitlines() if line.strip()]
-    code_paths = [p for p in changed if _is_code_path(p)]
-    if not code_paths:
+    kept = [p for p in changed if keep(p)]
+    if not kept:
         return "", []
     diff = _run_git(
-        ["diff", f"{base}..{head}", "--", *code_paths],
+        ["diff", f"{base}..{head}", "--", *kept],
         cwd=repo_root,
     )
-    return diff, code_paths
+    return diff, kept
 
 
-def _truncate_diff(diff: str) -> str:
+def get_code_diff(base: str, head: str, repo_root: Path) -> tuple[str, list[str]]:
+    """Return (diff_text, changed_paths) for code-only changes between refs."""
+    return _diff_matching(base, head, repo_root, _is_code_path)
+
+
+def get_docs_diff(base: str, head: str, repo_root: Path) -> tuple[str, list[str]]:
+    """Return (diff_text, changed_paths) for user documentation changes between refs."""
+    return _diff_matching(base, head, repo_root, _is_user_docs_path)
+
+
+def truncate_diff(diff: str) -> str:
     if len(diff) <= _MAX_DIFF_BYTES:
         return diff
     return (
@@ -326,7 +364,7 @@ def check_docs(base: str, head: str) -> CheckResult:
         return CheckResult(changes=())
     prompt = _CHECK_PROMPT.format(
         paths="\n".join(paths),
-        diff=_truncate_diff(diff),
+        diff=truncate_diff(diff),
     )
     # tools (not just allowed_tools) is restricted: under bypassPermissions
     # the allowlist approves rather than limits, and the check must stay
@@ -358,7 +396,7 @@ def update_docs(
     prompt = _UPDATE_PROMPT.format(
         changes="\n".join(f"- `{c.file}`: {c.change}" for c in changes),
         paths="\n".join(paths),
-        diff=_truncate_diff(diff),
+        diff=truncate_diff(diff),
     )
     payload = run_claude(
         prompt,

--- a/scripts/functions/release_summary.py
+++ b/scripts/functions/release_summary.py
@@ -1,10 +1,18 @@
-"""Have Claude write the human-facing release content from the commit log.
+"""Have Claude write the human-facing release content from the changes.
 
-Given the list of commit subjects since the previous release, ask Claude to
-produce a short headline, a one-line summary, and a self-contained Markdown
-body: a readable list of the user-facing changes only, with no external links,
-pull-request numbers, or author mentions. Internal work (refactors, crate
-reorganization, dependency bumps, build and codegen changes) is left out.
+Given everything merged since the previous release (the commit subjects, the
+code diff, and the user documentation diff), ask Claude to produce a short
+headline, a one-line summary, and a self-contained Markdown body: a readable
+list of the user-facing changes only, with no external links, pull-request
+numbers, or author mentions. Internal work (refactors, crate reorganization,
+dependency bumps, build changes, peppy's own tests) is left out.
+
+The diffs are what makes the judgement reliable: a commit subject says where
+the author worked, not what users get, and the code peppy generates into users'
+projects or the test harness their tests call can hide behind subjects such as
+"testing:" or "generator:". Truncation is applied to each diff separately so a
+large code diff never crowds out the documentation diff, the strongest signal
+that a change is user-facing.
 """
 
 from __future__ import annotations
@@ -14,6 +22,8 @@ from pathlib import Path
 
 from .claude import run_claude
 from .cli import ReleaseError
+from .docs import get_code_diff, get_docs_diff, truncate_diff
+from .repo import get_commit_subjects
 
 _FIELDS: tuple[str, ...] = ("title", "description", "notes")
 
@@ -31,27 +41,58 @@ _CONTENT_SCHEMA: dict = {
     "additionalProperties": False,
 }
 
+_NO_COMMITS = "(no commits since the last release)"
+_NO_CODE_CHANGES = "(no code changes)"
+_NO_DOCS_CHANGES = "(no user documentation changes)"
+_NO_PREVIOUS_RELEASE = "(no previous release to diff against)"
+_FIRST_RELEASE = (
+    "none: no release has been published yet, so the commit subjects cover the "
+    "full history and there is nothing to diff against"
+)
+
 _PROMPT = """\
 You are writing the public release notes for "peppy", a developer tool shipped
 as Rust crates with an Astro Starlight documentation site. This is release
-{tag}.
+{tag}; the previous release is {previous}.
 
-Below is the exhaustive list of commits merged since the previous release
-(commit subjects, one per line). It is the only source of truth. Do not invent
-changes that are not listed.
+Below are the changes merged since the previous release, in three parts: the
+commit subjects (one per line), the unified diff of the code with its changed
+paths, and the unified diff of the user documentation (the pages under
+`docs/src/content/docs/`) with its changed paths. Together they are the only
+source of truth. Do not invent changes they do not show.
+
+Judge each change from the diffs, not from the wording of its commit subject.
+Subjects are short and their prefixes describe where the author worked, not
+what users get: a commit labelled "testing:", "generator:", or "refactor:" can
+still add or change something users type, call, or see. A change to the user
+documentation is strong evidence that the underlying change is user-facing:
+every behaviour the documentation diff starts or stops describing belongs in
+the notes.
 
 Respond with the three fields "title" (a headline), "description" (one
 sentence), and "notes" (Markdown).
 
 Write for a user of the peppy tool, and include only changes such a user would
 notice or care about: new or changed CLI commands and flags, the `peppy.json5`
-configuration and schema, message and output formats, runtime behavior, and
-user-facing documentation. Renaming, adding, or removing something a user types
-or sees is user-facing and stays in, even when the commit is phrased as a
-rename: a CLI command or flag, a `peppy.json5` field, the configuration file
-name, or a schema identifier (for example "node/v1") all count. Before
-mentioning anything, ask "would a peppy user notice or care about this?"; if not,
-leave it out entirely, across every field.
+configuration and schema, message and output formats, runtime behavior, the
+code peppy generates into users' projects, and user-facing documentation.
+Renaming, adding, or removing something a user types or sees is user-facing and
+stays in, even when the commit is phrased as a rename: a CLI command or flag, a
+`peppy.json5` field, the configuration file name, or a schema identifier (for
+example "node/v1") all count. Before mentioning anything, ask "would a peppy
+user notice or care about this?"; if not, leave it out entirely, across every
+field.
+
+Two parts of this repository sound internal but are products users depend on:
+- The code generator (peppygen) and its templates. What it emits is compiled
+  into users' nodes and imported by their tests: the production bindings, the
+  `peppygen.mock` / `peppygen::mock` and `peppygen.fixtures` /
+  `peppygen::fixtures` test surfaces, and the test harness they provide. A
+  change to the generated code or to the harness API (a new configuration knob,
+  fixture, method, or behaviour that user tests rely on) is user-facing. Only
+  changes to how the generator itself is built or tested are internal.
+- The testing features peppy gives its users. "Test-only" below means peppy's
+  own test suite, never what users write their tests against.
 
 Field requirements:
 - "title": a concise, human headline for the release theme (max ~70 chars),
@@ -82,43 +123,141 @@ changes" subheading entirely when there are none.
 Leave out every internal change, even when it spans many commits: code refactors
 and restructuring, renames and reorganization confined to internal code (crates,
 modules, and private fields or APIs that users never reference), removal of
-unused or internal fields, dependency version bumps, build, CI, code-generator,
-and release-tooling changes, test-only changes, and log-string tweaks. Also omit
-version bumps, release commits, and merge commits.
+unused or internal fields, dependency version bumps, build, CI, and
+release-tooling changes, log-string tweaks, and changes confined to peppy's own
+test suite (the tests, golden files, and test helpers in this repository that
+verify peppy itself). Also omit version bumps, release commits, and merge
+commits.
 
-Commits since the previous release:
+Commit subjects since the previous release:
 {changes}
+
+Changed code paths:
+{code_paths}
+
+Code diff:
+{code_diff}
+
+Changed user documentation paths:
+{docs_paths}
+
+User documentation diff:
+{docs_diff}
 """
 
 
 @dataclass(frozen=True)
 class ReleaseContent:
-    """The release fields Claude writes from the commit log."""
+    """The release fields Claude writes from the changes."""
 
     title: str
     description: str
     notes: str
 
 
+@dataclass(frozen=True)
+class PathDiff:
+    """A unified diff restricted to a set of paths, with those paths listed."""
+
+    text: str
+    paths: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ReleaseDiffs:
+    """The code and user documentation diffs from the previous release."""
+
+    previous_tag: str
+    code: PathDiff
+    docs: PathDiff
+
+
+@dataclass(frozen=True)
+class ReleaseChanges:
+    """Everything Claude sees about a release: what was merged since the last one.
+
+    ``diffs`` is None only when no release has been published yet: the commit
+    subjects then cover the full history and there is no earlier state to diff
+    against.
+    """
+
+    commit_subjects: tuple[str, ...]
+    diffs: ReleaseDiffs | None
+
+
+def collect_release_changes(
+    previous_tag: str | None, head: str, repo_root: Path
+) -> ReleaseChanges:
+    """Gather the commit subjects and diffs between ``previous_tag`` and ``head``.
+
+    ``previous_tag`` is the tag of the last published release, or None when
+    there is none, in which case the commit subjects span the full history and
+    no diff is collected.
+    """
+    subjects = tuple(get_commit_subjects(previous_tag, head))
+    if previous_tag is None:
+        return ReleaseChanges(commit_subjects=subjects, diffs=None)
+    code_diff, code_paths = get_code_diff(previous_tag, head, repo_root)
+    docs_diff, docs_paths = get_docs_diff(previous_tag, head, repo_root)
+    return ReleaseChanges(
+        commit_subjects=subjects,
+        diffs=ReleaseDiffs(
+            previous_tag=previous_tag,
+            code=PathDiff(text=code_diff, paths=tuple(code_paths)),
+            docs=PathDiff(text=docs_diff, paths=tuple(docs_paths)),
+        ),
+    )
+
+
+def _render_paths(diff: PathDiff, empty: str) -> str:
+    return "\n".join(diff.paths) or empty
+
+
+def _render_diff(diff: PathDiff, empty: str) -> str:
+    # Each diff is truncated on its own: the code diff between two releases
+    # can exceed the budget, and must not push the documentation diff out.
+    return truncate_diff(diff.text) if diff.text else empty
+
+
+def _render_prompt(changes: ReleaseChanges, tag: str) -> str:
+    subjects = "\n".join(f"- {s}" for s in changes.commit_subjects) or _NO_COMMITS
+    diffs = changes.diffs
+    if diffs is None:
+        return _PROMPT.format(
+            tag=tag,
+            previous=_FIRST_RELEASE,
+            changes=subjects,
+            code_paths=_NO_PREVIOUS_RELEASE,
+            code_diff=_NO_PREVIOUS_RELEASE,
+            docs_paths=_NO_PREVIOUS_RELEASE,
+            docs_diff=_NO_PREVIOUS_RELEASE,
+        )
+    return _PROMPT.format(
+        tag=tag,
+        previous=diffs.previous_tag,
+        changes=subjects,
+        code_paths=_render_paths(diffs.code, _NO_CODE_CHANGES),
+        code_diff=_render_diff(diffs.code, _NO_CODE_CHANGES),
+        docs_paths=_render_paths(diffs.docs, _NO_DOCS_CHANGES),
+        docs_diff=_render_diff(diffs.docs, _NO_DOCS_CHANGES),
+    )
+
+
 def generate_release_content(
-    commit_subjects: list[str],
+    changes: ReleaseChanges,
     tag: str,
     repo_root: Path,
 ) -> ReleaseContent:
     """Ask Claude to draft the release title, description, and notes.
 
-    ``commit_subjects`` are the git commit subjects since the previous release.
-    Claude runs with no tools (a pure transformation) and is instructed to emit
-    a self-contained list of user-facing changes only, with no links,
-    pull-request numbers, or author mentions.
+    Claude runs with no tools (a pure transformation of ``changes``) and is
+    instructed to emit a self-contained list of user-facing changes only, with
+    no links, pull-request numbers, or author mentions.
     """
-    changes = "\n".join(f"- {subject}" for subject in commit_subjects) or (
-        "(no commits since the last release)"
-    )
-    prompt = _PROMPT.format(tag=tag, changes=changes)
-    # No tools: this is a pure transformation of the commit list. Giving Claude
-    # repository access leads it to explore git history and answer with an
-    # analysis narrative instead of the release content.
+    prompt = _render_prompt(changes, tag)
+    # No tools: the prompt already carries the commit subjects and both diffs.
+    # Giving Claude repository access leads it to explore git history and answer
+    # with an analysis narrative instead of the release content.
     payload = run_claude(
         prompt,
         allowed_tools="",

--- a/scripts/tests/test_build_release.py
+++ b/scripts/tests/test_build_release.py
@@ -33,7 +33,7 @@ from functions.docs import (
     UpdateResult,
 )
 from functions.github import RepoSlug
-from functions.release_summary import ReleaseContent
+from functions.release_summary import ReleaseChanges, ReleaseContent
 
 DEV_COMMIT = "1111111111111111111111111111111111111111"
 MAIN_COMMIT = "2222222222222222222222222222222222222222"
@@ -1458,11 +1458,11 @@ def test_confirm_release_content_edits_then_accepts() -> None:
 
 @patch("functions.build_release._confirm_release_content", side_effect=lambda c: c)
 @patch("functions.build_release.generate_release_content")
-@patch("functions.build_release.get_commit_subjects")
+@patch("functions.build_release.collect_release_changes")
 @patch("functions.build_release.get_latest_release")
 def test_prepare_release_content_uses_previous_release_tag(
     mock_latest: MagicMock,
-    mock_commits: MagicMock,
+    mock_collect: MagicMock,
     mock_generate: MagicMock,
     mock_confirm: MagicMock,
     tmp_path: Path,
@@ -1470,39 +1470,44 @@ def test_prepare_release_content_uses_previous_release_tag(
     from functions.github import RepoSlug
 
     mock_latest.return_value = {"tag_name": "v0.11.1"}
-    subjects = ["fix(x): do thing", "feat(y): add y"]
-    mock_commits.return_value = subjects
+    changes = ReleaseChanges(commit_subjects=("fix(x): do thing",), diffs=None)
+    mock_collect.return_value = changes
     content = ReleaseContent("T", "D", "N")
     mock_generate.return_value = content
     client = MagicMock()
     slug = RepoSlug(owner="o", repo="r")
 
-    result = _prepare_release_content(client, slug, "v0.12.0", tmp_path)
+    result = _prepare_release_content(
+        client, slug, "v0.12.0", DEV_COMMIT, tmp_path
+    )
 
     assert result == content
-    # Commits are listed from the previous release tag, not via the GitHub API.
-    mock_commits.assert_called_once_with("v0.11.1")
-    mock_generate.assert_called_once_with(subjects, "v0.12.0", tmp_path)
+    # Changes are gathered from the previous release tag up to the exact commit
+    # being released, not via the GitHub API.
+    mock_collect.assert_called_once_with("v0.11.1", DEV_COMMIT, tmp_path)
+    mock_generate.assert_called_once_with(changes, "v0.12.0", tmp_path)
     mock_confirm.assert_called_once_with(content)
 
 
 @patch("functions.build_release._confirm_release_content", side_effect=lambda c: c)
 @patch("functions.build_release.generate_release_content")
-@patch("functions.build_release.get_commit_subjects")
+@patch("functions.build_release.collect_release_changes")
 @patch("functions.build_release.get_latest_release", return_value=None)
 def test_prepare_release_content_handles_no_previous_release(
     mock_latest: MagicMock,
-    mock_commits: MagicMock,
+    mock_collect: MagicMock,
     mock_generate: MagicMock,
     mock_confirm: MagicMock,
     tmp_path: Path,
 ) -> None:
     from functions.github import RepoSlug
 
-    mock_commits.return_value = ["initial commit"]
+    mock_collect.return_value = ReleaseChanges(("initial commit",), diffs=None)
     mock_generate.return_value = ReleaseContent("T", "D", "N")
 
-    _prepare_release_content(MagicMock(), RepoSlug("o", "r"), "v0.1.0", tmp_path)
+    _prepare_release_content(
+        MagicMock(), RepoSlug("o", "r"), "v0.1.0", DEV_COMMIT, tmp_path
+    )
 
-    # With no prior release, the commit range falls back to the full history.
-    mock_commits.assert_called_once_with(None)
+    # With no prior release, the change collection falls back to the full history.
+    mock_collect.assert_called_once_with(None, DEV_COMMIT, tmp_path)

--- a/scripts/tests/test_docs.py
+++ b/scripts/tests/test_docs.py
@@ -21,8 +21,10 @@ from functions.docs import (
     _is_code_path,
     _parse_check_response,
     _parse_update_response,
-    _truncate_diff,
     check_docs,
+    get_code_diff,
+    get_docs_diff,
+    truncate_diff,
     update_docs,
 )
 
@@ -50,6 +52,7 @@ def _minor(file: str = "docs/y.mdx", change: str = "reword") -> RequiredChange:
         ("crates/peppy/src/main.rs", True),
         ("scripts/functions/cli.py", True),
         ("Cargo.toml", True),
+        ("Cargo.lock", False),
         ("docs/src/content/docs/guides/installation.mdx", False),
         ("docs/astro.config.mjs", False),
         ("target/debug/foo", False),
@@ -63,19 +66,110 @@ def test_is_code_path(path: str, expected: bool) -> None:
     assert _is_code_path(path) is expected
 
 
-# --- _truncate_diff ---
+# --- truncate_diff ---
 
 
 def test_truncate_diff_short_unchanged() -> None:
     diff = "a" * 1000
-    assert _truncate_diff(diff) == diff
+    assert truncate_diff(diff) == diff
 
 
 def test_truncate_diff_long_truncated() -> None:
     diff = "a" * 500_000
-    out = _truncate_diff(diff)
+    out = truncate_diff(diff)
     assert len(out) < len(diff)
     assert "diff truncated" in out
+
+
+# --- get_code_diff / get_docs_diff ---
+
+
+def _mock_git_diff(names: str, diff: str = "DIFF", returncode: int = 0) -> MagicMock:
+    """Build a subprocess.run replacement answering the two git diff calls.
+
+    ``--name-only`` returns ``names``; the path-scoped diff returns ``diff``.
+    """
+
+    def _run(cmd: list[str], *args: object, **kwargs: object) -> MagicMock:
+        assert cmd[:2] == ["git", "diff"], cmd
+        mock = MagicMock()
+        mock.returncode = returncode
+        mock.stdout = names if "--name-only" in cmd else diff
+        mock.stderr = "boom" if returncode else ""
+        return mock
+
+    return MagicMock(side_effect=_run)
+
+
+_CHANGED = (
+    "Cargo.lock\n"
+    "crates/peppy/src/main.rs\n"
+    "crates/generator-internal/templates/peppygen/python/peppygen/clock.py\n"
+    "docs/astro.config.mjs\n"
+    "docs/src/content/docs/advanced_guides/testing.mdx\n"
+    "docs/src/content/docs/guides/snippets/rust/hello_receiver/src/lib.rs\n"
+    "docs/src/content/releases/v0.25.1.html\n"
+    ".github/workflows/ci.yml\n"
+)
+
+
+def test_get_code_diff_keeps_code_paths_only(tmp_path: Path) -> None:
+    run = _mock_git_diff(_CHANGED)
+    with patch("functions.docs.subprocess.run", run):
+        diff, paths = get_code_diff("v0.1.0", "HEAD", tmp_path)
+    assert diff == "DIFF"
+    assert paths == [
+        "crates/peppy/src/main.rs",
+        "crates/generator-internal/templates/peppygen/python/peppygen/clock.py",
+    ]
+    # The diff itself is scoped to the kept paths, so excluded files never
+    # reach the prompt even when they changed.
+    assert run.call_args.args[0] == [
+        "git",
+        "diff",
+        "v0.1.0..HEAD",
+        "--",
+        *paths,
+    ]
+    assert run.call_args.kwargs["cwd"] == tmp_path
+
+
+def test_get_docs_diff_keeps_user_documentation_only(tmp_path: Path) -> None:
+    run = _mock_git_diff(_CHANGED)
+    with patch("functions.docs.subprocess.run", run):
+        diff, paths = get_docs_diff("v0.1.0", "HEAD", tmp_path)
+    assert diff == "DIFF"
+    # Embedded snippets are part of the rendered pages; release notes and the
+    # site configuration are not user documentation.
+    assert paths == [
+        "docs/src/content/docs/advanced_guides/testing.mdx",
+        "docs/src/content/docs/guides/snippets/rust/hello_receiver/src/lib.rs",
+    ]
+    assert run.call_args.args[0] == ["git", "diff", "v0.1.0..HEAD", "--", *paths]
+
+
+@pytest.mark.parametrize(
+    "getter, names",
+    [
+        (get_code_diff, "Cargo.lock\ndocs/src/content/docs/x.mdx\n"),
+        (get_docs_diff, "crates/peppy/src/main.rs\ndocs/astro.config.mjs\n"),
+    ],
+)
+def test_diff_getters_skip_the_diff_when_nothing_matches(
+    getter: object, names: str, tmp_path: Path
+) -> None:
+    run = _mock_git_diff(names)
+    with patch("functions.docs.subprocess.run", run):
+        assert getter("v0.1.0", "HEAD", tmp_path) == ("", [])  # type: ignore[operator]
+    # Only the name listing ran: there is nothing to diff.
+    assert run.call_count == 1
+    assert "--name-only" in run.call_args.args[0]
+
+
+def test_get_code_diff_raises_when_git_fails(tmp_path: Path) -> None:
+    with patch("functions.docs.subprocess.run", _mock_git_diff("", returncode=128)):
+        with pytest.raises(ReleaseError, match="git diff --name-only v9.9.9..HEAD failed"):
+            get_code_diff("v9.9.9", "HEAD", tmp_path)
 
 
 # --- the schemas the CLI enforces ---

--- a/scripts/tests/test_release_summary.py
+++ b/scripts/tests/test_release_summary.py
@@ -10,10 +10,25 @@ import pytest
 from functions.cli import ReleaseError
 from functions.release_summary import (
     _CONTENT_SCHEMA,
+    PathDiff,
+    ReleaseChanges,
     ReleaseContent,
+    ReleaseDiffs,
     _parse_release_content,
+    collect_release_changes,
     generate_release_content,
 )
+
+
+def _changes(
+    subjects: tuple[str, ...] = ("fix(apptainer): pre-flight bind mounts",),
+    code: PathDiff = PathDiff("+fn main() {}", ("crates/peppy/src/main.rs",)),
+    docs: PathDiff = PathDiff("+## The clock", ("docs/src/content/docs/x.mdx",)),
+) -> ReleaseChanges:
+    return ReleaseChanges(
+        commit_subjects=subjects,
+        diffs=ReleaseDiffs(previous_tag="v0.11.1", code=code, docs=docs),
+    )
 
 
 # --- _CONTENT_SCHEMA ---
@@ -74,6 +89,14 @@ def test_parse_release_content_non_string_field() -> None:
 # --- generate_release_content (mocked run_claude) ---
 
 
+def _capture_prompt(captured: dict[str, object]) -> object:
+    def _fake_run_claude(prompt: str, **kwargs: object) -> dict:
+        captured["prompt"] = prompt
+        return {"title": "T", "description": "D", "notes": "N"}
+
+    return _fake_run_claude
+
+
 def test_generate_release_content_runs_claude_without_tools(tmp_path: Path) -> None:
     captured: dict[str, object] = {}
 
@@ -96,12 +119,11 @@ def test_generate_release_content_runs_claude_without_tools(tmp_path: Path) -> N
         captured["effort"] = effort
         return {"title": "T", "description": "D", "notes": "N"}
 
+    changes = _changes(
+        subjects=("fix(apptainer): pre-flight bind mounts", "refactor: extract helper")
+    )
     with patch("functions.release_summary.run_claude", side_effect=_fake_run_claude):
-        result = generate_release_content(
-            ["fix(apptainer): pre-flight bind mounts", "refactor: extract helper"],
-            "v0.12.0",
-            tmp_path,
-        )
+        result = generate_release_content(changes, "v0.12.0", tmp_path)
 
     assert result == ReleaseContent("T", "D", "N")
     # Pure transformation: tools disabled so Claude cannot explore and ramble.
@@ -111,19 +133,138 @@ def test_generate_release_content_runs_claude_without_tools(tmp_path: Path) -> N
     assert captured["cwd"] == tmp_path
     # The response shape is enforced CLI-side.
     assert captured["json_schema"] == _CONTENT_SCHEMA
-    # The commit subjects and tag are interpolated into the prompt.
-    assert "- fix(apptainer): pre-flight bind mounts" in captured["prompt"]
-    assert "v0.12.0" in captured["prompt"]
+    # The tag, the previous tag, and the commit subjects are interpolated.
+    prompt = captured["prompt"]
+    assert isinstance(prompt, str)
+    assert "release\nv0.12.0; the previous release is v0.11.1." in prompt
+    assert "- fix(apptainer): pre-flight bind mounts\n- refactor: extract helper" in prompt
 
 
-def test_generate_release_content_handles_no_commits(tmp_path: Path) -> None:
-    captured: dict[str, str] = {}
+def test_generate_release_content_feeds_both_diffs_and_their_paths(
+    tmp_path: Path,
+) -> None:
+    captured: dict[str, object] = {}
+    changes = _changes(
+        code=PathDiff(
+            "+fn main() {}",
+            ("crates/peppy/src/main.rs", "crates/peppy/src/cli.rs"),
+        ),
+        docs=PathDiff("+## The clock", ("docs/src/content/docs/x.mdx",)),
+    )
+    with patch("functions.release_summary.run_claude", side_effect=_capture_prompt(captured)):
+        generate_release_content(changes, "v0.12.0", tmp_path)
 
-    def _fake_run_claude(prompt: str, **kwargs: object) -> dict:
-        captured["prompt"] = prompt
-        return {"title": "T", "description": "D", "notes": "N"}
+    prompt = captured["prompt"]
+    assert isinstance(prompt, str)
+    assert (
+        "Changed code paths:\ncrates/peppy/src/main.rs\ncrates/peppy/src/cli.rs\n"
+        in prompt
+    )
+    assert "Code diff:\n+fn main() {}\n" in prompt
+    assert "Changed user documentation paths:\ndocs/src/content/docs/x.mdx\n" in prompt
+    assert "User documentation diff:\n+## The clock\n" in prompt
 
-    with patch("functions.release_summary.run_claude", side_effect=_fake_run_claude):
-        generate_release_content([], "v0.1.0", tmp_path)
 
-    assert "no commits since the last release" in captured["prompt"]
+def test_generate_release_content_truncates_each_diff_separately(
+    tmp_path: Path,
+) -> None:
+    captured: dict[str, object] = {}
+    changes = _changes(
+        code=PathDiff("c" * 500_000, ("crates/peppy/src/main.rs",)),
+        docs=PathDiff("d" * 1000, ("docs/src/content/docs/x.mdx",)),
+    )
+    with patch("functions.release_summary.run_claude", side_effect=_capture_prompt(captured)):
+        generate_release_content(changes, "v0.12.0", tmp_path)
+
+    prompt = captured["prompt"]
+    assert isinstance(prompt, str)
+    # The oversized code diff is cut, and the docs diff survives untouched.
+    assert prompt.count("diff truncated") == 1
+    assert "d" * 1000 in prompt
+    assert "c" * 500_000 not in prompt
+
+
+def test_generate_release_content_names_empty_sections(tmp_path: Path) -> None:
+    captured: dict[str, object] = {}
+    changes = _changes(
+        subjects=(),
+        code=PathDiff("", ()),
+        docs=PathDiff("", ()),
+    )
+    with patch("functions.release_summary.run_claude", side_effect=_capture_prompt(captured)):
+        generate_release_content(changes, "v0.12.0", tmp_path)
+
+    prompt = captured["prompt"]
+    assert isinstance(prompt, str)
+    assert "(no commits since the last release)" in prompt
+    assert prompt.count("(no code changes)") == 2
+    assert prompt.count("(no user documentation changes)") == 2
+
+
+def test_generate_release_content_without_a_previous_release(tmp_path: Path) -> None:
+    captured: dict[str, object] = {}
+    changes = ReleaseChanges(commit_subjects=("initial commit",), diffs=None)
+    with patch("functions.release_summary.run_claude", side_effect=_capture_prompt(captured)):
+        generate_release_content(changes, "v0.1.0", tmp_path)
+
+    prompt = captured["prompt"]
+    assert isinstance(prompt, str)
+    assert "the previous release is none: no release has been published yet" in prompt
+    assert "- initial commit" in prompt
+    # Every diff section says why it is empty rather than claiming no changes.
+    assert prompt.count("(no previous release to diff against)") == 4
+    assert "(no code changes)" not in prompt
+    assert "(no user documentation changes)" not in prompt
+
+
+# --- collect_release_changes ---
+
+
+def test_collect_release_changes_gathers_subjects_and_both_diffs(
+    tmp_path: Path,
+) -> None:
+    with patch(
+        "functions.release_summary.get_commit_subjects",
+        return_value=["feat: b", "fix: a"],
+    ) as subjects, patch(
+        "functions.release_summary.get_code_diff",
+        return_value=("CODE", ["crates/peppy/src/main.rs"]),
+    ) as code, patch(
+        "functions.release_summary.get_docs_diff",
+        return_value=("DOCS", ["docs/src/content/docs/x.mdx"]),
+    ) as docs:
+        changes = collect_release_changes("v0.11.1", "abc123", tmp_path)
+
+    assert changes == ReleaseChanges(
+        commit_subjects=("feat: b", "fix: a"),
+        diffs=ReleaseDiffs(
+            previous_tag="v0.11.1",
+            code=PathDiff("CODE", ("crates/peppy/src/main.rs",)),
+            docs=PathDiff("DOCS", ("docs/src/content/docs/x.mdx",)),
+        ),
+    )
+    # Everything is measured over the same range: previous tag to the exact
+    # commit being released.
+    subjects.assert_called_once_with("v0.11.1", "abc123")
+    code.assert_called_once_with("v0.11.1", "abc123", tmp_path)
+    docs.assert_called_once_with("v0.11.1", "abc123", tmp_path)
+
+
+def test_collect_release_changes_skips_diffs_without_a_previous_release(
+    tmp_path: Path,
+) -> None:
+    with patch(
+        "functions.release_summary.get_commit_subjects",
+        return_value=["initial commit"],
+    ) as subjects, patch(
+        "functions.release_summary.get_code_diff"
+    ) as code, patch(
+        "functions.release_summary.get_docs_diff"
+    ) as docs:
+        changes = collect_release_changes(None, "abc123", tmp_path)
+
+    assert changes == ReleaseChanges(commit_subjects=("initial commit",), diffs=None)
+    # The full history is listed; there is no earlier state to diff against.
+    subjects.assert_called_once_with(None, "abc123")
+    code.assert_not_called()
+    docs.assert_not_called()


### PR DESCRIPTION
## Why

`./scripts/build_release.sh` for v0.25.2 proposed "Maintenance release" with no user-facing changes, although the range since v0.25.1 contains #396 (`use_sim_time`, `harness.clock`, per-node clock `init`, two docs pages). The notes step fed Claude only `git log --no-merges --format=%s` (three lines: a deps bump, a release commit, and `testing: give every generated harness the daemon's clock`) and told it to drop "test-only" and "code-generator" changes with no tools and no diff to disambiguate, so the one real commit was classified by its `testing:` prefix.

## What changes

- `release_summary.collect_release_changes(previous_tag, release_commit, repo_root)` gathers the commit subjects plus two diffs over `previous_tag..release_commit`: the code diff and changed paths from the same `get_code_diff` the docs freshness check uses, and the diff of the user documentation under `docs/src/content/docs/` (new `get_docs_diff`, sharing one `_diff_matching` helper). With no previous release, the subjects cover the full history and `diffs` is `None`, which the prompt states explicitly.
- Each diff is truncated separately (`truncate_diff`, now shared): between recent tags the code diff ranges from 17KB to 687KB while docs diffs stay under 60KB, so a large code diff must not push the docs diff out.
- `Cargo.lock` is excluded from the code diff for both the docs check and the notes: it sorts first in `git diff` output and only records dependency versions.
- The prompt now judges from the diffs rather than subject wording, treats a docs change as strong evidence of a user-facing change, names the generator's output and the generated test harness API (`peppygen.mock` / `peppygen.fixtures` / harness) as user-facing, and defines "test-only" as peppy's own test suite.
- `_prepare_release_content` takes the release commit so subjects and diffs share one range.

## Verification

- `pixi run test-one "not test_install and not test_lima"`: 247 passed (new tests for `get_code_diff` / `get_docs_diff` path filtering and short-circuit, separate truncation, empty-section and first-release rendering, `collect_release_changes`, and the updated `_prepare_release_content` wiring).
- Real `claude -p` run through `generate_release_content` on `v0.25.1..HEAD` (nothing published), title: "Clock control and sim-time testing in the generated harness"; the notes list `harness.clock`, `set_offset_ns`, the `use_sim_time` knob and its wall/sim enforcement, `StandaloneConfig.with_use_sim_time`, and the per-node `init` rebinding. Prompt size for that range: 66KB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Peppy-bot/codesmith/peppy/pr/397"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789825836&installation_model_id=433186&pr_number=397&repository=Peppy-bot%2Fpeppy&return_to=https%3A%2F%2Fgithub.com%2FPeppy-bot%2Fpeppy%2Fpull%2F397&signature=e64ffe7a3ba10c3399afce08b208b91dc32eefe3a4244a5f99c5ced544274215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->