### PR TITLE
feat: add `peppy --version` flag reading version from a shared const

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -60,6 +60,7 @@ Non-goals:
 | `peppy platform` | Log in, log out, and show the current platform identity |
 | `peppy service` | Install, serve, stop, uninstall, and reset the background service |
 | `peppy info` | Print the CLI version, container setup, and daemon info |
+| `peppy --version` | Print the CLI version alone, without contacting the daemon |
 
 ## 📚 Documentation
 

--- a/crates/core-node-internal/src/services.rs
+++ b/crates/core-node-internal/src/services.rs
@@ -24,7 +24,7 @@ use config::{
     schema::PeppySchema,
 };
 use core_node_api::{ActionId, ServiceId, TopicId};
-use daemon_config::consts::PeppyDirs;
+use daemon_config::consts::{PEPPY_GIT_TAG, PeppyDirs};
 use futures::future::{BoxFuture, FutureExt, select_all, try_join_all};
 use names_generator2::get_random;
 use node_stack::NodeStack;
@@ -44,7 +44,7 @@ use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tracing::info;
 
-const CORE_NODE_TAG: &str = match option_env!("PEPPY_GIT_TAG") {
+const CORE_NODE_TAG: &str = match PEPPY_GIT_TAG {
     Some(tag) => tag,
     None => "dev",
 };

--- a/crates/core-node-internal/src/services/clock.rs
+++ b/crates/core-node-internal/src/services/clock.rs
@@ -6,8 +6,8 @@ use core_node_api::{ServiceId, TopicId};
 // The clock-source abstraction and the NTP-style request handler live in
 // `peppylib::clock`, shared with the test harness's clock stand-in
 // (`peppylib::testing::MockClock`) so both serve identical semantics.
-pub use peppylib::clock::{ClockSource, SimClockSource, WallClockSource};
 use peppylib::clock::handle_clock_request;
+pub use peppylib::clock::{ClockSource, SimClockSource, WallClockSource};
 use peppylib::messaging::{SenderTarget, Subscription, TopicPublisher};
 use peppylib::{MessengerHandle, ServiceMessenger, TopicMessenger};
 use std::sync::Arc;
@@ -313,5 +313,4 @@ mod tests {
             .expect("heartbeat task should not panic");
         outcome.expect("heartbeat should exit Ok after a clean cancel");
     }
-
 }

--- a/crates/core-node-internal/src/services/info.rs
+++ b/crates/core-node-internal/src/services/info.rs
@@ -4,6 +4,7 @@ use crate::services::response::into_service_response;
 use core_node_api::ServiceId;
 use core_node_api::encoding::{ContainerInfo, InfoRequest, InfoResponse};
 use core_node_api::names;
+use daemon_config::consts::PEPPY_VERSION;
 use node_stack::NodeStack;
 use peppylib::messaging::SenderTarget;
 use peppylib::messaging::ServiceRequestContext;
