### PR TITLE
Strip build host identity from release artifacts

### DIFF
--- a/crates/containers-internal/build.rs
+++ b/crates/containers-internal/build.rs
@@ -44,10 +44,11 @@ mod apptainer_build {
     /// afterwards) squashfuse is compiled for the target ISA, so it can only be
     /// produced inside the build environment that built apptainer itself.
     ///
-    /// r3 scrubs the building user's home directory out of the installed man
-    /// pages, which render flag defaults from `$HOME` at build time and ship
-    /// inside release archives otherwise.
-    const APPTAINER_RECIPE_REVISION: u32 = 3;
+    /// r3 and r4 scrub the building user's home directory out of the installed
+    /// man pages, which render flag defaults from `$HOME` at build time and
+    /// ship inside release archives otherwise. r4 extends the scrub to the
+    /// native Linux build path, which r3 covered only inside Lima guests.
+    const APPTAINER_RECIPE_REVISION: u32 = 4;
 
     /// Directory, relative to the apptainer install prefix, holding the shared
     /// libraries bundled with the binaries (see [`APPTAINER_CGO_LDFLAGS`]).
@@ -228,6 +229,13 @@ mod apptainer_build {
     /// Guest-side installation path for apptainer inside the Lima VM.
     /// Must match the `--prefix` used at build time.
     const GUEST_APPTAINER_DIR: &str = "/tmp/peppy/apptainer";
+
+    /// Replacement for the building user's home directory in generated man
+    /// pages: apptainer renders flag defaults in them from `$HOME` at build
+    /// time, and the pages ship inside release archives, so neither the guest
+    /// build script nor [`scrub_man_page_builder_home`] may leave the real one
+    /// in place.
+    const MAN_PAGE_HOME_PLACEHOLDER: &str = "/home/apptainer-builder";
 
     // -----------------------------------------------------------------------
     // Cache helpers
@@ -1623,6 +1631,10 @@ mod apptainer_build {
             return false;
         }
 
+        if !scrub_man_page_builder_home(install_dir) {
+            return false;
+        }
+
         // Clean up source directory
         std::fs::remove_dir_all(&source_dir).ok();
 
@@ -1643,6 +1655,55 @@ mod apptainer_build {
         // Refusing a mismatched result here turns a wrong-arch build into a
         // build failure instead of a cache entry every later release reuses.
         installed_arch_matches(install_dir, target_arch, "built natively")
+    }
+
+    /// Rewrite the building user's home directory out of the installed man
+    /// pages. The guest build script does the same with `sed` right after its
+    /// `make install`; this covers the native Linux source build, which
+    /// installs through `run_command` instead. Returns false on an I/O error,
+    /// failing the build rather than shipping an identifying tree.
+    fn scrub_man_page_builder_home(install_dir: &Path) -> bool {
+        let Some(home) = std::env::var_os("HOME") else {
+            // Without a home directory nothing was baked into the pages.
+            return true;
+        };
+        let home = home.to_string_lossy();
+        let man_dir = install_dir.join("share/man");
+        let mut stack = vec![man_dir];
+        while let Some(dir) = stack.pop() {
+            let entries = match std::fs::read_dir(&dir) {
+                Ok(entries) => entries,
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(e) => {
+                    println!(
+                        "cargo:warning=Failed to read man page directory {:?}: {}",
+                        dir, e
+                    );
+                    return false;
+                }
+            };
+            for entry in entries {
+                let Ok(entry) = entry else {
+                    continue;
+                };
+                let path = entry.path();
+                if path.is_dir() {
+                    stack.push(path);
+                    continue;
+                }
+                let Ok(contents) = std::fs::read_to_string(&path) else {
+                    continue;
+                };
+                if contents.contains(home.as_ref()) {
+                    let scrubbed = contents.replace(home.as_ref(), MAN_PAGE_HOME_PLACEHOLDER);
+                    if let Err(e) = std::fs::write(&path, scrubbed) {
+                        println!("cargo:warning=Failed to scrub man page {:?}: {}", path, e);
+                        return false;
+                    }
+                }
+            }
+        }
+        true
     }
 
     /// Build apptainer from source inside a Lima VM and copy the result back.
@@ -1805,7 +1866,7 @@ echo "=== Scrubbing the builder home from man pages ==="
 # Apptainer renders flag defaults in its man pages from the building user's
 # $HOME; a generic path keeps the build account out of release archives.
 if [ -d {install_dir}/share/man ]; then
-  find {install_dir}/share/man -type f -exec sed -i "s|$HOME|/home/apptainer-builder|g" {{}} +
+  find {install_dir}/share/man -type f -exec sed -i "s|$HOME|{man_page_home}|g" {{}} +
 fi
 echo "=== Bundling {libseccomp} ==="
 # The rpaths above point the binaries here, so the bundle — not the runtime
@@ -1848,8 +1909,9 @@ rm -rf /tmp/apptainer-{version} /tmp/apptainer-{version}.tar.gz"#,
             cgo_ldflags = APPTAINER_CGO_LDFLAGS,
             libseccomp = LIBSECCOMP_SONAME,
             lib_dir = APPTAINER_BUNDLED_LIB_DIR,
-            sq_version = SQUASHFUSE_VERSION,
+            man_page_home = MAN_PAGE_HOME_PLACEHOLDER,
             sq_sha = SQUASHFUSE_SHA256,
+            sq_version = SQUASHFUSE_VERSION,
             sq_url = squashfuse_source_url(SQUASHFUSE_VERSION),
         )
     }

