### PR TITLE
repo: report a node's own pairing slots and their peers in `repo show`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -587,7 +587,7 @@ dependencies = [
 [[package]]
 name = "build-helpers"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#1cff48b16380b2e621d6091c1a78782cfbd18945"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#acc4fa7a2723b7b321ef0e683076291f82ee2c3f"
 dependencies = [
  "sha2",
 ]
@@ -675,12 +675,12 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "rand_core 0.10.1",
 ]
 
@@ -785,7 +785,7 @@ dependencies = [
 [[package]]
 name = "config-test-support"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#1cff48b16380b2e621d6091c1a78782cfbd18945"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#acc4fa7a2723b7b321ef0e683076291f82ee2c3f"
 dependencies = [
  "askama",
  "git2",
@@ -931,7 +931,7 @@ dependencies = [
 [[package]]
 name = "core-node-api"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#1cff48b16380b2e621d6091c1a78782cfbd18945"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#acc4fa7a2723b7b321ef0e683076291f82ee2c3f"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -957,9 +957,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
 dependencies = [
  "libc",
 ]
@@ -1113,7 +1113,7 @@ dependencies = [
  "const_format",
  "core-node-api",
  "dirs 6.0.0",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "peppy-config-model",
  "peppy-mcp-catalog",
  "serde",
@@ -1313,7 +1313,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1422,7 +1422,7 @@ dependencies = [
  "capnp",
  "capnpc",
  "daemon-config",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "peppy-config-model",
  "proc-macro2",
  "serde_json5",
@@ -1462,7 +1462,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1562,9 +1562,9 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1754,7 +1754,7 @@ dependencies = [
  "config-test-support",
  "daemon-config",
  "encoding",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "json5-pretty",
  "mcp-test-support",
  "message-codec",
@@ -1869,9 +1869,9 @@ dependencies = [
 
 [[package]]
 name = "gix-path"
-version = "0.12.5"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b075e730586bba7341304d6fc1b4efc1d10cf64532622521c0e07f30e661046"
+checksum = "38fc6f029ea67de83cbcbd33fd98c05a48360d2932b39d9fdacbc6eae802d475"
 dependencies = [
  "bstr",
  "gix-trace",
@@ -1950,7 +1950,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -2036,9 +2036,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+checksum = "e17592d60ebacc7d5e169f4663c5f84f9161cc90328abcfe8456f41e4dfcb284"
 
 [[package]]
 name = "hex"
@@ -2195,9 +2195,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
+checksum = "27b501faa50e7a26c3d3560ca625132f4078a17771f4810baf70475ae48cbe43"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2472,9 +2472,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
@@ -2696,7 +2696,7 @@ dependencies = [
 [[package]]
 name = "json5-pretty"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#1cff48b16380b2e621d6091c1a78782cfbd18945"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#acc4fa7a2723b7b321ef0e683076291f82ee2c3f"
 dependencies = [
  "serde",
  "serde_json",
@@ -2839,9 +2839,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
+checksum = "d7955dfc218a8afb29dfeffd540e3a6e96baeb94fe7138228dd7cc6937fbbf96"
 dependencies = [
  "libc",
 ]
@@ -3035,9 +3035,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.9"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -3172,7 +3172,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3497,11 +3497,11 @@ dependencies = [
 
 [[package]]
 name = "pem"
-version = "3.0.6"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+checksum = "d354a98a3d1251555de99e8fdd8afda05573c31b82f59063a7b0a29b5527f120"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "serde_core",
 ]
 
@@ -3572,11 +3572,11 @@ dependencies = [
 [[package]]
 name = "peppy-config-model"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#1cff48b16380b2e621d6091c1a78782cfbd18945"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#acc4fa7a2723b7b321ef0e683076291f82ee2c3f"
 dependencies = [
  "capnp",
  "clap",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "serde",
  "serde_json",
  "serde_json5",
@@ -3591,9 +3591,9 @@ dependencies = [
 [[package]]
 name = "peppy-mcp-catalog"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#1cff48b16380b2e621d6091c1a78782cfbd18945"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#acc4fa7a2723b7b321ef0e683076291f82ee2c3f"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "peppy-config-model",
  "serde",
  "serde_json",
@@ -3603,7 +3603,7 @@ dependencies = [
 [[package]]
 name = "peppy-mcp-runtime"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#1cff48b16380b2e621d6091c1a78782cfbd18945"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#acc4fa7a2723b7b321ef0e683076291f82ee2c3f"
 dependencies = [
  "axum",
  "base64 0.23.1",
@@ -3625,7 +3625,7 @@ version = "0.0.1"
 [[package]]
 name = "peppylib-rs"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#1cff48b16380b2e621d6091c1a78782cfbd18945"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#acc4fa7a2723b7b321ef0e683076291f82ee2c3f"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -3706,7 +3706,7 @@ checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
  "hashbrown 0.15.5",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "serde",
 ]
 
@@ -3813,7 +3813,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64 0.22.1",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "quick-xml",
  "serde",
  "time",
@@ -3822,7 +3822,7 @@ dependencies = [
 [[package]]
 name = "pmi"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#1cff48b16380b2e621d6091c1a78782cfbd18945"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#acc4fa7a2723b7b321ef0e683076291f82ee2c3f"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -3947,7 +3947,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e3f4237d0e4741eb50bc5584db701f1299c85fa31ff0274dd6445e79dc42d12"
 dependencies = [
  "futures",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "nix 0.31.3",
  "tokio",
  "tracing",
@@ -4057,7 +4057,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.5",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4139,9 +4139,9 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.14.9"
+version = "0.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091e7a8e7d86e6feb87a27ce8e2cba29d49eff9507afeebefab7eeb2ca667fb4"
+checksum = "8774e05a7d0de114588e6a28fe7e71694b82614ed569d86d8b389dfbc98b8ad8"
 dependencies = [
  "pem",
  "ring",
@@ -4322,9 +4322,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "3.1.4"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a15bc53261a9dc37e105df006e4656c598379a8f9581f8950debb130f27a7cf"
+checksum = "42b6914fac0be956fe704a38239c3f44a9f841d1b06a5713d2f638065593f5b5"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -4334,7 +4334,7 @@ dependencies = [
  "http",
  "http-body",
  "http-body-util",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "pastey",
  "pin-project-lite",
  "rand 0.10.2",
@@ -4499,7 +4499,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4567,7 +4567,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4758,7 +4758,7 @@ version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "itoa",
  "memchr",
  "serde",
@@ -4841,7 +4841,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "jiff",
  "schemars 0.9.0",
  "schemars 1.2.2",
@@ -4869,7 +4869,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "itoa",
  "ryu",
  "serde",
@@ -4910,7 +4910,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "digest 0.11.3",
 ]
 
@@ -4945,7 +4945,7 @@ version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
 dependencies = [
- "dirs 4.0.0",
+ "dirs 6.0.0",
 ]
 
 [[package]]
@@ -5294,7 +5294,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5538,7 +5538,7 @@ version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "serde_core",
  "serde_spanned",
  "toml_datetime",
@@ -5562,7 +5562,7 @@ version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "toml_datetime",
  "toml_parser",
  "toml_writer",
@@ -5632,7 +5632,7 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -5963,9 +5963,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.25.0"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f053576934f05a761a402421fbbe3d425d9366f75f978806a037b3ca481abecc"
+checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -6210,7 +6210,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7118,7 +7118,7 @@ checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
 dependencies = [
  "crc32fast",
  "flate2",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "memchr",
  "typed-path",
  "zopfli",

--- a/crates/core-node-internal/src/lib.rs
+++ b/crates/core-node-internal/src/lib.rs
@@ -23,8 +23,8 @@ pub use services::repo::index::{
 };
 pub use services::repo::{
     Consumer, Implementer, IndexedNode, InitOutcome, MatchedItem, Observer, Participant, PinStatus,
-    PublishedDoc, SearchOutcome, SearchQuery, SearchReport, ShowOutcome, ensure_default_repos,
-    search_repo_items, show_repo_items,
+    PublishedDoc, SearchOutcome, SearchQuery, SearchReport, ShowOutcome, SlotPeers,
+    ensure_default_repos, search_repo_items, show_repo_items,
 };
 pub use services::{
     CoreNode, CoreNodeArguments, CoreNodeConfig, NAME_CLAIM_LINKED_SETTLE, TEARDOWN_REAP_BUDGET,

--- a/crates/core-node-internal/src/services/repo.rs
+++ b/crates/core-node-internal/src/services/repo.rs
@@ -17,8 +17,8 @@ pub use refresh::listen_for_repo_refresh;
 pub use remove::listen_for_repo_remove;
 pub use search::{
     Consumer, Implementer, IndexedNode, MatchedItem, Observer, Participant, PinStatus,
-    PublishedDoc, SearchOutcome, SearchQuery, SearchReport, ShowOutcome, search_repo_items,
-    show_repo_items,
+    PublishedDoc, SearchOutcome, SearchQuery, SearchReport, ShowOutcome, SlotPeers,
+    search_repo_items, show_repo_items,
 };
 
 use crate::services::repo::cache::{EntryOrigin, NodeCacheEntry, UNOWNED_REPO_ID};

--- a/crates/core-node-internal/src/services/repo/search.rs
+++ b/crates/core-node-internal/src/services/repo/search.rs
@@ -11,8 +11,8 @@
 
 use crate::services::repo::cache::{
     ContractCacheEntry, DeclaredLinks, LauncherCacheEntry, McpExposureCacheEntry, NodeCacheEntry,
-    PairingCacheEntry, RepoCacheEntry, excluded_repositories_hint, load_contract_cache,
-    load_node_cache, load_pairing_cache, load_repo_cache, lookup_repo_entry,
+    PairingCacheEntry, PairingSlot, RepoCacheEntry, excluded_repositories_hint,
+    load_contract_cache, load_node_cache, load_pairing_cache, load_repo_cache, lookup_repo_entry,
     lookup_repo_entry_by_sha256,
 };
 use crate::services::repo::{
@@ -216,6 +216,29 @@ pub struct Observer {
     pub pin: PinStatus,
 }
 
+/// One `depends_on.pairings` slot the searched node declares, with the
+/// slots that could fill it: a pairing has two roles, so a peer is any
+/// indexed node declaring the same pairing in the role this slot does not
+/// play.
+///
+/// Reported for node identities only, and only for participant slots. An
+/// observer watches a pair two other nodes form, so its slot is filled by
+/// that pair rather than by a complementary role, and a contract slot's
+/// candidates are the contract's implementers, one `repo show` away.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SlotPeers {
+    /// The slot, as a launcher's `links:` names it.
+    pub link_id: String,
+    pub pairing_name: String,
+    pub pairing_tag: String,
+    /// The role the searched node plays; a peer plays the other one.
+    pub role: String,
+    /// The slot may run with no peer, so an empty `peers` is survivable.
+    pub optional: bool,
+    /// The complementary slots, ordered as every other section is.
+    pub peers: Vec<Participant>,
+}
+
 /// The document a reference resolves to: the lowest-id repository's copy,
 /// or, for a digest query, the copy carrying that digest.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -267,7 +290,9 @@ pub struct ShowOutcome {
 }
 
 /// Who uses one identity: the nodes that implement, consume, participate
-/// in, or observe it, read from the links `repo refresh` recorded.
+/// in, or observe it, read from the links `repo refresh` recorded. When the
+/// identity is a node, also what its own pairing slots can pair with, which
+/// is the same cache read in the other direction.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SearchReport {
     pub name: String,
@@ -276,6 +301,10 @@ pub struct SearchReport {
     pub consumers: Vec<Consumer>,
     pub participants: Vec<Participant>,
     pub observers: Vec<Observer>,
+    /// The searched node's own `depends_on.pairings` slots in manifest
+    /// order, each with the peers that could fill it. Empty for every
+    /// other kind, and for a node that declares no pairing slot.
+    pub pairing_slots: Vec<SlotPeers>,
 }
 
 /// Searches this machine's caches for every indexed item the query
@@ -469,8 +498,10 @@ fn kind_rank(kind: RepoItemKind) -> u8 {
 }
 
 /// Who uses `name:tag`: the nodes whose cached links implement, consume,
-/// participate in, or observe it, with each claim's pin checked. Each
-/// section is ordered by repository id, then node name, tag and slot.
+/// participate in, or observe it, with each claim's pin checked, and, when
+/// `name:tag` is itself a node, what each of its pairing slots can pair
+/// with. Each section is ordered by repository id, then node name, tag and
+/// slot.
 fn usage_report(
     nodes: &[NodeCacheEntry],
     contracts: &[ContractCacheEntry],
@@ -490,10 +521,35 @@ fn usage_report(
         claim_name.as_str() == name && claim_tag == tag
     };
 
+    // The pairing slots `name:tag` declares when it is a node, read from
+    // the copy a launch resolves to, so the peers reported are the peers
+    // that node asks for. Empty for every other kind.
+    let own_slots: Vec<PairingSlot> = lookup_repo_entry(nodes, name, tag)
+        .map_err(|ambiguity| ambiguity.to_string())?
+        .map(|entry| entry.links.pairings.clone())
+        .unwrap_or_default();
+    // Each slot's pairing resolves to its own document, so a peer's pin is
+    // checked against the pairing it claims, not against `name:tag`.
+    let slot_docs: Vec<Option<PublishedDoc>> = own_slots
+        .iter()
+        .map(|slot| published_doc(pairings, repos, slot.name.as_str(), &slot.tag))
+        .collect::<Result<_, _>>()?;
+    let slot_pin = |index: usize, slot: &PairingSlot, sha256: Option<&str>| {
+        pin_status(
+            pairings,
+            slot_docs[index].as_ref(),
+            repos,
+            slot.name.as_str(),
+            &slot.tag,
+            sha256,
+        )
+    };
+
     let mut implementers = Vec::new();
     let mut consumers = Vec::new();
     let mut participants = Vec::new();
     let mut observers = Vec::new();
+    let mut slot_peers: Vec<Vec<Participant>> = vec![Vec::new(); own_slots.len()];
     for RepoNodes { repo, nodes } in nodes_by_repository(repos, nodes) {
         for node in &nodes {
             let DeclaredLinks {
@@ -539,12 +595,52 @@ fn usage_report(
                     pin: pairing_pin(slot.sha256.as_deref()),
                 });
             }
+            // The other direction: this node's pairing slots against the
+            // searched node's, one peer per slot of the same pairing in
+            // the role the searched slot leaves to the other end. What
+            // the role test leaves out is every slot playing the searched
+            // slot's own role, the searched slot included; a node
+            // declaring both roles pairs two of its own instances, so it
+            // is a peer of itself here.
+            for (index, own) in own_slots.iter().enumerate() {
+                let complementary = pairings.iter().filter(|slot| {
+                    slot.name.as_str() == own.name.as_str()
+                        && slot.tag == own.tag
+                        && slot.role != own.role
+                });
+                for slot in complementary {
+                    slot_peers[index].push(Participant {
+                        node: indexed(repo, node),
+                        role: slot.role.clone(),
+                        link_id: slot.link_id.clone(),
+                        optional: slot.optional,
+                        sha256: slot.sha256.clone(),
+                        pin: slot_pin(index, own, slot.sha256.as_deref()),
+                    });
+                }
+            }
         }
     }
     implementers.sort_by_key(|hit| hit_order(&hit.node, &hit.link_id));
     consumers.sort_by_key(|hit| hit_order(&hit.node, &hit.link_id));
     participants.sort_by_key(|hit| hit_order(&hit.node, &hit.link_id));
     observers.sort_by_key(|hit| hit_order(&hit.node, &hit.link_id));
+
+    let pairing_slots = own_slots
+        .into_iter()
+        .zip(slot_peers)
+        .map(|(slot, mut peers)| {
+            peers.sort_by_key(|hit| hit_order(&hit.node, &hit.link_id));
+            SlotPeers {
+                link_id: slot.link_id,
+                pairing_name: slot.name.as_str().to_owned(),
+                pairing_tag: slot.tag,
+                role: slot.role,
+                optional: slot.optional,
+                peers,
+            }
+        })
+        .collect();
 
     Ok(SearchReport {
         name: name.to_owned(),
@@ -553,6 +649,7 @@ fn usage_report(
         consumers,
         participants,
         observers,
+        pairing_slots,
     })
 }
 
@@ -963,6 +1060,161 @@ mod tests {
                 sha256: None,
                 pin: PinStatus::Unpinned,
             }]
+        );
+        assert_eq!(
+            report.pairing_slots,
+            vec![],
+            "no node is published as `rgb_camera:v1`, so it declares no slots"
+        );
+    }
+
+    /// A node's report reads its own pairing slots the other way: each
+    /// slot in manifest order, with the slots that could fill it, which
+    /// are the slots of the same pairing in the role the searched slot
+    /// leaves open. Same-role slots, observers, and the searched node's
+    /// own slot are not peers; a slot nothing complements reports none.
+    #[test]
+    fn a_nodes_pairing_slots_report_the_peers_that_could_fill_them() {
+        let home = Home::new();
+        let hub = home.repo("hub");
+        home.configure(&[(1, &hub)]);
+        let pairing = pairing_entry("arm_link", "v1", fs(hub.join("pairings/arm.json5")));
+        let pairing_sha = pairing.sha256.as_str().to_owned();
+        home.cache(&[pairing]);
+        home.cache(&[
+            with_links(
+                node_entry("arm", "v1", fs(hub.join("arm/peppy.json5"))),
+                DeclaredLinks {
+                    pairings: vec![
+                        participates("arm_link", "v1", "arm", "link", false, None),
+                        participates("solo_link", "v1", "watcher", "solo", true, None),
+                    ],
+                    ..DeclaredLinks::default()
+                },
+            ),
+            with_links(
+                node_entry("controller", "v1", fs(hub.join("controller/peppy.json5"))),
+                DeclaredLinks {
+                    pairings: vec![participates(
+                        "arm_link",
+                        "v1",
+                        "controller",
+                        "arm",
+                        false,
+                        Some(&pairing_sha),
+                    )],
+                    ..DeclaredLinks::default()
+                },
+            ),
+            with_links(
+                node_entry("second_arm", "v1", fs(hub.join("second_arm/peppy.json5"))),
+                DeclaredLinks {
+                    pairings: vec![participates("arm_link", "v1", "arm", "link", true, None)],
+                    ..DeclaredLinks::default()
+                },
+            ),
+            with_links(
+                node_entry("logger", "v1", fs(hub.join("logger/peppy.json5"))),
+                DeclaredLinks {
+                    pairing_observers: vec![observes(
+                        "arm_link",
+                        "v1",
+                        "controller",
+                        "watch",
+                        Cardinality::One,
+                        None,
+                    )],
+                    ..DeclaredLinks::default()
+                },
+            ),
+        ]);
+
+        let outcome = show(&home, "arm:v1").expect("shows");
+
+        let report = &outcome.reports[0];
+        assert_eq!(
+            report.pairing_slots,
+            vec![
+                SlotPeers {
+                    link_id: "link".to_owned(),
+                    pairing_name: "arm_link".to_owned(),
+                    pairing_tag: "v1".to_owned(),
+                    role: "arm".to_owned(),
+                    optional: false,
+                    peers: vec![Participant {
+                        node: IndexedNode {
+                            node_name: "controller".to_owned(),
+                            node_tag: "v1".to_owned(),
+                            repo_id: 1,
+                            repo_label: label(&hub),
+                            source_type: RepoSourceKind::Fs,
+                            path: label(&hub.join("controller/peppy.json5")),
+                            shadowed_by: None,
+                        },
+                        role: "controller".to_owned(),
+                        link_id: "arm".to_owned(),
+                        optional: false,
+                        sha256: Some(pairing_sha),
+                        pin: PinStatus::Current,
+                    }],
+                },
+                SlotPeers {
+                    link_id: "solo".to_owned(),
+                    pairing_name: "solo_link".to_owned(),
+                    pairing_tag: "v1".to_owned(),
+                    role: "watcher".to_owned(),
+                    optional: true,
+                    peers: Vec::new(),
+                },
+            ],
+        );
+    }
+
+    /// A node declaring both roles of one pairing pairs two of its own
+    /// instances, so it is its own peer: only the searched slot itself is
+    /// left out, not every slot the node declares.
+    #[test]
+    fn a_node_playing_both_roles_is_its_own_peer() {
+        let home = Home::new();
+        let hub = home.repo("hub");
+        home.configure(&[(1, &hub)]);
+        home.cache(&[pairing_entry(
+            "arm_link",
+            "v1",
+            fs(hub.join("pairings/arm.json5")),
+        )]);
+        home.cache(&[with_links(
+            node_entry("backbone", "v1", fs(hub.join("backbone/peppy.json5"))),
+            DeclaredLinks {
+                pairings: vec![
+                    participates("arm_link", "v1", "controller", "downstream", false, None),
+                    participates("arm_link", "v1", "arm", "upstream", true, None),
+                ],
+                ..DeclaredLinks::default()
+            },
+        )]);
+
+        let outcome = show(&home, "backbone:v1").expect("shows");
+
+        let slots = &outcome.reports[0].pairing_slots;
+        assert_eq!(slots.len(), 2);
+        assert_eq!(slots[0].link_id, "downstream");
+        assert_eq!(
+            slots[0]
+                .peers
+                .iter()
+                .map(|peer| peer.link_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["upstream"],
+            "the other role's slot on the same node fills it"
+        );
+        assert_eq!(
+            slots[1]
+                .peers
+                .iter()
+                .map(|peer| peer.link_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["downstream"],
         );
     }
 

--- a/crates/peppy/src/commands/repo/search.rs
+++ b/crates/peppy/src/commands/repo/search.rs
@@ -262,6 +262,7 @@ pub(super) mod fixtures {
             consumers: Vec::new(),
             participants: Vec::new(),
             observers: Vec::new(),
+            pairing_slots: Vec::new(),
         }
     }
 }
@@ -359,13 +360,21 @@ mod tests {
     #[test]
     fn human_output_phrases_a_single_match() {
         let outcome = SearchOutcome {
-            matches: vec![matched(RepoItemKind::Contract, "rgb_camera", "v1", contract())],
+            matches: vec![matched(
+                RepoItemKind::Contract,
+                "rgb_camera",
+                "v1",
+                contract(),
+            )],
             excluded_hint: String::new(),
         };
 
         let text = render_human(&query("rgb_camera:v1"), &outcome, false, None);
 
-        assert!(text.contains("\n1 item matches `rgb_camera:v1`\n"), "{text}");
+        assert!(
+            text.contains("\n1 item matches `rgb_camera:v1`\n"),
+            "{text}"
+        );
         assert!(text.contains("│ contract │ rgb_camera:v1 │"), "{text}");
     }
 

--- a/crates/peppy/src/commands/repo/show.rs
+++ b/crates/peppy/src/commands/repo/show.rs
@@ -1,10 +1,15 @@
 use std::collections::BTreeSet;
 
-use core_node::{IndexedNode, MatchedItem, PinStatus, SearchQuery, SearchReport, ShowOutcome};
+use core_node::{
+    IndexedNode, MatchedItem, Participant, PinStatus, SearchQuery, SearchReport, ShowOutcome,
+    SlotPeers,
+};
 use core_node_api::encoding::RepoItemKind;
 use daemon_config::consts::PeppyDirs;
 
-use super::search::{display_id, kind_label, matches_json, no_match_phrase, query_json, short_fingerprint};
+use super::search::{
+    display_id, kind_label, matches_json, no_match_phrase, query_json, short_fingerprint,
+};
 use crate::commands::colors::{BINDING_COLOR, COUNT_COLOR, NODE_COLOR, ORANGE, RED, paint};
 use crate::commands::table::render_table;
 use crate::error::{Error, Result};
@@ -88,10 +93,16 @@ fn render_human(
     out
 }
 
+/// The columns of a section listing claims on a contract, and of one
+/// listing roles played in a pairing.
+const CONTRACT_HEADERS: [&str; 5] = ["NODE", "TAG", "SLOT", "PIN", "PATH"];
+const PAIRING_HEADERS: [&str; 6] = ["NODE", "TAG", "ROLE", "SLOT", "PIN", "PATH"];
+
 /// One identity's report: one published line per document of the
-/// identity, then the four usage sections. A contract or pairing nobody
-/// uses says so; the other kinds have no usage sections to be empty, so
-/// their published line is the whole answer.
+/// identity, then the four usage sections, then, for a node, one section
+/// per pairing slot it declares. A contract or pairing nobody uses says
+/// so; a launcher or an MCP exposure has neither kind of section to be
+/// empty, so its published line is the whole answer.
 fn report_block(
     report: &SearchReport,
     items: &[&MatchedItem],
@@ -105,8 +116,6 @@ fn report_block(
     }
 
     let mut sections = String::new();
-    const CONTRACT_HEADERS: [&str; 5] = ["NODE", "TAG", "SLOT", "PIN", "PATH"];
-    const PAIRING_HEADERS: [&str; 6] = ["NODE", "TAG", "ROLE", "SLOT", "PIN", "PATH"];
     sections.push_str(&section(
         "Implemented by",
         &CONTRACT_HEADERS,
@@ -175,7 +184,55 @@ fn report_block(
         ));
     }
     out.push_str(&sections);
+    // Judged on the usage sections alone: an identity published as both a
+    // node and a contract still says the contract half is unused.
+    for slot in &report.pairing_slots {
+        out.push_str(&peer_section(slot, colorize, max_width));
+    }
     out
+}
+
+/// One declared pairing slot and what can fill it: the nodes playing the
+/// pairing's other role, under a title naming the slot, the pairing it
+/// resolves through and the role this node plays. The rows are the peers'
+/// own slots, so they read exactly as the pairing's own report does.
+///
+/// A slot no indexed node can pair with says so on one line rather than
+/// vanishing, because that is the answer, and on a slot that is not
+/// `optional` it is the answer that no indexed node completes a launch of
+/// this one. Being listed here is a match of pairing and role, which is
+/// what pairing requires and all the caches record; whether a stack of the
+/// two is one worth running is a launcher's business.
+fn peer_section(slot: &SlotPeers, colorize: bool, max_width: Option<usize>) -> String {
+    let label = format!(
+        "Slot {} ({} as {}{})",
+        paint(colorize, BINDING_COLOR, &slot.link_id),
+        paint(
+            colorize,
+            NODE_COLOR,
+            &format!("{}:{}", slot.pairing_name, slot.pairing_tag)
+        ),
+        slot.role,
+        if slot.optional { ", optional" } else { "" },
+    );
+    if slot.peers.is_empty() {
+        return format!("\n{label}: no indexed node plays the other role\n");
+    }
+    section(
+        &format!("{label} can pair with"),
+        &PAIRING_HEADERS,
+        &slot.peers,
+        |hit| &hit.node,
+        |hit| {
+            vec![
+                hit.role.clone(),
+                slot_cell(&hit.link_id, hit.optional.then_some("optional"), colorize),
+                pin_cell(hit.sha256.as_deref(), &hit.pin, colorize),
+            ]
+        },
+        colorize,
+        max_width,
+    )
 }
 
 /// Where one matching document is stored: the copy a plain reference
@@ -318,7 +375,8 @@ fn render_json(query: &SearchQuery, outcome: &ShowOutcome) -> String {
 }
 
 /// One usage report: every section with each hit's node, slot facts, raw
-/// pin and pin state.
+/// pin and pin state, and, under `pairing_slots`, the node's own pairing
+/// slots with the peers each can take.
 fn report_json(report: &SearchReport) -> serde_json::Value {
     let implementers: Vec<serde_json::Value> = report
         .implementers
@@ -345,20 +403,8 @@ fn report_json(report: &SearchReport) -> serde_json::Value {
             })
         })
         .collect();
-    let participants: Vec<serde_json::Value> = report
-        .participants
-        .iter()
-        .map(|hit| {
-            serde_json::json!({
-                "node": node_json(&hit.node),
-                "role": hit.role,
-                "link_id": hit.link_id,
-                "optional": hit.optional,
-                "sha256": hit.sha256,
-                "pin": pin_json(&hit.pin),
-            })
-        })
-        .collect();
+    let participants: Vec<serde_json::Value> =
+        report.participants.iter().map(participant_json).collect();
     let observers: Vec<serde_json::Value> = report
         .observers
         .iter()
@@ -373,6 +419,19 @@ fn report_json(report: &SearchReport) -> serde_json::Value {
             })
         })
         .collect();
+    let pairing_slots: Vec<serde_json::Value> = report
+        .pairing_slots
+        .iter()
+        .map(|slot| {
+            serde_json::json!({
+                "link_id": slot.link_id,
+                "pairing": { "name": slot.pairing_name, "tag": slot.pairing_tag },
+                "role": slot.role,
+                "optional": slot.optional,
+                "peers": slot.peers.iter().map(participant_json).collect::<Vec<_>>(),
+            })
+        })
+        .collect();
     serde_json::json!({
         "name": report.name,
         "tag": report.tag,
@@ -380,6 +439,20 @@ fn report_json(report: &SearchReport) -> serde_json::Value {
         "consumers": consumers,
         "participants": participants,
         "observers": observers,
+        "pairing_slots": pairing_slots,
+    })
+}
+
+/// One pairing role a node plays: the section's rows and a slot's peers
+/// are the same claim, so they carry the same fields.
+fn participant_json(hit: &Participant) -> serde_json::Value {
+    serde_json::json!({
+        "node": node_json(&hit.node),
+        "role": hit.role,
+        "link_id": hit.link_id,
+        "optional": hit.optional,
+        "sha256": hit.sha256,
+        "pin": pin_json(&hit.pin),
     })
 }
 
@@ -492,6 +565,123 @@ mod tests {
                 contract(),
             )],
         )
+    }
+
+    /// A node whose report carries its own pairing slots: one filled by
+    /// two engines, one nothing complements.
+    fn node_with_slots() -> ShowOutcome {
+        let report = SearchReport {
+            name: "sim_rgb_camera".to_owned(),
+            tag: "v1".to_owned(),
+            pairing_slots: vec![
+                SlotPeers {
+                    link_id: "engine".to_owned(),
+                    pairing_name: "sim_rgb_camera_link".to_owned(),
+                    pairing_tag: "v1".to_owned(),
+                    role: "viewer".to_owned(),
+                    optional: false,
+                    peers: vec![
+                        Participant {
+                            node: node("openarm_sim_isaac", "openarm/sim_isaac/peppy.json5"),
+                            role: "camera".to_owned(),
+                            link_id: "wrist_left".to_owned(),
+                            optional: true,
+                            sha256: None,
+                            pin: PinStatus::Unpinned,
+                        },
+                        Participant {
+                            node: node("openarm_sim_mujoco", "openarm/sim_mujoco/peppy.json5"),
+                            role: "camera".to_owned(),
+                            link_id: "wrist_left".to_owned(),
+                            optional: true,
+                            sha256: Some(sha('a')),
+                            pin: PinStatus::Current,
+                        },
+                    ],
+                },
+                SlotPeers {
+                    link_id: "clock".to_owned(),
+                    pairing_name: "sim_clock_link".to_owned(),
+                    pairing_tag: "v1".to_owned(),
+                    role: "follower".to_owned(),
+                    optional: true,
+                    peers: Vec::new(),
+                },
+            ],
+            ..empty_report()
+        };
+        shown(
+            vec![report],
+            vec![matched(
+                RepoItemKind::Node,
+                "sim_rgb_camera",
+                "v1",
+                PublishedDoc {
+                    repo_id: 1000,
+                    repo_label: HUB.to_owned(),
+                    path: "sim_rgb_camera/peppy.json5".to_owned(),
+                    sha256: ManifestFingerprint::parse(&sha('b')).unwrap(),
+                },
+            )],
+        )
+    }
+
+    /// A node's report ends with one section per pairing slot it
+    /// declares, titled with the slot, the pairing it resolves through
+    /// and the role the node plays, listing the peers' own slots. A slot
+    /// nothing can fill says so on one line instead of vanishing, and
+    /// carries the `optional` that decides whether that is fatal.
+    #[test]
+    fn human_output_lists_a_nodes_pairing_slot_peers() {
+        let text = render_human(&query("sim_rgb_camera:v1"), &node_with_slots(), false, None);
+
+        let expected = [
+            "sim_rgb_camera:v1",
+            "  node sim_rgb_camera:v1 published by https://github.com/Peppy-bot/nodes-hub.git (ref: main) at sim_rgb_camera/peppy.json5 (sha256 bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)",
+            "",
+            "Slot engine (sim_rgb_camera_link:v1 as viewer) can pair with 2 indexed nodes",
+            "  https://github.com/Peppy-bot/nodes-hub.git (ref: main):",
+            "    ┌────────────────────┬─────┬────────┬───────────────────────┬────────────────────────┬────────────────────────────────┐",
+            "    │ NODE               │ TAG │ ROLE   │ SLOT                  │ PIN                    │ PATH                           │",
+            "    ├────────────────────┼─────┼────────┼───────────────────────┼────────────────────────┼────────────────────────────────┤",
+            "    │ openarm_sim_isaac  │ v1  │ camera │ wrist_left (optional) │ unpinned               │ openarm/sim_isaac/peppy.json5  │",
+            "    │ openarm_sim_mujoco │ v1  │ camera │ wrist_left (optional) │ pin aaaaaaaa (current) │ openarm/sim_mujoco/peppy.json5 │",
+            "    └────────────────────┴─────┴────────┴───────────────────────┴────────────────────────┴────────────────────────────────┘",
+            "",
+            "Slot clock (sim_clock_link:v1 as follower, optional): no indexed node plays the other role",
+            "",
+        ]
+        .join("\n");
+        assert_eq!(text, expected, "\n{text}");
+        assert!(
+            !text.contains("No indexed node implements"),
+            "a node is not a thing other nodes implement or consume: {text}"
+        );
+    }
+
+    /// The slot and the pairing it resolves through are tinted like every
+    /// other link id and identity, and the count like every other count.
+    #[test]
+    fn human_output_tints_a_slots_peers_like_every_other_section() {
+        use crate::commands::colors::RESET;
+
+        let text = render_human(&query("sim_rgb_camera:v1"), &node_with_slots(), true, None);
+
+        assert!(
+            text.contains(&format!(
+                "Slot {BINDING_COLOR}engine{RESET} \
+                 ({NODE_COLOR}sim_rgb_camera_link:v1{RESET} as viewer) \
+                 can pair with {COUNT_COLOR}2{RESET} indexed nodes"
+            )),
+            "{text}"
+        );
+        assert!(
+            text.contains(&format!(
+                "Slot {BINDING_COLOR}clock{RESET} ({NODE_COLOR}sim_clock_link:v1{RESET} \
+                 as follower, optional): no indexed node plays the other role"
+            )),
+            "{text}"
+        );
     }
 
     /// Every section, with the published document first, rows aligned
@@ -907,10 +1097,49 @@ mod tests {
             })
         );
 
+        assert_eq!(
+            report["pairing_slots"],
+            serde_json::json!([]),
+            "a contract declares no slots of its own"
+        );
+
         let digest = sha('a');
         let text = render_json(&query(&format!("rgb_camera:v1@{digest}")), &full());
         let doc: serde_json::Value = serde_json::from_str(&text).expect("valid JSON");
         assert_eq!(doc["query"]["sha256"], digest);
+    }
+
+    /// A node's JSON carries its pairing slots in manifest order, each
+    /// with the pairing it resolves through and its peers as full
+    /// participant records; a slot with no peer keeps its entry.
+    #[test]
+    fn json_output_carries_a_nodes_pairing_slots() {
+        let text = render_json(&query("sim_rgb_camera:v1"), &node_with_slots());
+
+        let doc: serde_json::Value = serde_json::from_str(&text).expect("valid JSON");
+        let slots = doc["reports"][0]["pairing_slots"]
+            .as_array()
+            .expect("array");
+        assert_eq!(slots.len(), 2);
+        assert_eq!(slots[0]["link_id"], "engine");
+        assert_eq!(
+            slots[0]["pairing"],
+            serde_json::json!({ "name": "sim_rgb_camera_link", "tag": "v1" })
+        );
+        assert_eq!(slots[0]["role"], "viewer");
+        assert_eq!(slots[0]["optional"], false);
+        let peers = slots[0]["peers"].as_array().expect("array");
+        assert_eq!(peers.len(), 2);
+        assert_eq!(peers[0]["node"]["node_name"], "openarm_sim_isaac");
+        assert_eq!(peers[0]["role"], "camera");
+        assert_eq!(peers[0]["link_id"], "wrist_left");
+        assert_eq!(peers[0]["optional"], true);
+        assert!(peers[0]["sha256"].is_null());
+        assert_eq!(peers[0]["pin"]["status"], "unpinned");
+        assert_eq!(peers[1]["pin"], serde_json::json!({ "status": "current" }));
+        assert_eq!(slots[1]["link_id"], "clock");
+        assert_eq!(slots[1]["optional"], true);
+        assert_eq!(slots[1]["peers"], serde_json::json!([]));
     }
 
     /// An unusable pin's JSON carries the reason a sync would print.

--- a/crates/peppy/tests/repo_search.rs
+++ b/crates/peppy/tests/repo_search.rs
@@ -69,7 +69,8 @@ fn write_node(dir: &Path, name: &str, manifest_extra: &str, interfaces: &str) {
 /// One fs repository publishing every indexed kind: the `rgb_camera:v1`
 /// contract, the `arm_link:v1` pairing, the `demo` launcher, the
 /// `camera_surface:v1` MCP exposure, and a node for each way of using the
-/// contract and pairing, refreshed into the emulated daemon's caches.
+/// contract and pairing, both of the pairing's roles included, refreshed
+/// into the emulated daemon's caches.
 /// Returns the Peppy home, the repository root (canonical, as the caches
 /// record it) and the contract's fingerprint.
 fn seeded(
@@ -109,6 +110,12 @@ fn seeded(
         &repo_dir.join("follower_arm"),
         "follower_arm",
         r#", depends_on: { pairings: [{ name: "arm_link", tag: "v1", role: "arm", link_id: "link", optional: true }] }"#,
+        "{}",
+    );
+    write_node(
+        &repo_dir.join("leader_arm"),
+        "leader_arm",
+        r#", depends_on: { pairings: [{ name: "arm_link", tag: "v1", role: "controller", link_id: "arm" }] }"#,
         "{}",
     );
     write_node(
@@ -205,11 +212,15 @@ fn repo_show_reports_a_pairings_participants_and_observers() {
     );
     assert!(!text.contains("contract arm_link"), "{text}");
     assert!(
-        text.contains("\nPairing roles played by 1 indexed node\n"),
+        text.contains("\nPairing roles played by 2 indexed nodes\n"),
         "{text}"
     );
     assert!(
-        text.contains("    │ follower_arm │ v1  │ arm  │ link (optional) │ unpinned │ "),
+        text.contains("    │ follower_arm │ v1  │ arm        │ link (optional) │ unpinned │ "),
+        "{text}"
+    );
+    assert!(
+        text.contains("    │ leader_arm   │ v1  │ controller │ arm             │ unpinned │ "),
         "{text}"
     );
     assert!(text.contains("\nObserved by 1 indexed node\n"), "{text}");
@@ -219,6 +230,61 @@ fn repo_show_reports_a_pairings_participants_and_observers() {
     );
     assert!(!text.contains("Implemented by"), "{text}");
     assert!(!text.contains("Consumed by"), "{text}");
+}
+
+/// A node show reads the same cache the other way: its own pairing slots,
+/// each with the nodes playing the pairing's other role. The observer of
+/// the same pairing is not one of them, and neither is the node itself.
+#[test]
+fn repo_show_reports_a_nodes_pairing_slot_peers() {
+    let (_rt, serve, ctx, _work_dir) = setup();
+    let (peppy_dirs, repo_dir, _) = seeded(&serve, &ctx);
+
+    let text = show_rendered(&peppy_dirs, "follower_arm:v1", false, None).expect("shows");
+
+    assert!(
+        text.contains(&format!(
+            "  node follower_arm:v1 published by {} at {} ",
+            repo_dir.display(),
+            repo_dir
+                .join("follower_arm")
+                .join(NODE_CONFIG_FILE)
+                .display(),
+        )),
+        "{text}"
+    );
+    assert!(
+        text.contains("\nSlot link (arm_link:v1 as arm, optional) can pair with 1 indexed node\n"),
+        "{text}"
+    );
+    assert!(
+        text.contains("    │ leader_arm │ v1  │ controller │ arm  │ unpinned │ "),
+        "{text}"
+    );
+    assert!(
+        !text.contains("arm_logger"),
+        "an observer watches the pair, it does not fill a slot: {text}"
+    );
+    assert!(
+        !text.contains("follower_arm │"),
+        "a node's own slot is not its peer: {text}"
+    );
+
+    // The other end reports the mirror image, and a node with no pairing
+    // slot has nothing to add to its published line.
+    let leader = show_rendered(&peppy_dirs, "leader_arm:v1", false, None).expect("shows");
+    assert!(
+        leader.contains("\nSlot arm (arm_link:v1 as controller) can pair with 1 indexed node\n"),
+        "{leader}"
+    );
+    assert!(
+        leader.contains("    │ follower_arm │ v1  │ arm  │ link (optional) │"),
+        "{leader}"
+    );
+
+    let plain = show_rendered(&peppy_dirs, "plain:v1", false, None).expect("shows");
+    assert_eq!(plain.lines().count(), 2, "{plain}");
+    assert!(!plain.contains("Slot "), "{plain}");
 }
 
 /// A bare name is a pattern matching any tag: the contract's report comes

--- a/docs/src/content/docs/advanced_guides/pairing.mdx
+++ b/docs/src/content/docs/advanced_guides/pairing.mdx
@@ -60,7 +60,7 @@ The rules:
 - `topics` is one flat list; every topic's `emitted_by` must name one of the two roles, and topic names must be unique across the whole list.
 - Pairings declare **topics only**: no services, no actions.
 
-After `peppy repo refresh`, the pairing is cached and addressable by `(name, tag)`. `peppy repo show <name>:<tag>` lists the indexed nodes that play its roles and the ones that observe them (see [Show what a query matches](/advanced_guides/repositories/#show-what-a-query-matches)).
+After `peppy repo refresh`, the pairing is cached and addressable by `(name, tag)`. `peppy repo show <name>:<tag>` lists the indexed nodes that play its roles and the ones that observe them, and `peppy repo show <node>:<tag>` answers the same question from a node's side, one section per pairing slot it declares (see [Show what a query matches](/advanced_guides/repositories/#show-what-a-query-matches)).
 
 ## Configure the nodes
 

--- a/docs/src/content/docs/advanced_guides/repositories.mdx
+++ b/docs/src/content/docs/advanced_guides/repositories.mdx
@@ -122,7 +122,7 @@ peppy repo show <name-regex>[:<tag-regex>][@<sha256>]
 
 Takes the same query as [`peppy repo search`](#search-the-repositories) and prints the full report of every identity it matches, in the search's order, the way `apt show` prints one record per named package: `peppy repo show '^rgb_camera$:^v1$'` reports the one contract (the anchors keep names like `sim_rgb_camera` out, since each unanchored part matches anywhere in the name or tag), and `peppy repo show 'rgb_camera:v[12]'` answers who still uses each version in one pass.
 
-A report's first lines name each document of the identity with its kind, repository, path, and sha256; contracts and pairings are separate namespaces, so an identity published as both is reported as both, and one report covers them. For a contract or pairing, one section per way a node uses it follows: implementing it (`manifest.implements`), consuming it (`depends_on.contracts`), playing a role in it (`depends_on.pairings`), or observing one of its roles (`depends_on.pairing_observers`). Sections are grouped by repository like `peppy repo list`, each group a table with one row per slot: `NODE` and `TAG`, `ROLE` (pairing sections only), `SLOT` (the `link_id`, with its cardinality or `optional`), `PIN`, and `PATH` (the manifest path). A node, launcher, or MCP exposure has no usage sections; its published line is the whole answer. A table wider than the terminal gives up width from its widest columns first, never below a header's width, and wraps over-long cells onto continuation lines inside the outline; piped output is never wrapped.
+A report's first lines name each document of the identity with its kind, repository, path, and sha256; contracts and pairings are separate namespaces, so an identity published as both is reported as both, and one report covers them. For a contract or pairing, one section per way a node uses it follows: implementing it (`manifest.implements`), consuming it (`depends_on.contracts`), playing a role in it (`depends_on.pairings`), or observing one of its roles (`depends_on.pairing_observers`). Sections are grouped by repository like `peppy repo list`, each group a table with one row per slot: `NODE` and `TAG`, `ROLE` (pairing sections only), `SLOT` (the `link_id`, with its cardinality or `optional`), `PIN`, and `PATH` (the manifest path). A launcher or an MCP exposure has no usage sections; its published line is the whole answer. A table wider than the terminal gives up width from its widest columns first, never below a header's width, and wraps over-long cells onto continuation lines inside the outline; piped output is never wrapped.
 
 ```text
 ^rgb_camera$:^v1$
@@ -146,6 +146,32 @@ Consumed by 1 indexed node
     └──────────────────┴─────┴──────────────────────┴──────────┴────────────────────────────────────────────┘
 ```
 
+For a **node**, the report reads the same cache the other way: one section per pairing slot the node declares (`depends_on.pairings`), in manifest order, listing the nodes whose own slot plays the pairing's other role. The title names the slot, the pairing it resolves through, the role this node plays, and `optional` where the slot may run with no peer; the rows are the peers' own slots, in the columns a pairing's own report uses, and the count is of nodes, so a node offering two complementary slots takes two rows and counts once. Being listed here is a match of pairing and role, which is what pairing requires and what the caches record; whether a stack of the two is one worth running is a launcher's business (see [Launch files](/guides/launch_files/)).
+
+```text
+^sim_rgb_camera$:^v1$
+  node sim_rgb_camera:v1 published by https://github.com/Peppy-bot/nodes-hub.git (ref: main) at sim_rgb_camera/peppy.json5 (sha256 34d40c0140066c9055879c2d4bd022a7f665752ab834247a9ff69e4fd68a1899)
+
+Slot engine (sim_rgb_camera_link:v1 as viewer) can pair with 2 indexed nodes
+  https://github.com/Peppy-bot/nodes-hub.git (ref: main):
+    ┌────────────────────┬─────┬────────┬────────────────────────┬──────────┬────────────────────────────────┐
+    │ NODE               │ TAG │ ROLE   │ SLOT                   │ PIN      │ PATH                           │
+    ├────────────────────┼─────┼────────┼────────────────────────┼──────────┼────────────────────────────────┤
+    │ openarm_sim_isaac  │ v1  │ camera │ wrist_left (optional)  │ unpinned │ openarm/sim_isaac/peppy.json5  │
+    │ openarm_sim_isaac  │ v1  │ camera │ wrist_right (optional) │ unpinned │ openarm/sim_isaac/peppy.json5  │
+    │ openarm_sim_mujoco │ v1  │ camera │ wrist_left (optional)  │ unpinned │ openarm/sim_mujoco/peppy.json5 │
+    │ openarm_sim_mujoco │ v1  │ camera │ wrist_right (optional) │ unpinned │ openarm/sim_mujoco/peppy.json5 │
+    └────────────────────┴─────┴────────┴────────────────────────┴──────────┴────────────────────────────────┘
+```
+
+A slot nothing complements keeps its line and says so, which on a slot that is not `optional` means no indexed node completes a launch of this one:
+
+```text
+Slot engine (sim_rgb_camera_link:v1 as viewer): no indexed node plays the other role
+```
+
+A node's other links have no such section: a contract slot's candidates are that contract's own implementers, one `peppy repo show` away, and an observer slot watches a pair two other nodes form rather than filling a role itself. A node that declares no pairing slot has no section at all, so its published line is the whole answer.
+
 The `PIN` column says what a sync does with the claim's `sha256`:
 
 | `PIN` value | Meaning |
@@ -158,7 +184,7 @@ The `PIN` column says what a sync does with the claim's `sha256`:
 
 `(shadowed by <repository>)` means what it means in `peppy repo list`: a lower-`id` repository provides the same `name:tag`, so a launch resolves to that node, which may not make this claim at all.
 
-The show reads the same caches as the search and needs no daemon. A query nothing matches is an error, since the command was asked for a report it cannot print, and so is an identity one repository publishes twice: its report has no answer a launch would accept. `--json` prints one JSON document with `query`, `matches`, and `excluded` as the search prints them, plus `reports`: one usage report per matched identity in match order, each with its `implementers`, `consumers`, `participants`, and `observers`.
+The show reads the same caches as the search and needs no daemon. A query nothing matches is an error, since the command was asked for a report it cannot print, and so is an identity one repository publishes twice: its report has no answer a launch would accept. `--json` prints one JSON document with `query`, `matches`, and `excluded` as the search prints them, plus `reports`: one usage report per matched identity in match order, each with its `implementers`, `consumers`, `participants`, `observers`, and `pairing_slots` (one entry per pairing slot a matched node declares, with its `link_id`, `pairing`, `role`, `optional`, and the `peers` that could fill it).
 
 ### Refresh the index
 


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Peppy-bot/codesmith/peppy/pr/422"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790856051&installation_model_id=433186&pr_number=422&repository=Peppy-bot%2Fpeppy&return_to=https%3A%2F%2Fgithub.com%2FPeppy-bot%2Fpeppy%2Fpull%2F422&signature=678f9aa5a65b5f701601403aa702f86421bdb7e69c0c98530b697f8253e77e3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->