### PR TITLE
ci: run every test suite in its own job

### DIFF
--- a/.github/actions/cargo-suite/action.yml
+++ b/.github/actions/cargo-suite/action.yml
@@ -1,0 +1,40 @@
+name: Cargo test suite
+description: >-
+  Runs one cargo test command against a peppy data root private to the job,
+  then proves the build consumed the committed lockfile. Expects the
+  rust-build-env action to have run first.
+
+inputs:
+  command:
+    description: The cargo command that runs the suite.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    # The suite gets its own peppy data root so the runner does not accumulate
+    # or collide on /tmp/.peppy across runs. Only the cargo command opts in via
+    # env; the release scripts job never goes through this action, so
+    # scripts/install.sh keeps defaulting PEPPY_HOME to $HOME/.peppy.
+    - name: Run the suite in an isolated peppy data root
+      shell: bash
+      run: |
+        peppy_home="$RUNNER_TEMP/peppy-home"
+        mkdir -p "$peppy_home/tmpdir"
+        export PEPPY_HOME="$peppy_home" TMPDIR="$peppy_home/tmpdir"
+        ${{ inputs.command }}
+
+    # Proves the build consumed the committed lockfile rather than re-resolving
+    # it, so the tested dependency graph is the shipped one. Must stay after the
+    # suite: placed before it, it proves nothing.
+    - name: Prove CI did not rewrite the shipping lockfile
+      shell: bash
+      run: git diff --exit-code -- Cargo.lock
+
+    # Reclaim the data root so disk does not grow on every run. Runs even when
+    # the suite failed. The persistent build-tool cache at $HOME/.peppy/tmp is
+    # intentionally left in place (see build_helpers::cache_dir).
+    - name: Clean up isolated peppy data root
+      if: always()
+      shell: bash
+      run: rm -rf "$RUNNER_TEMP/peppy-home"

--- a/.github/actions/changed-test-inputs/detect.py
+++ b/.github/actions/changed-test-inputs/detect.py
@@ -43,12 +43,12 @@ TREE_SUITES = {
     "scripts": ["scripts/**"],
 }
 
-# The tests.yml step each gate guards, so a skip reason names what CI did
+# The tests.yml job each gate guards, so a skip reason names what CI did
 # not run. Presentation only; an unknown suite falls back to its key.
