### PR TITLE
Never read a bare launcher name from the current directory

### DIFF
--- a/crates/peppy/src/commands/stack/launch.rs
+++ b/crates/peppy/src/commands/stack/launch.rs
@@ -9,7 +9,7 @@ use core_node_api::encoding::{
     LauncherOrigin, NodeAddLogEntry, NodeBuildLogEntry, NodeRunLogEntry, PlacementSpec,
 };
 use daemon_config::core_node_name::CoreNodeName;
-use daemon_config::launcher::{PeppyLauncherParser, compose};
+use daemon_config::launcher::{PeppyLauncher, PeppyLauncherParser, compose};
 use peppylib::ActionMessenger;
 use peppylib::messaging::ResultStatus;
 use tracing::info;
@@ -163,10 +163,9 @@ fn looks_like_fs_path(input: &Path) -> bool {
     input.extension().is_some_and(|ext| ext == "json5")
 }
 
-/// Resolves a user-supplied launcher path, treating a bare name as shorthand for the `.json5`
-/// file. If the path does not have a `.json5` extension and a sibling `<path>.json5` exists as
-/// a file, that is returned; otherwise the original path is returned unchanged so the caller's
-/// existing not-found error path fires.
+/// Resolves a user-supplied launcher path, treating a path without the `.json5` extension as
+/// shorthand for the sibling file that has it. When no such sibling exists the original path
+/// is returned unchanged so the caller's existing not-found error path fires.
 ///
 /// Lives in the CLI (the sole caller) rather than `core-node-api`: it touches the filesystem
 /// (`is_file`), which a pure wire-codec crate should not do.
@@ -180,33 +179,35 @@ fn resolve_launcher_path(path: PathBuf) -> PathBuf {
     if candidate.is_file() { candidate } else { path }
 }
 
+/// Parses a launcher file, naming the file in the error: the parse error alone locates the
+/// offending field within the document, not the document on disk.
+pub(super) fn parse_launcher_file(path: &Path) -> Result<PeppyLauncher> {
+    PeppyLauncherParser::from_path(path)
+        .map_err(|e| Error::ExecutionFailed(format!("launcher file {}: {e}", path.display())))
+}
+
 /// Decide whether the user wants a filesystem launcher or a repository launcher.
 ///
