### PR TITLE
release: keep the drafted notes to one short sentence per capability

### DIFF
--- a/scripts/functions/release_summary.py
+++ b/scripts/functions/release_summary.py
@@ -103,11 +103,19 @@ Field requirements:
   users. Mention only user-facing themes, so the headline never promises changes
   the notes leave out.
 - "notes": the release body in Markdown, as a bulleted list of the user-facing
-  changes only, one bullet per change, each rewritten as a clear, self-contained
-  sentence. Group related changes under short "### " subheadings when it improves
-  readability. Do NOT include any links, URLs, pull-request or issue numbers (for
-  example "#123"), commit hashes, author or "@" mentions, or a "Full Changelog"
-  line.
+  changes only. Keep it short: one bullet per capability a user gains or loses,
+  written as a single plain sentence of at most about 30 words that says what
+  the user can now do (or must do differently), not how it is implemented or
+  enforced. A capability's details (its options, defaults, error cases,
+  guardrails, and per-language spellings) stay in the documentation unless
+  the sentence has room for one of them; name an API once, in whichever
+  language's spelling reads most naturally, rather than quoting both the
+  Python and the Rust forms. Add
+  short "### " subheadings only when the release spans several unrelated
+  themes (plus the "### Breaking changes" subheading described below whenever
+  it applies); a release with one theme is a flat list. Do NOT include any
+  links, URLs, pull-request or issue numbers (for example "#123"), commit
+  hashes, author or "@" mentions, or a "Full Changelog" line.
 
 Call out backward-incompatible changes. A user-facing change is breaking when a
 user must update their `peppy.json5`, commands, scripts, or workflow to keep


### PR DESCRIPTION
## Why

With the code and docs diffs in view (#397), the notes prompt's "one bullet per change" made every guardrail and per-language spelling a change of its own: the v0.25.2 draft came out as seven bullets under three subheadings for a single feature.

## What changes

The `notes` field requirement in `release_summary.py` now asks for one bullet per capability a user gains or loses, written as a single sentence of at most about 30 words that says what the user can do, with details (options, defaults, error cases, guardrails, per-language spellings) left to the documentation, APIs named once rather than in both Python and Rust forms, and `### ` subheadings only when a release spans unrelated themes (besides the breaking-changes subheading when it applies).

## Verification

Real `claude -p` run through `generate_release_content` on `v0.25.1..HEAD` (nothing published): 5 one-sentence bullets, 778 characters, no subheadings, still naming `harness.clock`, `use_sim_time`, `set_offset_ns`, `StandaloneConfig.with_use_sim_time`, and the per-node `init` rebinding. `pixi run test-one release_summary`: 17 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Peppy-bot/codesmith/peppy/pr/398"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789826648&installation_model_id=433186&pr_number=398&repository=Peppy-bot%2Fpeppy&return_to=https%3A%2F%2Fgithub.com%2FPeppy-bot%2Fpeppy%2Fpull%2F398&signature=70ad29189f9661939a6216066e671945d4b5fb6fd2b040f8e8b8a6f33f8d13b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->