### PR TITLE
ci: gate the release scripts suite on changed inputs and report skip reasons

### DIFF
--- a/.github/actions/changed-test-inputs/action.yml
+++ b/.github/actions/changed-test-inputs/action.yml
@@ -4,7 +4,9 @@ description: >-
   when the change set touches that suite's inputs. The per-suite crate sets
   are derived from cargo metadata's resolve graph at run time, so newly
   added or rewired workspace crates are picked up with nothing to maintain
-  here. Fails open: on any detection error every suite runs.
+  here. Gated-off suites get their skip reason reported to the job's
+  annotations and step summary. Fails open: on any detection error every
+  suite runs.
 inputs:
   base:
     description: Commit the branch's changes are diffed against (the PR

--- a/.github/actions/changed-test-inputs/detect.py
+++ b/.github/actions/changed-test-inputs/detect.py
@@ -3,7 +3,8 @@
 
 Emits one boolean output per suite, true when the branch's diff against the
 base commit touched anything that suite compiles from this workspace or
-reads at run time.
+reads at run time. A suite gated off gets its skip reason reported to the
+job's annotations and step summary.
 
 The crate sets are not listed here: they are derived from cargo metadata's
 resolve graph (internal path dependencies, transitive, including dev and
@@ -40,6 +41,14 @@ SUITES = {
 TREE_SUITES = {
     # ./scripts/run_tests.sh --all
     "scripts": ["scripts/**"],
+}
+
+# The tests.yml step each gate guards, so a skip reason names what CI did
+# not run. Presentation only; an unknown suite falls back to its key.
+STEP_NAMES = {
+    "container_e2e": "Run container e2e tests",
+    "docs_integration": "Run documentation integration tests",
+    "scripts": "Run release scripts tests",
 }
 
 # Build and tooling inputs shared by every suite. These track CI and build
@@ -124,6 +133,35 @@ def touches(files, globs, dirs):
     return False
 
 
+def report_skips(gates, base):
+    """Say why each gated-off suite is skipped: a job annotation per suite
+    plus a step summary section, because the gray "skipped" mark a workflow
+    shows explains nothing."""
+    skipped = [
+        (suite, STEP_NAMES.get(suite, suite))
+        for suite, gate in sorted(gates.items())
+        if not gate
+    ]
+    if not skipped:
+        return
+    versus = base[:12] if base else "the base commit"
+    for _, step in skipped:
+        print(
+            '::notice::Skipped "%s": none of the files it builds from or '
+            "reads changed vs %s" % (step, versus)
+        )
+    summary_file = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_file:
+        with open(summary_file, "a") as handle:
+            handle.write("### Skipped test suites\n")
+            handle.write(
+                "No file these suites build from or read changed in the "
+                "diff vs `%s`, so the Tests workflow skips them:\n" % versus
+            )
+            for suite, step in skipped:
+                handle.write("- **%s** (gate `%s`)\n" % (step, suite))
+
+
 def main():
     base = os.environ.get("INPUT_BASE", "")
     try:
@@ -151,6 +189,7 @@ def main():
         with open(output_file, "a") as handle:
             for suite, gate in gates.items():
                 handle.write("%s=%s\n" % (suite, "true" if gate else "false"))
+    report_skips(gates, base)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,8 +52,10 @@ jobs:
       # Which of the later gated suites have had their inputs touched. The
       # per-suite source sets are derived from cargo metadata's resolve graph
       # at run time (see the action), so added or rewired crates are picked
-      # up with nothing to maintain here. Needs cargo on PATH, hence the
-      # placement after rust-build-env.
+      # up with nothing to maintain here. A suite whose inputs are untouched
+      # is skipped, and the action reports the reason in the job's
+      # annotations and summary. Needs cargo on PATH, hence the placement
+      # after rust-build-env.
       - name: Detect changed test inputs
         id: changes
         uses: ./.github/actions/changed-test-inputs
@@ -97,9 +99,7 @@ jobs:
           cargo test --locked -p docs-integration-tests
 
       - name: Run release scripts tests
-        if: |
-          (github.event_name == 'pull_request' && github.base_ref == 'main')
-          || steps.changes.outputs.scripts == 'true'
+        if: steps.changes.outputs.scripts == 'true'
         run: |
           # The install tests boot Lima VMs, whose QEMU the runner image
           # lacks (limactl itself comes from the pixi environment). The


### PR DESCRIPTION
## What

- `Run release scripts tests` now runs **only** when the files the suite builds from or reads changed (`steps.changes.outputs.scripts == 'true'`), dropping the always-run clause for PRs to `main`. `Run documentation integration tests` already had this shape and is unchanged.
- A gated-off suite now gets its skip reason reported: a `::notice` job annotation (`Skipped "Run release scripts tests": none of the files it builds from or reads changed vs <base>`) plus a `### Skipped test suites` section on the run summary, because GitHub's gray skipped mark explains nothing. Covers all three suites the action gates (container e2e included).

## Why

Full release-scripts runs (QEMU/Lima VM boots) and docs integration runs cost real CI time even when nothing they consume changed. Detection still fails open — any error runs every suite — and `Cargo.lock`, `tests.yml`, and the actions themselves are shared inputs, so CI/build breakage still trips every gate.

## Verification

Ran `detect.py` against real `cargo metadata` in the repo:

- empty diff vs HEAD → all gates false, three notices + summary written
- `scripts/tests/test_install.sh` changed → only `scripts=true`, docs + container skip reasons emitted
- `docs/src/content/docs/guides/snippets/weave.sh` or `docs/tests/integration/src/main.rs` changed → only `docs_integration=true`
- unreachable base sha → fail open, all gates true, no notices
- both YAML files parse; `detect.py` compiles

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Peppy-bot/codesmith/peppy/pr/415"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790461799&installation_model_id=433186&pr_number=415&repository=Peppy-bot%2Fpeppy&return_to=https%3A%2F%2Fgithub.com%2FPeppy-bot%2Fpeppy%2Fpull%2F415&signature=196c808d859d572d1895032f58ec82f3792fe40067560a9096833432250c764a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->