### PR TITLE
Configure pairings-hub as a default repository

### DIFF
--- a/crates/core-node-internal/assets/default_repositories.json5
+++ b/crates/core-node-internal/assets/default_repositories.json5
@@ -23,4 +23,10 @@
     url: "https://github.com/Peppy-bot/mcp-hub.git",
     ref: "main"
   },
+  {
+    id: 1004,
+    type: "git",
+    url: "https://github.com/Peppy-bot/pairings-hub.git",
+    ref: "main"
+  },
 ]

--- a/docs/src/content/docs/advanced_guides/repositories.mdx
+++ b/docs/src/content/docs/advanced_guides/repositories.mdx
@@ -13,12 +13,13 @@ Repositories tell Peppy where to look for nodes, launchers, contracts, pairings,
 - **Pairings**, identified by content: every `.json5` file whose body declares `peppy_schema: "pairing/v1"` is treated as a pairing, regardless of its filename. A pairing is a two-role, topics-only contract that two node instances pair 1:1 over, keyed by the `name:tag` declared in its manifest; see [Pairing](/advanced_guides/pairing/).
 - **MCP exposures**, identified by content: every `.json5` file whose body declares `peppy_schema: "mcp_exposure/v1"` is treated as an MCP exposure, regardless of its filename, keyed by the `name:tag` declared in its manifest. An exposure selects members of contracts and gives them stable public names, MCP-facing prose, and operational policies; a launcher lists exposures by `name:tag` and the server built into `peppy` serves them, and [`peppy repo index --check --validate-mcp-exposures`](#check-the-exposures-a-repository-publishes) validates each one against the contracts it references. See [MCP exposure](/advanced_guides/mcp/).
 
-Out of the box, four repositories are configured:
+Out of the box, five repositories are configured:
 
 - **`nodes-hub`** (`https://github.com/Peppy-bot/nodes-hub.git`, tracked on `main`, id `1000`): a curated collection of ready-to-use nodes.
 - **`launchers-hub`** (`https://github.com/Peppy-bot/launchers-hub.git`, tracked on `main`, id `1001`): community launch files that compose nodes from the hubs.
 - **`contracts-hub`** (`https://github.com/Peppy-bot/contracts-hub.git`, tracked on `main`, id `1002`): shared contract definitions that nodes claim by `name:tag` in `manifest.implements`.
 - **`mcp-hub`** (`https://github.com/Peppy-bot/mcp-hub.git`, tracked on `main`, id `1003`): [MCP exposure](/advanced_guides/mcp/) documents that a launcher lists by `name:tag` and the server built into `peppy` serves.
+- **`pairings-hub`** (`https://github.com/Peppy-bot/pairings-hub.git`, tracked on `main`, id `1004`): shared pairing definitions that nodes play roles in by `name:tag` in `depends_on.pairings`; see [Pairing](/advanced_guides/pairing/).
 
 The `id` is the priority key when several repositories provide the same `name:tag`, so the defaults resolve in this order.
 


### PR DESCRIPTION
The pairing documents moved from `contracts-hub` to `Peppy-bot/pairings-hub` (pairings-hub#1), so the default repositories must include the new hub or every `depends_on.pairings` slot stops resolving on default-configured machines once contracts-hub#44 merges its side of the move.

Changes:

- `default_repositories.json5`: id `1004`, `https://github.com/Peppy-bot/pairings-hub.git`, tracked on `main`, after mcp-hub. `ensure_default_repos` needs no code change: it appends any default whose id is missing, so upgrading machines gain the entry on the next daemon start or `peppy repo init`.
- `repositories.mdx`: the out-of-the-box list becomes five, with the pairings-hub row.

Tests: `cargo test -p core-node --lib services::repo::init` (7), `--test listen_for_repo_add` (14), `--test listen_for_repo_refresh` (15), all green.

**Release coupling:** this must merge and ship in a release before contracts-hub#44 merges; the hub CI runners and default-configured machines install peppy from releases, not from `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Peppy-bot/codesmith/peppy/pr/421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790775131&installation_model_id=433186&pr_number=421&repository=Peppy-bot%2Fpeppy&return_to=https%3A%2F%2Fgithub.com%2FPeppy-bot%2Fpeppy%2Fpull%2F421&signature=b9b2f1942ebfcb4880f751beaf7f325c2ee411dd2d10a1bc3c4fbb657c7e37cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->