--- a/crates/containers-internal/build.rs
+++ b/crates/containers-internal/build.rs
@@ -43,7 +43,11 @@ mod apptainer_build {
     /// gocryptfs (a prebuilt download that can be dropped into any cache
     /// afterwards) squashfuse is compiled for the target ISA, so it can only be
     /// produced inside the build environment that built apptainer itself.
-    const APPTAINER_RECIPE_REVISION: u32 = 2;
+    ///
+    /// r3 scrubs the building user's home directory out of the installed man
+    /// pages, which render flag defaults from `$HOME` at build time and ship
+    /// inside release archives otherwise.
+    const APPTAINER_RECIPE_REVISION: u32 = 3;
 
     /// Directory, relative to the apptainer install prefix, holding the shared
     /// libraries bundled with the binaries (see [`APPTAINER_CGO_LDFLAGS`]).
@@ -238,11 +242,18 @@ mod apptainer_build {
     /// squashfuse is compiled into the tree with no version marker of its own —
     /// unlike gocryptfs, which carries a version-keyed sentinel of its own
     /// ([`gocryptfs_sentinel_path`]) and so re-installs itself on a bump.
-    fn apptainer_cache_sentinel_path(cache_dir: &Path, version: &str) -> PathBuf {
-        cache_dir.join(format!(
+    /// The bare file name, also exported to the crate (see
+    /// [`emit_constant_env_vars`]) so runtime code can locate the sentinel
+    /// without a compile-time path naming the build machine.
+    fn apptainer_cache_sentinel_name(version: &str) -> String {
+        format!(
             ".peppy-version-{}-r{}-sq{}",
             version, APPTAINER_RECIPE_REVISION, SQUASHFUSE_VERSION
-        ))
+        )
+    }
+
+    fn apptainer_cache_sentinel_path(cache_dir: &Path, version: &str) -> PathBuf {
+        cache_dir.join(apptainer_cache_sentinel_name(version))
     }
 
     fn write_cache_sentinel(cache_dir: &Path, version: &str) {
@@ -257,8 +268,38 @@ mod apptainer_build {
         .unwrap_or_else(|e| panic!("Failed to write cache sentinel {:?}: {}", sentinel, e));
     }
 
+    /// The bare directory name, also exported to the crate (see
+    /// [`emit_constant_env_vars`]) so runtime code can find the cache without
+    /// a compile-time path naming the build machine.
+    fn apptainer_cache_dir_name(version: &str, arch: &str) -> String {
+        format!("apptainer-{}-{}-nosuid", version, arch)
+    }
+
     fn apptainer_cache_dir(version: &str, arch: &str) -> PathBuf {
-        build_helpers::cache_dir(&format!("apptainer-{}-{}-nosuid", version, arch))
+        build_helpers::cache_dir(&apptainer_cache_dir_name(version, arch))
+    }
+
+    /// Name of the Lima cache directory under the shared build cache. Lima is
+    /// only ever bundled for the arm64 macOS host that builds it, so the name
+    /// carries no runtime-arch variable. Exported to the crate like the
+    /// apptainer names above.
+    fn lima_cache_dir_name() -> String {
+        format!("lima-{}-Darwin-arm64", LIMA_VERSION)
+    }
+
+    /// Stable digest of a cache path, for `.copy-source` sentinels. The
+    /// sentinel only decides whether the copy under OUT_DIR is current, so a
+    /// digest distinguishes source directories as well as the path did
+    /// without writing the building machine's home directory into trees that
+    /// ship inside release archives. The hash algorithm is not stable across
+    /// compiler versions; a change at worst triggers one redundant re-copy.
+    fn cache_path_digest(path: &Path) -> String {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+
+        let mut hasher = DefaultHasher::new();
+        path.to_string_lossy().hash(&mut hasher);
+        format!("{:016x}", hasher.finish())
     }
 
     /// The ELF e_machine a binary for `arch` must carry.
@@ -1760,6 +1801,12 @@ echo "=== Compiling apptainer ==="
 make -C builddir -j"$(nproc)"
 echo "=== Installing apptainer ==="
 make -C builddir install
+echo "=== Scrubbing the builder home from man pages ==="
+# Apptainer renders flag defaults in its man pages from the building user's
+# $HOME; a generic path keeps the build account out of release archives.
+if [ -d {install_dir}/share/man ]; then
+  find {install_dir}/share/man -type f -exec sed -i "s|$HOME|/home/apptainer-builder|g" {{}} +
+fi
 echo "=== Bundling {libseccomp} ==="
 # The rpaths above point the binaries here, so the bundle — not the runtime
 # host's libseccomp — is what they load.
@@ -1983,6 +2030,12 @@ echo "=== Apptainer build complete ==="
     }
 
     fn emit_constant_env_vars() {
+        // Runtime code derives the machine-local cache locations from these
+        // names joined onto the user's home directory. Names, not absolute
+        // paths: a compiled-in path would ship the building machine's home
+        // directory inside the binary.
+        let target_arch =
+            env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_else(|_| "aarch64".to_string());
         println!("cargo:rustc-env=LIMA_INSTANCE={}", LIMA_INSTANCE);
         println!("cargo:rustc-env=LIMA_TEMPLATE={}", LIMA_TEMPLATE);
         println!("cargo:rustc-env=APPTAINER_VERSION={}", APPTAINER_VERSION);
@@ -1992,6 +2045,18 @@ echo "=== Apptainer build complete ==="
         println!(
             "cargo:rustc-env=GUEST_APPTAINER_DIR={}",
             GUEST_APPTAINER_DIR
+        );
+        println!(
+            "cargo:rustc-env=APPTAINER_CACHE_DIR_NAME={}",
+            apptainer_cache_dir_name(APPTAINER_VERSION, &target_arch)
+        );
+        println!(
+            "cargo:rustc-env=APPTAINER_CACHE_SENTINEL_NAME={}",
+            apptainer_cache_sentinel_name(APPTAINER_VERSION)
+        );
+        println!(
+            "cargo:rustc-env=LIMA_CACHE_DIR_NAME={}",
+            lima_cache_dir_name()
         );
     }
 
@@ -2013,10 +2078,13 @@ echo "=== Apptainer build complete ==="
         };
 
         // Copy Lima installation to OUT_DIR for the crate to reference at compile time.
-        // Use a sentinel to skip the copy when the source hasn't changed.
+        // Use a sentinel to skip the copy when the source hasn't changed. The
+        // sentinel stores a digest of the cache path, not the path itself:
+        // `.copy-source` ships inside release archives and must not name the
+        // building machine.
         let out_lima_dir = PathBuf::from(out_dir).join("lima-install");
         let lima_sentinel_path = out_lima_dir.join(".copy-source");
-        let lima_sentinel_content = format!("{}", lima_cache_dir.display());
+        let lima_sentinel_content = cache_path_digest(&lima_cache_dir);
         let lima_needs_copy = !lima_sentinel_path.exists()
             || std::fs::read_to_string(&lima_sentinel_path)
                 .map_or(true, |s| s.trim() != lima_sentinel_content.trim());
@@ -2029,14 +2097,6 @@ echo "=== Apptainer build complete ==="
             }
             std::fs::write(&lima_sentinel_path, &lima_sentinel_content).ok();
         }
