### PR TITLE
stack resolve: hold the flat plan to the client-checkable link rules

### DIFF
--- a/crates/core-node-internal/src/lib.rs
+++ b/crates/core-node-internal/src/lib.rs
@@ -8,9 +8,9 @@ pub mod test_support;
 
 pub use error::{Error, Result};
 pub use services::repo::cache::{
-    contracts_repo_cache_path, launchers_repo_cache_path, mcp_exposures_repo_cache_path,
-    nodes_repo_cache_path, pairings_repo_cache_path, repositories_list_path,
-    resolve_repo_launcher_path,
+    EntryOrigin, NodeCacheEntry, contracts_repo_cache_path, launchers_repo_cache_path,
+    load_node_cache, lookup, mcp_exposures_repo_cache_path, nodes_repo_cache_path,
+    pairings_repo_cache_path, repositories_list_path, resolve_repo_launcher_path,
 };
 pub use services::repo::exposure::{
     ExposureDrift, PublishedExposure, check_exposure, exposure_bundle_path, publish_exposure,

--- a/crates/peppy/src/commands/stack/resolve.rs
+++ b/crates/peppy/src/commands/stack/resolve.rs
@@ -1,9 +1,14 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use config::node::{NodeConfig, NodeConfigParser};
 use core_node_api::encoding::LauncherOrigin;
 use daemon_config::consts::PeppyDirs;
-use daemon_config::launcher::{PeppyLauncherParser, compose};
+use daemon_config::launcher::{
+    AlreadyPairedSlots, BindingValidationItem, ExternallyCoveredSlots, PairingValidationItem,
+    PeppyLauncher, PeppyLauncherParser, compose, validate_link_slots, validate_pairings,
+};
+use daemon_config::repository::EntryOrigin;
 use tracing::info;
 
 use super::launch::infer_launcher_origin;
@@ -13,18 +18,25 @@ use crate::error::{Error, Result};
 /// `peppy stack resolve <name|path> [--with ...]`: print the flat launcher
 /// a composed launch would run, and the report of what the selection did.
 ///
-/// Needs no running stack and touches nothing. A filesystem input is read
-/// where it stands; a repository name resolves through this machine's
-/// launcher cache, exactly as a launch would, minus the goal. The flattened
-/// `launcher/v1` document goes to stdout, so it doubles as the escape
-/// hatch: flatten, hand-edit, launch the flat file. The resolution report
-/// goes to stderr.
+/// Needs no running stack. A filesystem input is read where it stands; a
+/// repository name resolves through this machine's launcher cache, exactly
+/// as a launch would, minus the goal. The flattened `launcher/v1` document
+/// goes to stdout, so it doubles as the escape hatch: flatten, hand-edit,
+/// launch the flat file. The resolution report goes to stderr.
+///
+/// The flat plan is then held to the launch-time link rules that need no
+/// daemon: slot-key and vacancy legality, and the pairing rules, coverage
+/// included, so a launcher that leaves an optional pairing slot neither
+/// paired nor vacant fails here instead of minutes later at launch. The
+/// node manifests come from this machine's nodes cache; when one is not
+/// readable locally the check is skipped and says so, because a partial
+/// item list would misreport rules that need both endpoints.
 pub fn resolve(
     _ctx: &Arc<AppContext>,
     launcher_config_path: PathBuf,
     with: Vec<String>,
 ) -> Result<()> {
-    let (document, report) = resolve_rendered(launcher_config_path, &with)?;
+    let (document, report) = resolve_rendered(&PeppyDirs::default(), launcher_config_path, &with)?;
     for line in report {
         eprintln!("{line}");
     }
@@ -34,18 +46,20 @@ pub fn resolve(
 
 /// The resolve command's whole verdict in printable form: the flattened
 /// document for stdout and the report lines for stderr. Split from
-/// [`resolve`] so a test can read the output instead of capturing stdout.
+/// [`resolve`] so a test can read the output instead of capturing stdout,
+/// and handed its `PeppyDirs` so a test validates against a root it wrote
+/// rather than whatever this machine's caches hold. Link-rule violations
+/// are an `Err`, exactly as the launch they predict would be.
 pub fn resolve_rendered(
+    dirs: &PeppyDirs,
     launcher_config_path: PathBuf,
     with: &[String],
 ) -> Result<(String, Vec<String>)> {
     let path = match infer_launcher_origin(launcher_config_path)? {
         LauncherOrigin::Fs(path) => path,
         LauncherOrigin::Repository { name } => {
-            core_node::resolve_repo_launcher_path(&name, &PeppyDirs::default(), &|message: &str| {
-                info!("{message}")
-            })
-            .map_err(Error::ExecutionFailed)?
+            core_node::resolve_repo_launcher_path(&name, dirs, &|message: &str| info!("{message}"))
+                .map_err(Error::ExecutionFailed)?
         }
     };
 
@@ -53,7 +67,139 @@ pub fn resolve_rendered(
     let (flat, report) =
         compose(&parsed, &path, with).map_err(|e| Error::ExecutionFailed(e.to_string()))?;
 
+    let mut lines = report.render_lines();
+    check_link_plan(&flat, dirs, &mut lines)?;
+
     let document = json5_pretty::to_string_pretty(&flat)
         .map_err(|e| Error::ExecutionFailed(format!("cannot serialize the flat launcher: {e}")))?;
-    Ok((document, report.render_lines()))
+    Ok((document, lines))
+}
+
+/// Hold the flat plan to the launch-time link rules a client can check: the
+/// cross-family slot-key and vacancy rules, then the pairing rules. Both
+/// validators read only the flat launcher and the deployed nodes' manifests,
+/// so they run here without a daemon; the contract-binding rules stay
+/// launch-only because satisfying them can involve the root node, which only
+/// the daemon knows.
+///
+/// Manifests come from the nodes cache. The check runs only when every
+/// deployed node's manifest is readable on this machine: the pairing rules
+/// judge links by both endpoints' declarations, so validating a partial item
+/// list would trade missed errors for false ones. When something is missing
+/// the report says which check was skipped and why, so a clean exit is never
+/// mistaken for a validated plan.
+fn check_link_plan(flat: &PeppyLauncher, dirs: &PeppyDirs, report: &mut Vec<String>) -> Result<()> {
+    let entries = match core_node::load_node_cache(dirs) {
+        Ok(entries) if !entries.is_empty() => entries,
+        Ok(_) => {
+            report.push(
+                "link rules not checked: the nodes cache is empty; run `peppy repo refresh`"
+                    .to_string(),
+            );
+            return Ok(());
+        }
+        Err(e) => {
+            report.push(format!(
+                "link rules not checked: the nodes cache is not readable ({e}); run `peppy repo refresh`"
+            ));
+            return Ok(());
+        }
+    };
+
+    let mut unavailable: Vec<String> = Vec::new();
+    let mut manifests: Vec<(String, String, usize, NodeConfig)> = Vec::new();
+    for (index, deployment) in flat.deployments.iter().enumerate() {
+        let name = deployment.source.name.as_str();
+        let tag = deployment.source.tag.as_str();
+        let id = format!("{name}:{tag}");
+        let entry = match core_node::lookup(&entries, name, tag) {
+            Ok(Some(entry)) => entry,
+            Ok(None) => {
+                unavailable.push(format!("{id} (not in the nodes cache)"));
+                continue;
+            }
+            Err(ambiguity) => {
+                unavailable.push(format!("{id} ({ambiguity})"));
+                continue;
+            }
+        };
+        let manifest_path = match &entry.origin {
+            EntryOrigin::Fs { path } => path.clone(),
+            EntryOrigin::Git { .. } => {
+                // A git-backed manifest may need a fetch to read, which this
+                // command must not do; the launch that follows will.
+                unavailable.push(format!(
+                    "{id} (a git entry's manifest needs materializing to read)"
+                ));
+                continue;
+            }
+        };
+        match NodeConfigParser::from_path(&manifest_path) {
+            Ok(config) => manifests.push((name.to_string(), tag.to_string(), index, config)),
+            Err(e) => {
+                unavailable.push(format!("{id} ({e})"));
+            }
+        }
+    }
+    if !unavailable.is_empty() {
+        report.push(format!(
+            "link rules not checked, {} manifest(s) unavailable: {}",
+            unavailable.len(),
+            unavailable.join(", ")
+        ));
+        return Ok(());
+    }
+
+    let binding_items: Vec<BindingValidationItem<'_>> = manifests
+        .iter()
+        .map(|(name, tag, index, config)| BindingValidationItem {
+            node_name: name,
+            node_tag: tag,
+            instances: &flat.deployments[*index].instances,
+            depends_on: config.manifest.depends_on.as_ref(),
+            implements: &config.manifest.implements,
+        })
+        .collect();
+    let mut errors = validate_link_slots(&binding_items);
+    if errors.is_empty() {
+        let pairing_items: Vec<PairingValidationItem<'_>> = manifests
+            .iter()
+            .map(|(name, tag, index, config)| PairingValidationItem {
+                node_name: name,
+                node_tag: tag,
+                instances: &flat.deployments[*index].instances,
+                pairing_deps: config
+                    .manifest
+                    .depends_on
+                    .as_ref()
+                    .map(|d| d.pairings.as_slice())
+                    .unwrap_or_default(),
+                observer_deps: config
+                    .manifest
+                    .depends_on
+                    .as_ref()
+                    .map(|d| d.pairing_observers.as_slice())
+                    .unwrap_or_default(),
+                preexisting: false,
+            })
+            .collect();
+        errors = validate_pairings(
+            &pairing_items,
+            &AlreadyPairedSlots::new(),
+            &ExternallyCoveredSlots::new(),
+        )
+        .errors;
+    }
+    if errors.is_empty() {
+        report.push(format!(
+            "link rules hold: slot keys, vacancies and pairing coverage checked over {} node manifest(s)",
+            manifests.len()
+        ));
+        return Ok(());
+    }
+    let rendered: Vec<String> = errors.iter().map(ToString::to_string).collect();
+    Err(Error::ExecutionFailed(format!(
+        "the flat launcher breaks link rules a launch would reject:{}",
+        daemon_config::format_bulleted(&rendered)
+    )))
 }

--- a/crates/peppy/src/commands/stack/resolve.rs
+++ b/crates/peppy/src/commands/stack/resolve.rs
@@ -126,8 +126,8 @@ fn check_link_plan(flat: &PeppyLauncher, dirs: &PeppyDirs, report: &mut Vec<Stri
         let manifest_path = match &entry.origin {
             EntryOrigin::Fs { path } => path.clone(),
             EntryOrigin::Git { .. } => {
-                // A git-backed manifest may need a fetch to read, which this
-                // command must not do; the launch that follows will.
+                // A git-backed manifest may need a fetch to read, and this
+                // command never fetches.
                 unavailable.push(format!(
                     "{id} (a git entry's manifest needs materializing to read)"
                 ));

--- a/crates/peppy/tests/stack_launch.rs
+++ b/crates/peppy/tests/stack_launch.rs
@@ -4631,9 +4631,12 @@ fn stack_resolve_prints_the_flat_launcher_and_report() {
     )
     .expect("launcher");
 
-    let (document, report) =
-        peppy::commands::stack::resolve_rendered(launcher, &["recorder=on".to_owned()])
-            .expect("resolves");
+    let (document, report) = peppy::commands::stack::resolve_rendered(
+        &empty_peppy_dirs(),
+        launcher,
+        &["recorder=on".to_owned()],
+    )
+    .expect("resolves");
 
     assert!(
         document.contains("recorder_inst") && document.contains("panel_inst"),
@@ -4700,6 +4703,7 @@ fn stack_resolve_refuses_a_selection_the_constraints_exclude() {
     .expect("launcher");
 
     let err = peppy::commands::stack::resolve_rendered(
+        &empty_peppy_dirs(),
         launcher.clone(),
         &["mujoco".to_owned(), "cameras".to_owned()],
     )
@@ -4712,9 +4716,12 @@ fn stack_resolve_refuses_a_selection_the_constraints_exclude() {
         "the refusal names the guard, the requirement, and the reason: {msg}"
     );
 
-    let (document, _report) =
-        peppy::commands::stack::resolve_rendered(launcher, &["cameras".to_owned()])
-            .expect("the legal sibling resolves");
+    let (document, _report) = peppy::commands::stack::resolve_rendered(
+        &empty_peppy_dirs(),
+        launcher,
+        &["cameras".to_owned()],
+    )
+    .expect("the legal sibling resolves");
     assert!(
         document.contains("cam_inst") && document.contains("arm_inst"),
         "the flat document carries the selected options: {document}"
@@ -4722,5 +4729,192 @@ fn stack_resolve_refuses_a_selection_the_constraints_exclude() {
     assert!(
         !document.contains("constraints"),
         "the flat document is an ordinary launcher with no composition keys: {document}"
+    );
+}
+
+/// A peppy root whose nodes cache holds nothing, for resolve tests that are
+/// about composition rather than the link rules: the check reports itself
+/// skipped instead of reading whatever this machine's real caches hold.
+fn empty_peppy_dirs() -> daemon_config::consts::PeppyDirs {
+    static EMPTY_ROOT: std::sync::OnceLock<tempfile::TempDir> = std::sync::OnceLock::new();
+    let dir = EMPTY_ROOT.get_or_init(|| tempfile::tempdir().expect("temp peppy root"));
+    daemon_config::consts::PeppyDirs::new(dir.path())
+}
+
+/// A peppy root, a node manifest declaring one optional pairing slot, and a
+/// nodes cache pointing at it, so `stack resolve` can hold a launcher to the
+/// pairing rules without a daemon. Returns the dirs and the launcher dir;
+/// the caller writes the launcher it wants judged.
+fn peppy_root_with_pairing_node() -> (daemon_config::consts::PeppyDirs, tempfile::TempDir) {
+    let root = tempfile::tempdir().expect("temp peppy root");
+    let node_dir = root.path().join("nodes/viewer");
+    fs::create_dir_all(&node_dir).expect("node dir");
+    fs::write(
+        node_dir.join("peppy.json5"),
+        r#"{
+            peppy_schema: "node/v1",
+            manifest: {
+                name: "viewer",
+                tag: "v1",
+                depends_on: {
+                    pairings: [
+                        { name: "camera_link", tag: "v1", role: "viewer",
+                          link_id: "camera", optional: true },
+                    ],
+                },
+            },
+            execution: { language: "rust", run_cmd: ["./bin/viewer"] },
+        }"#,
+    )
+    .expect("node manifest");
+    let cache_dir = root.path().join("cache");
+    fs::create_dir_all(&cache_dir).expect("cache dir");
+    fs::write(
+        cache_dir.join("nodes.json5"),
+        format!(
+            r#"[{{ node_name: "viewer", node_tag: "v1",
+                  sha256: "{}",
+                  origin: {{ source_type: "fs", path: "{}" }} }}]"#,
+            "0".repeat(64),
+            node_dir.join("peppy.json5").display(),
+        ),
+    )
+    .expect("nodes cache");
+    let dirs = daemon_config::consts::PeppyDirs::new(root.path());
+    (dirs, root)
+}
+
+/// The gap this check exists to close: a launcher that leaves an optional
+/// pairing slot neither paired nor vacant used to pass `stack resolve` and
+/// fail minutes later at launch. Resolve now refuses it with the launch's
+/// own error.
+#[test]
+fn stack_resolve_fails_an_optional_pairing_slot_left_uncovered() {
+    let (dirs, root) = peppy_root_with_pairing_node();
+    let launcher = root.path().join("solo.json5");
+    fs::write(
+        &launcher,
+        r#"{
+            peppy_schema: "launcher/v1",
+            deployments: [
+                { source: { name: "viewer", tag: "v1" },
+                  instances: [{ instance_id: "viewer_inst" }] },
+            ],
+        }"#,
+    )
+    .expect("launcher");
+
+    let err = peppy::commands::stack::resolve_rendered(&dirs, launcher, &[])
+        .expect_err("an uncovered optional pairing slot must not resolve");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("optional pairing slot `camera`") && msg.contains("with no pair"),
+        "the refusal names the slot and the rule: {msg}"
+    );
+    assert!(
+        msg.contains("vacant"),
+        "the refusal offers the vacancy escape hatch: {msg}"
+    );
+}
+
+/// The same launcher with the slot declared vacant resolves, and the report
+/// says the link rules were actually checked rather than skipped.
+#[test]
+fn stack_resolve_accepts_a_vacant_pairing_slot_and_says_it_checked() {
+    let (dirs, root) = peppy_root_with_pairing_node();
+    let launcher = root.path().join("solo.json5");
+    fs::write(
+        &launcher,
+        r#"{
+            peppy_schema: "launcher/v1",
+            deployments: [
+                { source: { name: "viewer", tag: "v1" },
+                  instances: [{ instance_id: "viewer_inst",
+                                links: { camera: { vacant: "no camera in this test" } } }] },
+            ],
+        }"#,
+    )
+    .expect("launcher");
+
+    let (_document, report) = peppy::commands::stack::resolve_rendered(&dirs, launcher, &[])
+        .expect("a vacant slot is covered");
+    let report_text = report.join(
+        "
+",
+    );
+    assert!(
+        report_text.contains("link rules hold"),
+        "the report confirms the rules ran: {report_text}"
+    );
+}
+
+/// A deployment whose manifest is not in the nodes cache turns the check
+/// into a named skip, never a silent pass and never a false error: the
+/// pairing rules judge links by both endpoints' declarations, so a partial
+/// item list must not be validated.
+#[test]
+fn stack_resolve_reports_the_check_skipped_when_a_manifest_is_missing() {
+    let (dirs, root) = peppy_root_with_pairing_node();
+    let launcher = root.path().join("solo.json5");
+    fs::write(
+        &launcher,
+        r#"{
+            peppy_schema: "launcher/v1",
+            deployments: [
+                { source: { name: "viewer", tag: "v1" },
+                  instances: [{ instance_id: "viewer_inst" }] },
+                { source: { name: "stranger", tag: "v1" },
+                  instances: [{ instance_id: "stranger_inst" }] },
+            ],
+        }"#,
+    )
+    .expect("launcher");
+
+    let (_document, report) = peppy::commands::stack::resolve_rendered(&dirs, launcher, &[])
+        .expect("a cache miss skips the check rather than failing the resolve");
+    let report_text = report.join(
+        "
+",
+    );
+    assert!(
+        report_text.contains("link rules not checked")
+            && report_text.contains("stranger:v1")
+            && report_text.contains("not in the nodes cache"),
+        "the skip names the missing manifest: {report_text}"
+    );
+    assert!(
+        !report_text.contains("link rules hold"),
+        "a skipped check must not also claim to have run: {report_text}"
+    );
+}
+
+/// An empty nodes cache (a machine that never ran `peppy repo refresh`)
+/// keeps resolve usable and says the check was skipped.
+#[test]
+fn stack_resolve_reports_the_check_skipped_on_an_empty_cache() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let launcher = dir.path().join("solo.json5");
+    fs::write(
+        &launcher,
+        r#"{
+            peppy_schema: "launcher/v1",
+            deployments: [
+                { source: { name: "viewer", tag: "v1" },
+                  instances: [{ instance_id: "viewer_inst" }] },
+            ],
+        }"#,
+    )
+    .expect("launcher");
+
+    let (_document, report) =
+        peppy::commands::stack::resolve_rendered(&empty_peppy_dirs(), launcher, &[])
+            .expect("an empty cache skips the check rather than failing the resolve");
+    let report_text = report.join(
+        "
+",
+    );
+    assert!(
+        report_text.contains("link rules not checked") && report_text.contains("repo refresh"),
+        "the skip tells the user how to enable the check: {report_text}"
     );
 }

