### PR TITLE
test: rename openarm_commander fixture to openarm_web_commander in st…

### DIFF
--- a/crates/core-node-internal/assets/default_repositories.json5
+++ b/crates/core-node-internal/assets/default_repositories.json5
@@ -11,21 +11,14 @@
     url: "https://github.com/Peppy-bot/launchers-hub.git",
     ref: "main"
   },
-  // OpenArm01 specific nodes
   {
     id: 1002,
-    type: "git",
-    url: "https://github.com/Peppy-bot/openarm-nodes.git",
-    ref: "main"
-  },
-  {
-    id: 1003,
     type: "git",
     url: "https://github.com/Peppy-bot/contracts-hub.git",
     ref: "main"
   },
   {
-    id: 1004,
+    id: 1003,
     type: "git",
     url: "https://github.com/Peppy-bot/mcp-hub.git",
     ref: "main"

--- a/crates/peppy/tests/fixtures/hub/nodes/openarm_web_commander/peppy.json5
+++ b/crates/peppy/tests/fixtures/hub/nodes/openarm_web_commander/peppy.json5
@@ -1,7 +1,7 @@
 {
   peppy_schema: "node/v1",
   manifest: {
-    name: "openarm_commander",
+    name: "openarm_web_commander",
     tag: "v1",
     implements: [
       // Runtime on/off for the backbone's self-collision governor, driven by
@@ -33,7 +33,7 @@
   },
   execution: {
     language: "rust",
-    run_cmd: ["./bin/openarm_commander"]
+    run_cmd: ["./bin/openarm_web_commander"]
   },
   interfaces: {
     services: {

--- a/crates/peppy/tests/stack_launch.rs
+++ b/crates/peppy/tests/stack_launch.rs
@@ -3619,11 +3619,11 @@ async fn stack_launch_serves_a_commander_panels_observer_slots() {
         })
         .collect();
     staged.push((
-        "openarm_commander",
+        "openarm_web_commander",
         "v1",
         stage_hub_fixture_node(
             nodes_dir.path(),
-            "openarm_commander",
+            "openarm_web_commander",
             &git_hash,
             &commander_run_cmd,
         ),
@@ -3649,7 +3649,7 @@ async fn stack_launch_serves_a_commander_panels_observer_slots() {
         ("openarm_joint_follower", "follower_2"),
         ("openarm_gripper_leader", "grip_leader_1"),
         ("openarm_gripper_follower", "grip_follower_1"),
-        ("openarm_commander", "commander_inst"),
+        ("openarm_web_commander", "commander_inst"),
     ] {
         let ready = listen_for_node_ready(
             &node_messenger,
@@ -3720,7 +3720,7 @@ async fn stack_launch_serves_a_commander_panels_observer_slots() {
         &node_messenger,
         &core_node_name,
         "commander_inst",
-        test_node_target("openarm_commander"),
+        test_node_target("openarm_web_commander"),
         Arc::new(obs_senders),
     )
     .await
@@ -3765,7 +3765,7 @@ async fn stack_launch_serves_a_commander_panels_observer_slots() {
                     instances: [{ instance_id: "grip_follower_1" }]
                 },
                 {
-                    source: { name: "openarm_commander:v1" },
+                    source: { name: "openarm_web_commander:v1" },
                     instances: [{
                         instance_id: "commander_inst",
                         links: {


### PR DESCRIPTION
…ack_launch test

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Peppy-bot/codesmith/peppy/pr/411"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790334176&installation_model_id=433186&pr_number=411&repository=Peppy-bot%2Fpeppy&return_to=https%3A%2F%2Fgithub.com%2FPeppy-bot%2Fpeppy%2Fpull%2F411&signature=9a925460b5d31586408e34f74be4bf30794c0710e3782de9f714088a5264436e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->