-        println!(
-            "cargo:rustc-env=LIMA_INSTALL_DIR={}",
-            out_lima_dir.display()
-        );
-        println!(
-            "cargo:rustc-env=LIMA_BUILD_HOME={}",
-            lima.lima_home.display()
-        );
 
         lima
     }
@@ -2295,24 +2355,14 @@ echo "=== Apptainer build complete ==="
         // is meant for builds that only type-check, such as the CI cross-target
         // check job: provisioning apptainer for a foreign architecture needs a
         // Lima VM or a pre-seeded cache, neither of which a bare runner has,
-        // and a check build never runs containers. The compile-time env vars
-        // still point at the per-arch cache location so dependent crates
-        // compile; a binary produced under this knob cannot start containers
-        // until a provisioning build fills that cache.
+        // and a check build never runs containers. The cache-name env vars are
+        // still emitted so dependent crates compile; a binary produced under
+        // this knob cannot start containers until a provisioning build fills
+        // that cache.
         if env::var("PEPPY_SKIP_APPTAINER_PROVISION").as_deref() == Ok("1") {
-            let cache_dir = apptainer_cache_dir(APPTAINER_VERSION, &arch);
-            let cache_sentinel = apptainer_cache_sentinel_path(&cache_dir, APPTAINER_VERSION);
             println!(
                 "cargo:warning=Skipping apptainer provisioning \
                  (PEPPY_SKIP_APPTAINER_PROVISION=1); this build cannot run containers"
-            );
-            println!(
-                "cargo:rustc-env=APPTAINER_CACHE_SENTINEL={}",
-                cache_sentinel.display()
-            );
-            println!(
-                "cargo:rustc-env=APPTAINER_INSTALL_DIR={}",
-                cache_dir.display()
             );
             return;
         }
@@ -2332,22 +2382,16 @@ echo "=== Apptainer build complete ==="
         let cache_sentinel = apptainer_cache_sentinel_path(&cache_dir, APPTAINER_VERSION);
         println!("cargo:rerun-if-changed={}", cache_sentinel.display());
 
-        // Export the sentinel path so the cache-consistency test asserts on the
-        // name this build actually wrote. Only `apptainer_cache_sentinel_path`
-        // knows the naming scheme, so changing it cannot desync the test.
-        println!(
-            "cargo:rustc-env=APPTAINER_CACHE_SENTINEL={}",
-            cache_sentinel.display()
-        );
-
         // Step 3: Copy apptainer installation to OUT_DIR for release packaging.
         // Use a sentinel to skip the copy when the source hasn't changed,
-        // avoiding mtime bumps that trigger unnecessary recompilation.
+        // avoiding mtime bumps that trigger unnecessary recompilation. Like
+        // the Lima sentinel, it stores a digest of the source path so the
+        // building machine's directories never ship in release archives.
         let out_install_dir = PathBuf::from(&out_dir).join("apptainer-install");
         let sentinel_path = out_install_dir.join(".copy-source");
         let sentinel_content = format!(
             "{}\ngocryptfs={}\nsquashfuse={}",
-            cache_dir.display(),
+            cache_path_digest(&cache_dir),
             GOCRYPTFS_VERSION,
             SQUASHFUSE_VERSION
         );
@@ -2363,11 +2407,6 @@ echo "=== Apptainer build complete ==="
             });
             std::fs::write(&sentinel_path, &sentinel_content).ok();
         }
-
-        println!(
-            "cargo:rustc-env=APPTAINER_INSTALL_DIR={}",
-            cache_dir.display()
-        );
     }
 }
 