-STEP_NAMES = {
-    "container_e2e": "Run container e2e tests",
-    "docs_integration": "Run documentation integration tests",
-    "scripts": "Run release scripts tests",
+JOB_NAMES = {
+    "container_e2e": "container-e2e",
+    "docs_integration": "docs-integration",
+    "scripts": "release-scripts",
 }
 
 # Build and tooling inputs shared by every suite. These track CI and build
@@ -59,6 +59,7 @@ SHARED = [
     "Cargo.lock",
     ".cargo/config.toml",
     ".github/actions/rust-build-env/**",
+    ".github/actions/cargo-suite/**",
     ".github/actions/changed-test-inputs/**",
     ".github/workflows/tests.yml",
 ]
@@ -138,17 +139,17 @@ def report_skips(gates, base):
     plus a step summary section, because the gray "skipped" mark a workflow
     shows explains nothing."""
     skipped = [
-        (suite, STEP_NAMES.get(suite, suite))
+        (suite, JOB_NAMES.get(suite, suite))
         for suite, gate in sorted(gates.items())
         if not gate
     ]
     if not skipped:
         return
     versus = base[:12] if base else "the base commit"
-    for _, step in skipped:
+    for _, job in skipped:
         print(
             '::notice::Skipped "%s": none of the files it builds from or '
-            "reads changed vs %s" % (step, versus)
+            "reads changed vs %s" % (job, versus)
         )
     summary_file = os.environ.get("GITHUB_STEP_SUMMARY")
     if summary_file:
@@ -158,8 +159,8 @@ def report_skips(gates, base):
                 "No file these suites build from or read changed in the "
                 "diff vs `%s`, so the Tests workflow skips them:\n" % versus
             )
-            for suite, step in skipped:
-                handle.write("- **%s** (gate `%s`)\n" % (step, suite))
+            for suite, job in skipped:
+                handle.write("- **%s** (gate `%s`)\n" % (job, suite))
 
 
 def main():

--- a/.github/workflows/latency.yml
+++ b/.github/workflows/latency.yml
@@ -5,7 +5,7 @@ name: Latency
 # job-level `if` further restricts the head to `dev`, so routine PRs into `dev`
 # (and any PR into other branches) never trigger these heavy real-node tests.
 # The latency tests are `#[ignore]` by default, so the normal `cargo test`
-# step in tests.yml never runs them — they run only here, via `--ignored`.
+# job in tests.yml never runs them — they run only here, via `--ignored`.
 on:
   pull_request:
     types: [opened, reopened, synchronize]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,47 +20,96 @@ env:
   # is cold. Cross-arch apptainer is separate, gated by PEPPY_CROSS_ARCH.
   PEPPY_CROSS_BUILD: "1"
 
+# Every suite runs in a job of its own, so the workflow finishes with its
+# slowest suite rather than the sum of them. Each cargo job builds from a cold
+# target directory; that build is a small fixed cost next to the suite it
+# unblocks. The gated suites wait only for the changes job, never for another
+# suite.
 jobs:
-  test:
-    runs-on: blacksmith-16vcpu-ubuntu-2404
+  # Which of the gated suites have had their inputs touched. The per-suite
+  # source sets are derived from cargo metadata's resolve graph at run time
+  # (see the action), so added or rewired crates are picked up with nothing
+  # to maintain here. A suite whose inputs are untouched has its job skipped,
+  # and the action reports the reason in this job's annotations and summary.
+  changes:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read
-      pull-requests: read
+    outputs:
+      container_e2e: ${{ steps.changes.outputs.container_e2e }}
+      docs_integration: ${{ steps.changes.outputs.docs_integration }}
+      scripts: ${{ steps.changes.outputs.scripts }}
 
     steps:
       - uses: actions/checkout@v6
         with:
+          # The detection diffs the branch against its base, so both sides of
+          # the history must be present.
           fetch-depth: 0
-          # Nothing in this job pushes, so it has no use for a writable
+          # Nothing in this workflow pushes, so no job has a use for a writable
           # credential sitting in .git/config for every later step to inherit.
           persist-credentials: false
 
-      # Give this run its own peppy data root so the runner does not accumulate
-      # or collide on /tmp/.peppy across runs. Only the Rust cargo steps below
-      # opt in via env; the release-scripts step is left alone so
-      # scripts/install.sh keeps defaulting PEPPY_HOME to $HOME/.peppy.
-      - name: Set up isolated peppy data root
-        run: |
-          PEPPY_RUN_HOME="$RUNNER_TEMP/peppy-home"
-          mkdir -p "$PEPPY_RUN_HOME/tmpdir"
-          echo "PEPPY_RUN_HOME=$PEPPY_RUN_HOME" >> "$GITHUB_ENV"
-
-      # Rust toolchain plus the system libraries the container build script
-      # compiles apptainer against. Must precede every cargo step.
+      # The detection queries cargo metadata, and the action is where the
+      # toolchain pin lives.
       - uses: ./.github/actions/rust-build-env
 
-      # Which of the later gated suites have had their inputs touched. The
-      # per-suite source sets are derived from cargo metadata's resolve graph
-      # at run time (see the action), so added or rewired crates are picked
-      # up with nothing to maintain here. A suite whose inputs are untouched
-      # is skipped, and the action reports the reason in the job's
-      # annotations and summary. Needs cargo on PATH, hence the placement
-      # after rust-build-env.
       - name: Detect changed test inputs
         id: changes
         uses: ./.github/actions/changed-test-inputs
         with:
           base: ${{ github.event.pull_request.base.sha || github.event.before }}
+
+  workspace-tests:
+    runs-on: blacksmith-16vcpu-ubuntu-2404
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      # Rust toolchain plus the system libraries the container build script
+      # compiles apptainer against. Must precede every cargo step.
+      - uses: ./.github/actions/rust-build-env
+
+      - uses: ./.github/actions/cargo-suite
+        with:
+          command: cargo test --locked
+
+  container-e2e:
+    needs: changes
+    if: needs.changes.outputs.container_e2e == 'true'
+    runs-on: blacksmith-16vcpu-ubuntu-2404
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: ./.github/actions/rust-build-env
+
+      - uses: ./.github/actions/cargo-suite
+        with:
+          command: cargo test --locked -p core-node --features container_e2e --test container_e2e
+
+  multi-daemon-e2e:
+    runs-on: blacksmith-16vcpu-ubuntu-2404
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: ./.github/actions/rust-build-env
 
       # A persistent Docker builder: setup-docker-builder starts a buildkitd
       # whose layer cache lives on a sticky disk, hydrated from this job's
@@ -76,30 +125,57 @@ jobs:
         with:
           cache-key: peppy/multi-daemon-e2e-image
 
-      - name: Run tests
-        run: |
-          export PEPPY_HOME="$PEPPY_RUN_HOME" TMPDIR="$PEPPY_RUN_HOME/tmpdir"
-          cargo test --locked
+      - uses: ./.github/actions/cargo-suite
+        with:
+          command: cargo test --locked -p peppy --features multi_daemon_e2e --test multi_daemon_e2e
 
-      - name: Run container e2e tests
-        if: steps.changes.outputs.container_e2e == 'true'
-        run: |
-          export PEPPY_HOME="$PEPPY_RUN_HOME" TMPDIR="$PEPPY_RUN_HOME/tmpdir"
-          cargo test --locked -p core-node --features container_e2e --test container_e2e
+  docs-integration:
+    needs: changes
+    if: needs.changes.outputs.docs_integration == 'true'
+    runs-on: blacksmith-16vcpu-ubuntu-2404
+    permissions:
+      contents: read
 
-      - name: Run multi-daemon Docker e2e test
-        run: |
-          export PEPPY_HOME="$PEPPY_RUN_HOME" TMPDIR="$PEPPY_RUN_HOME/tmpdir"
-          cargo test --locked -p peppy --features multi_daemon_e2e --test multi_daemon_e2e
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
 
-      - name: Run documentation integration tests
-        if: steps.changes.outputs.docs_integration == 'true'
-        run: |
-          export PEPPY_HOME="$PEPPY_RUN_HOME" TMPDIR="$PEPPY_RUN_HOME/tmpdir"
-          cargo test --locked -p docs-integration-tests
+      - uses: ./.github/actions/rust-build-env
+
+      # The snippet node tests run cargo offline
+      # (snippet_runner::run_cargo_node_tests) and resolve against the registry
+      # cache. This suite's own build fetches only the crates it links, and a
+      # synced node's dev-dependencies reach further: peppygen's `testing`
+      # feature turns on peppylib's, whose crates (ctor among them) only a
+      # workspace member's test build pulls in. Fetching the whole lockfile
+      # puts every crate the workspace resolves into the cache, which is what
+      # a synced node can count on.
+      - name: Fetch every crate in the lockfile for the offline snippet builds
+        run: cargo fetch --locked
+
+      - uses: ./.github/actions/cargo-suite
+        with:
+          command: cargo test --locked -p docs-integration-tests
+
+  release-scripts:
+    needs: changes
+    if: needs.changes.outputs.scripts == 'true'
+    runs-on: blacksmith-16vcpu-ubuntu-2404
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      # Provides the pixi the suite runs under.
+      - uses: ./.github/actions/rust-build-env
 
       - name: Run release scripts tests
-        if: steps.changes.outputs.scripts == 'true'
         run: |
           # The install tests boot Lima VMs, whose QEMU the runner image
           # lacks (limactl itself comes from the pixi environment). The
@@ -111,19 +187,6 @@ jobs:
             sudo chmod 666 /dev/kvm
           fi
           ./scripts/run_tests.sh --all
-
-      # Proves the build consumed the committed lockfile rather than re-resolving
-      # it, so the tested dependency graph is the shipped one. Must stay after the
-      # cargo steps: placed before them it proves nothing.
-      - name: Prove CI did not rewrite the shipping lockfile
-        run: git diff --exit-code -- Cargo.lock
-
-      # Reclaim the per-run data root so disk does not grow on every run. Runs
-      # even when a test step failed. The persistent build-tool cache at
-      # $HOME/.peppy/tmp is intentionally left in place (see build_helpers::cache_dir).
-      - name: Clean up isolated peppy data root
-        if: always()
-        run: rm -rf "$RUNNER_TEMP/peppy-home"
 
   # Build scripts execute on the build host even when cargo compiles for
   # another target, so a build script that runs a binary selected by the
@@ -165,3 +228,31 @@ jobs:
           PEPPY_SKIP_APPTAINER_PROVISION: "1"
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
         run: cargo check --locked --target aarch64-unknown-linux-gnu -p peppy
+
+  # The one status check the branch rulesets on dev and main require. It is
+  # green only when every job above succeeded or was gated off, so a red
+  # suite blocks the merge whichever job it ran in.
+  test:
+    needs:
+      - changes
+      - workspace-tests
+      - container-e2e
+      - multi-daemon-e2e
+      - docs-integration
+      - release-scripts
+      - cross-check
+    # Runs whatever happened above: on the default condition a failed or
+    # cancelled suite would leave this check unreported instead of red.
+    if: always()
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    permissions: {}
+
+    steps:
+      - name: Report every job's result
+        env:
+          RESULTS: ${{ toJSON(needs) }}
+        run: echo "$RESULTS"
+
+      - name: Fail when any job failed or was cancelled
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1


### PR DESCRIPTION
## Summary

The `Tests` workflow ran every suite in one serial job, so the wall clock was the sum of the suites: 31 to 58 minutes on recent runs (`Run tests` 11 to 16 min, container e2e 2.5 to 4.5 min, multi-daemon e2e 2 to 3.5 min, docs integration 15 to 21 min, release scripts 10 to 12 min). Each suite now runs in a job of its own, so the workflow finishes with its slowest suite. The cold workspace build every job pays is about 3 minutes (measured from the job logs), small next to the suites it unblocks; the expected wall clock is the docs job, roughly 20 to 25 minutes, whether or not the release scripts suite runs.

## Layout

- `changes` (4 vCPU): runs the input detection once; the gated jobs read its outputs, the ungated jobs never wait for it.
- `workspace-tests`, `container-e2e`, `multi-daemon-e2e`, `docs-integration`, `release-scripts`: one suite each, same commands and gates as before. The shared cargo plumbing (isolated peppy data root, lockfile proof, cleanup) moves into a `cargo-suite` composite action, so each job is checkout + `rust-build-env` + the suite.
- `cross-check`: unchanged.
- `test` (2 vCPU, `if: always()`): fails when any job above failed or was cancelled, passes when every job succeeded or was gated off. The branch rulesets on `dev` and `main` require the status check named `test`, so this keeps them covering the whole workflow with no ruleset change. Note that `cross-check` is now part of that gate; it was a separate, non-required check before.

## One hidden dependency the split exposed

The docs suite's snippet node tests run `cargo test` offline (`snippet_runner::run_cargo_node_tests`) and resolve against the registry cache. In the serial job that cache was warmed by the full workspace build first. The docs suite's own build does not fetch everything a synced node needs: `peppygen`'s `testing` feature enables `peppylib`'s, whose `ctor` dependency is in the workspace graph (via `mcp-server-internal`'s dev-deps) but not in `docs-integration-tests`' graph (verified with `cargo tree` diffs). The docs job therefore runs `cargo fetch --locked` before the suite, which puts every crate in the lockfile in the cache.

## Also

- `detect.py` names the jobs (not steps) in its skip notices and step summary, and lists the new composite action among the shared inputs.
- `latency.yml`'s comment refers to the `cargo test` job rather than step.

## Verification

- `actionlint` is clean apart from the Blacksmith runner labels it does not know (same as `latency.yml`).
- `detect.py` exercised locally against `origin/dev` and `HEAD`; the gate outputs and the skip notices/summary render the job names.
- This PR's own run of the workflow exercises every job: `tests.yml` is a shared input, so every gate is on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Peppy-bot/codesmith/peppy/pr/417"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790516448&installation_model_id=433186&pr_number=417&repository=Peppy-bot%2Fpeppy&return_to=https%3A%2F%2Fgithub.com%2FPeppy-bot%2Fpeppy%2Fpull%2F417&signature=40fbefd112e53196dd783985a4baabe22ac0903f017470aace9e4a5ebf4f7eb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->