-/// `./demo.json5`, `/abs/path`, `foo.json5` → `Fs`, with the path canonicalized so the daemon
-/// finds it regardless of its working directory. A bare name like `openarm01_sim_teleop` first
-/// tries the filesystem (sibling `.json5` shorthand from `resolve_launcher_path`) and only
-/// falls back to `Repository` when no file exists at that name.
+/// `./demo.json5`, `/abs/path`, `dir/foo`, `foo.json5` → `Fs`, with the path canonicalized so
+/// the daemon finds it regardless of its working directory. A bare name like
+/// `openarm01_sim_teleop` (no separator, no `.json5` extension) → `Repository`, whatever the
+/// current directory holds: the decision is made on the argument alone, and a same-named file
+/// next to the caller is never read.
 pub(super) fn infer_launcher_origin(input: PathBuf) -> Result<LauncherOrigin> {
-    if looks_like_fs_path(&input) {
-        let resolved = resolve_launcher_path(input);
-        let canonical = resolved.canonicalize().map_err(|e| {
-            Error::ExecutionFailed(format!(
-                "Failed to resolve launcher config path '{}': {}",
-                resolved.display(),
-                e
-            ))
-        })?;
-        return Ok(LauncherOrigin::Fs(canonical));
+    if !looks_like_fs_path(&input) {
+        return Ok(LauncherOrigin::Repository {
+            name: input.to_string_lossy().into_owned(),
+        });
     }
-
-    let resolved = resolve_launcher_path(input.clone());
-    if let Ok(canonical) = resolved.canonicalize() {
-        return Ok(LauncherOrigin::Fs(canonical));
-    }
-
-    Ok(LauncherOrigin::Repository {
-        name: input.to_string_lossy().into_owned(),
-    })
+    let resolved = resolve_launcher_path(input);
+    let canonical = resolved.canonicalize().map_err(|e| {
+        Error::ExecutionFailed(format!(
+            "Failed to resolve launcher config path '{}': {}",
+            resolved.display(),
+            e
+        ))
+    })?;
+    Ok(LauncherOrigin::Fs(canonical))
 }
 
 /// The `--place` / `--local` wiring as the user typed it.
@@ -313,7 +314,7 @@ async fn launch_async(
     // used: placement and the `--with` selection are resolved against the document the
     // COORDINATOR read, so that a repository launcher and a file one resolve identically.
     if let LauncherOrigin::Fs(path) = &launcher_origin {
-        let parsed = PeppyLauncherParser::from_path(path).map_err(Error::DaemonConfig)?;
+        let parsed = parse_launcher_file(path)?;
         compose(&parsed, path, &with).map_err(|e| Error::ExecutionFailed(e.to_string()))?;
     }
 
@@ -675,17 +676,33 @@ mod tests {
         }
     }
 
+    /// The decision is made on the argument alone: a bare name is a
+    /// repository launcher without a look at the filesystem. The integration
+    /// suite runs the binary next to a same-named file to hold that.
     #[test]
-    fn infer_launcher_origin_falls_back_to_repository_for_bare_name() {
-        // Use a name that is unlikely to collide with any sibling .json5 in the test cwd.
-        let bare = PathBuf::from("definitely_not_a_real_launcher_xyz123");
-        let origin = infer_launcher_origin(bare.clone()).expect("bare name should not error");
+    fn infer_launcher_origin_resolves_a_bare_name_through_the_repository() {
+        let origin =
+            infer_launcher_origin(PathBuf::from("openarm_v2")).expect("bare name should not error");
         match origin {
-            LauncherOrigin::Repository { name } => {
-                assert_eq!(name, "definitely_not_a_real_launcher_xyz123");
-            }
+            LauncherOrigin::Repository { name } => assert_eq!(name, "openarm_v2"),
             other => panic!("expected Repository, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn parse_launcher_file_names_the_file_in_its_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join("openarm_v2.json5");
+        std::fs::write(&file, r#"{ peppy_schema: "mcp_exposure/v1" }"#).unwrap();
+
+        let err = parse_launcher_file(&file).expect_err("an exposure is not a launcher");
+
+        let message = err.to_string();
+        assert!(message.contains(&file.display().to_string()), "{message}");
+        assert!(
+            message.contains("expected peppy_schema 'launcher/v1', got 'mcp_exposure/v1'"),
+            "{message}"
+        );
     }
 
     fn places(pairs: &[(&str, &str)]) -> PlacementArgs {

--- a/crates/peppy/src/commands/stack/resolve.rs
+++ b/crates/peppy/src/commands/stack/resolve.rs
@@ -6,13 +6,12 @@ use core_node_api::encoding::LauncherOrigin;
 use daemon_config::consts::PeppyDirs;
 use daemon_config::launcher::{
     AlreadyPairedSlots, BindingValidationItem, DeploymentSource, ExternallyCoveredSlots,
-    PairingValidationItem, PeppyLauncher, PeppyLauncherParser, compose, validate_link_slots,
-    validate_pairings,
+    PairingValidationItem, PeppyLauncher, compose, validate_link_slots, validate_pairings,
 };
 use daemon_config::repository::EntryOrigin;
 use tracing::info;
 
-use super::launch::infer_launcher_origin;
+use super::launch::{infer_launcher_origin, parse_launcher_file};
 use crate::context::AppContext;
 use crate::error::{Error, Result};
 
@@ -64,7 +63,7 @@ pub fn resolve_rendered(
         }
     };
 
-    let parsed = PeppyLauncherParser::from_path(&path).map_err(Error::DaemonConfig)?;
+    let parsed = parse_launcher_file(&path)?;
     let (flat, report) =
         compose(&parsed, &path, with).map_err(|e| Error::ExecutionFailed(e.to_string()))?;
 

--- a/crates/peppy/tests/stack_launch.rs
+++ b/crates/peppy/tests/stack_launch.rs
@@ -4965,3 +4965,40 @@ fn stack_resolve_reports_the_check_skipped_on_an_empty_cache() {
         "the skip tells the user how to enable the check: {report_text}"
     );
 }
+
+/// A bare name is a repository launcher whatever the current directory
+/// holds: `peppy stack resolve openarm_v2` run next to a valid
+/// `openarm_v2.json5` still goes to the repository cache, and is refused
+/// there because this root has none. Drives the binary because the current
+/// directory is per process.
+#[test]
+fn stack_resolve_never_reads_a_bare_name_from_the_current_directory() {
+    let cwd = tempfile::tempdir().expect("temp cwd");
+    fs::write(
+        cwd.path().join("openarm_v2.json5"),
+        r#"{ peppy_schema: "launcher/v1", deployments: [] }"#,
+    )
+    .expect("same-named launcher file");
+    let home = tempfile::tempdir().expect("temp home");
+
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_peppy"))
+        .args(["stack", "resolve", "openarm_v2"])
+        .current_dir(cwd.path())
+        .env(config::consts::PEPPY_HOME_ENV, home.path())
+        .output()
+        .expect("failed to run peppy");
+
+    let printed = format!(
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert!(
+        !output.status.success(),
+        "the same-named file was resolved instead of the repository:\n{printed}"
+    );
+    assert!(
+        printed.contains("launcher `openarm_v2` not found"),
+        "the refusal comes from the repository lookup:\n{printed}"
+    );
+}

--- a/docs/src/content/docs/guides/launch_files.mdx
+++ b/docs/src/content/docs/guides/launch_files.mdx
@@ -126,7 +126,7 @@ Launchers discovered by `peppy repo refresh` (see [Repositories](/advanced_guide
 peppy stack launch openarm01_sim_teleop
 ```
 
-An argument that contains a path separator or ends in `.json5` is always resolved as a filesystem path. A bare name (no separator, no extension) is first tried on disk as `<name>.json5` next to your current directory, and only falls back to the repository cache at `~/.peppy/cache/launchers.json5` when no such file exists. Run `peppy repo refresh` first on the machine you submit the launch to; the launcher document, like every repository source, resolves on that machine alone.
+An argument that contains a path separator or ends in `.json5` is resolved as a filesystem path: `./my_launcher.json5`, `/abs/my_launcher.json5`, `my_launcher.json5`. A bare name (no separator, no extension) is a repository launcher and is never looked up on disk, whatever the current directory holds: `peppy stack launch my_launcher` resolves through the repository cache at `~/.peppy/cache/launchers.json5` even when a `my_launcher.json5` sits next to the caller. Run `peppy repo refresh` first on the machine you submit the launch to; the launcher document, like every repository source, resolves on that machine alone.
 
 If the name resolves neither to a file nor to a cached launcher, the launch fails with an explicit "not found" error. If one repository provides two launcher files with that name, the launch fails with a distinct ambiguity error naming both: launchers are keyed by filename, so two identically named `.json5` files anywhere in one repository contest the same name even in different directories.
 


### PR DESCRIPTION
## Summary

`peppy stack launch openarm_v2 --with=isaac_sim,scene_commander,mcp_commander`, run from mcp-hub's `openarm/` directory, died before contacting the daemon:

```
Error: Config error: Cannot parse configuration: peppy_schema: expected peppy_schema 'launcher/v1', got 'mcp_exposure/v1'
```

`infer_launcher_origin` promoted a bare launcher name to `<name>.json5` in the current directory whenever such a file existed, and mcp-hub's `openarm/openarm_v2.json5` is the exposure named after the launcher it serves. The error named neither the file nor the reason the name had been read as a file.

## Behaviour

- A bare name (no path separator, no `.json5` extension) is a repository launcher. The decision is made on the argument alone; the current directory is never consulted, so `peppy stack launch my_launcher` means the repository even next to a `my_launcher.json5`.
- An argument that is a path (`./x.json5`, `/abs/x`, `dir/x`, `x.json5`) is resolved on disk, as before; `./demo` still stands for `./demo.json5` when that sibling exists.
- The launch pre-parse and `stack resolve` share `parse_launcher_file`, so a parse error names the file: `launcher file /abs/x.json5: Cannot parse configuration: peppy_schema: expected peppy_schema 'launcher/v1', got 'mcp_exposure/v1'`.
- `guides/launch_files.mdx` states the rule.

## Verification

Test-first. `stack_resolve_never_reads_a_bare_name_from_the_current_directory` (`crates/peppy/tests/stack_launch.rs`) drives the built binary from a temp directory holding a *valid* same-named `openarm_v2.json5` launcher, with `PEPPY_HOME` on an empty root, and expects the repository lookup's refusal (``launcher `openarm_v2` not found``). Against the previous code it failed with `the same-named file was resolved instead of the repository` (exit 0, the flattened file on stdout); it passes now. It runs the binary because the current directory is per process, which keeps the unit suite free of `chdir`.

- `cargo test -p peppy --lib`: 216 passed
- `cargo test -p peppy --test integration -- stack_resolve`: 9 passed
- `cargo clippy -p peppy --all-targets`: nothing reported in the changed files

Revised after review: the first push kept the on-disk probe and skipped same-named files by reading their `peppy_schema`; that fallback is gone, along with the schema-sniffing helper it needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