--- a/crates/containers-internal/src/apptainer/facade.rs
+++ b/crates/containers-internal/src/apptainer/facade.rs
@@ -428,7 +428,7 @@ impl Apptainer {
     /// Resolution order:
     /// 1. `PEPPY_APPTAINER_DIR` environment variable
     /// 2. `apptainer/` relative to the current executable (installed layout)
-    /// 3. Compile-time `APPTAINER_INSTALL_DIR` set by build.rs
+    /// 3. The apptainer build cache under `~/.peppy/tmp` (development machines)
     ///
     /// # Blocking
     ///
@@ -1101,8 +1101,8 @@ impl Apptainer {
         lima::resolve_install_dir(
             "PEPPY_APPTAINER_DIR",
             "apptainer",
-            option_env!("APPTAINER_INSTALL_DIR"),
-            "APPTAINER_INSTALL_DIR",
+            lima::peppy_home_dir(&format!("tmp/{}", crate::APPTAINER_CACHE_DIR_NAME)),
+            "apptainer build cache",
             || {
                 Error::ApptainerNotFound(
                     "Apptainer installation not found. Install apptainer or set PEPPY_APPTAINER_DIR."

--- a/crates/containers-internal/src/apptainer/lima.rs
+++ b/crates/containers-internal/src/apptainer/lima.rs
@@ -662,18 +662,31 @@ pub(crate) fn ensure_guest_apptainer(
     Ok(guest_bin)
 }
 
+/// A directory under the user's `~/.peppy` root, resolved at runtime.
+///
+/// Build scripts provision their caches under `~/.peppy/tmp` via
+/// `build_helpers::cache_dir`; deriving the same locations at runtime (rather
+/// than compiling in the paths build.rs used) keeps the building machine's
+/// home directory out of the shipped binary. `None` when no home directory is
+/// known.
+pub(crate) fn peppy_home_dir(rel: &str) -> Option<PathBuf> {
+    std::env::var_os("HOME").map(|home| Path::new(&home).join(".peppy").join(rel))
+}
+
 /// Resolve an installation directory using a standard three-step fallback:
 ///
 /// 1. Runtime override via `env_var` environment variable.
 /// 2. `exe_subdir` relative to the current executable (installed layout).
-/// 3. Compile-time path from build.rs (passed as `compile_time_dir`).
+/// 3. `fallback_dir`, a machine-local location resolved at runtime (the
+///    build-tool caches under `~/.peppy/tmp`; no path from the build machine
+///    is compiled in).
 ///
 /// Returns the first directory that exists, or the error from `not_found_err`.
 pub(crate) fn resolve_install_dir(
     env_var: &str,
     exe_subdir: &str,
-    compile_time_dir: Option<&str>,
-    compile_time_label: &str,
+    fallback_dir: Option<PathBuf>,
+    fallback_label: &str,
     not_found_err: impl FnOnce() -> Error,
 ) -> Result<PathBuf> {
     // 1) Runtime override via environment variable
@@ -698,13 +711,15 @@ pub(crate) fn resolve_install_dir(
         }
     }
 
-    // 3) Compile-time path injected by build.rs
-    if let Some(dir) = compile_time_dir {
-        let path = PathBuf::from(dir);
-        if path.is_dir() {
-            return Ok(path);
+    // 3) Machine-local fallback (build-tool cache), resolved at runtime
+    if let Some(dir) = fallback_dir {
+        if dir.is_dir() {
+            return Ok(dir);
         }
-        tracing::debug!("Compile-time {compile_time_label} path {dir} does not exist at runtime");
+        tracing::debug!(
+            "{fallback_label} path {} does not exist at runtime",
+            dir.display()
+        );
     }
 
     Err(not_found_err())
@@ -715,13 +730,13 @@ pub(crate) fn resolve_install_dir(
 /// Resolution order:
 /// 1. `PEPPY_LIMA_DIR` environment variable
 /// 2. `lima/` relative to the current executable (installed layout)
-/// 3. Compile-time `LIMA_INSTALL_DIR` set by build.rs
+/// 3. The Lima build cache under `~/.peppy/tmp` (development machines)
 pub(crate) fn resolve_lima_dir() -> Result<PathBuf> {
     resolve_install_dir(
         "PEPPY_LIMA_DIR",
         "lima",
-        option_env!("LIMA_INSTALL_DIR"),
-        "LIMA_INSTALL_DIR",
+        peppy_home_dir(&format!("tmp/{}", crate::LIMA_CACHE_DIR_NAME)),
+        "Lima build cache",
         || Error::LimaRequired,
     )
 }
@@ -730,7 +745,7 @@ pub(crate) fn resolve_lima_dir() -> Result<PathBuf> {
 ///
 /// Resolution order:
 /// 1. `{exe_dir}/../lima-data/`: installed layout (`~/.peppy/lima-data/`).
-/// 2. Compile-time `LIMA_BUILD_HOME`: reuses the build-time VM during development.
+/// 2. `~/.peppy/lima-build/`: reuses the build-time VM during development.
 /// 3. `~/.peppy/lima-data/`: fallback for unusual layouts.
 pub(crate) fn resolve_lima_home() -> Result<PathBuf> {
     // 1) Relative to the current executable: {exe_dir}/../lima-data/
@@ -745,14 +760,14 @@ pub(crate) fn resolve_lima_home() -> Result<PathBuf> {
         }
     }
 
-    // 2) Compile-time build home: during `cargo test` / `cargo run` in the
-    //    source tree the exe-relative path won't exist, so fall back to the
-    //    LIMA_HOME used at build time (typically ~/.peppy/lima-build/).
-    if let Some(dir) = option_env!("LIMA_BUILD_HOME") {
-        let path = PathBuf::from(dir);
-        if path.is_dir() {
-            return Ok(path);
-        }
+    // 2) Build-time VM data (during `cargo test` / `cargo run` in the source
+    //    tree the exe-relative path won't exist, so reuse the build VM's
+    //    home). Always `~/.peppy/lima-build`, resolved at runtime so no
+    //    build-machine path is compiled into the binary.
+    if let Some(path) = peppy_home_dir("lima-build")
+        && path.is_dir()
+    {
+        return Ok(path);
     }
 
     // 3) Fallback: well-known location in the user's home

--- a/crates/containers-internal/src/apptainer/tests.rs
+++ b/crates/containers-internal/src/apptainer/tests.rs
@@ -997,47 +997,99 @@ fn shell_escape_single_quoted_survives_embedded_quotes() {
 // Compile-time cache consistency test
 // ---------------------------------------------------------------------------
 
-/// Verifies that the compile-time `APPTAINER_INSTALL_DIR` injected by build.rs
-/// points to a valid cache directory with the expected sentinel and binary. The
-/// sentinel path comes from build.rs too, via `APPTAINER_CACHE_SENTINEL`: the
-/// name is keyed on every input that changes the produced tree (apptainer
-/// version, recipe revision, squashfuse version), so re-deriving it here would
-/// go stale the next time the cache key changes.
+/// Verifies that the apptainer cache provisioned for this binary's
+/// architecture exists with its completed-build sentinel and binary. The
+/// location is derived at runtime from the exported cache names, so the
+/// binary carries no path from the machine that built it.
 ///
 /// If this test fails after deleting `~/.peppy`, it means the build cache is
 /// stale and `cargo build` needs to re-run build.rs (which the
 /// `rerun-if-changed` directive on the sentinel file should ensure).
 #[cfg(target_os = "linux")]
 #[test]
-fn compile_time_apptainer_dir_exists_with_sentinel() {
-    let install_dir = env!(
-        "APPTAINER_INSTALL_DIR",
-        "APPTAINER_INSTALL_DIR should be set by build.rs at compile time"
-    );
+fn apptainer_cache_dir_exists_with_sentinel() {
+    let Some(install_dir) = linux_apptainer_cache_dir() else {
+        panic!("HOME is not set; cannot locate the apptainer build cache");
+    };
 
-    let path = Path::new(install_dir);
     assert!(
-        path.is_dir(),
-        "APPTAINER_INSTALL_DIR={} does not exist; was ~/.peppy deleted without rebuilding?",
+        install_dir.is_dir(),
+        "apptainer cache {:?} does not exist; was ~/.peppy deleted without rebuilding?",
         install_dir
     );
 
-    let sentinel = Path::new(env!(
-        "APPTAINER_CACHE_SENTINEL",
-        "APPTAINER_CACHE_SENTINEL should be set by build.rs at compile time"
-    ));
+    let sentinel = install_dir.join(crate::APPTAINER_CACHE_SENTINEL_NAME);
     assert!(
         sentinel.exists(),
         "Cache sentinel {:?} is missing; the apptainer cache may be corrupt",
         sentinel
     );
 
-    let apptainer_bin = path.join("bin/apptainer");
+    let apptainer_bin = install_dir.join("bin/apptainer");
     assert!(
         apptainer_bin.exists(),
-        "bin/apptainer not found in APPTAINER_INSTALL_DIR={}",
+        "bin/apptainer not found in the apptainer cache {:?}",
         install_dir
     );
+}
+
+/// The apptainer build cache for this binary's architecture, derived at
+/// runtime exactly as production code derives it.
+#[cfg(target_os = "linux")]
+fn linux_apptainer_cache_dir() -> Option<PathBuf> {
+    super::lima::peppy_home_dir(&format!("tmp/{}", crate::APPTAINER_CACHE_DIR_NAME))
+}
+
+/// The trees build.rs copies into OUT_DIR ship inside release archives: their
+/// `.copy-source` sentinels and the generated apptainer man pages must not
+/// carry the building machine's home directory.
+#[test]
+fn out_dir_trees_carry_no_build_machine_paths() {
+    let Some(home) = std::env::var_os("HOME") else {
+        panic!("HOME is not set; cannot check OUT_DIR trees for host paths");
+    };
+    let home = home.to_string_lossy();
+    let out_dir = Path::new(env!("OUT_DIR"));
+
+    for marker in [
+        "apptainer-install/.copy-source",
+        "lima-install/.copy-source",
+    ] {
+        let path = out_dir.join(marker);
+        if let Ok(contents) = fs::read_to_string(&path) {
+            assert!(
+                !contents.contains(home.as_ref()),
+                "{marker} embeds the building machine's home directory: {contents:?}"
+            );
+        }
+    }
+
+    let man_dir = out_dir.join("apptainer-install/share/man");
+    if !man_dir.is_dir() {
+        // A PEPPY_SKIP_APPTAINER_PROVISION build provisions nothing; there is
+        // no tree to check, same self-skip the integration tests apply.
+        eprintln!(
+            "SKIPPING: no apptainer tree in OUT_DIR at {:?}; build without \
+             PEPPY_SKIP_APPTAINER_PROVISION to check it",
+            man_dir
+        );
+        return;
+    }
+    let mut stack = vec![man_dir];
+    while let Some(dir) = stack.pop() {
+        for entry in fs::read_dir(&dir).expect("read man page directory") {
+            let entry = entry.expect("read man page entry");
+            if entry.path().is_dir() {
+                stack.push(entry.path());
+            } else if let Ok(contents) = fs::read_to_string(entry.path()) {
+                assert!(
+                    !contents.contains(home.as_ref()),
+                    "{} embeds the building machine's home directory",
+                    entry.path().display()
+                );
+            }
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1054,8 +1106,9 @@ fn compile_time_apptainer_dir_exists_with_sentinel() {
 #[cfg(target_os = "linux")]
 #[test]
 fn gocryptfs_bundled_in_apptainer_install_dir() {
-    let install_dir = env!("APPTAINER_INSTALL_DIR");
-    let path = Path::new(install_dir);
+    let install_dir =
+        linux_apptainer_cache_dir().expect("HOME is not set; cannot locate the apptainer cache");
+    let path = install_dir;
 
     let gocryptfs_bin = path.join("libexec/apptainer/bin/gocryptfs");
     assert!(
@@ -1091,8 +1144,9 @@ fn gocryptfs_bundled_in_apptainer_install_dir() {
 #[cfg(target_os = "linux")]
 #[test]
 fn gocryptfs_bundled_binary_is_runnable() {
-    let install_dir = env!("APPTAINER_INSTALL_DIR");
-    let gocryptfs_bin = Path::new(install_dir).join("libexec/apptainer/bin/gocryptfs");
+    let install_dir =
+        linux_apptainer_cache_dir().expect("HOME is not set; cannot locate the apptainer cache");
+    let gocryptfs_bin = install_dir.join("libexec/apptainer/bin/gocryptfs");
 
     let output = Command::new(&gocryptfs_bin)
         .arg("--version")
@@ -1187,8 +1241,9 @@ fn squashfuse_bundled_in_apptainer_install_dir() {
 #[cfg(target_os = "linux")]
 #[test]
 fn squashfuse_bundled_binary_is_runnable() {
-    let install_dir = env!("APPTAINER_INSTALL_DIR");
-    let squashfuse_bin = Path::new(install_dir).join("libexec/apptainer/bin/squashfuse_ll");
+    let install_dir =
+        linux_apptainer_cache_dir().expect("HOME is not set; cannot locate the apptainer cache");
+    let squashfuse_bin = install_dir.join("libexec/apptainer/bin/squashfuse_ll");
 
     // Invoked with no arguments: `squashfuse_ll` has no `--version` flag, and
     // its usage banner carries the version. Apptainer scans the same output for

--- a/crates/containers-internal/src/lib.rs
+++ b/crates/containers-internal/src/lib.rs
@@ -38,3 +38,13 @@ pub const GOCRYPTFS_VERSION: &str = env!("GOCRYPTFS_VERSION");
 /// which is both slow and fatal on hosts whose `/tmp` is a quota-limited
 /// tmpfs.
 pub const SQUASHFUSE_VERSION: &str = env!("SQUASHFUSE_VERSION");
+
+/// Name of the apptainer cache directory under `~/.peppy/tmp`, as provisioned
+/// by the build script for this binary's architecture. A name, not a path, so
+/// the binary carries no directory layout of the machine it was built on.
+pub const APPTAINER_CACHE_DIR_NAME: &str = env!("APPTAINER_CACHE_DIR_NAME");
+/// Name of the sentinel file marking that cache directory as complete.
+pub const APPTAINER_CACHE_SENTINEL_NAME: &str = env!("APPTAINER_CACHE_SENTINEL_NAME");
+/// Name of the Lima cache directory under `~/.peppy/tmp`, same rationale as
+/// [`APPTAINER_CACHE_DIR_NAME`].
+pub const LIMA_CACHE_DIR_NAME: &str = env!("LIMA_CACHE_DIR_NAME");

--- a/crates/latency-report/src/baseline.rs
+++ b/crates/latency-report/src/baseline.rs
@@ -54,19 +54,74 @@ pub fn baseline_path(subdir: &str) -> PathBuf {
     path_in(&target_dir(), subdir, &machine_id())
 }
 
-/// The machine-local `target/` directory baselines live under: `$CARGO_TARGET_DIR`
-/// when set, else the workspace `target/` resolved relative to this crate.
+/// The machine-local `target/` directory baselines live under: the invoking
+/// environment's `$CARGO_TARGET_DIR` when set, else the workspace `target/`
+/// found by walking up from the running executable, else the peppy cache root.
+/// Resolved at runtime so the binary carries no path from the machine that
+/// built it.
 fn target_dir() -> PathBuf {
-    std::env::var_os("CARGO_TARGET_DIR")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| {
-            // CARGO_MANIFEST_DIR is `<repo>/crates/latency-report`; the workspace
-            // `target/` is two levels up.
-            Path::new(env!("CARGO_MANIFEST_DIR"))
-                .join("..")
-                .join("..")
-                .join("target")
-        })
+    if let Some(dir) = std::env::var_os("CARGO_TARGET_DIR") {
+        return PathBuf::from(dir);
+    }
+    // Cargo lays built binaries out under the workspace `target/` as
+    // `target/[<triple>/]<profile>/[deps/]`, so walking a bounded number of
+    // parents up from the running executable finds it without compiling the
+    // building machine's checkout path into the binary.
+    if let Some(exe) = std::env::current_exe().ok()
+        && let Some(dir) = workspace_target_dir_of(&exe)
+    {
+        return dir;
+    }
+    // Installed binaries have no `target/` ancestor; keep baselines
+    // machine-local under the peppy cache root instead.
+    match std::env::var_os("HOME") {
+        Some(home) => Path::new(&home).join(".peppy/tmp/latency-report"),
+        None => std::env::temp_dir().join("peppy-latency-report"),
+    }
+}
+
+/// The first ancestor of `exe` named `target`, or `None` within five levels.
+fn workspace_target_dir_of(exe: &Path) -> Option<PathBuf> {
+    let mut dir = exe.parent()?;
+    for _ in 0..5 {
+        if dir.file_name() == Some(std::ffi::OsStr::new("target")) {
+            return Some(dir.to_path_buf());
+        }
+        dir = dir.parent()?;
+    }
+    None
+}
+
+#[cfg(test)]
+mod target_dir_tests {
+    use super::workspace_target_dir_of;
+    use std::path::Path;
+
+    #[test]
+    fn finds_the_workspace_target_from_a_bench_binary_layout() {
+        let exe = Path::new("/ws/target/release/deps/bench-abc");
+        assert_eq!(
+            workspace_target_dir_of(exe),
+            Some(Path::new("/ws/target").to_path_buf())
+        );
+    }
+
+    #[test]
+    fn finds_the_workspace_target_from_a_crosscompiled_layout() {
+        let exe = Path::new("/ws/target/aarch64-unknown-linux-gnu/release/peppy");
+        assert_eq!(
+            workspace_target_dir_of(exe),
+            Some(Path::new("/ws/target").to_path_buf())
+        );
+    }
+
+    #[test]
+    fn returns_none_for_an_installed_binary() {
+        assert_eq!(
+            workspace_target_dir_of(Path::new("/usr/local/bin/peppy")),
+            None
+        );
+    }
 }
 
 /// Pure path join, split out so the layout is testable without reading the

--- a/scripts/functions/build.py
+++ b/scripts/functions/build.py
@@ -24,6 +24,24 @@ class BuildArtifact:
     target_triple: str
 
 
+def _release_rustflags(repo_root: Path) -> str:
+    """RUSTFLAGS that keep build machine paths out of the compiled binary.
+
+    rustc records absolute source paths in panic locations and debug data: the
+    cargo registry under CARGO_HOME and the workspace checkout both name the
+    machine the release is built on. Remapping them to fixed prefixes removes
+    that identity from the shipped binary. Appended to any RUSTFLAGS the
+    environment already carries so local wrappers keep working.
+    """
+    cargo_home = Path(os.environ.get("CARGO_HOME", str(Path.home() / ".cargo")))
+    parts = [
+        os.environ.get("RUSTFLAGS", ""),
+        f"--remap-path-prefix={cargo_home}=/cargo-home",
+        f"--remap-path-prefix={repo_root}=/peppy",
+    ]
+    return " ".join(part for part in parts if part)
+
+
 def cargo_build(
     tag: str,
     target_triple: str,
@@ -46,6 +64,7 @@ def cargo_build(
     """
     console.print(f"Building peppy for [bold]{target_triple}[/bold]...")
     env = {**os.environ, "PEPPY_GIT_TAG": tag, "PEPPY_CROSS_ARCH": "1"}
+    env["RUSTFLAGS"] = _release_rustflags(repo_root)
     if target_dir is not None:
         env["CARGO_TARGET_DIR"] = str(target_dir)
     try:
@@ -177,6 +196,18 @@ def find_build_dir(
     )
 
 
+def _sanitize_tar_member(member: tarfile.TarInfo) -> tarfile.TarInfo:
+    """Zero member ownership so the archive never carries the packer's uid,
+    gid, or user and group names. A root install restoring them would either
+    abort in a user namespace or hand the tree to the packing machine's (or a
+    same-named local) account."""
+    member.uid = 0
+    member.gid = 0
+    member.uname = ""
+    member.gname = ""
+    return member
+
+
 def package_release(
     target_triple: str,
     repo_root: Path,
@@ -218,7 +249,7 @@ def package_release(
 
         with tarfile.open(asset_path, "w:gz") as tar:
             for child in sorted(pkg_dir.iterdir()):
-                tar.add(child, arcname=f"./{child.name}")
+                tar.add(child, arcname=f"./{child.name}", filter=_sanitize_tar_member)
 
     console.print(f"Built artifact: [bold]{asset_path}[/bold]")
     return BuildArtifact(

--- a/scripts/functions/verify_release.py
+++ b/scripts/functions/verify_release.py
@@ -1,4 +1,4 @@
-"""Verify that release archives contain all required binaries."""
+"""Verify that release archives are sound and free of build machine identity."""
 
 from __future__ import annotations
 
@@ -39,12 +39,16 @@ def _elf_machine(header: bytes) -> int | None:
 
 
 def verify_release_archive(archive_path: Path, triple: str) -> list[str]:
-    """Verify a single .tgz archive contains all required binaries, and that
-    each Linux binary is built for the triple's architecture.
+    """Verify a single .tgz archive contains all required binaries, that each
+    Linux binary is built for the triple's architecture, and that no member
+    carries ownership of the machine that packed it.
 
     Returns a list of problems (empty if the archive is sound). Presence alone
     is not enough: a binary for the wrong machine sits at the right path and
-    fails only at exec on the consumer's host.
+    fails only at exec on the consumer's host. Ownership is checked because
+    GNU tar restores it on root installs, where a foreign uid aborts the
+    install inside user namespaces and a resolvable user or group name hands
+    the tree to a same-named local account.
     """
     problems: list[str] = []
 
@@ -77,6 +81,14 @@ def verify_release_archive(archive_path: Path, triple: str) -> list[str]:
                     f"{item} is built for ELF machine {machine}, "
                     f"the {triple} archive needs {expected_machine}"
                 )
+
+    for name, member in members.items():
+        if member.uid != 0 or member.gid != 0 or member.uname or member.gname:
+            problems.append(
+                f"{name} carries build host ownership "
+                f"(uid={member.uid}, gid={member.gid}, "
+                f"uname={member.uname!r}, gname={member.gname!r})"
+            )
 
     return problems
 

--- a/scripts/tests/test_build.py
+++ b/scripts/tests/test_build.py
@@ -11,6 +11,7 @@ import pytest
 
 from functions.build import (
     _get_target_dir,
+    _release_rustflags,
     build_and_package,
     find_build_dir,
     find_peppy_binary,
@@ -256,6 +257,71 @@ def test_package_release_respects_peppy_dist_dir(tmp_path: Path) -> None:
         )
 
     assert artifact.asset_path.parent == custom_dist
+
+
+def test_package_release_tarball_has_zeroed_ownership(tmp_path: Path) -> None:
+    """Every member must be owned by uid 0 with no user or group names.
+
+    GNU tar restores ownership on root installs: a foreign uid aborts the
+    install inside user namespaces, and a resolvable name hands the tree to
+    a same-named local account. The archive must not carry the packer's.
+    """
+    triple = "aarch64-apple-darwin"
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+
+    peppy_bin = tmp_path / "peppy"
+    peppy_bin.write_bytes(b"peppy binary")
+    zenohd_bin = tmp_path / "zenohd"
+    zenohd_bin.write_bytes(b"zenohd binary")
+
+    apptainer_dir = tmp_path / "apptainer-install"
+    apptainer_dir.mkdir()
+    (apptainer_dir / "bin").mkdir(parents=True)
+    (apptainer_dir / "bin" / "apptainer").write_bytes(b"apptainer")
+
+    dist_dir = tmp_path / "dist"
+    with patch.dict(os.environ, {"PEPPY_DIST_DIR": str(dist_dir)}):
+        artifact = package_release(
+            triple, repo_root, peppy_bin, zenohd_bin, apptainer_dir
+        )
+
+    with tarfile.open(artifact.asset_path, "r:gz") as tar:
+        members = tar.getmembers()
+
+    assert members
+    for member in members:
+        assert member.uid == 0, member.name
+        assert member.gid == 0, member.name
+        assert member.uname == "", member.name
+        assert member.gname == "", member.name
+
+
+def test_release_rustflags_remap_build_machine_paths(tmp_path: Path) -> None:
+    """The release build remaps CARGO_HOME and the checkout to fixed prefixes
+
+    so panic locations and debug data in the shipped binary cannot name the
+    machine it was built on, while an inherited RUSTFLAGS keeps its flags.
+    """
+    env = {
+        "CARGO_HOME": str(tmp_path / "cargo-home"),
+        "RUSTFLAGS": "--cfg inherited",
+    }
+    repo_root = tmp_path / "repo"
+    with patch.dict(os.environ, env):
+        flags = _release_rustflags(repo_root)
+
+    assert f"--remap-path-prefix={tmp_path / 'cargo-home'}=/cargo-home" in flags
+    assert f"--remap-path-prefix={repo_root}=/peppy" in flags
+    assert flags.startswith("--cfg inherited")
+
+
+def test_release_rustflags_without_inherited_flags(tmp_path: Path) -> None:
+    with patch.dict(os.environ, {"RUSTFLAGS": ""}):
+        flags = _release_rustflags(tmp_path / "repo")
+
+    assert not flags.startswith(" ")
+    assert flags.count("--remap-path-prefix") == 2
 
 
 def test_build_and_package_rejects_unsupported_triple(tmp_path: Path) -> None:

--- a/scripts/tests/test_verify_release.py
+++ b/scripts/tests/test_verify_release.py
@@ -35,14 +35,24 @@ def _create_archive(
     members: list[str],
     triple: str,
     content_overrides: dict[str, bytes] | None = None,
+    *,
+    uid: int = 0,
+    gid: int = 0,
+    uname: str = "",
+    gname: str = "",
 ) -> None:
-    """Create a .tgz archive whose members carry the triple's binary shape."""
+    """Create a .tgz archive whose members carry the triple's binary shape
+    and, by default, the zeroed ownership release packaging must produce."""
     overrides = content_overrides or {}
     with tarfile.open(path, "w:gz") as tar:
         for name in members:
             data = overrides.get(name, _binary_for(triple))
             info = tarfile.TarInfo(name=f"./{name}")
             info.size = len(data)
+            info.uid = uid
+            info.gid = gid
+            info.uname = uname
+            info.gname = gname
             tar.addfile(info, io.BytesIO(data))
 
 
@@ -188,3 +198,30 @@ def test_verify_archive_rejects_a_binary_that_is_not_elf(tmp_path: Path) -> None
 
     problems = verify_release_archive(archive, triple)
     assert any("bin/peppy" in p for p in problems), problems
+
+
+def test_verify_archive_rejects_build_host_ownership(tmp_path: Path) -> None:
+    """Members stamped with the packing machine's uid or account names fail.
+
+    GNU tar restores ownership on root installs: a foreign uid aborts the
+    install inside user namespaces, and a resolvable user or group name hands
+    the tree to a same-named local account.
+    """
+    triple = "aarch64-unknown-linux-gnu"
+    archive = tmp_path / f"peppy-{triple}.tgz"
+    _create_archive(
+        archive,
+        _all_required_members(triple),
+        triple,
+        uid=501,
+        gid=20,
+        uname="builder",
+        gname="staff",
+    )
+
+    problems = verify_release_archive(archive, triple)
+    expected = (
+        "bin/peppy carries build host ownership "
+        "(uid=501, gid=20, uname='builder', gname='staff')"
+    )
+    assert expected in problems


### PR DESCRIPTION
v0.26.0 and v0.26.1 tarballs shipped the packer's ownership (tuatini/staff, uid 501, gid 20) on every entry, which aborts root installs inside user namespaces and silently mis-owns files as plain root or on hosts with a same-named account. The archives and binaries also leaked build machine paths: .copy-source markers recorded absolute cache paths, the bundled apptainer man pages embedded the build user's home directory, and the binary itself carried compile-time paths from the building machine. This change zeroes member ownership in package_release, writes digest-based .copy-source sentinels, scrubs the builder home from the generated man pages (with an apptainer recipe revision bump so stale caches rebuild), derives every runtime cache location from the user's home instead of compiled-in paths, remaps CARGO_HOME and the checkout through RUSTFLAGS during release builds so panic locations stop naming the build machine, and makes verify_release_archive fail on any member carrying build host ownership so this class of leak cannot ship again.

## Test plan

- pytest scripts/tests/test_build.py scripts/tests/test_verify_release.py scripts/tests/test_build_release.py scripts/tests/test_release_summary.py: 98 passed, including new tests that packaged tarballs carry uid 0 with empty names and that owned members fail verification
- PEPPY_SKIP_APPTAINER_PROVISION=1 cargo check --locked --tests -p containers -p latency-report, plus cargo check --locked -p peppy: clean
- cargo test --locked -p latency-report: 29 passed, including new target-dir resolution tests
- cargo test -p containers out_dir_trees_carry_no_build_machine_paths: passes, self-skips under a skip-provision build and asserts on provisioned trees
- apptainer_cache_dir_exists_with_sentinel now derives the cache path at runtime and demands the new r3 sentinel, proving the derivation matches build.rs naming and the recipe bump invalidates stale caches
- compiled artifacts with the release RUSTFLAGS contain zero /home/<user> strings and show /cargo-home/registry panic locations instead

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Peppy-bot/codesmith/peppy/pr/414"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790461555&installation_model_id=433186&pr_number=414&repository=Peppy-bot%2Fpeppy&return_to=https%3A%2F%2Fgithub.com%2FPeppy-bot%2Fpeppy%2Fpull%2F414&signature=2b3904369d6d748b6210fd61a77c2f343a268edf83924f9b36d452568e339985"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->