### PR TITLE
Cargo.lock: take peppylib's Error::Node variant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -587,7 +587,7 @@ dependencies = [
 [[package]]
 name = "build-helpers"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#d5253d393d84541ca43dd4e699631650a641c706"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#ed3d6ccc560c1121191eecd9ce75d6c27e70d4b7"
 dependencies = [
  "sha2",
 ]
@@ -785,7 +785,7 @@ dependencies = [
 [[package]]
 name = "config-test-support"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#d5253d393d84541ca43dd4e699631650a641c706"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#ed3d6ccc560c1121191eecd9ce75d6c27e70d4b7"
 dependencies = [
  "askama",
  "git2",
@@ -930,7 +930,7 @@ dependencies = [
 [[package]]
 name = "core-node-api"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#d5253d393d84541ca43dd4e699631650a641c706"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#ed3d6ccc560c1121191eecd9ce75d6c27e70d4b7"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -2687,7 +2687,7 @@ dependencies = [
 [[package]]
 name = "json5-pretty"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#d5253d393d84541ca43dd4e699631650a641c706"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#ed3d6ccc560c1121191eecd9ce75d6c27e70d4b7"
 dependencies = [
  "serde",
  "serde_json",
@@ -3513,7 +3513,7 @@ dependencies = [
 [[package]]
 name = "peppy-config-model"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#d5253d393d84541ca43dd4e699631650a641c706"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#ed3d6ccc560c1121191eecd9ce75d6c27e70d4b7"
 dependencies = [
  "capnp",
  "clap",
@@ -3532,7 +3532,7 @@ dependencies = [
 [[package]]
 name = "peppy-mcp-catalog"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#d5253d393d84541ca43dd4e699631650a641c706"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#ed3d6ccc560c1121191eecd9ce75d6c27e70d4b7"
 dependencies = [
  "serde",
  "serde_json",
@@ -3541,7 +3541,7 @@ dependencies = [
 [[package]]
 name = "peppy-mcp-runtime"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#d5253d393d84541ca43dd4e699631650a641c706"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#ed3d6ccc560c1121191eecd9ce75d6c27e70d4b7"
 dependencies = [
  "axum",
  "base64 0.23.1",
@@ -3563,7 +3563,7 @@ version = "0.0.1"
 [[package]]
 name = "peppylib-rs"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#d5253d393d84541ca43dd4e699631650a641c706"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#ed3d6ccc560c1121191eecd9ce75d6c27e70d4b7"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -3758,7 +3758,7 @@ dependencies = [
 [[package]]
 name = "pmi"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#d5253d393d84541ca43dd4e699631650a641c706"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#ed3d6ccc560c1121191eecd9ce75d6c27e70d4b7"
 dependencies = [
  "build-helpers",
  "bytes",


### PR DESCRIPTION
## Why this is needed before the next release

`generator-internal` embeds peppylib's source into the peppy binary at compile
time:

```rust
#[derive(Embed)]
#[folder = "$PEPPY_SHARED_DIR/peppylib-rs/"]
pub(crate) struct EmbeddedPeppylib;
```

`peppy node sync` writes `.peppy/libs/peppylib` out of that embedded copy, so a
node's peppylib is whatever rev this lockfile pins — there is no fetch at sync
time. Cutting a release without this bump ships without
[public-peppy-libs#115](https://github.com/Peppy-bot/public-peppy-libs/pull/115),
and nodes still have nowhere to put their own refusals.

## What moved

The nine public-peppy-libs crates go from `d5253d39` to `ed3d6cc`. Cargo moves
them together since they share a source. Eight commits:

- `ed3d6cc` / `2f6aa94` / `ab78a1d` — the `Error::Node` variant (#115)
- `a57cc03` / `f928e6b` / `2d27519` / `099b3c1` / `f6ae860` — CI workflow
  changes (Blacksmith migration, setup-uv pins)

No runtime code outside the variant, which is purely additive (+10/-0).

## Verification

Nine `source` lines change and nothing else: +9/-9.

Deliberately **not** done with `cargo update -p peppylib-rs`. That re-resolves the
whole tree with the MSRV-aware resolver against the running toolchain — on rustc
1.96.0 it reported *"Locking 9 packages to latest Rust 1.96.0 compatible
versions"* and downgraded `windows-sys` 0.61.2 to 0.59.0, pulling `dirs` and
`rustix` back with it. The repo pins no `rust-toolchain.toml`, so that would
silently move the tree to whatever rustc the person bumping happens to have. Git
dependencies carry no checksums, so replacing the rev directly is exact;
`cargo metadata --locked` passes, confirming cargo wants no further edits.

`peppylib-rs` and `peppylib-py` both compile against the new rev — worth stating
explicitly because `Error` is not `#[non_exhaustive]`, so an added variant could
in principle break an exhaustive match downstream. It does not.

I could not run the full `cargo check -p generator` here: `peppylib-py`'s build
script requires `uv`, which this Linux box lacks. That is environmental and the
release host has it via pixi, but the generator build is unverified on my side
and CI should be the judge.

## Unrelated, worth raising

Nothing pins a toolchain for this repo, so any `cargo update` rewrites the lock
to the runner's MSRV. A `rust-toolchain.toml` would make that deterministic.
