### PR TITLE
docs: sync with the code being released (edf5fe74e541)

### DIFF
--- a/docs/src/content/docs/guides/launch_files.mdx
+++ b/docs/src/content/docs/guides/launch_files.mdx
@@ -446,7 +446,7 @@ Composition changes instances from a distance, so it ships with an audit command
 peppy stack resolve openarm_v2 --with=xr_commander,lerobot_recorder
 ```
 
-`stack resolve` needs no running stack and touches nothing. It prints the flattened `launcher/v1` document to stdout and a resolution report to stderr:
+`stack resolve` needs no running stack. It prints the flattened `launcher/v1` document to stdout and a resolution report to stderr:
 
 ```
 components: robot=real (default)  commander=xr_commander  recorder=lerobot_recorder
@@ -457,6 +457,10 @@ adjustments applied:
 
 adjustments skipped:
   sim_inst.arguments.hardware_version        sim_inst is not in this selection  openarm_v2.json5 (base)
+
+link rules hold: slot keys, vacancies and pairing coverage checked over 6 node manifest(s)
 ```
 
 Every applied adjustment is listed with the value it replaced and the fragment it came from, and every skip says why. Because stdout is a plain launcher, it doubles as the escape hatch: flatten, hand-edit, launch the flat file.
+
+The report ends by holding the flat plan to the launch-time link rules that need no daemon. `stack resolve` reads this machine's nodes cache at `~/.peppy/cache/nodes.json5`, loads each deployed node's manifest, and checks slot-key legality, vacancies, and pairing coverage across them; the `link rules hold` line names how many manifests it checked. The contract-binding rules stay launch-only, because satisfying them can involve the root node that only a running daemon knows. When the plan breaks a rule a launch would reject, say an optional pairing slot left neither paired nor vacant, `stack resolve` fails with that launch's own error instead of surfacing it minutes later at launch. When a manifest cannot be read locally the check is skipped rather than run on a partial picture: the report says `link rules not checked`, names the missing manifest, and advises `peppy repo refresh` when the cache is empty or unreadable.


### PR DESCRIPTION
Automated docs update produced by the release script (`scripts/functions/docs.py`), which found `docs/` lagging the code at the commit the release was being cut from.

Release commit: edf5fe74e5411991e40a91a3b024b2f0d310d528

Gaps the check reported:

- `docs/src/content/docs/guides/launch_files.mdx`: Update the "Auditing a composed launch" section: `stack resolve` no longer just "touches nothing" and prints; it now reads the local nodes cache to validate the flat plan against the launch-time link rules (slot keys, vacancies, pairing coverage), adds "link rules hold" / "link rules not checked" report lines, fails with an error when the plan breaks those rules, and skips the check (advising `peppy repo refresh`) when manifests are missing.

Merge this into `dev`, then re-run the release.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Peppy-bot/codesmith/peppy/pr/408"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789965578&installation_model_id=433186&pr_number=408&repository=Peppy-bot%2Fpeppy&return_to=https%3A%2F%2Fgithub.com%2FPeppy-bot%2Fpeppy%2Fpull%2F408&signature=e57db9e6b4fa81f9e8288fb1b2a7a19d0ae30392f96b0772b08b3a70f57d4e93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->