@@ -100,8 +101,6 @@ fn handle_info_request_inner(
     let uptime_secs = start_time.elapsed().as_secs();
     let host_name = current_host_name();
     let node_count = node_stack.len() as u32;
-    let git_version = option_env!("PEPPY_GIT_TAG").unwrap_or("unknown");
-
     let container_info = ContainerInfo {
         apptainer_version: containers::APPTAINER_VERSION.to_owned(),
         lima_version: containers::LIMA_VERSION.to_owned(),
@@ -113,7 +112,7 @@ fn handle_info_request_inner(
         instance_id,
         host_name,
         node_count,
-        git_version,
+        PEPPY_VERSION,
         container_info,
         messaging_port,
     )

--- a/crates/daemon-config-internal/src/consts.rs
+++ b/crates/daemon-config-internal/src/consts.rs
@@ -13,6 +13,18 @@ pub const REPOSITORY_INDEX_FILE: &str = "peppy_repository.json5";
 
 pub const PEPPY_MESSAGING_PORT_VAR_NAME: &str = "PEPPY_MESSAGING_PORT";
 
+/// Release tag the binary was built from, read at compile time from the
+/// `PEPPY_GIT_TAG` environment variable the release build sets. A plain
+/// `cargo build` has none.
+pub const PEPPY_GIT_TAG: Option<&str> = option_env!("PEPPY_GIT_TAG");
+
+/// Version the CLI and the daemon report for themselves: the release tag, or
+/// `unknown` for a build without one.
+pub const PEPPY_VERSION: &str = match PEPPY_GIT_TAG {
+    Some(tag) => tag,
+    None => "unknown",
+};
+
 /// Default base container image for Rust nodes (Ubuntu 24.04 + Rust via rustup, build-essential).
 pub const DEFAULT_RUST_BASE_IMAGE: &str = "peppybot/rust-cargo-base:latest";
 

--- a/crates/daemon-config-internal/src/lib.rs
+++ b/crates/daemon-config-internal/src/lib.rs
@@ -72,9 +72,9 @@ pub mod env {
 pub mod consts {
     pub use crate::internal::consts::{
         AppEnv, CREDENTIALS_FILE, DEFAULT_ALPINE_BASE_IMAGE, DEFAULT_PYTHON_BASE_IMAGE,
-        DEFAULT_RUST_BASE_IMAGE, PEPPY_MESSAGING_PORT_VAR_NAME, PEPPY_OUTPUT_DIR,
-        PEPPYLIB_OUTPUT_PATH, PeppyDirs, REPOSITORY_INDEX_FILE, non_empty_env_path, peppy_root_dir,
-        set_app_env,
+        DEFAULT_RUST_BASE_IMAGE, PEPPY_GIT_TAG, PEPPY_MESSAGING_PORT_VAR_NAME, PEPPY_OUTPUT_DIR,
+        PEPPY_VERSION, PEPPYLIB_OUTPUT_PATH, PeppyDirs, REPOSITORY_INDEX_FILE, non_empty_env_path,
+        peppy_root_dir, set_app_env,
     };
 }
 

--- a/crates/peppy/src/commands/info.rs
+++ b/crates/peppy/src/commands/info.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use core_node_api::encoding::InfoRequest;
+use daemon_config::consts::PEPPY_VERSION;
 
 use super::{CALLER_INSTANCE_ID, Command};
 use crate::context::AppContext;
@@ -42,11 +43,9 @@ impl Command for InfoCommand {
 }
 
 async fn info_async(ctx: &Arc<AppContext>) -> Result<()> {
-    let client_version = option_env!("PEPPY_GIT_TAG").unwrap_or("unknown");
-
     println!("Peppy client info");
     println!("----------");
-    println!("Version: {}", client_version);
+    println!("Version: {PEPPY_VERSION}");
 
     // Local container setup check (works without the daemon running)
     print_container_setup_status();

--- a/crates/peppy/src/main.rs
+++ b/crates/peppy/src/main.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use clap::{Parser, Subcommand};
 use tracing::error;
 
-use daemon_config::consts::AppEnv;
+use daemon_config::consts::{AppEnv, PEPPY_VERSION};
 use peppy::{
     commands::{Command, container, info, node, platform, repo, service, stack},
     context::AppContext,
@@ -18,6 +18,7 @@ use logging::{LogStyle, init_tracing};
 #[derive(Parser)]
 #[command(name = "peppy")]
 #[command(about = "The Peppy cli tool")]
+#[command(version = PEPPY_VERSION)]
 struct Cli {
     #[command(subcommand)]
     command: Commands,
@@ -158,6 +159,20 @@ mod tests {
     fn core_node_flag_defaults_to_none() {
         let cli = Cli::try_parse_from(["peppy", "stack", "list"]).expect("plain parse");
         assert_eq!(cli.core_node, None, "absent flag targets the local daemon");
+    }
+
+    /// `--version` is answered by the parser itself, before the app context
+    /// or the daemon come into play, so a freshly extracted binary on a
+    /// machine with no peppy state still states which release it is.
+    #[test]
+    fn version_flag_prints_the_release_tag() {
+        for flag in ["--version", "-V"] {
+            let err = Cli::try_parse_from(["peppy", flag])
+                .err()
+                .expect("--version ends parsing with a DisplayVersion error");
+            assert_eq!(err.kind(), clap::error::ErrorKind::DisplayVersion);
+            assert_eq!(err.to_string().trim_end(), format!("peppy {PEPPY_VERSION}"));
+        }
     }
 
     /// A malformed `--core-node` must be rejected at parse time — the same

--- a/crates/peppy/tests/main.rs
+++ b/crates/peppy/tests/main.rs
@@ -27,3 +27,4 @@ mod service_serve;
 mod stack_launch;
 mod stack_list;
 mod stack_reset;
+mod version;

--- a/crates/peppy/tests/multi_daemon_e2e.rs
+++ b/crates/peppy/tests/multi_daemon_e2e.rs
@@ -304,7 +304,9 @@ async fn build_e2e_daemon_image(release: &str) {
         // cache, so the count is the run-to-run reuse made visible.
         let cached_steps = stderr.lines().filter(|l| l.contains(" CACHED ")).count();
         let elapsed = built_at.elapsed().as_secs_f32();
-        println!("built {tag} through the default buildx builder in {elapsed:.1}s ({cached_steps} cached steps)");
+        println!(
+            "built {tag} through the default buildx builder in {elapsed:.1}s ({cached_steps} cached steps)"
+        );
         // The test harness captures stdout, so surface the same numbers in the
         // GitHub step summary, where a passing run still shows them.
         if let Some(summary) = std::env::var_os("GITHUB_STEP_SUMMARY") {

--- a/crates/peppy/tests/version.rs
+++ b/crates/peppy/tests/version.rs
@@ -1,0 +1,27 @@
+use std::process::Command;
+
+use daemon_config::consts::PEPPY_VERSION;
+
+/// `peppy --version` is what a consumer's CI runs right after extracting a
+/// release: no daemon, no state on disk, nothing but the binary. The answer
+/// has to come from the binary alone, on stdout, with nothing on stderr.
+#[test]
+fn version_flag_answers_without_peppy_state_or_daemon() {
+    let home = tempfile::tempdir().expect("temp PEPPY_HOME");
+    let output = Command::new(env!("CARGO_BIN_EXE_peppy"))
+        .arg("--version")
+        .env("PEPPY_HOME", home.path())
+        .output()
+        .expect("peppy --version runs");
+
+    assert!(output.status.success(), "{output:?}");
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim_end(),
+        format!("peppy {PEPPY_VERSION}")
+    );
+    assert!(
+        output.stderr.is_empty(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Peppy-bot/codesmith/peppy/pr/402"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789899666&installation_model_id=433186&pr_number=402&repository=Peppy-bot%2Fpeppy&return_to=https%3A%2F%2Fgithub.com%2FPeppy-bot%2Fpeppy%2Fpull%2F402&signature=f926559114636f972fae9c6169248571091881cfbe29111e4ea291440bff0387"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->