### PR TITLE
Settle feedback-less MCP tasks on a parked result request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1075,6 +1075,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914a755b7c2d4af2bdcff7ce1739e2db9a1b81a9b07123d8015786ae03c0980d"
+dependencies = [
+ "link-section",
+ "linktime-proc-macro",
+]
+
+[[package]]
 name = "daemon"
 version = "0.0.1"
 dependencies = [
@@ -2848,6 +2858,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "link-section"
+version = "0.19.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39c29a617ce3df32c08497bdc1ab6e2376e0b17948ac166a2fbe5977c5954cd9"
+
+[[package]]
+name = "linktime-proc-macro"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e57c38c1e860fd37c604281cdfb1dd2216977fd76a50f85ba2f388ef3219616"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3609,9 +3631,11 @@ dependencies = [
  "capnp",
  "capnpc",
  "core-node-api",
+ "ctor",
  "flume 0.12.0",
  "futures",
  "jsonschema",
+ "libc",
  "peppy-config-model",
  "pmi",
  "schemars 1.2.2",

--- a/crates/mcp-server-internal/Cargo.toml
+++ b/crates/mcp-server-internal/Cargo.toml
@@ -28,3 +28,9 @@ thiserror = "2.0"
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "time"] }
 tokio-util = "0.7"
 tracing = "0.1"
+
+[dev-dependencies]
+# The provider double and the ephemeral router the bridge tests drive a
+# real goal through.
+peppylib = { workspace = true, features = ["testing"] }
+tokio = { version = "1", features = ["sync"] }

--- a/crates/mcp-server-internal/src/bridges.rs
+++ b/crates/mcp-server-internal/src/bridges.rs
@@ -8,17 +8,22 @@ use crate::serve::ServeError;
 use config::node::{MessageFormat, NativeExposedAction};
 use message_codec::MessageCodec;
 use message_codec::consumer::{
-    ActionClient, ConsumerIdentity, GoalOutcome, MemberBinding, ServiceClient, TopicConsumer,
+    ActionClient, ConsumerError, ConsumerIdentity, GoalHandle, GoalOutcome, MemberBinding,
+    ServiceClient, TopicConsumer,
 };
 use peppy_mcp_catalog::{BundleContractPin, ExposureBundle, ValidatedExposure};
 use peppy_mcp_runtime::{ActionContext, ActionExit, ResourceIngest, ToolCallError};
 use peppylib::config::QoSProfile;
-use peppylib::messaging::SenderTarget;
+use peppylib::messaging::{MessengerHandle, ProducerRef, SenderTarget};
 use peppylib::runtime::NodeRunner;
 use serde_json::Value;
 use std::collections::HashMap;
+use std::future::Future;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
+
+#[cfg(test)]
+mod tests;
 
 /// One exposure ready to serve: its catalog and the bridge behind every
 /// entry.
@@ -74,9 +79,10 @@ pub(crate) struct PreparedTask {
     pub binding: Binding,
     pub client: ActionClient,
     pub feedback_qos: QoSProfile,
-    /// Whether the action declares a feedback message; a feedback-less
-    /// action's stream carries only the terminal sentinel, which is not
-    /// reported as task progress.
+    /// Whether the action declares a feedback message. A goal on such an
+    /// action settles once the provider closes the stream at the terminal
+    /// result; a feedback-less action's stream carries nothing, not even
+    /// that close, so a goal on it settles on a parked result request.
     pub reports_feedback: bool,
     pub deadline: Duration,
 }
