### PR TITLE
docs: sync with the code being released (688738132f21)

### DIFF
--- a/docs/src/content/docs/advanced_guides/repositories.mdx
+++ b/docs/src/content/docs/advanced_guides/repositories.mdx
@@ -13,13 +13,12 @@ Repositories tell Peppy where to look for nodes, launchers, contracts, pairings,
 - **Pairings**, identified by content: every `.json5` file whose body declares `peppy_schema: "pairing/v1"` is treated as a pairing, regardless of its filename. A pairing is a two-role, topics-only contract that two node instances pair 1:1 over, keyed by the `name:tag` declared in its manifest; see [Pairing](/advanced_guides/pairing/).
 - **MCP exposures**, identified by content: every `.json5` file whose body declares `peppy_schema: "mcp_exposure/v1"` is treated as an MCP exposure, regardless of its filename, keyed by the `name:tag` declared in its manifest. An exposure selects members of contracts and gives them stable public names, MCP-facing prose, and operational policies; a launcher lists exposures by `name:tag` and the server built into `peppy` serves them, and [`peppy repo index --check --validate-mcp-exposures`](#check-the-exposures-a-repository-publishes) validates each one against the contracts it references. See [MCP exposure](/advanced_guides/mcp/).
 
-Out of the box, five repositories are configured:
+Out of the box, four repositories are configured:
 
 - **`nodes-hub`** (`https://github.com/Peppy-bot/nodes-hub.git`, tracked on `main`, id `1000`): a curated collection of ready-to-use nodes.
 - **`launchers-hub`** (`https://github.com/Peppy-bot/launchers-hub.git`, tracked on `main`, id `1001`): community launch files that compose nodes from the hubs.
-- **`openarm-nodes`** (`https://github.com/Peppy-bot/openarm-nodes.git`, tracked on `main`, id `1002`): nodes specific to the OpenArm01 robot.
-- **`contracts-hub`** (`https://github.com/Peppy-bot/contracts-hub.git`, tracked on `main`, id `1003`): shared contract definitions that nodes claim by `name:tag` in `manifest.implements`.
-- **`mcp-hub`** (`https://github.com/Peppy-bot/mcp-hub.git`, tracked on `main`, id `1004`): [MCP exposure](/advanced_guides/mcp/) documents that a launcher lists by `name:tag` and the server built into `peppy` serves.
+- **`contracts-hub`** (`https://github.com/Peppy-bot/contracts-hub.git`, tracked on `main`, id `1002`): shared contract definitions that nodes claim by `name:tag` in `manifest.implements`.
+- **`mcp-hub`** (`https://github.com/Peppy-bot/mcp-hub.git`, tracked on `main`, id `1003`): [MCP exposure](/advanced_guides/mcp/) documents that a launcher lists by `name:tag` and the server built into `peppy` serves.
 
 The `id` is the priority key when several repositories provide the same `name:tag`, so the defaults resolve in this order.
 


### PR DESCRIPTION
Automated docs update produced by the release script (`scripts/functions/docs.py`), which found `docs/` lagging the code at the commit the release was being cut from.

Release commit: 688738132f21ecf82592906ca94c1ae88375eb4e

Gaps the check reported:

- `docs/src/content/docs/advanced_guides/repositories.mdx`: Update the default-repositories list (lines 16-24): change "five repositories" to four, remove the openarm-nodes (OpenArm01) entry, and renumber contracts-hub to id 1002 and mcp-hub to id 1003.

Merge this into `dev`, then re-run the release.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Peppy-bot/codesmith/peppy/pr/412"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790345265&installation_model_id=433186&pr_number=412&repository=Peppy-bot%2Fpeppy&return_to=https%3A%2F%2Fgithub.com%2FPeppy-bot%2Fpeppy%2Fpull%2F412&signature=916134ee040c43d5cfe65712ff0800b073790b8a4c7d61d85c9d2f4546654ed9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->