### PR TITLE
generator: read string lists in topic and action payloads

### DIFF
--- a/crates/generator-internal/src/generator/rust/deserialization.rs
+++ b/crates/generator-internal/src/generator/rust/deserialization.rs
@@ -454,6 +454,32 @@ fn generate_primitive_array_reader(
             })?;
     }];
 
+    // A text list's iterator yields `Result<text::Reader, capnp::Error>` per
+    // element (each string can fail to decode on its own), unlike a numeric
+    // list's plain values, so string elements convert through the same
+    // fallible path the scalar string reader uses.
+    let collect_strings = |vec_ident: &Ident| {
+        quote! {
+            let #vec_ident = #reader_ident
+                .iter()
+                .map(|element| {
+                    element
+                        .map_err(|source| source.to_string())
+                        .and_then(|text| {
+                            text.to_str().map(str::to_owned).map_err(|source| source.to_string())
+                        })
+                        .map_err(|source| {
+                            #[allow(clippy::all)]
+                            let context = #context_expr;
+                            crate::Error::Deserialization(
+                                format!("field '{}' in {}: {}", #field_literal, context, source)
+                            )
+                        })
+                })
+                .collect::<::std::result::Result<Vec<String>, crate::Error>>()?;
+        }
+    };
+
     if let Some(len) = length {
         let len_lit = Literal::usize_unsuffixed(len);
         statements.push(quote! {
@@ -464,12 +490,30 @@ fn generate_primitive_array_reader(
                 ));
             }
         });
-        statements.push(quote! {
-            let mut #value_ident: [#element_ty; #len_lit] = [#element_ty::default(); #len_lit];
-            for (idx, element) in #reader_ident.iter().enumerate() {
-                #value_ident[idx] = element;
-            }
-        });
+        if matches!(token, TypeToken::String) {
+            let vec_ident = names.next("strings");
+            statements.push(collect_strings(&vec_ident));
+            statements.push(quote! {
+                let #value_ident: [String; #len_lit] = match #vec_ident.try_into() {
+                    Ok(array) => array,
+                    // Unreachable: the length was checked above.
+                    Err(elements) => {
+                        return Err(crate::Error::Deserialization(
+                            format!("invalid fixed list length for field '{}': expected {}, got {}", #field_literal, #len_lit, elements.len())
+                        ));
+                    }
+                };
+            });
+        } else {
+            statements.push(quote! {
+                let mut #value_ident: [#element_ty; #len_lit] = [#element_ty::default(); #len_lit];
+                for (idx, element) in #reader_ident.iter().enumerate() {
+                    #value_ident[idx] = element;
+                }
+            });
+        }
+    } else if matches!(token, TypeToken::String) {
+        statements.push(collect_strings(&value_ident));
     } else {
         statements.push(quote! {
             let #value_ident = #reader_ident.iter().collect::<Vec<#element_ty>>();

--- a/crates/generator-internal/tests/helpers.rs
+++ b/crates/generator-internal/tests/helpers.rs
@@ -1460,6 +1460,10 @@ pub const EMITTED_TOPIC_EXAMPLE: &str = r#"
     frame: {
       $type: "array",
       $items: "u8"
+    },
+    tags: {
+      $type: "array",
+      $items: "string"
     }
   }
 }
@@ -1478,6 +1482,10 @@ pub const SUBSCRIBED_TOPIC_FORMAT_EXAMPLE: &str = r#"
   frame: {
     $type: "array",
     $items: "u8"
+  },
+  tags: {
+    $type: "array",
+    $items: "string"
   }
 }
 "#;

--- a/crates/generator-internal/tests/python/topics_communication.rs
+++ b/crates/generator-internal/tests/python/topics_communication.rs
@@ -228,6 +228,7 @@ async def setup(parameters, node_runner) -> list[asyncio.Task]:
                     640,
                     480,
                     bytes([1, 2, 3]),
+                    ["left", "right"],
                 )
             )
             if frame_id == 0:

--- a/crates/generator-internal/tests/rust/multi_binding_communication.rs
+++ b/crates/generator-internal/tests/rust/multi_binding_communication.rs
@@ -168,6 +168,7 @@ fn main() -> Result<()> {
                 break;
             };
             assert_eq!(frame.width, 640, "frame payload must decode per producer");
+            assert_eq!(frame.tags, ["left", "right"], "string list must decode");
             seen.insert(producer.instance_id.clone());
         }
         let mut seen: Vec<String> = seen.into_iter().collect();
@@ -290,6 +291,7 @@ fn main() -> Result<()> {
                     640,
                     480,
                     vec![1, 2, 3],
+                    vec!["left".to_owned(), "right".to_owned()],
                 )
                 .expect("build video_stream message");
                 publisher

--- a/crates/generator-internal/tests/rust/topics_communication.rs
+++ b/crates/generator-internal/tests/rust/topics_communication.rs
@@ -105,6 +105,7 @@ fn main() -> Result<()> {
     NodeBuilder::new().run(|_parameters: peppygen::Parameters, node_runner| async move {
         let mut subscription = subscribe(&node_runner).await?;
         if let Some((producer, frame)) = subscription.next().await? {
+            assert_eq!(frame.tags, ["left", "right"], "string list must decode");
             println!(
                 "got {}x{} frame encoded as {} from {}/{}",
                 frame.width, frame.height, frame.encoding, producer.core_node, producer.instance_id
@@ -194,6 +195,7 @@ fn main() -> Result<()> {
                     640,
                     480,
                     vec![1, 2, 3],
+                    vec!["left".to_owned(), "right".to_owned()],
                 )
                 .expect("build video_stream message");
                 publisher


### PR DESCRIPTION
The generated reader for an array<string> message field did not compile: a capnp text list's iterator yields Result<text::Reader> per element, unlike a numeric list's plain values, and the reader collected it as if it were already Vec<String>. The fixed-length branch had a second problem, requiring Copy for the element default. Publishing string lists always worked, so the gap only surfaced for the first consumer of such a field.

The fix converts string elements through the same fallible path the scalar string reader already uses, for both the sized and unsized forms, with the same field-and-context error wrapping.

Coverage: the shared video_stream example format gains a tags array<string> field, so the existing end-to-end communication tests now build, publish, decode, and value-assert a string list through generated code in both Rust suites (topics_communication asserts the decoded values in the receiver, multi_binding_communication asserts them across both producers) and exercise the Python emitter path. Ran locally: the two Rust communication suites (26 tests) and the generator unit tests (227) pass; the Python suite needs uv/ruff and runs in CI.

Found by the first array<string> topic in contracts-hub (limb_state's name tables, Peppy-bot/contracts-hub#42): the backbone's test harness could not compile its generated subscriber, and a generated MCP server listing that topic as a resource would hit the same wall.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Peppy-bot/codesmith/peppy/pr/407"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789944714&installation_model_id=433186&pr_number=407&repository=Peppy-bot%2Fpeppy&return_to=https%3A%2F%2Fgithub.com%2FPeppy-bot%2Fpeppy%2Fpull%2F407&signature=cd99d1f1dc556ec33ca1fb70190723f0e46e0b678de26c5a33b0014f915e889d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved decoding of string lists, including clearer handling of invalid elements and fixed-length arrays.
  * Added support for string-array `tags` fields in video frame messages.

* **Tests**
  * Expanded communication coverage across Python and Rust integrations.
  * Verified that transmitted tags are correctly decoded as `["left", "right"]`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->