@@ -245,7 +251,7 @@ pub(crate) fn prepare(
 
 /// The feedback subscription follows the contract: the QoS profile the
 /// action's feedback topic declares picks the subscriber's buffering tier,
-/// and a feedback-less action's sentinel-only stream takes the default.
+/// and a feedback-less action's empty stream takes the default.
 fn feedback_qos(action: &NativeExposedAction) -> QoSProfile {
     action
         .feedback_topic
@@ -327,14 +333,29 @@ pub(crate) async fn call_tool(
         .map_err(|error| ToolCallError::Failed(error.to_string()))
 }
 
-/// Runs the action behind a task: fires the goal, pumps feedback into the
-/// task's status, forwards `tasks/cancel` cooperatively, and maps the Peppy
-/// terminal result onto the MCP terminal state.
-///
-/// The deadline is the whole-goal deadline, so every await after the goal
-/// is fired spends what is left of it rather than restarting it: a
-/// provider that keeps sending feedback, or a cancel that takes its own
-/// time, cannot push the bridge past the deadline the tool advertises.
+/// The runtime-side surface a goal drives while it runs: its feedback
+/// becomes the task's status message, and the client's `tasks/cancel`
+/// reaches the provider through it.
+pub(crate) trait TaskSurface: Sync {
+    fn report_feedback(&self, message: String);
+
+    /// Resolves once the client has requested cancellation (immediately, if
+    /// it already has).
+    fn cancel_requested(&self) -> impl Future<Output = ()> + Send;
+}
+
+impl TaskSurface for ActionContext {
+    fn report_feedback(&self, message: String) {
+        ActionContext::report_feedback(self, message);
+    }
+
+    fn cancel_requested(&self) -> impl Future<Output = ()> + Send {
+        ActionContext::cancel_requested(self)
+    }
+}
+
+/// Runs the action behind a task on the producer the launcher bound to its
+/// target.
 pub(crate) async fn run_task(
     task: &PreparedTask,
     node_runner: &NodeRunner,
@@ -342,12 +363,42 @@ pub(crate) async fn run_task(
     input: Value,
     context: ActionContext,
 ) -> Result<Value, ActionExit> {
-    let messenger = node_runner.messenger();
     let binding = task.binding.member_binding(node_runner);
     let producer = node_runner
         .processor()
         .sole_bound_producer(&task.binding.target)
         .clone();
+    drive_goal(
+        task,
+        node_runner.messenger(),
+        identity,
+        &binding,
+        &producer,
+        input,
+        &context,
+    )
+    .await
+}
+
+/// Drives the goal behind a task: fires it at `producer`, settles it on the
+/// provider's terminal result, and maps that result onto the MCP terminal
+/// state. Cancellation is cooperative on both sides: `tasks/cancel` is
+/// forwarded once to the Peppy cancel path, and the terminal result the
+/// provider settles on decides the task's terminal state.
+///
+/// The deadline is the whole-goal deadline, so every await after the goal
+/// is fired spends what is left of it rather than restarting it: a
+/// provider that keeps sending feedback, or a cancel that takes its own
+/// time, cannot push the bridge past the deadline the tool advertises.
+pub(crate) async fn drive_goal(
+    task: &PreparedTask,
+    messenger: &MessengerHandle,
+    identity: &ConsumerIdentity,
+    binding: &MemberBinding,
+    producer: &ProducerRef,
+    input: Value,
+    surface: &impl TaskSurface,
+) -> Result<Value, ActionExit> {
     let started = Instant::now();
     let deadline = task.deadline;
     let remaining = || deadline.saturating_sub(started.elapsed());
@@ -357,8 +408,8 @@ pub(crate) async fn run_task(
         .fire_goal(
             messenger,
             identity,
-            &binding,
-            &producer,
+            binding,
+            producer,
             &input,
             task.feedback_qos.clone(),
             deadline,
@@ -372,11 +423,33 @@ pub(crate) async fn run_task(
         }));
     }
 
-    // Cancellation is cooperative on both sides: `tasks/cancel` is
-    // forwarded once to the Peppy cancel path, and the terminal result the
-    // provider settles on decides the task's terminal state. The feedback
-    // stream ends at the terminal result (clean close) or when the producer
-    // disappears; either way the result reply below settles the outcome.
+    let outcome = if task.reports_feedback {
+        settle_after_feedback(&mut handle, messenger, surface, &remaining).await
+    } else {
+        settle_on_result(&handle, messenger, surface, &remaining).await
+    }
+    .map_err(|error| ActionExit::Failed(error.to_string()))?;
+    match outcome {
+        GoalOutcome::Completed(value) => Ok(value),
+        GoalOutcome::Cancelled => Err(ActionExit::Cancelled),
+        GoalOutcome::Abandoned => Err(ActionExit::Failed(
+            "the provider abandoned the goal".to_owned(),
+        )),
+        GoalOutcome::Expired => Err(ActionExit::Failed(
+            "the goal expired before reaching a terminal result".to_owned(),
+        )),
+    }
+}
+
+/// Settles a goal on an action with feedback: every message is reported as
+/// the task's status until the provider closes the stream at the terminal
+/// result (or disappears), then the result reply decides the outcome.
+async fn settle_after_feedback(
+    handle: &mut GoalHandle,
+    messenger: &MessengerHandle,
+    surface: &impl TaskSurface,
+    remaining: &impl Fn() -> Duration,
+) -> Result<GoalOutcome, ConsumerError> {
     let mut cancel_pending = false;
     let mut cancel_forwarded = false;
     // Armed once rather than per message: a feedback stream can be fast,
@@ -391,31 +464,39 @@ pub(crate) async fn run_task(
         }
         tokio::select! {
             _ = &mut expiry => break,
-            _ = context.cancel_requested(), if !cancel_forwarded => {
+            _ = surface.cancel_requested(), if !cancel_forwarded => {
                 cancel_pending = true;
             }
             message = handle.next_feedback() => match message {
-                Ok(Some(value)) => {
-                    if task.reports_feedback {
-                        context.report_feedback(value.to_string());
-                    }
-                }
+                Ok(Some(value)) => surface.report_feedback(value.to_string()),
                 Ok(None) | Err(_) => break,
             }
         }
     }
-    let outcome = handle
-        .result(messenger, remaining())
-        .await
-        .map_err(|error| ActionExit::Failed(error.to_string()))?;
-    match outcome {
-        GoalOutcome::Completed(value) => Ok(value),
-        GoalOutcome::Cancelled => Err(ActionExit::Cancelled),
-        GoalOutcome::Abandoned => Err(ActionExit::Failed(
-            "the provider abandoned the goal".to_owned(),
-        )),
-        GoalOutcome::Expired => Err(ActionExit::Failed(
-            "the goal expired before reaching a terminal result".to_owned(),
-        )),
+    handle.result(messenger, remaining()).await
+}
+
+/// Settles a goal on a feedback-less action: its stream carries nothing,
+/// not even a close at the terminal result, so the result request is parked
+/// on the provider from the start and its reply decides the outcome. The
+/// request stays parked while a cancel is forwarded; the provider settling
+/// the goal cancelled is what answers it.
+async fn settle_on_result(
+    handle: &GoalHandle,
+    messenger: &MessengerHandle,
+    surface: &impl TaskSurface,
+    remaining: &impl Fn() -> Duration,
+) -> Result<GoalOutcome, ConsumerError> {
+    let result = handle.result(messenger, remaining());
+    tokio::pin!(result);
+    let mut cancel_forwarded = false;
+    loop {
+        tokio::select! {
+            outcome = &mut result => return outcome,
+            _ = surface.cancel_requested(), if !cancel_forwarded => {
+                cancel_forwarded = true;
+                let _ = handle.cancel(messenger, remaining()).await;
+            }
+        }
     }
 }

--- a/crates/mcp-server-internal/src/bridges/tests.rs
+++ b/crates/mcp-server-internal/src/bridges/tests.rs
@@ -1,0 +1,265 @@
+//! The goal loop driven against a real provider: an ephemeral router, a
+//! mock action server running peppylib's production goal engine, and the
+//! bridge settling on each outcome a provider can reach. Every step waits
+//! on the peer's action, never on the clock: the deadline only bounds the
+//! failure path.
+
+use super::{Binding, PreparedTask, TaskSurface, drive_goal};
+use config::node::{MessageFormat, QoSProfile};
+use message_codec::MessageCodec;
+use message_codec::consumer::{ActionClient, ConsumerIdentity, MemberBinding};
+use peppy_mcp_runtime::ActionExit;
+use peppylib::messaging::{MessengerHandle, NonEmptyPayload, ProducerRef, SenderTarget};
+use peppylib::testing::{
+    EphemeralRouter, MockActionServerCore, READINESS_TIMEOUT, wait_action_reachable,
+};
+use peppylib::types::Payload;
+use serde_json::{Value, json};
+use std::future::Future;
+use std::sync::Mutex;
+use std::time::Duration;
+use tokio_util::sync::CancellationToken;
+
+const CORE_NODE: &str = "test_core";
+const PROVIDER_INSTANCE: &str = "backbone_inst";
+const BRIDGE_INSTANCE: &str = "commander_inst";
+const LINK_ID: &str = "limb_motion";
+const MEMBER: &str = "move_gripper";
+/// The whole-goal deadline: a bound on the failure path only, every step
+/// below settles the moment the provider acts.
+const DEADLINE: Duration = Duration::from_secs(10);
+
+/// The runtime surface, scripted: cancellation fires when the test says so
+/// and every feedback message is kept for the assertions.
+struct ScriptedSurface {
+    cancel: CancellationToken,
+    feedback: Mutex<Vec<String>>,
+}
+
+impl ScriptedSurface {
+    fn new() -> Self {
+        Self {
+            cancel: CancellationToken::new(),
+            feedback: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn feedback(&self) -> Vec<String> {
+        self.feedback
+            .lock()
+            .expect("no test panicked with the lock")
+            .clone()
+    }
+}
+
+impl TaskSurface for ScriptedSurface {
+    fn report_feedback(&self, message: String) {
+        self.feedback
+            .lock()
+            .expect("no test panicked with the lock")
+            .push(message);
+    }
+
+    fn cancel_requested(&self) -> impl Future<Output = ()> + Send {
+        self.cancel.cancelled()
+    }
+}
+
+/// One mesh per test: the router, a session per side, and the provider's
+/// identity as the launcher would have bound it to the task's target.
+struct Mesh {
+    bridge_messenger: MessengerHandle,
+    _provider_messenger: MessengerHandle,
+    _router: EphemeralRouter,
+    contract: SenderTarget,
+    producer: ProducerRef,
+}
+
+/// Starts the mesh and exposes `MEMBER` on it, returning once the bridge's
+/// session can reach the provider.
+async fn mesh(has_feedback: bool) -> (Mesh, MockActionServerCore) {
+    let router = EphemeralRouter::start()
+        .await
+        .expect("the ephemeral router starts");
+    let provider_messenger = router.connect().await.expect("the provider connects");
+    let bridge_messenger = router.connect().await.expect("the bridge connects");
+    let contract = SenderTarget::contract("limb_motion", "v1").expect("a valid contract identity");
+    let provider = MockActionServerCore::expose(
+        &provider_messenger,
+        CORE_NODE,
+        PROVIDER_INSTANCE,
+        contract.clone(),
+        MEMBER,
+        has_feedback,
+    )
+    .await
+    .expect("the provider exposes the action");
+    let producer = ProducerRef::new(CORE_NODE, PROVIDER_INSTANCE);
+    wait_action_reachable(
+        &bridge_messenger,
+        CORE_NODE,
+        BRIDGE_INSTANCE,
+        contract.clone(),
+        MEMBER,
+        &producer,
+        READINESS_TIMEOUT,
+    )
+    .await
+    .expect("the action becomes reachable");
+    (
+        Mesh {
+            bridge_messenger,
+            _provider_messenger: provider_messenger,
+            _router: router,
+            contract,
+            producer,
+        },
+        provider,
+    )
+}
+
+fn codec(label: &str, format: Value) -> MessageCodec {
+    let format: MessageFormat = serde_json::from_value(format).expect("the format parses");
+    MessageCodec::new(label, format).expect("the format lays out")
+}
+
+fn result_codec() -> MessageCodec {
+    codec("move_gripper_result", json!({ "success": "bool" }))
+}
+
+fn encoded(codec: &MessageCodec, value: Value) -> Payload {
+    Payload::from(codec.encode(&value).expect("the value fits the format"))
+}
+
+/// The task as `prepare` lays it out for an action with a result and,
+/// optionally, a feedback message.
+fn prepared_task(mesh: &Mesh, feedback: Option<MessageCodec>) -> PreparedTask {
+    PreparedTask {
+        name: "openarm.move_gripper".to_owned(),
+        binding: Binding {
+            target: LINK_ID.to_owned(),
+            contract: mesh.contract.clone(),
+            member: MEMBER.to_owned(),
+        },
+        reports_feedback: feedback.is_some(),
+        client: ActionClient::new(None, feedback, Some(result_codec())),
+        feedback_qos: QoSProfile::Reliable,
+        deadline: DEADLINE,
+    }
+}
+
+/// Drives one goal through the bridge exactly as `run_task` does once the
+/// node runner has resolved the binding.
+async fn drive(
+    mesh: &Mesh,
+    task: &PreparedTask,
+    surface: &ScriptedSurface,
+) -> Result<Value, ActionExit> {
+    let identity = ConsumerIdentity {
+        core_node: CORE_NODE.to_owned(),
+        instance_id: BRIDGE_INSTANCE.to_owned(),
+    };
+    let binding = MemberBinding {
+        target: mesh.contract.clone(),
+        member: MEMBER.to_owned(),
+        producers: vec![mesh.producer.clone()],
+    };
+    drive_goal(
+        task,
+        &mesh.bridge_messenger,
+        &identity,
+        &binding,
+        &mesh.producer,
+        json!({}),
+        surface,
+    )
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_feedback_less_goal_settles_on_its_completed_result() {
+    let (mesh, mut provider) = mesh(false).await;
+    let task = prepared_task(&mesh, None);
+    let surface = ScriptedSurface::new();
+
+    let (outcome, _context) = tokio::join!(drive(&mesh, &task, &surface), async {
+        let goal = provider
+            .next_goal(READINESS_TIMEOUT)
+            .await
+            .expect("the goal reaches the provider");
+        let context = goal
+            .accept(Payload::new())
+            .await
+            .expect("the provider accepts the goal");
+        context
+            .complete(encoded(&result_codec(), json!({ "success": true })))
+            .await
+            .expect("the provider completes the goal");
+        context
+    });
+
+    assert_eq!(outcome, Ok(json!({ "success": true })));
+    assert_eq!(surface.feedback(), Vec::<String>::new());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_feedback_less_goal_settles_cancelled_once_the_provider_honors_the_cancel() {
+    let (mesh, mut provider) = mesh(false).await;
+    let task = prepared_task(&mesh, None);
+    let surface = ScriptedSurface::new();
+
+    let (outcome, _context) = tokio::join!(drive(&mesh, &task, &surface), async {
+        let goal = provider
+            .next_goal(READINESS_TIMEOUT)
+            .await
+            .expect("the goal reaches the provider");
+        let context = goal
+            .accept(Payload::new())
+            .await
+            .expect("the provider accepts the goal");
+        // The client cancels while the goal runs: the bridge forwards it,
+        // and the provider settles the goal cancelled once it observes it.
+        surface.cancel.cancel();
+        context.cancel_signal().await;
+        context
+            .complete_cancelled(Payload::new())
+            .await
+            .expect("the provider settles the goal cancelled");
+        context
+    });
+
+    assert_eq!(outcome, Err(ActionExit::Cancelled));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_goal_with_feedback_reports_it_and_settles_on_its_result() {
+    let (mesh, mut provider) = mesh(true).await;
+    let feedback = codec("move_gripper_feedback", json!({ "percent": "u8" }));
+    let task = prepared_task(&mesh, Some(feedback.clone()));
+    let surface = ScriptedSurface::new();
+
+    let (outcome, _context) = tokio::join!(drive(&mesh, &task, &surface), async {
+        let goal = provider
+            .next_goal(READINESS_TIMEOUT)
+            .await
+            .expect("the goal reaches the provider");
+        let context = goal
+            .accept(Payload::new())
+            .await
+            .expect("the provider accepts the goal");
+        let progress = NonEmptyPayload::try_new(encoded(&feedback, json!({ "percent": 50 })))
+            .expect("an encoded message is never empty");
+        context
+            .publish_feedback(progress)
+            .await
+            .expect("the provider publishes feedback");
+        context
+            .complete(encoded(&result_codec(), json!({ "success": true })))
+            .await
+            .expect("the provider completes the goal");
+        context
+    });
+
+    assert_eq!(outcome, Ok(json!({ "success": true })));
+    assert_eq!(surface.feedback(), vec![r#"{"percent":50}"#.to_owned()]);
+}


### PR DESCRIPTION
`peppy mcp serve` drove every task the same way: drain the goal's feedback stream until the provider closes it at the terminal result, then request the result with whatever was left of the deadline. A feedback-less action (`postures:v1`, `limb_motion:v1`) never closes that stream, because peppylib declares no per-goal feedback publisher for it, so every accepted goal waited out the whole deadline and then polled the result with a zero budget, surfacing as `action '<member>' for instance '<instance>' is unreachable for result` while the provider had in fact completed the move. The bridge now settles by what the contract declares: a task on an action with feedback keeps pumping the stream into the task's status until its close, and a task on a feedback-less action parks its result request on the provider from the start, the way generated consumers wait for such results, with `tasks/cancel` still forwarded once while the request stays parked. To drive that loop against a real provider, the goal loop runs over a messenger, a binding and a producer (`drive_goal`) behind a two-method `TaskSurface` trait that `ActionContext` implements, since rmcp's `TaskContext` cannot be built outside the runtime. peppylib's `testing` feature joins the crate's dev-dependencies, which adds `ctor` and its two helpers to `Cargo.lock`.

## Test plan

- [x] New `bridges::tests`, each on an ephemeral zenoh router with `peppylib::testing::MockActionServerCore` running the production goal engine: a feedback-less goal settles on its completed result; a feedback-less goal settles cancelled once the provider honors the forwarded cancel; a goal with feedback still reports it and settles on its result. Every step waits on the peer's action, never on the clock.
- [x] Written first against the unchanged bridge: the two feedback-less tests failed with `action 'move_gripper' for instance 'backbone_inst' is unreachable for result` after the 10 s deadline and the feedback test passed; with the fix all three pass in about 0.3 s, over five consecutive `cargo test -p mcp-server --locked` runs.
- [x] `cargo clippy -p mcp-server --all-targets` and `cargo fmt --check` clean.
- [x] Live, on a MuJoCo OpenArm v2 stack with the `mcp_commander` launcher option (Peppy-bot/mcp-hub#2, Peppy-bot/launchers-hub#41) on a Jetson: with v0.26.1 every accepted `openarm.*` move failed after exactly its deadline with the message above; with a daemon running this branch's `peppy` binary, `openarm_v2_demo.py demo` runs all six steps to completion with each tool's structured result (`move_to_ready`, four `move_gripper`, `move_to_home`), a `move_to_ready` interrupted by SIGINT settles `cancelled` through `tasks/cancel`, `move_arm` returns the backbone's planner verdict, a refused goal still comes back as `failed: the provider rejected the goal: opening 2 outside [0, 1]`, and `peppy stack reset` leaves no server behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Peppy-bot/codesmith/peppy/pr/413"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790457895&installation_model_id=433186&pr_number=413&repository=Peppy-bot%2Fpeppy&return_to=https%3A%2F%2Fgithub.com%2FPeppy-bot%2Fpeppy%2Fpull%2F413&signature=557c4c93b4bbd93ba0628c96337f755529fb9267a23bee85403f9a8f7db7298a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