--- a/crates/peppy/tests/stack_launch.rs
+++ b/crates/peppy/tests/stack_launch.rs
@@ -4784,10 +4784,9 @@ fn peppy_root_with_pairing_node() -> (daemon_config::consts::PeppyDirs, tempfile
     (dirs, root)
 }
 
-/// The gap this check exists to close: a launcher that leaves an optional
-/// pairing slot neither paired nor vacant used to pass `stack resolve` and
-/// fail minutes later at launch. Resolve now refuses it with the launch's
-/// own error.
+/// A launcher that leaves an optional pairing slot neither paired nor
+/// vacant fails `stack resolve` with the launch's own error, before any
+/// image is built.
 #[test]
 fn stack_resolve_fails_an_optional_pairing_slot_left_uncovered() {
     let (dirs, root) = peppy_root_with_pairing_node();


### PR DESCRIPTION
## The gap

A launcher that leaves an optional pairing slot neither paired nor declared
vacant passes `peppy repo index --check` and `peppy stack resolve`, and fails
only at launch, minutes of image builds later:

```
instance `sim_inst` declares optional pairing slot `wrist_left`
(pairing `sim_rgb_camera_link:v1`, role `camera`) with no pair. ...
```

This is how the OpenArm sim-camera work shipped a launcher set where every
sim combination that took no cameras failed to launch while both checks
stayed green (context in Peppy-bot/launchers-hub#37).

## The fix

`stack resolve` now holds the flat plan to the launch-time link rules a
client can check with no daemon:

- `validate_link_slots`: slot-key and vacancy legality, each node judged by
  its own manifest.
- `validate_pairings`: all the pairing rules, coverage included, judged by
  the two endpoints' declarations.

Node manifests come from this machine's nodes cache. On a violation, resolve
refuses with the same error text the launch would produce, so the failure
moves from after the image builds to before them.

The contract-binding rules stay launch-only on purpose: satisfying a
contract slot can involve the root node, which only the daemon knows, so
checking them here would reject plans a launch accepts.

## Never guessing on partial information

The pairing rules judge links by both endpoints, so validating a partial
item list would trade missed errors for false ones. When the cache is
empty, a deployed node is missing from it, or a manifest is git-backed and
not materialized locally, the check is skipped and the report names what
was skipped and why:

```
link rules not checked, 1 manifest(s) unavailable: stranger:v1 (not in the nodes cache)
```

so a clean exit is never mistaken for a validated plan. When everything is
readable the report says so instead:

```
link rules hold: slot keys, vacancies and pairing coverage checked over 9 node manifest(s)
```

Materializing git-backed manifests (a fetch resolve should not do on its
own) is left as a follow-up if wanted; on a machine with fs repositories
the check is complete.

## Verification

- Reproduced the original failure against the launchers-hub tree with the
  vacancy fix stripped: the new resolve exits 1 with the identical three
  errors the launch produced. With the fix in place, the same selections
  pass and report the rules held.
- Four new tests beside the existing resolve tests: the uncovered-slot
  refusal, the vacant-slot pass, the missing-manifest skip, and the
  empty-cache skip. The refusal test fails when the error path is removed,
  checked by mutation.
- `resolve_rendered` now takes `PeppyDirs`, so the tests validate against a
  root they wrote rather than whatever the machine's caches hold.

## Scope: why `repo index --check` is not extended

The Slack report named both commands, and only resolve changes here.
`repo index --check` is a hermetic commit gate: it reads one repository's
tree and already holds every launcher family member to flattening
(`check_composition`). The link rules judge a launcher against the deployed
nodes' manifests, which live in other repositories and reach a machine
through its nodes cache; wiring them into the index check would make the
same commit pass or fail depending on what that machine has refreshed.
Machine-state validation is what resolve is for, so the rules land there.
If the index check should grow a cache-aware, skip-when-unavailable variant
of the same pass, that is a separate decision about that command's contract.
