### PR TITLE
[jarednm/FRAMEWORK-202] launch: hand the fleet's clock source every machine of the launch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -587,7 +587,7 @@ dependencies = [
 [[package]]
 name = "build-helpers"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#98874c01d6c4a39d8b0b2f6e693d53265951c7cd"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#7d156fecf76e22532246b7a7154b63528f7ce130"
 dependencies = [
  "sha2",
 ]
@@ -785,7 +785,7 @@ dependencies = [
 [[package]]
 name = "config-test-support"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#98874c01d6c4a39d8b0b2f6e693d53265951c7cd"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#7d156fecf76e22532246b7a7154b63528f7ce130"
 dependencies = [
  "askama",
  "git2",
@@ -931,7 +931,7 @@ dependencies = [
 [[package]]
 name = "core-node-api"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#98874c01d6c4a39d8b0b2f6e693d53265951c7cd"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#7d156fecf76e22532246b7a7154b63528f7ce130"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -1313,7 +1313,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1462,7 +1462,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2696,7 +2696,7 @@ dependencies = [
 [[package]]
 name = "json5-pretty"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#98874c01d6c4a39d8b0b2f6e693d53265951c7cd"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#7d156fecf76e22532246b7a7154b63528f7ce130"
 dependencies = [
  "serde",
  "serde_json",
@@ -3187,7 +3187,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3587,7 +3587,7 @@ dependencies = [
 [[package]]
 name = "peppy-config-model"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#98874c01d6c4a39d8b0b2f6e693d53265951c7cd"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#7d156fecf76e22532246b7a7154b63528f7ce130"
 dependencies = [
  "capnp",
  "clap",
@@ -3606,7 +3606,7 @@ dependencies = [
 [[package]]
 name = "peppy-mcp-catalog"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#98874c01d6c4a39d8b0b2f6e693d53265951c7cd"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#7d156fecf76e22532246b7a7154b63528f7ce130"
 dependencies = [
  "indexmap 2.14.1",
  "peppy-config-model",
@@ -3618,7 +3618,7 @@ dependencies = [
 [[package]]
 name = "peppy-mcp-runtime"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#98874c01d6c4a39d8b0b2f6e693d53265951c7cd"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#7d156fecf76e22532246b7a7154b63528f7ce130"
 dependencies = [
  "axum",
  "base64 0.23.1",
@@ -3640,7 +3640,7 @@ version = "0.0.1"
 [[package]]
 name = "peppylib-rs"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#98874c01d6c4a39d8b0b2f6e693d53265951c7cd"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#7d156fecf76e22532246b7a7154b63528f7ce130"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -3837,7 +3837,7 @@ dependencies = [
 [[package]]
 name = "pmi"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#98874c01d6c4a39d8b0b2f6e693d53265951c7cd"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#7d156fecf76e22532246b7a7154b63528f7ce130"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -4072,7 +4072,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.5",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4514,7 +4514,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4582,7 +4582,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4960,7 +4960,7 @@ version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
 dependencies = [
- "dirs 6.0.0",
+ "dirs 4.0.0",
 ]
 
 [[package]]
@@ -5309,7 +5309,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6225,7 +6225,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/core-node-internal/src/services.rs
+++ b/crates/core-node-internal/src/services.rs
@@ -440,6 +440,7 @@ impl CoreNode {
             // versions never has two answers to choose between.
             peppy_version: CORE_NODE_TAG.to_owned(),
             root_instance_id: self.instance_id().to_owned(),
+            serves_sim_time: self.daemon_use_sim_time,
             shutdown_token: self.shutdown_token.clone(),
         }
     }

--- a/crates/core-node-internal/src/services/clock.rs
+++ b/crates/core-node-internal/src/services/clock.rs
@@ -151,7 +151,7 @@ async fn run_clock_publisher(
 /// Each spawned node runs a watchdog subscribed to this topic; if the beats go
 /// silent past the configured grace period the node shuts itself down, so an
 /// uncatchable daemon death (SIGKILL / OOM / crash) does not leave orphans. The
-/// payload is a constant `ClockTick(0)` reused purely as a cheap carrier; the
+/// payload is a constant `ClockTick` reused purely as a cheap carrier; the
 /// node only cares that a message arrived, not its value.
 ///
 /// `SensorData` QoS (best-effort, newest-wins, no back-pressure) is correct for
@@ -184,7 +184,7 @@ async fn run_heartbeat_publisher(
 ) -> Result<()> {
     // The value is never read by the node (only the message's arrival matters)
     // so encode the constant payload once, outside the loop.
-    let payload = ClockTick::new(0).encode()?;
+    let payload = ClockTick::new(ClockTick::MIN_TIME_NS).encode()?;
     let mut ticker = tokio::time::interval(interval);
     // A late beat is uninteresting; skip catch-up bursts after a stall.
     ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
@@ -244,14 +244,10 @@ pub async fn subscribe_external_clock(
                     None => break,
                 },
             };
+            // A decoded tick is never `0` (`ClockTick` clamps on decode), so
+            // storing it can never write the cache's not-ready sentinel.
             match ClockTick::decode(message.payload_bytes().as_ref()) {
-                Ok(tick) => {
-                    // `0` is reserved as "not ready"; a simulator publishing
-                    // a literal zero would be a bug, and clamping it to 1 is a
-                    // safer surprise than silently masking the not-ready state.
-                    let stored = if tick.time == 0 { 1 } else { tick.time };
-                    cache.store(stored, Ordering::Relaxed);
-                }
+                Ok(tick) => cache.store(tick.time(), Ordering::Relaxed),
                 Err(e) => warn!("dropped malformed clock tick: {e}"),
             }
         }

--- a/crates/core-node-internal/src/services/federation/service.rs
+++ b/crates/core-node-internal/src/services/federation/service.rs
@@ -50,6 +50,10 @@ pub(crate) struct FederationServiceContext {
     /// The daemon's own root-entity instance id, folded into the coordinator's
     /// global instance-id uniqueness check.
     pub(crate) root_instance_id: String,
+    /// Whether this daemon serves simulated time (`--clock-source=sim`),
+    /// reported on every reservation so a coordinator placing sim-time
+    /// instances here can refuse a wall-mode machine before touching it.
+    pub(crate) serves_sim_time: bool,
     /// Cancelled on daemon shutdown so a coordinator-presence watch does not
     /// outlive the daemon generation that spawned it.
     pub(crate) shutdown_token: CancellationToken,
@@ -190,9 +194,13 @@ async fn reserve_inner(
         ReserveOutcome::AlreadyHeld => {}
     }
 
-    ParticipantReserveResponse::accepted(&context.peppy_version, &context.root_instance_id)
-        .encode()
-        .map_err(Into::into)
+    ParticipantReserveResponse::accepted(
+        &context.peppy_version,
+        &context.root_instance_id,
+        context.serves_sim_time,
+    )
+    .encode()
+    .map_err(Into::into)
 }
 
 /// Decodes every deployment's pins and refuses any that could not be

--- a/crates/core-node-internal/src/services/node/run.rs
+++ b/crates/core-node-internal/src/services/node/run.rs
@@ -460,12 +460,19 @@ pub(crate) async fn assemble_runtime_config(
         .await
         .unwrap_or((DEFAULT_MESSAGING_HOST.to_string(), DEFAULT_MESSAGING_PORT));
 
+    // The one clock rule is enforced here, where the plan becomes a config
+    // on the daemon that spawns: simulated time, read or published, needs a
+    // daemon that serves it. Every spawn path (launches, `node run`, a peer's
+    // dispatched goal) passes through this call.
+    let node_instance = goal
+        .instance_plan
+        .clone()
+        .resolve(action_context.daemon_defaults.use_sim_time)
+        .map_err(|e| e.to_string())?;
     RuntimeConfig::new(
         messaging_host.as_str(),
         messaging_port,
-        goal.instance_plan
-            .clone()
-            .resolve(action_context.daemon_defaults.use_sim_time),
+        node_instance,
         goal.node_name.as_str(),
         goal.tag.as_str(),
         action_context.core_node_name.as_str(),

--- a/crates/core-node-internal/src/services/stack/launch.rs
+++ b/crates/core-node-internal/src/services/stack/launch.rs
@@ -290,6 +290,119 @@ fn is_built_in(item: &PlannedDeployment) -> bool {
 /// and these adds operate on a tree materialized from an already-verified pin.
 pub const STACK_LAUNCH_GIT_HASH: &str = "stack-launch";
 
+/// The machines of the launch: every core node at least one planned instance
+/// runs on, parsed into the participant set a time source is handed. A
+/// core-node name and a runtime `Name` share one character set, so the
+/// conversion cannot fail for a name that reached a `Placements`; the error
+/// path exists so that invariant is checked, not assumed, and it is checked
+/// before anything is torn down.
+fn launch_fleet(
+    planned: &[PlannedDeployment],
+    placements: &daemon_config::launcher::Placements,
+) -> std::result::Result<config::runtime::SimTimeParticipants, String> {
+    let instance_ids: Vec<&str> = planned
+        .iter()
+        .flat_map(|item| &item.deployment.instances)
+        .map(|instance| instance.instance_id.as_str())
+        .collect();
+    let names = placements
+        .participants(instance_ids)
+        .into_iter()
+        .map(|core_node| {
+            config::runtime::Name::new(core_node)
+                .map_err(|e| format!("core node `{core_node}` is not a valid runtime name: {e}"))
+        })
+        .collect::<std::result::Result<Vec<_>, String>>()?;
+    config::runtime::SimTimeParticipants::try_from(names)
+        .map_err(|e| format!("the launch resolved no valid machine set: {e}"))
+}
+
+/// The coordinator's own half of the clock-agreement rule the federated
+/// preflight applies to each peer, asked only when the coordinator is one of
+/// the fleet's machines. A machine running none of the launch is not its
+/// business.
+///
+/// Only one refusal is reachable here: a wall-serving coordinator hosting a
+/// simulated launch, whose own ticks would feed the key those instances
+/// read. The demand is read off this same daemon, so a wall demand implies
+/// this daemon serves wall time; the mirror refusal (a sim machine in a wall
+/// launch) exists for peers alone, in the preflight.
+fn check_coordinator_clock(
+    coordinator_hosts: bool,
+    clock_demand: &federated::ClockDemand,
+    coordinator: &str,
+    coordinator_serves_sim_time: bool,
+) -> std::result::Result<(), String> {
+    if !coordinator_hosts {
+        return Ok(());
+    }
+    federated::check_clock_agreement(coordinator, coordinator_serves_sim_time, clock_demand)
+}
+
+/// One advisory line for each clock state a launch accepts but an operator
+/// probably did not intend; the states a launch refuses already speak for
+/// themselves.
+///
+/// A declared source in a wall launch resolves inert
+/// ([`config::runtime::NodeInstancePlan::resolve`]) so the launch succeeds
+/// silently; say so, or a forgotten `--clock-source=sim` is discoverable only
+/// from diverging timestamps. A simulated launch declaring no source starts,
+/// and then every sim-time instance waits at `clock not ready` for a tick
+/// nothing in the launch publishes; say who is missing. A fully-placed launch
+/// (`ClockDemand::HostsDecide`) learns its clock from its machines at
+/// preflight, after this point, so it gets no advisory here.
+async fn advise_on_clock_shape(
+    ctx: &ProcessLaunchContext,
+    planned: &[PlannedDeployment],
+    clock_demand: &federated::ClockDemand,
+) {
+    let declared_source = planned
+        .iter()
+        .flat_map(|item| &item.deployment.instances)
+        .find(|instance| instance.framework.publishes_sim_time);
+    match (declared_source, clock_demand) {
+        // Name the source on every launch that may run on its clock: a
+        // declared source that never publishes then hangs the fleet at
+        // `clock not ready` with a named suspect in the launch output.
+        (Some(instance), federated::ClockDemand::Sim(_) | federated::ClockDemand::HostsDecide) => {
+            publish_stdout(
+                ctx,
+                format!(
+                    "instance `{}` is this launch's source of simulated time",
+                    instance.instance_id
+                ),
+                LaunchFeedbackStep::LauncherStep,
+            )
+            .await;
+        }
+        (Some(instance), federated::ClockDemand::Wall) => {
+            publish_stdout(
+                ctx,
+                format!(
+                    "instance `{}` declares a simulated-time source, but this launch runs on \
+                     wall time, so it will publish nothing. Start the coordinating daemon with \
+                     `peppy service serve --clock-source=sim` to run on its clock.",
+                    instance.instance_id
+                ),
+                LaunchFeedbackStep::LauncherStep,
+            )
+            .await;
+        }
+        (None, federated::ClockDemand::Sim(_)) => {
+            publish_stderr(
+                ctx,
+                "this simulated launch declares no time source (no instance sets `framework: \
+                 { publishes_sim_time: true }`): every sim-time instance will wait at `clock \
+                 not ready` until an external publisher feeds each machine's `clock` topic."
+                    .to_owned(),
+                LaunchFeedbackStep::LauncherStep,
+            )
+            .await;
+        }
+        _ => {}
+    }
+}
+
 /// Which core nodes host at least one instance of `key`, in a stable order.
 ///
 /// A node is added and built on every machine that runs part of it, which is
@@ -762,7 +875,10 @@ async fn start_node_instances(
     planned_observations: &[daemon_config::launcher::PlannedObservation],
     placements: &daemon_config::launcher::Placements,
     federated: &federated::FederatedLaunch,
+    // Every machine of the launch, handed to the declared time source.
+    fleet: &config::runtime::SimTimeParticipants,
 ) -> std::result::Result<(), LaunchResult> {
+    let participants = federated.core_nodes();
     // Register the planned observations whose OBSERVER runs on this daemon,
     // keyed by observer instance. As each instance reaches Running its
     // `node_run` notifies the coordinator, which delivers the source pin to
@@ -924,7 +1040,6 @@ async fn start_node_instances(
             .insert(earlier.link_id.clone(), pair_target(earlier, later));
     }
 
-    let participants = federated.core_nodes();
     for key in ordered {
         let Some(item) = planned_by_key.get(key) else {
             continue;
@@ -955,6 +1070,7 @@ async fn start_node_instances(
             let instance_plan = config::runtime::NodeInstancePlan {
                 arguments: instance.arguments.clone(),
                 use_sim_time: instance.framework.use_sim_time,
+                sim_time_source: instance.framework.publishes_sim_time.then(|| fleet.clone()),
                 slot_bindings,
                 ..config::runtime::NodeInstancePlan::new(instance.instance_id.clone())
             };
@@ -1299,17 +1415,56 @@ async fn process_launch(goal: LaunchGoal, ctx: ProcessLaunchContext) -> LaunchRe
         return launch_result;
     }
 
-    // Step 4: Federated preflight. Reachability and reservations, each
-    // carrying its participant's pins, all BEFORE anything is torn down: a
-    // refusal at this point has cost no machine, including this one, its
-    // stack.
-    let federated = match federated::preflight(&ctx, &goal.launch_id, &planned, &placements).await {
-        Ok(federated) => federated,
+    // Step 3c: What the launch asks of every machine's clock. A simulated
+    // launch needs every machine it spans to serve simulated time, since a
+    // wall-mode daemon floods the key its sim-time nodes read; refusing the
+    // coordinator here, and each peer in the preflight below, keeps the check
+    // ahead of the teardown. The spawn-time rule
+    // (`NodeInstancePlan::resolve`) stays the backstop for every other path.
+    // The launch's machines, derived once and before anything is torn down:
+    // whether the coordinator is one of them shapes the clock demand, and the
+    // same set is what the launch's time source is handed when instances
+    // start.
+    let fleet = match launch_fleet(&planned, &placements) {
+        Ok(fleet) => fleet,
         Err(reason) => {
             publish_stderr(&ctx, reason.clone(), LaunchFeedbackStep::LauncherStep).await;
             return LaunchResult::failure(&ctx.log_path, reason);
         }
     };
+    let coordinator_hosts = fleet
+        .iter()
+        .any(|machine| machine.as_str() == ctx.bound_core_node);
+    let clock_demand = federated::ClockDemand::of(
+        planned.iter().flat_map(|item| &item.deployment.instances),
+        ctx.daemon_defaults.use_sim_time,
+        coordinator_hosts,
+    );
+    if let Err(reason) = check_coordinator_clock(
+        coordinator_hosts,
+        &clock_demand,
+        &ctx.bound_core_node,
+        ctx.daemon_defaults.use_sim_time,
+    ) {
+        publish_stderr(&ctx, reason.clone(), LaunchFeedbackStep::LauncherStep).await;
+        return LaunchResult::failure(&ctx.log_path, reason);
+    }
+    advise_on_clock_shape(&ctx, &planned, &clock_demand).await;
+
+    // Step 4: Federated preflight. Reachability and reservations, each
+    // carrying its participant's pins, all BEFORE anything is torn down: a
+    // refusal at this point has cost no machine, including this one, its
+    // stack.
+    let federated =
+        match federated::preflight(&ctx, &goal.launch_id, &planned, &placements, &clock_demand)
+            .await
+        {
+            Ok(federated) => federated,
+            Err(reason) => {
+                publish_stderr(&ctx, reason.clone(), LaunchFeedbackStep::LauncherStep).await;
+                return LaunchResult::failure(&ctx.log_path, reason);
+            }
+        };
     let participants = federated.core_nodes();
 
     // Step 4b: A planned instance id must not collide with a participant's
@@ -1444,6 +1599,7 @@ async fn process_launch(goal: LaunchGoal, ctx: ProcessLaunchContext) -> LaunchRe
             &planned_observations,
             &placements,
             &federated,
+            &fleet,
         )
         .await
     }
@@ -1847,6 +2003,118 @@ mod tests {
         assert!(error.contains("robot_inst"), "got: {error}");
     }
 
+    /// One deployment of plain instances, each optionally placed. Enough for
+    /// the placement-derived checks, which read instance ids and nothing else.
+    fn planned_deployment(
+        node_name: &str,
+        instances: &[(&str, Option<&str>)],
+    ) -> PlannedDeployment {
+        planned_container_deployment(
+            node_name,
+            DEFAULTED_OUTPUT_DIR,
+            &[],
+            &instances
+                .iter()
+                .map(|(id, core_node)| (*id, *core_node, BTreeMap::new()))
+                .collect::<Vec<_>>(),
+        )
+    }
+
+    /// The fan-out list is every machine the launch actually runs on, the
+    /// coordinator included when it hosts something, each named once however
+    /// many instances it holds. This is what makes the clock reach a fleet
+    /// without any launcher naming a machine, and what keeps it right when a
+    /// launch grows more instances.
+    #[test]
+    fn the_sim_time_participants_are_every_machine_of_the_launch() {
+        let planned = vec![
+            planned_deployment("engine", &[("sim_inst", None)]),
+            planned_deployment(
+                "arm",
+                &[
+                    ("arm_a", Some("cn-robot-a")),
+                    ("arm_b", Some("cn-robot-b")),
+                    ("arm_c", Some("cn-robot-b")),
+                ],
+            ),
+        ];
+        let placements = placements_with(
+            "cn-sim",
+            &[
+                ("arm_a", "cn-robot-a"),
+                ("arm_b", "cn-robot-b"),
+                ("arm_c", "cn-robot-b"),
+            ],
+        );
+
+        let fleet =
+            launch_fleet(&planned, &placements).expect("core node names are valid runtime names");
+        assert_eq!(
+            fleet.iter().map(|name| name.as_str()).collect::<Vec<_>>(),
+            ["cn-robot-a", "cn-robot-b", "cn-sim"]
+        );
+
+        // A single-machine launch is the same derivation with one answer.
+        let solo = vec![planned_deployment("engine", &[("sim_inst", None)])];
+        let solo_fleet =
+            launch_fleet(&solo, &placements_with("cn-solo", &[])).expect("valid names");
+        assert_eq!(
+            solo_fleet
+                .iter()
+                .map(|name| name.as_str())
+                .collect::<Vec<_>>(),
+            ["cn-solo"]
+        );
+    }
+
+    /// The one refusal reachable at the coordinator (a wall daemon hosting a
+    /// simulated launch) fires, and only when the coordinator is one of the
+    /// launch's machines.
+    #[test]
+    fn a_coordinator_hosting_part_of_a_launch_must_agree_with_its_clock() {
+        let sim_demand =
+            federated::ClockDemand::Sim(federated::SimDemandOrigin::Instance("relay".to_owned()));
+
+        let error = check_coordinator_clock(true, &sim_demand, "cn-sim", false)
+            .expect_err("a wall coordinator cannot host a simulated launch");
+        assert!(error.contains("`cn-sim`"), "got: {error}");
+        assert!(error.contains("--clock-source=sim"), "got: {error}");
+        assert!(
+            error.contains("instance `relay`"),
+            "the refusal names what committed the launch: {error}"
+        );
+
+        assert!(
+            check_coordinator_clock(true, &federated::ClockDemand::Wall, "cn-sim", false).is_ok(),
+            "a wall coordinator hosts a wall launch"
+        );
+        assert!(
+            check_coordinator_clock(
+                true,
+                &federated::ClockDemand::Sim(federated::SimDemandOrigin::CoordinatorClock),
+                "cn-sim",
+                true
+            )
+            .is_ok(),
+            "a sim-mode coordinator hosts a simulated launch"
+        );
+
+        // Everything placed on peers: the coordinator is not of the fleet, so
+        // its own clock mode is not this launch's business, in either mode.
+        for serves_sim_time in [false, true] {
+            for demand in [
+                sim_demand.clone(),
+                federated::ClockDemand::Wall,
+                federated::ClockDemand::HostsDecide,
+            ] {
+                assert!(
+                    check_coordinator_clock(false, &demand, "cn-sim", serves_sim_time).is_ok(),
+                    "a coordinator hosting nothing is never refused"
+                );
+            }
+        }
+    }
+
     fn plan_with(use_sim_time: Option<bool>) -> config::runtime::NodeInstancePlan {
         config::runtime::NodeInstancePlan {
             use_sim_time,
@@ -1856,25 +2124,52 @@ mod tests {
         }
     }
 
-    /// Per-instance override beats the daemon default in either direction.
-    /// `Some(true)` forces sim even when the daemon default is wall;
-    /// `Some(false)` forces wall even when the daemon default is sim.
-    ///
-    /// Resolution happens on the daemon that spawns the node, because only it
-    /// knows its own default. A plan shipped from another machine carries the
-    /// override unresolved, which is why this is tested on the plan rather than
-    /// on a launcher-side helper.
+    /// A per-instance override resolves against the daemon default on the
+    /// daemon that spawns the node, because only it knows its own default. A
+    /// plan shipped from another machine carries the override unresolved,
+    /// which is why this is tested on the plan rather than on a launcher-side
+    /// helper. `Some(false)` forces wall time on a sim-mode daemon; the other
+    /// direction is not an override but a refusal, since a wall-mode daemon
+    /// cannot serve the simulated time the instance asked for.
     #[test]
-    fn a_per_instance_use_sim_time_override_wins_over_the_daemon_default() {
-        assert!(plan_with(Some(true)).resolve(false).framework.use_sim_time);
-        assert!(!plan_with(Some(false)).resolve(true).framework.use_sim_time);
+    fn a_per_instance_use_sim_time_override_resolves_on_the_spawning_daemon() {
+        assert!(
+            !plan_with(Some(false))
+                .resolve(true)
+                .expect("forcing wall time on a sim daemon is legal")
+                .framework
+                .use_sim_time
+        );
+        assert!(
+            plan_with(Some(true))
+                .resolve(true)
+                .expect("sim time on a sim daemon resolves")
+                .framework
+                .use_sim_time
+        );
+        let refused = plan_with(Some(true))
+            .resolve(false)
+            .expect_err("sim time on a wall daemon is refused, not resolved");
+        assert_eq!(refused.instance_id, "inst_1");
     }
 
     /// When the instance omits the override, the spawning daemon decides.
     #[test]
     fn an_absent_override_falls_through_to_the_daemon_default() {
-        assert!(!plan_with(None).resolve(false).framework.use_sim_time);
-        assert!(plan_with(None).resolve(true).framework.use_sim_time);
+        assert!(
+            !plan_with(None)
+                .resolve(false)
+                .expect("wall on wall resolves")
+                .framework
+                .use_sim_time
+        );
+        assert!(
+            plan_with(None)
+                .resolve(true)
+                .expect("sim on sim resolves")
+                .framework
+                .use_sim_time
+        );
     }
 
     #[test]

--- a/crates/core-node-internal/src/services/stack/launch/federated/mod.rs
+++ b/crates/core-node-internal/src/services/stack/launch/federated/mod.rs
@@ -71,6 +71,88 @@ struct ParticipantSlice {
     root_instance_id: String,
 }
 
+/// What a launch asks of every machine's clock.
+///
+/// Simulated time is the operator's choice, made per machine with
+/// `peppy service serve --clock-source`, so the launch reads it off the
+/// coordinator rather than inventing it: a launch typed at a sim-mode daemon
+/// is a simulated launch, and every machine it spans must serve simulated
+/// time too. An instance that names `use_sim_time: true` outright asks for it
+/// wherever it lands, so it commits the launch on its own.
+///
+/// A declared time source does NOT commit the launch. The same launcher
+/// describes a robot whether or not the operator started the daemon in sim
+/// mode; on a wall-mode machine the declaration resolves to no participants
+/// and the source publishes nothing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum ClockDemand {
+    Wall,
+    Sim(SimDemandOrigin),
+    /// The coordinator hosts none of the launch and no instance forces a
+    /// clock, so the machines that do host it decide: they must agree among
+    /// themselves, checked when their reservations come back
+    /// ([`check_hosts_agree`]). The coordinator's own clock stays out of it;
+    /// a machine running none of the launch is not its business.
+    HostsDecide,
+}
+
+/// What committed a launch to simulated time, carried in [`ClockDemand::Sim`]
+/// and rendered into the clock refusals so the operator sees every fix, not
+/// only the restart.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum SimDemandOrigin {
+    /// The coordinating daemon serves simulated time, so every launch typed
+    /// at it is simulated.
+    CoordinatorClock,
+    /// The named instance sets `framework: { use_sim_time: true }`, which
+    /// commits the launch wherever it lands.
+    Instance(String),
+}
+
+impl SimDemandOrigin {
+    /// The refusal clause naming what committed the launch.
+    fn because(&self) -> String {
+        match self {
+            Self::CoordinatorClock => "because the coordinating daemon serves it".to_owned(),
+            Self::Instance(instance_id) => {
+                format!("because instance `{instance_id}` sets `use_sim_time: true`")
+            }
+        }
+    }
+
+    /// The refusal's alternative remedy, where one exists.
+    fn alternative(&self) -> String {
+        match self {
+            Self::CoordinatorClock => String::new(),
+            Self::Instance(instance_id) => {
+                format!(", or drop `{instance_id}`'s `use_sim_time` override")
+            }
+        }
+    }
+}
+
+impl ClockDemand {
+    pub(super) fn of<'a>(
+        instances: impl IntoIterator<Item = &'a daemon_config::launcher::DeploymentInstance>,
+        coordinator_serves_sim_time: bool,
+        coordinator_hosts: bool,
+    ) -> Self {
+        if coordinator_hosts && coordinator_serves_sim_time {
+            return Self::Sim(SimDemandOrigin::CoordinatorClock);
+        }
+        if let Some(reader) = instances
+            .into_iter()
+            .find(|instance| instance.framework.use_sim_time == Some(true))
+        {
+            return Self::Sim(SimDemandOrigin::Instance(reader.instance_id.to_string()));
+        }
+        if coordinator_hosts {
+            return Self::Wall;
+        }
+        Self::HostsDecide
+    }
+}
+
 /// The pins each peer participant receives with its reservation, one
 /// serialized [`DeploymentPins`] per pinned deployment with at least one
 /// instance on it.
@@ -160,6 +242,7 @@ async fn reserve_participants(
     launch_id: &str,
     peers: BTreeMap<String, Vec<String>>,
     own_version: &str,
+    clock_demand: &ClockDemand,
 ) -> std::result::Result<Vec<ParticipantSlice>, String> {
     let acks = join_all(peers.into_iter().map(|(core_node, pins)| {
         let request =
@@ -184,17 +267,23 @@ async fn reserve_participants(
     let mut to_release: Vec<String> = Vec::new();
     let mut refusals: Vec<String> = Vec::new();
 
+    let mut host_clocks: Vec<(String, bool)> = Vec::new();
     for (core_node, outcome) in acks {
         match outcome {
             Ok(response) if response.accepted => {
                 to_release.push(core_node.clone());
-                // The reservation is already recorded above, so a version
-                // refusal here still releases it.
-                match check_version(&core_node, &response, own_version) {
-                    Ok(()) => slices.push(ParticipantSlice {
-                        core_node,
-                        root_instance_id: response.root_instance_id,
-                    }),
+                // The reservation is already recorded above, so a version or
+                // clock refusal here still releases it.
+                match check_version(&core_node, &response, own_version)
+                    .and_then(|()| check_clock_source(&core_node, &response, clock_demand))
+                {
+                    Ok(()) => {
+                        host_clocks.push((core_node.clone(), response.serves_sim_time));
+                        slices.push(ParticipantSlice {
+                            core_node,
+                            root_instance_id: response.root_instance_id,
+                        });
+                    }
                     Err(reason) => refusals.push(reason),
                 }
             }
@@ -217,6 +306,12 @@ async fn reserve_participants(
         }
     }
 
+    if refusals.is_empty()
+        && matches!(clock_demand, ClockDemand::HostsDecide)
+        && let Err(reason) = check_hosts_agree(&host_clocks)
+    {
+        refusals.push(reason);
+    }
     if refusals.is_empty() {
         return Ok(slices);
     }
@@ -256,6 +351,74 @@ fn check_version(
          launch requires the same version on every participant; upgrade the older machine.",
         response.peppy_version
     ))
+}
+
+/// Every machine of a launch must serve the same kind of time, so this
+/// refuses a peer whose clock source disagrees with the launch, in either
+/// direction. Refused before any stack is touched, naming the machine and the
+/// flag that fixes it.
+fn check_clock_source(
+    core_node: &str,
+    response: &ParticipantReserveResponse,
+    clock_demand: &ClockDemand,
+) -> std::result::Result<(), String> {
+    check_clock_agreement(core_node, response.serves_sim_time, clock_demand)
+}
+
+/// The one clock-agreement refusal, applied to a peer from its reservation
+/// and to the coordinator from its own defaults.
+///
+/// Both disagreements are real failures, not tidiness. A wall-mode machine in
+/// a simulated launch publishes its own ticks onto the very key the sim-time
+/// instances there read, so their time alternates. A sim-mode machine in a
+/// wall launch is the mirror: every instance placed there resolves to
+/// simulated time that nothing in this launch publishes, so each one waits at
+/// "clock not ready" for as long as it runs.
+pub(super) fn check_clock_agreement(
+    core_node: &str,
+    serves_sim_time: bool,
+    clock_demand: &ClockDemand,
+) -> std::result::Result<(), String> {
+    match (clock_demand, serves_sim_time) {
+        // The machines of a HostsDecide launch are held to each other, not to
+        // a demand, in [`check_hosts_agree`] once every reservation is in.
+        (ClockDemand::HostsDecide, _) => Ok(()),
+        (ClockDemand::Sim(_), true) | (ClockDemand::Wall, false) => Ok(()),
+        (ClockDemand::Sim(origin), false) => Err(format!(
+            "`{core_node}` serves wall time but this launch runs on simulated time, {because}. \
+             Every machine of a simulated launch must serve it, because a wall-mode daemon \
+             publishes its own ticks onto the key its sim-time instances read: restart \
+             `{core_node}` with `peppy service serve --clock-source=sim`{alternative}.",
+            because = origin.because(),
+            alternative = origin.alternative(),
+        )),
+        (ClockDemand::Wall, true) => Err(format!(
+            "`{core_node}` serves simulated time but this launch runs on wall time. Every \
+             instance placed there would resolve to simulated time that nothing in this launch \
+             publishes, and wait at `clock not ready`: restart `{core_node}` with `peppy \
+             service serve` to serve wall time, or launch from a daemon started with \
+             `--clock-source=sim`."
+        )),
+    }
+}
+
+/// A fully-placed launch takes its clock from the machines that host it,
+/// which must agree among themselves, in either mode. Unanimous simulated
+/// hosts run the launch on the declared source's ticks; unanimous wall hosts
+/// run it on their own; a split is refused naming one machine of each side,
+/// with every reservation released.
+pub(super) fn check_hosts_agree(hosts: &[(String, bool)]) -> std::result::Result<(), String> {
+    let sim_machine = hosts.iter().find(|(_, serves)| *serves);
+    let wall_machine = hosts.iter().find(|(_, serves)| !*serves);
+    match (sim_machine, wall_machine) {
+        (Some((sim_machine, _)), Some((wall_machine, _))) => Err(format!(
+            "the machines of this launch disagree about the clock: `{sim_machine}` serves \
+             simulated time while `{wall_machine}` serves wall time. Every machine of a launch \
+             serves the same kind of time; restart one side until they agree (`peppy service \
+             serve --clock-source=sim` for simulated, plain `peppy service serve` for wall)."
+        )),
+        _ => Ok(()),
+    }
 }
 
 /// Best-effort release of every named participant. Failures are logged, not
@@ -319,6 +482,7 @@ pub(super) async fn preflight(
     launch_id: &str,
     planned: &[super::PlannedDeployment],
     placements: &Placements,
+    clock_demand: &ClockDemand,
 ) -> std::result::Result<FederatedLaunch, String> {
     if !placements.is_federated() {
         return Ok(FederatedLaunch::default());
@@ -343,6 +507,7 @@ pub(super) async fn preflight(
         launch_id,
         peers,
         &ctx.peppy_version,
+        clock_demand,
     )
     .await?;
 
@@ -507,7 +672,7 @@ mod tests {
 
     #[test]
     fn a_version_mismatch_is_refused_and_names_both_versions() {
-        let response = ParticipantReserveResponse::accepted("v0.19.0", "gen_1");
+        let response = ParticipantReserveResponse::accepted("v0.19.0", "gen_1", false);
         let error =
             check_version("cn-atlas", &response, "v0.20.0").expect_err("skew must be refused");
         assert!(error.contains("v0.19.0"), "got: {error}");
@@ -517,8 +682,131 @@ mod tests {
 
     #[test]
     fn a_matching_version_passes() {
-        let response = ParticipantReserveResponse::accepted("v0.20.0", "gen_1");
+        let response = ParticipantReserveResponse::accepted("v0.20.0", "gen_1", false);
         assert!(check_version("cn-atlas", &response, "v0.20.0").is_ok());
+    }
+
+    /// A peer must serve the same kind of time the launch runs on, in either
+    /// direction, and each refusal names the machine and the way out. The
+    /// mirror case matters as much as the obvious one: a sim-mode peer in a
+    /// wall launch strands every instance placed there at "clock not ready".
+    #[test]
+    fn a_peer_whose_clock_disagrees_with_the_launch_is_refused() {
+        let wall_peer = ParticipantReserveResponse::accepted("v0.20.0", "gen_1", false);
+        let sim_peer = ParticipantReserveResponse::accepted("v0.20.0", "gen_1", true);
+
+        let coordinator_sim = ClockDemand::Sim(SimDemandOrigin::CoordinatorClock);
+        assert!(check_clock_source("cn-atlas", &wall_peer, &ClockDemand::Wall).is_ok());
+        assert!(check_clock_source("cn-atlas", &sim_peer, &coordinator_sim).is_ok());
+
+        let wall_in_sim = check_clock_source("cn-atlas", &wall_peer, &coordinator_sim)
+            .expect_err("a wall peer cannot host simulated time");
+        assert!(wall_in_sim.contains("`cn-atlas`"), "got: {wall_in_sim}");
+        assert!(
+            wall_in_sim.contains("--clock-source=sim"),
+            "got: {wall_in_sim}"
+        );
+        assert!(
+            wall_in_sim.contains("coordinating daemon serves it"),
+            "the refusal says what committed the launch: {wall_in_sim}"
+        );
+
+        // Committed by an instance instead: the refusal names it and offers
+        // dropping its override as the other way out.
+        let reader_sim = ClockDemand::Sim(SimDemandOrigin::Instance("relay".to_owned()));
+        let by_reader = check_clock_source("cn-atlas", &wall_peer, &reader_sim)
+            .expect_err("a wall peer cannot host simulated time");
+        assert!(
+            by_reader.contains("instance `relay` sets `use_sim_time: true`"),
+            "got: {by_reader}"
+        );
+        assert!(
+            by_reader.contains("drop `relay`'s `use_sim_time` override"),
+            "got: {by_reader}"
+        );
+
+        let sim_in_wall = check_clock_source("cn-atlas", &sim_peer, &ClockDemand::Wall)
+            .expect_err("a sim peer strands a wall launch's instances");
+        assert!(sim_in_wall.contains("`cn-atlas`"), "got: {sim_in_wall}");
+        assert!(
+            sim_in_wall.contains("clock not ready"),
+            "got: {sim_in_wall}"
+        );
+    }
+
+    /// A launch runs on simulated time because the operator started the
+    /// coordinator in sim mode, or because an instance asks for it outright.
+    /// Declaring a time source does not: that same launcher has to keep
+    /// working against a wall-mode daemon, where it publishes nothing.
+    #[test]
+    fn the_clock_demand_follows_the_coordinator_and_explicit_readers() {
+        let parse = |json5: &str| -> DeploymentInstance {
+            serde_json5::from_str(json5).expect("instance fixture should parse")
+        };
+        let wall = parse(r#"{ instance_id: "arm" }"#);
+        let forced_wall = parse(r#"{ instance_id: "cam", framework: { use_sim_time: false } }"#);
+        let reader = parse(r#"{ instance_id: "relay", framework: { use_sim_time: true } }"#);
+        let source = parse(r#"{ instance_id: "sim", framework: { publishes_sim_time: true } }"#);
+
+        assert_eq!(
+            ClockDemand::of([&wall, &forced_wall], false, true),
+            ClockDemand::Wall
+        );
+        assert_eq!(
+            ClockDemand::of([&wall, &reader], false, true),
+            ClockDemand::Sim(SimDemandOrigin::Instance("relay".to_owned())),
+            "the demand carries which instance committed the launch"
+        );
+        assert_eq!(
+            ClockDemand::of([&source], false, true),
+            ClockDemand::Wall,
+            "a declared source alone leaves a wall-mode launch on wall time"
+        );
+        assert_eq!(
+            ClockDemand::of([&wall], true, true),
+            ClockDemand::Sim(SimDemandOrigin::CoordinatorClock)
+        );
+        assert_eq!(ClockDemand::of([], false, true), ClockDemand::Wall);
+
+        // A coordinator hosting none of the launch does not get a vote: the
+        // hosting machines decide, unless an instance forces the clock, which
+        // commits the launch wherever it lands.
+        assert_eq!(
+            ClockDemand::of([&wall], false, false),
+            ClockDemand::HostsDecide
+        );
+        assert_eq!(
+            ClockDemand::of([&wall], true, false),
+            ClockDemand::HostsDecide,
+            "a non-hosting sim workstation cannot commit a launch to its clock"
+        );
+        assert_eq!(
+            ClockDemand::of([&wall, &reader], false, false),
+            ClockDemand::Sim(SimDemandOrigin::Instance("relay".to_owned()))
+        );
+    }
+
+    /// The machines of a fully-placed launch are held to each other: any
+    /// unanimous clock passes, a split is refused naming one machine of each
+    /// side.
+    #[test]
+    fn the_hosts_of_a_fully_placed_launch_must_agree_with_each_other() {
+        let unanimous_sim = [("cn-a".to_owned(), true), ("cn-b".to_owned(), true)];
+        let unanimous_wall = [("cn-a".to_owned(), false), ("cn-b".to_owned(), false)];
+        assert!(check_hosts_agree(&unanimous_sim).is_ok());
+        assert!(check_hosts_agree(&unanimous_wall).is_ok());
+        assert!(check_hosts_agree(&[]).is_ok());
+
+        let split = [("cn-sim".to_owned(), true), ("cn-wall".to_owned(), false)];
+        let refusal = check_hosts_agree(&split).expect_err("a split fleet is refused");
+        assert!(
+            refusal.contains("`cn-sim`") && refusal.contains("`cn-wall`"),
+            "one machine of each side is named: {refusal}"
+        );
+        assert!(
+            refusal.contains("--clock-source=sim"),
+            "the refusal says how to move either way: {refusal}"
+        );
     }
 
     fn slice(core_node: &str) -> ParticipantSlice {

--- a/crates/core-node-internal/tests/common/services.rs
+++ b/crates/core-node-internal/tests/common/services.rs
@@ -176,7 +176,7 @@ pub async fn assert_clock_topic_emits_monotonic_ticks(
 
         let tick = ClockTick::decode(message.payload().as_ref())
             .expect("clock tick decode should succeed");
-        times.push(tick.time);
+        times.push(tick.time());
     }
 
     // Strict (not non-strict) so a publisher that re-emits the same payload

--- a/crates/daemon-config-internal/src/error.rs
+++ b/crates/daemon-config-internal/src/error.rs
@@ -162,6 +162,19 @@ pub struct DuplicateInstanceIdAcrossStack {
     pub tag_b: String,
 }
 
+/// Payload for [`ParsingError::MultipleSimTimeSources`]. More than one
+/// instance in the stack declared `framework.publishes_sim_time`, so the
+/// fleet would have two clocks feeding every machine's `clock` topic.
+#[derive(Debug, Clone, Error)]
+#[error(
+    "instances {instance_ids} each declare `framework: {{ publishes_sim_time: true }}`; a launch \
+     has one source of simulated time, so keep the declaration on exactly one of them"
+)]
+pub struct MultipleSimTimeSources {
+    /// The declaring instance ids, quoted and comma-separated.
+    pub instance_ids: String,
+}
+
 /// Payload for [`ParsingError::LinkUnknownSlot`]. A `links:` key (or
 /// `--link KEY`) that names no declared slot of the instance's node across
 /// any family: `depends_on.{nodes,contracts}` producer slots or
@@ -572,6 +585,11 @@ pub enum ParsingError {
     /// variants.
     #[error(transparent)]
     DuplicateInstanceIdAcrossStack(Box<DuplicateInstanceIdAcrossStack>),
+    /// More than one instance declared itself the launch's simulated-time
+    /// source. Boxed for the same `result_large_err` reason as the other
+    /// binding variants.
+    #[error(transparent)]
+    MultipleSimTimeSources(Box<MultipleSimTimeSources>),
 
     // -- launcher/CLI: pairings
     #[error(transparent)]

--- a/crates/daemon-config-internal/src/launcher.rs
+++ b/crates/daemon-config-internal/src/launcher.rs
@@ -20,7 +20,9 @@ pub use flatten::{
     AppliedAdjustment, AppliedChange, ComponentSelection, CompositionError, FlattenReport,
     SelectionEntry, SelectionSource, SkipReason, SkippedAdjustment, check_composition, compose,
 };
-pub use links::{ValidatedLinkPlan, validate_link_plan, validate_link_slots};
+pub use links::{
+    ValidatedLinkPlan, validate_link_plan, validate_link_slots, validate_sim_time_source,
+};
 pub use observations::{PlannedObservation, ValidatedObservations, validate_observations};
 pub use pairings::{
     AlreadyPairedSlots, ExternallyCoveredSlots, PairingValidationItem, PlannedPairEndpoint,

--- a/crates/daemon-config-internal/src/launcher/links.rs
+++ b/crates/daemon-config-internal/src/launcher/links.rs
@@ -2,8 +2,8 @@
 //!
 //! The per-mechanism validators (`bindings`, `pairings`, `observations`) each
 //! own the keys that name their own slot kind and silently skip the rest. This
-//! pass is the single place that sees every declared slot at once, so it owns
-//! the two rules that need the union of all families:
+//! pass is the single place that sees every instance of the plan at once, so it
+//! owns the rules that need the whole picture rather than one family:
 //!   - a `links` key naming no declared slot in any family is
 //!     [`ParsingError::LinkUnknownSlot`];
 //!   - a `{ vacant: "<why>" }` value on a slot the node's own manifest does not
@@ -14,15 +14,21 @@
 //!     DOES, and why. A slot the manifest declares required cannot be vacated
 //!     at all, and one that already has a spelling for "empty" (`[]`, or an
 //!     omitted key on a `zero_or_more` slot) keeps using it, because one
-//!     spelling per fact is the point.
+//!     spelling per fact is the point;
+//!   - two instances both declaring `framework.publishes_sim_time` is
+//!     [`ParsingError::MultipleSimTimeSources`]. This one reads no slots at
+//!     all, only the instance list, but it needs the same whole-plan view: a
+//!     launch has one source of simulated time, and the pair that breaks that
+//!     can sit in different deployments.
 //!
 //! It reuses [`BindingValidationItem`] because that item already carries the
-//! full `depends_on` (all three families), so callers build no extra item type.
+//! full `depends_on` (all three families) and every instance, so callers build
+//! no extra item type.
 
 use super::types::Placements;
 use crate::error::{
-    BINDING_EMPTIABLE_KEY, LinkUnknownSlot, OBSERVER_EMPTIABLE_KEY, PARTICIPANT_EMPTIABLE_KEY,
-    ParsingError, VacancyRefusal,
+    BINDING_EMPTIABLE_KEY, LinkUnknownSlot, MultipleSimTimeSources, OBSERVER_EMPTIABLE_KEY,
+    PARTICIPANT_EMPTIABLE_KEY, ParsingError, VacancyRefusal,
 };
 use config::node::{Cardinality, DependsOn};
 use std::collections::BTreeMap;
@@ -58,6 +64,7 @@ pub fn validate_link_plan(
         errors: validate_link_slots(binding_items),
         ..ValidatedLinkPlan::default()
     };
+    out.errors.extend(validate_sim_time_source(binding_items));
     if !out.errors.is_empty() {
         return out;
     }
@@ -121,6 +128,28 @@ pub fn validate_link_slots(items: &[BindingValidationItem<'_>]) -> Vec<ParsingEr
     }
 
     errors
+}
+
+/// At most one instance in the plan may declare itself the launch's source of
+/// simulated time. Two sources would feed every machine's `clock` topic two
+/// timelines, so the second is refused here, on the flattened plan, which is
+/// what makes the rule hold however the document was expanded: by hand, by
+/// composition, or by anything that copies a bundle containing the source.
+pub fn validate_sim_time_source(items: &[BindingValidationItem<'_>]) -> Vec<ParsingError> {
+    let sources: Vec<&str> = items
+        .iter()
+        .flat_map(|item| item.instances)
+        .filter(|instance| instance.framework.publishes_sim_time)
+        .map(|instance| instance.instance_id.as_str())
+        .collect();
+    if sources.len() <= 1 {
+        return Vec::new();
+    }
+    vec![ParsingError::MultipleSimTimeSources(Box::new(
+        MultipleSimTimeSources {
+            instance_ids: crate::format_quoted_list(&sources),
+        },
+    ))]
 }
 
 #[derive(Clone, Copy)]
@@ -480,6 +509,41 @@ mod tests {
         assert!(
             !message.contains("empty array"),
             "a required slot has no empty spelling to be pointed at: {message}"
+        );
+    }
+
+    /// One declared time source is the fleet shape; two are refused naming
+    /// both, whichever deployments they sit in; none is every launch that runs
+    /// on wall time.
+    #[test]
+    fn at_most_one_instance_publishes_sim_time() {
+        let engine = parse_instances(
+            r#"[{ instance_id: "sim_inst", framework: { publishes_sim_time: true } }]"#,
+        );
+        let robots = parse_instances(
+            r#"[{ instance_id: "arm_a" }, { instance_id: "arm_b", framework: { use_sim_time: true } }]"#,
+        );
+        let second_engine = parse_instances(
+            r#"[{ instance_id: "sim_inst_2", framework: { publishes_sim_time: true } }]"#,
+        );
+
+        assert!(validate_sim_time_source(&[item(&robots, None)]).is_empty());
+        assert!(validate_sim_time_source(&[item(&engine, None), item(&robots, None)]).is_empty());
+
+        let errors = validate_sim_time_source(&[
+            item(&engine, None),
+            item(&robots, None),
+            item(&second_engine, None),
+        ]);
+        assert_eq!(errors.len(), 1);
+        let message = errors[0].to_string();
+        assert!(
+            message.contains("`sim_inst`") && message.contains("`sim_inst_2`"),
+            "both sources are named: {message}"
+        );
+        assert!(
+            !message.contains("arm_b"),
+            "a reader is not a source: {message}"
         );
     }
 }

--- a/crates/daemon-config-internal/src/launcher/types.rs
+++ b/crates/daemon-config-internal/src/launcher/types.rs
@@ -7,7 +7,7 @@ use serde::{
     Deserialize, Serialize,
     de::{self, Deserializer, MapAccess, Visitor},
 };
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 
 pub use crate::internal::source::DeploymentSource;
 
@@ -287,8 +287,9 @@ pub struct Deployment {
 impl DeploymentInstance {
     /// An instance entry carrying only its id, every other field at its
     /// default-empty value. Validation feeders use this to represent
-    /// already-running instances without fabricating per-instance data the
-    /// validators do not consult.
+    /// already-running instances. The default-empty `framework` reports the
+    /// instance as no simulated-time source, which is what an instance
+    /// started by an earlier launch is as far as this one is concerned.
     pub fn empty(instance_id: Name) -> Self {
         Self {
             instance_id,
@@ -873,13 +874,21 @@ impl<'de> Visitor<'de> for LinkEntriesVisitor {
 /// Per-instance framework knobs. Distinct from `arguments`: those are
 /// declared by the node author and validated against a per-node parameter
 /// schema; framework knobs are owned by peppylib, fixed-shape, and applied
-/// uniformly to every node. Each field is optional so the daemon can fall
-/// through to its own default when the instance omits the override.
+/// uniformly to every node.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct FrameworkOverrides {
+    /// Optional so the daemon falls through to its own `--clock-source`
+    /// default when the instance omits the override.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub use_sim_time: Option<bool>,
+    /// This instance is the launch's one source of simulated time: the daemon
+    /// hands it every machine of the launch, and its `SimTimePublisher` feeds
+    /// each machine's `clock` topic. At most one instance per launch may say
+    /// so; a second is refused when the flattened document is checked, which
+    /// is what keeps a fleet on one timeline whatever expanded the document.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub publishes_sim_time: bool,
 }
 
 fn deserialize_instances<'de, D>(deserializer: D) -> Result<Vec<DeploymentInstance>, D::Error>
@@ -1024,6 +1033,17 @@ mod tests {
         )
         .unwrap();
         assert_eq!(with_sim.framework.use_sim_time, Some(true));
+        assert!(!with_sim.framework.publishes_sim_time);
+
+        let source: DeploymentInstance = serde_json5::from_str(
+            "{ instance_id: \"sim_inst\", framework: { publishes_sim_time: true } }",
+        )
+        .unwrap();
+        assert!(source.framework.publishes_sim_time);
+        assert_eq!(source.framework.use_sim_time, None);
+        let source_reparsed: DeploymentInstance =
+            serde_json5::from_str(&serde_json5::to_string(&source).unwrap()).unwrap();
+        assert!(source_reparsed.framework.publishes_sim_time);
 
         let with_wall: DeploymentInstance = serde_json5::from_str(
             "{ instance_id: \"camera_front\", framework: { use_sim_time: false } }",
@@ -1522,6 +1542,40 @@ mod tests {
             "unexpected error: {msg}"
         );
     }
+
+    fn core_node(name: &str) -> crate::core_node_name::CoreNodeName {
+        crate::core_node_name::CoreNodeName::new(name).expect("valid test core node name")
+    }
+
+    /// The participants are the machines the given instances actually run
+    /// on: the coordinator only when something defaulted to it, every placed
+    /// machine once however many instances it holds, in a stable order.
+    #[test]
+    fn placements_participants_are_the_machines_the_instances_run_on() {
+        let placements = Placements::new(
+            core_node("cn-coord"),
+            BTreeMap::from([
+                ("robot_a".to_owned(), core_node("cn-b")),
+                ("robot_b".to_owned(), core_node("cn-b")),
+                ("robot_c".to_owned(), core_node("cn-a")),
+            ]),
+        );
+
+        assert_eq!(
+            placements.participants(["sim", "robot_a", "robot_b", "robot_c"]),
+            BTreeSet::from(["cn-a", "cn-b", "cn-coord"])
+        );
+        assert_eq!(
+            placements.participants(["robot_a", "robot_b"]),
+            BTreeSet::from(["cn-b"]),
+            "a coordinator hosting nothing is no participant"
+        );
+        assert_eq!(
+            Placements::all_on(core_node("cn-solo")).participants(["sim", "robot"]),
+            BTreeSet::from(["cn-solo"])
+        );
+        assert!(placements.participants([]).is_empty());
+    }
 }
 
 /// Where every instance of one launch runs.
@@ -1592,5 +1646,17 @@ impl Placements {
         self.by_instance
             .values()
             .any(|core_node| core_node != &self.coordinator)
+    }
+
+    /// Every core node at least one of `instance_ids` runs on, deduplicated
+    /// and in a stable order: the machines a launch-wide fact (the clock's
+    /// fan-out) has to reach. Derived from the instances rather than from the
+    /// placement map alone, since an instance that named no `core_node` runs
+    /// on the coordinator and a coordinator hosting nothing is no participant.
+    pub fn participants<'a>(
+        &'a self,
+        instance_ids: impl IntoIterator<Item = &'a str>,
+    ) -> BTreeSet<&'a str> {
+        instance_ids.into_iter().map(|id| self.of(id)).collect()
     }
 }

--- a/crates/daemon-config-internal/src/lib.rs
+++ b/crates/daemon-config-internal/src/lib.rs
@@ -102,7 +102,7 @@ pub mod launcher {
         SkippedAdjustment, VacantReason, ValidatedBindings, ValidatedLinkPlan,
         ValidatedObservations, ValidatedPairings, check_composition, compose,
         participant_vacancies, split_link_target, validate_bindings, validate_link_plan,
-        validate_link_slots, validate_observations, validate_pairings,
+        validate_link_slots, validate_observations, validate_pairings, validate_sim_time_source,
     };
 }
 

--- a/crates/peppy/src/commands/node/run.rs
+++ b/crates/peppy/src/commands/node/run.rs
@@ -405,11 +405,13 @@ async fn validate_links_against_stack(
             target_implements = info.config.manifest.implements.clone();
             target_seen_in_stack = true;
         }
-        // The validator only reads `instance_id` and `bindings` for
-        // inert items (`bindings` is unused under `depends_on: None`,
-        // but kept empty to satisfy the type). `arguments`, `env_vars`,
-        // and `framework` are not consulted; default-initialize them
-        // rather than fabricating data the validator would ignore.
+        // The validator reads `instance_id` and `bindings` for inert items
+        // (`bindings` is unused under `depends_on: None`, but kept empty to
+        // satisfy the type), plus `framework` for the one-simulated-time-source
+        // rule. A default-empty `framework` is the right answer there: whether
+        // an already-running instance is a time source was settled by the
+        // launch that started it, not by this one. `arguments` and `env_vars`
+        // are not consulted.
         let instances: Vec<DeploymentInstance> = node
             .instances
             .iter()

--- a/crates/peppy/src/commands/stack/resolve.rs
+++ b/crates/peppy/src/commands/stack/resolve.rs
@@ -7,6 +7,7 @@ use daemon_config::consts::PeppyDirs;
 use daemon_config::launcher::{
     AlreadyPairedSlots, BindingValidationItem, DeploymentSource, ExternallyCoveredSlots,
     PairingValidationItem, PeppyLauncher, compose, validate_link_slots, validate_pairings,
+    validate_sim_time_source,
 };
 use daemon_config::repository::EntryOrigin;
 use tracing::info;
@@ -195,6 +196,7 @@ fn check_link_plan(flat: &PeppyLauncher, dirs: &PeppyDirs, report: &mut Vec<Stri
         })
         .collect();
     let mut errors = validate_link_slots(&binding_items);
+    errors.extend(validate_sim_time_source(&binding_items));
     if errors.is_empty() {
         let pairing_items: Vec<PairingValidationItem<'_>> = manifests
             .iter()

--- a/crates/peppy/tests/fixtures/hub/nodes/sim_clock_probe/peppy.json5
+++ b/crates/peppy/tests/fixtures/hub/nodes/sim_clock_probe/peppy.json5
@@ -1,0 +1,16 @@
+{
+  peppy_schema: "node/v1",
+  manifest: {
+    name: "sim_clock_probe",
+    tag: "v1",
+    labels: ["clock"]
+  },
+  execution: {
+    language: "python",
+    build_cmd: ["uv", "sync", "--no-editable"],
+    run_cmd: ["./.venv/bin/python", "-m", "sim_clock_probe"],
+    parameters: {
+      poll_interval_ms: { $type: "u64", $default: 50 }
+    }
+  }
+}

--- a/crates/peppy/tests/fixtures/hub/nodes/sim_clock_probe/pyproject.toml
+++ b/crates/peppy/tests/fixtures/hub/nodes/sim_clock_probe/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "sim_clock_probe"
+version = "0.1.0"
+description = "Fixture clock reader: reports every sample its machine's resolved clock serves"
+requires-python = ">=3.13,<3.14"
+dependencies = ["peppygen", "peppylib"]
+
+[project.scripts]
+sim_clock_probe = "sim_clock_probe.__main__:main"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/sim_clock_probe"]
+
+[tool.uv.sources]
+peppygen = { path = ".peppy/libs/peppygen" }
+peppylib = { path = ".peppy/libs/peppylib" }

--- a/crates/peppy/tests/fixtures/hub/nodes/sim_clock_probe/src/sim_clock_probe/__main__.py
+++ b/crates/peppy/tests/fixtures/hub/nodes/sim_clock_probe/src/sim_clock_probe/__main__.py
@@ -1,0 +1,40 @@
+"""Reads this machine's resolved clock and reports every sample.
+
+Samples are numbered so a log reader can name "the Nth sample after this
+instant" and know the probe kept sampling; the values are whatever the
+machine's clock serves, reported verbatim.
+"""
+
+import asyncio
+
+from peppygen import NodeBuilder, NodeRunner, clock
+from peppygen.parameters import Parameters
+
+
+async def report_clock(node_runner: NodeRunner, params: Parameters) -> None:
+    await clock.init(node_runner)
+    interval = params.poll_interval_ms / 1000.0
+    token = node_runner.cancellation_token()
+    sample = 0
+    while not token.is_cancelled():
+        sample += 1
+        try:
+            print(
+                f"[clock-probe] sample={sample} now_ns={clock.now_ns()}",
+                flush=True,
+            )
+        except RuntimeError:
+            print(f"[clock-probe] sample={sample} clock not ready", flush=True)
+        await asyncio.sleep(interval)
+
+
+async def setup(params: Parameters, node_runner: NodeRunner) -> list[asyncio.Task]:
+    return [asyncio.create_task(report_clock(node_runner, params))]
+
+
+def main():
+    NodeBuilder().run(setup)
+
+
+if __name__ == "__main__":
+    main()

--- a/crates/peppy/tests/fixtures/hub/nodes/sim_clock_source/peppy.json5
+++ b/crates/peppy/tests/fixtures/hub/nodes/sim_clock_source/peppy.json5
@@ -1,0 +1,21 @@
+{
+  peppy_schema: "node/v1",
+  manifest: {
+    name: "sim_clock_source",
+    tag: "v1",
+    labels: ["clock"]
+  },
+  execution: {
+    language: "python",
+    build_cmd: ["uv", "sync", "--no-editable"],
+    run_cmd: ["./.venv/bin/python", "-m", "sim_clock_source"],
+    parameters: {
+      // The scripted ramp: ticks step_ns, 2*step_ns, ..., count*step_ns, one
+      // every interval_ms, then the final tick republished at the same
+      // cadence for the life of the node.
+      tick_step_ns: { $type: "u64", $default: 100000000 },
+      tick_count: { $type: "u32", $default: 50 },
+      tick_interval_ms: { $type: "u64", $default: 50 }
+    }
+  }
+}

--- a/crates/peppy/tests/fixtures/hub/nodes/sim_clock_source/peppy.json5
+++ b/crates/peppy/tests/fixtures/hub/nodes/sim_clock_source/peppy.json5
@@ -11,8 +11,9 @@
     run_cmd: ["./.venv/bin/python", "-m", "sim_clock_source"],
     parameters: {
       // The scripted ramp: ticks step_ns, 2*step_ns, ..., count*step_ns, one
-      // every interval_ms, then the final tick republished at the same
-      // cadence for the life of the node.
+      // every interval_ms. The final tick then repeats at the same cadence
+      // for the life of the node, so a probe whose subscription comes up
+      // after the ramp still converges on the final instant.
       tick_step_ns: { $type: "u64", $default: 100000000 },
       tick_count: { $type: "u32", $default: 50 },
       tick_interval_ms: { $type: "u64", $default: 50 }

--- a/crates/peppy/tests/fixtures/hub/nodes/sim_clock_source/pyproject.toml
+++ b/crates/peppy/tests/fixtures/hub/nodes/sim_clock_source/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "sim_clock_source"
+version = "0.1.0"
+description = "Fixture time source: publishes a scripted tick ramp to every machine of the launch, then republishes the final instant"
+requires-python = ">=3.13,<3.14"
+dependencies = ["peppygen", "peppylib"]
+
+[project.scripts]
+sim_clock_source = "sim_clock_source.__main__:main"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/sim_clock_source"]
+
+[tool.uv.sources]
+peppygen = { path = ".peppy/libs/peppygen" }
+peppylib = { path = ".peppy/libs/peppylib" }

--- a/crates/peppy/tests/fixtures/hub/nodes/sim_clock_source/src/sim_clock_source/__main__.py
+++ b/crates/peppy/tests/fixtures/hub/nodes/sim_clock_source/src/sim_clock_source/__main__.py
@@ -1,0 +1,48 @@
+"""The launch's scripted source of simulated time.
+
+Publishes a fixed ramp of ticks to every machine of the launch, then
+republishes the final instant at the same cadence for the life of the node:
+time tops out rather than going silent, so a machine whose subscription came
+up after the ramp still converges on the same final instant. The values are
+scripted rather than read from any clock, so a test can assert exact instants
+and a capped tail with no tolerance for host speed.
+"""
+
+import asyncio
+
+from peppygen import NodeBuilder, NodeRunner
+from peppygen.parameters import Parameters
+from peppylib.clock import SimTimePublisher
+
+
+async def publish_scripted_ticks(node_runner: NodeRunner, params: Parameters) -> None:
+    publisher = await SimTimePublisher.for_node(node_runner)
+    if publisher is None:
+        raise RuntimeError("the launch did not declare this instance its time source")
+    print(
+        f"[clock-source] publishing to {', '.join(publisher.participants)}",
+        flush=True,
+    )
+    interval = params.tick_interval_ms / 1000.0
+    for tick in range(1, params.tick_count + 1):
+        await publisher.publish(params.tick_step_ns * tick)
+        await asyncio.sleep(interval)
+    final_ns = params.tick_step_ns * params.tick_count
+    print(f"[clock-source] final tick {final_ns} published; holding", flush=True)
+
+    token = node_runner.cancellation_token()
+    while not token.is_cancelled():
+        await publisher.publish(final_ns)
+        await asyncio.sleep(interval)
+
+
+async def setup(params: Parameters, node_runner: NodeRunner) -> list[asyncio.Task]:
+    return [asyncio.create_task(publish_scripted_ticks(node_runner, params))]
+
+
+def main():
+    NodeBuilder().run(setup)
+
+
+if __name__ == "__main__":
+    main()

--- a/crates/peppy/tests/fixtures/hub/peppy_repository.json5
+++ b/crates/peppy/tests/fixtures/hub/peppy_repository.json5
@@ -21,6 +21,16 @@
         path: "nodes/reactive_policy/peppy.json5"
       }
     },
+    sim_clock_probe: {
+      v1: {
+        path: "nodes/sim_clock_probe/peppy.json5"
+      }
+    },
+    sim_clock_source: {
+      v1: {
+        path: "nodes/sim_clock_source/peppy.json5"
+      }
+    },
     uvc_camera_python_mock: {
       v1: {
         path: "nodes/uvc_camera_python_mock/peppy.json5"

--- a/crates/peppy/tests/multi_daemon_e2e.rs
+++ b/crates/peppy/tests/multi_daemon_e2e.rs
@@ -667,6 +667,28 @@ impl Daemon {
     }
 }
 
+/// Which time a daemon serves, the `peppy service serve --clock-source`
+/// choice. A federated launch requires every machine to make the same one, so
+/// the fixture has to be able to start a daemon either way.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ClockSource {
+    Wall,
+    Sim,
+}
+
+impl ClockSource {
+    /// The arguments this choice adds to `service serve`. Wall is the default
+    /// and passes no flag, which is also what every pre-existing daemon in
+    /// this suite starts with.
+    fn serve_args(self) -> Vec<&'static str> {
+        match self {
+            Self::Wall => Vec::new(),
+            Self::Sim => vec!["--clock-source=sim"],
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)] // One fixture, one call site per knob.
 async fn start_daemon(
     launch: &DaemonLaunch<'_>,
     name: &str,
@@ -676,6 +698,7 @@ async fn start_daemon(
     // Extra read-only mount, used by the federated tests to make the
     // documented launcher openable inside the coordinator.
     extra_mount: Option<(&Path, &str)>,
+    clock_source: ClockSource,
 ) -> Daemon {
     let repositories_config = launch.fixture.repositories_config();
     let mut request = GenericImage::new(launch.image_name, launch.image_tag)
@@ -709,7 +732,12 @@ async fn start_daemon(
         .with_env_var(PEPPY_HOME_ENV, CONTAINER_PEPPY_HOME)
         .with_env_var("PEPPY_APPTAINER_DIR", "/opt/peppy-apptainer")
         .with_env_var(PEPPY_CONFIG_ENV, config)
-        .with_cmd([CONTAINER_PEPPY_BINARY, "service", "serve"]);
+        .with_cmd(
+            [CONTAINER_PEPPY_BINARY, "service", "serve"]
+                .into_iter()
+                .chain(clock_source.serve_args())
+                .collect::<Vec<_>>(),
+        );
     if let Some((host_path, container_path)) = extra_mount {
         request = request.with_mount(read_only_bind(host_path, container_path));
     }
@@ -736,60 +764,14 @@ async fn start_daemon(
 /// one operator-run host router, and peppy owns none of its router lifecycle.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn two_container_daemons_are_enumerated_and_collisions_are_refused() {
-    require_docker().await;
-    let (image_name, image_tag) = e2e_image().await;
+    let substrate = Substrate::create().await;
 
-    let _router = ZenohAdapter::start_router_ephemeral_in_mode(
-        "0.0.0.0",
-        None,
-        false,
-        pmi::SubscriberBufferSizes::default(),
-        None,
-    )
-    .await
-    .expect("host zenohd should start");
-    let router_port = _router.port;
-
-    let peppy_binary = Path::new(env!("CARGO_BIN_EXE_peppy"));
-    let apptainer_dir = containers::Apptainer::resolve_apptainer_dir()
-        .expect("the test-built daemon should have a host Apptainer installation");
-    let newuidmap = executable_on_path("newuidmap");
-    let fixture = FixtureRepository::create();
-    let launch = DaemonLaunch {
-        image_name: &image_name,
-        image_tag: &image_tag,
-        peppy_binary,
-        apptainer_dir: &apptainer_dir,
-        newuidmap: &newuidmap,
-        fixture: &fixture,
-    };
-    let suffix = format!(
-        "{}-{}",
-        std::process::id(),
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("clock should be after epoch")
-            .as_millis()
-    );
-
-    let daemon_a = start_daemon(
-        &launch,
-        &format!("peppy-md-a-{suffix}"),
-        "robo-a",
-        &external_daemon_config("daemon-a", router_port),
-        None,
-        None,
-    )
-    .await;
-    let daemon_b = start_daemon(
-        &launch,
-        &format!("peppy-md-b-{suffix}"),
-        "robo-b",
-        &external_daemon_config("daemon-b", router_port),
-        None,
-        None,
-    )
-    .await;
+    let daemon_a = substrate
+        .start_daemon("peppy-md", "a", "robo-a", "daemon-a", ClockSource::Wall)
+        .await;
+    let daemon_b = substrate
+        .start_daemon("peppy-md", "b", "robo-b", "daemon-b", ClockSource::Wall)
+        .await;
 
     let both = daemon_a
         .wait_for_stack(|text| {
@@ -824,15 +806,9 @@ async fn two_container_daemons_are_enumerated_and_collisions_are_refused() {
         "explicit targeting must render one section:\n{targeted}"
     );
 
-    let collision = start_daemon(
-        &launch,
-        &format!("peppy-md-c-{suffix}"),
-        "robo-c",
-        &external_daemon_config("daemon-a", router_port),
-        None,
-        None,
-    )
-    .await;
+    let collision = substrate
+        .start_daemon("peppy-md", "c", "robo-c", "daemon-a", ClockSource::Wall)
+        .await;
     let collision_status = collision.wait_for_exit().await;
     assert_ne!(collision_status, 0, "colliding daemon must fail startup");
     let collision_logs = collision.logs().await;
@@ -906,6 +882,7 @@ async fn federated_router_peer_topology_daemons_are_enumerated_and_collisions_ar
             config: &router_a_pin,
         }),
         None,
+        ClockSource::Wall,
     )
     .await;
     let daemon_a_ip = daemon_a.bridge_ip().await;
@@ -925,6 +902,7 @@ async fn federated_router_peer_topology_daemons_are_enumerated_and_collisions_ar
             config: &router_b_pin,
         }),
         None,
+        ClockSource::Wall,
     )
     .await;
     let daemon_b_ip = daemon_b.bridge_ip().await;
@@ -982,6 +960,7 @@ async fn federated_router_peer_topology_daemons_are_enumerated_and_collisions_ar
             config: &collision_pin,
         }),
         None,
+        ClockSource::Wall,
     )
     .await;
     let collision_status = collision.wait_for_exit().await;
@@ -1024,6 +1003,8 @@ const SPLIT_COMPUTE_LAUNCHER_FILE: &str = "split_compute_manipulation.json5";
 const NODE_PROBE_LAUNCHER_FILE: &str = "node_probe.json5";
 const CALLER_ENV_PROBE_LAUNCHER_FILE: &str = "caller_env_probe.json5";
 const PEER_RUN_FAILURE_LAUNCHER_FILE: &str = "peer_run_failure.json5";
+const FLEET_CLOCK_LAUNCHER_FILE: &str = "fleet_clock.json5";
+const FULLY_PLACED_CLOCK_LAUNCHER_FILE: &str = "fully_placed_clock.json5";
 
 fn container_launcher(file_name: &str) -> String {
     format!("{CONTAINER_LAUNCHER_DIR}/{file_name}")
@@ -1099,6 +1080,100 @@ const PEER_RUN_FAILURE_LAUNCHER: &str = r#"{
   ],
 }
 "#;
+
+/// The ticket-shaped fleet: a launch spanning the simulator machine and two
+/// more. The scripted time source runs on the coordinator and declares itself
+/// the launch's source of simulated time; every machine, the coordinator
+/// included, runs a probe reporting what its resolved clock serves. Rendered
+/// from the same constants the test asserts with, so the asserted ramp and
+/// the launched ramp cannot diverge.
+fn fleet_clock_launcher() -> String {
+    format!(
+        r#"{{
+  peppy_schema: "launcher/v1",
+  core_nodes: ["station_a", "station_b"],
+  deployments: [
+    {{
+      source: {{ name: "sim_clock_source", tag: "v1" }},
+      instances: [
+        {{
+          instance_id: "{FLEET_CLOCK_SOURCE_INSTANCE}",
+          arguments: {{
+            tick_step_ns: {SCRIPTED_TICK_STEP_NS},
+            tick_count: {SCRIPTED_TICK_COUNT},
+            tick_interval_ms: 50,
+          }},
+          framework: {{ publishes_sim_time: true }},
+        }},
+      ],
+    }},
+    {{
+      source: {{ name: "sim_clock_probe", tag: "v1" }},
+      instances: [
+        {{ instance_id: "{FLEET_PROBE_COORD_INSTANCE}",
+          arguments: {{ poll_interval_ms: 50 }} }},
+        {{ instance_id: "{FLEET_PROBE_STATION_A_INSTANCE}", core_node: "station_a",
+          arguments: {{ poll_interval_ms: 50 }} }},
+        {{ instance_id: "{FLEET_PROBE_STATION_B_INSTANCE}", core_node: "station_b",
+          arguments: {{ poll_interval_ms: 50 }} }},
+      ],
+    }},
+  ],
+}}
+"#
+    )
+}
+
+/// The fully-placed sibling of [`fleet_clock_launcher`]: the same scripted
+/// source and probes, but everything lives on the stations and nothing on
+/// the coordinator, so the machine the launch is typed from is a bystander.
+fn fully_placed_clock_launcher() -> String {
+    format!(
+        r#"{{
+  peppy_schema: "launcher/v1",
+  core_nodes: ["station_a", "station_b"],
+  deployments: [
+    {{
+      source: {{ name: "sim_clock_source", tag: "v1" }},
+      instances: [
+        {{
+          instance_id: "{FLEET_CLOCK_SOURCE_INSTANCE}",
+          core_node: "station_a",
+          arguments: {{
+            tick_step_ns: {SCRIPTED_TICK_STEP_NS},
+            tick_count: {SCRIPTED_TICK_COUNT},
+            tick_interval_ms: 50,
+          }},
+          framework: {{ publishes_sim_time: true }},
+        }},
+      ],
+    }},
+    {{
+      source: {{ name: "sim_clock_probe", tag: "v1" }},
+      instances: [
+        {{ instance_id: "{FLEET_PROBE_STATION_A_INSTANCE}", core_node: "station_a",
+          arguments: {{ poll_interval_ms: 50 }} }},
+        {{ instance_id: "{FLEET_PROBE_STATION_B_INSTANCE}", core_node: "station_b",
+          arguments: {{ poll_interval_ms: 50 }} }},
+      ],
+    }},
+  ],
+}}
+"#
+    )
+}
+
+const FLEET_CLOCK_SOURCE_INSTANCE: &str = "clock_source_inst";
+const FLEET_PROBE_COORD_INSTANCE: &str = "probe_coord_inst";
+const FLEET_PROBE_STATION_A_INSTANCE: &str = "probe_station_a_inst";
+const FLEET_PROBE_STATION_B_INSTANCE: &str = "probe_station_b_inst";
+
+/// The ramp [`fleet_clock_launcher`] scripts: ticks `STEP`, `2 * STEP`, ...,
+/// `COUNT * STEP`, then the final tick republished at the same cadence, so a
+/// probe whose subscription came up after the ramp still converges on it.
+const SCRIPTED_TICK_STEP_NS: u64 = 100_000_000;
+const SCRIPTED_TICK_COUNT: u64 = 50;
+const SCRIPTED_FINAL_NS: u64 = SCRIPTED_TICK_STEP_NS * SCRIPTED_TICK_COUNT;
 
 /// Instances the launcher places on `robot_onboard`, i.e. everything the
 /// control loop touches.
@@ -1203,125 +1278,275 @@ fn assert_holds_exactly(stack: &str, daemon: &str, expected: &[&str], forbidden:
     }
 }
 
+/// What every set of daemon containers stands on: the built image, the shared
+/// host router, the fixture repository, and the launcher mount. One per test;
+/// every daemon of that test borrows from it, and it is held for their
+/// lifetime because the containers read the mounted directories off the host
+/// while they run.
+struct Substrate {
+    image_name: String,
+    image_tag: String,
+    router: pmi::ZenohdInstance,
+    apptainer_dir: PathBuf,
+    newuidmap: PathBuf,
+    fixture: FixtureRepository,
+    launcher_dir: tempfile::TempDir,
+    /// Uniquifies container names across concurrent tests in one run.
+    suffix: String,
+}
+
+impl Substrate {
+    async fn create() -> Self {
+        require_docker().await;
+        let (image_name, image_tag) = e2e_image().await;
+
+        let router = ZenohAdapter::start_router_ephemeral_in_mode(
+            "0.0.0.0",
+            None,
+            false,
+            pmi::SubscriberBufferSizes::default(),
+            None,
+        )
+        .await
+        .expect("host zenohd should start");
+
+        let apptainer_dir = containers::Apptainer::resolve_apptainer_dir()
+            .expect("the test-built daemon should have a host Apptainer installation");
+        let newuidmap = executable_on_path("newuidmap");
+        let fixture = FixtureRepository::create();
+        let suffix = format!(
+            "{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock should be after epoch")
+                .as_millis()
+        );
+
+        // Every launcher these tests drive, in one mountable directory: the
+        // file the guide documents, plus the probe launchers beside it.
+        let launcher_dir = tempfile::tempdir().expect("create launcher mount directory");
+        let documented_launcher = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../..")
+            .join(SPLIT_COMPUTE_LAUNCHER);
+        std::fs::copy(
+            &documented_launcher,
+            launcher_dir.path().join(SPLIT_COMPUTE_LAUNCHER_FILE),
+        )
+        .unwrap_or_else(|error| {
+            panic!(
+                "copying {} into the launcher mount: {error}",
+                documented_launcher.display()
+            )
+        });
+        for (file_name, launcher) in [
+            (NODE_PROBE_LAUNCHER_FILE, NODE_PROBE_LAUNCHER.to_owned()),
+            (
+                CALLER_ENV_PROBE_LAUNCHER_FILE,
+                CALLER_ENV_PROBE_LAUNCHER.to_owned(),
+            ),
+            (
+                PEER_RUN_FAILURE_LAUNCHER_FILE,
+                PEER_RUN_FAILURE_LAUNCHER.to_owned(),
+            ),
+            (FLEET_CLOCK_LAUNCHER_FILE, fleet_clock_launcher()),
+            (
+                FULLY_PLACED_CLOCK_LAUNCHER_FILE,
+                fully_placed_clock_launcher(),
+            ),
+        ] {
+            std::fs::write(launcher_dir.path().join(file_name), launcher).unwrap_or_else(|error| {
+                panic!("writing {file_name} into the launcher mount: {error}")
+            });
+        }
+
+        Self {
+            image_name,
+            image_tag,
+            router,
+            apptainer_dir,
+            newuidmap,
+            fixture,
+            launcher_dir,
+            suffix,
+        }
+    }
+
+    /// Starts one daemon container against this substrate's router, launcher
+    /// mount, and fixture repository.
+    async fn start_daemon(
+        &self,
+        prefix: &str,
+        role: &str,
+        hostname: &str,
+        core_node: &str,
+        clock: ClockSource,
+    ) -> Daemon {
+        let launch = DaemonLaunch {
+            image_name: &self.image_name,
+            image_tag: &self.image_tag,
+            peppy_binary: Path::new(env!("CARGO_BIN_EXE_peppy")),
+            apptainer_dir: &self.apptainer_dir,
+            newuidmap: &self.newuidmap,
+            fixture: &self.fixture,
+        };
+        start_daemon(
+            &launch,
+            &format!("{prefix}-{role}-{}", self.suffix),
+            hostname,
+            &external_daemon_config(core_node, self.router.port),
+            None,
+            Some((self.launcher_dir.path(), CONTAINER_LAUNCHER_DIR)),
+            clock,
+        )
+        .await
+    }
+
+    /// Starts the first spec as the coordinator and the rest as peers, then
+    /// runs the one bring-up sequence every multi-daemon test uses: the
+    /// coordinator serves and refreshes its repositories, the peers only
+    /// serve. Only the coordinator's cache decides what a launch runs: it
+    /// resolves every deployment once and ships pinned content to each peer,
+    /// which fetches whatever it does not already hold, so the peers
+    /// deliberately get NO refresh. Their empty caches are what prove the
+    /// pins carry the launch.
+    async fn start_coordinated(&self, prefix: &str, specs: &[DaemonSpec<'_>]) -> Vec<Daemon> {
+        let mut daemons = Vec::with_capacity(specs.len());
+        for spec in specs {
+            daemons.push(
+                self.start_daemon(prefix, spec.role, spec.hostname, spec.core_node, spec.clock)
+                    .await,
+            );
+        }
+        for (index, daemon) in daemons.iter().enumerate() {
+            daemon.wait_until_serving().await;
+            if index == 0 {
+                daemon.refresh_repos().await;
+            }
+        }
+        daemons
+    }
+}
+
+/// One daemon of a coordinated set: its container-name role, hostname, wired
+/// core-node name, and the clock it serves.
+struct DaemonSpec<'a> {
+    role: &'a str,
+    hostname: &'a str,
+    core_node: &'a str,
+    clock: ClockSource,
+}
+
 /// Two daemons on a shared router in one namespace, plus the launcher mounted
-/// into the coordinator. The substrate every federated test needs.
+/// into the coordinator. The shape every two-machine federated test needs.
 struct Federation {
     robot: Daemon,
     cloud: Daemon,
     robot_core_node: String,
     cloud_core_node: String,
-    _router: pmi::ZenohdInstance,
-    _launcher_dir: tempfile::TempDir,
-    /// Held for the federation's lifetime: both containers read this
-    /// repository off the host while they run.
-    _fixture: FixtureRepository,
+    _substrate: Substrate,
 }
 
 async fn start_federation(prefix: &str) -> Federation {
-    require_docker().await;
-    let (image_name, image_tag) = e2e_image().await;
+    start_federation_with_clocks(prefix, ClockSource::Wall, ClockSource::Wall).await
+}
 
-    let router = ZenohAdapter::start_router_ephemeral_in_mode(
-        "0.0.0.0",
-        None,
-        false,
-        pmi::SubscriberBufferSizes::default(),
-        None,
-    )
-    .await
-    .expect("host zenohd should start");
-    let router_port = router.port;
-
-    let peppy_binary = Path::new(env!("CARGO_BIN_EXE_peppy"));
-    let apptainer_dir = containers::Apptainer::resolve_apptainer_dir()
-        .expect("the test-built daemon should have a host Apptainer installation");
-    let newuidmap = executable_on_path("newuidmap");
-    let fixture = FixtureRepository::create();
-    let launch = DaemonLaunch {
-        image_name: &image_name,
-        image_tag: &image_tag,
-        peppy_binary,
-        apptainer_dir: &apptainer_dir,
-        newuidmap: &newuidmap,
-        fixture: &fixture,
-    };
-    let suffix = format!(
-        "{}-{}",
-        std::process::id(),
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("clock should be after epoch")
-            .as_millis()
-    );
-
-    // Every launcher these tests drive, in one mountable directory: the file
-    // the guide documents, plus the probe launcher beside it.
-    let launcher_dir = tempfile::tempdir().expect("create launcher mount directory");
-    let documented_launcher = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("../..")
-        .join(SPLIT_COMPUTE_LAUNCHER);
-    std::fs::copy(
-        &documented_launcher,
-        launcher_dir.path().join(SPLIT_COMPUTE_LAUNCHER_FILE),
-    )
-    .unwrap_or_else(|error| {
-        panic!(
-            "copying {} into the launcher mount: {error}",
-            documented_launcher.display()
+/// A federation whose two daemons serve the given clocks. Every launch in this
+/// suite but the clock tests wants both on wall time, which is what
+/// [`start_federation`] gives.
+async fn start_federation_with_clocks(
+    prefix: &str,
+    robot_clock: ClockSource,
+    cloud_clock: ClockSource,
+) -> Federation {
+    let substrate = Substrate::create().await;
+    let mut daemons = substrate
+        .start_coordinated(
+            prefix,
+            &[
+                DaemonSpec {
+                    role: "robot",
+                    hostname: "robo-robot",
+                    core_node: "cn-robot",
+                    clock: robot_clock,
+                },
+                DaemonSpec {
+                    role: "cloud",
+                    hostname: "robo-cloud",
+                    core_node: "cn-cloud",
+                    clock: cloud_clock,
+                },
+            ],
         )
-    });
-    std::fs::write(
-        launcher_dir.path().join(NODE_PROBE_LAUNCHER_FILE),
-        NODE_PROBE_LAUNCHER,
-    )
-    .expect("writing the probe launcher into the launcher mount");
-    std::fs::write(
-        launcher_dir.path().join(CALLER_ENV_PROBE_LAUNCHER_FILE),
-        CALLER_ENV_PROBE_LAUNCHER,
-    )
-    .expect("writing the caller-env probe launcher into the launcher mount");
-    std::fs::write(
-        launcher_dir.path().join(PEER_RUN_FAILURE_LAUNCHER_FILE),
-        PEER_RUN_FAILURE_LAUNCHER,
-    )
-    .expect("writing the peer-run-failure launcher into the launcher mount");
-
-    let robot = start_daemon(
-        &launch,
-        &format!("{prefix}-robot-{suffix}"),
-        "robo-robot",
-        &external_daemon_config("cn-robot", router_port),
-        None,
-        Some((launcher_dir.path(), CONTAINER_LAUNCHER_DIR)),
-    )
-    .await;
-    let cloud = start_daemon(
-        &launch,
-        &format!("{prefix}-cloud-{suffix}"),
-        "robo-cloud",
-        &external_daemon_config("cn-cloud", router_port),
-        None,
-        Some((launcher_dir.path(), CONTAINER_LAUNCHER_DIR)),
-    )
-    .await;
-
-    // Only the coordinator's cache decides what a launch runs: it resolves
-    // every deployment once and ships pinned content to the peer, which
-    // fetches whatever it does not already hold. The robot submits every
-    // launch in this suite, so the cloud daemon deliberately gets NO
-    // refresh: its empty cache is what proves the pins carry the launch.
-    robot.wait_until_serving().await;
-    robot.refresh_repos().await;
-    cloud.wait_until_serving().await;
+        .await;
+    let cloud = daemons.pop().expect("two daemons started");
+    let robot = daemons.pop().expect("two daemons started");
 
     Federation {
         robot,
         cloud,
         robot_core_node: "cn-robot".to_owned(),
         cloud_core_node: "cn-cloud".to_owned(),
-        _router: router,
-        _launcher_dir: launcher_dir,
-        _fixture: fixture,
+        _substrate: substrate,
+    }
+}
+
+/// The three machines of the fleet clock test: the coordinator (the simulator
+/// machine) and two stations, every daemon serving simulated time.
+struct Fleet {
+    coordinator: Daemon,
+    station_a: Daemon,
+    station_b: Daemon,
+    _substrate: Substrate,
+}
+
+const FLEET_COORDINATOR_CORE_NODE: &str = "cn-fleet-coord";
+const FLEET_STATION_A_CORE_NODE: &str = "cn-station-a";
+const FLEET_STATION_B_CORE_NODE: &str = "cn-station-b";
+
+async fn start_sim_fleet(prefix: &str) -> Fleet {
+    start_fleet(prefix, ClockSource::Sim).await
+}
+
+/// A fleet whose stations serve simulated time while the coordinator serves
+/// `coordinator_clock`: [`start_sim_fleet`] for the all-sim shape, or a wall
+/// bystander coordinator for the fully-placed tests.
+async fn start_fleet(prefix: &str, coordinator_clock: ClockSource) -> Fleet {
+    let substrate = Substrate::create().await;
+    let mut daemons = substrate
+        .start_coordinated(
+            prefix,
+            &[
+                DaemonSpec {
+                    role: "coord",
+                    hostname: "robo-fleet-coord",
+                    core_node: FLEET_COORDINATOR_CORE_NODE,
+                    clock: coordinator_clock,
+                },
+                DaemonSpec {
+                    role: "station-a",
+                    hostname: "robo-station-a",
+                    core_node: FLEET_STATION_A_CORE_NODE,
+                    clock: ClockSource::Sim,
+                },
+                DaemonSpec {
+                    role: "station-b",
+                    hostname: "robo-station-b",
+                    core_node: FLEET_STATION_B_CORE_NODE,
+                    clock: ClockSource::Sim,
+                },
+            ],
+        )
+        .await;
+    let station_b = daemons.pop().expect("three daemons started");
+    let station_a = daemons.pop().expect("three daemons started");
+    let coordinator = daemons.pop().expect("three daemons started");
+
+    Fleet {
+        coordinator,
+        station_a,
+        station_b,
+        _substrate: substrate,
     }
 }
 
@@ -1696,6 +1921,392 @@ async fn an_unreachable_peer_fails_the_launch_and_is_named() {
         "a refused preflight must not have started anything:\n{}",
         robot_stack.text
     );
+}
+
+// ── Clock agreement across a federation ───────────────────────────────────
+//
+// Simulated time is served per machine (`peppy service serve
+// --clock-source=sim`), and a launch spanning machines needs every one of them
+// to make the same choice. Both mismatches are real failures, and neither is
+// visible to a single-daemon test:
+//
+//   * a wall-mode machine in a simulated launch publishes its own ticks onto
+//     the very `clock` key its sim-time instances read, so their time
+//     alternates between the simulator's and the wall;
+//   * a sim-mode machine in a wall launch is the mirror. Every instance placed
+//     there resolves to simulated time that nothing in the launch publishes,
+//     and waits at "clock not ready" for as long as it runs.
+//
+// Both are refused in preflight, which is what makes them assertable without
+// building or starting anything: the refusal has to arrive before the launch
+// turns destructive, so the coordinator's stack is still untouched afterwards.
+
+/// Asserts a launch was refused for a clock mismatch, named the machine, and
+/// cost the coordinator nothing.
+async fn assert_clock_mismatch_refused(
+    federation: &Federation,
+    launch: ExecOutput,
+    offending_core_node: &str,
+    expected_detail: &str,
+) {
+    assert!(
+        !launch.success(),
+        "a launch whose machines disagree about the clock must fail:\n{}",
+        launch.text
+    );
+    assert!(
+        launch.text.contains(offending_core_node),
+        "the refusal must name `{offending_core_node}`:\n{}",
+        launch.text
+    );
+    assert!(
+        launch.text.contains(expected_detail),
+        "the refusal must carry `{expected_detail}`:\n{}",
+        launch.text
+    );
+
+    let robot_stack = federation.robot.stack_list(None).await;
+    assert!(
+        ROBOT_INSTANCES
+            .iter()
+            .all(|id| !holds_instance(&robot_stack.text, id)),
+        "a refused preflight must not have started anything:\n{}",
+        robot_stack.text
+    );
+}
+
+/// The coordinator serves simulated time and the peer serves wall time. The
+/// peer would flood its own `clock` key while the launch's source fed it, so
+/// the launch is refused before either machine is touched.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_simulated_launch_is_refused_when_a_peer_serves_wall_time() {
+    let federation =
+        start_federation_with_clocks("peppy-clock-wall-peer", ClockSource::Sim, ClockSource::Wall)
+            .await;
+
+    let launch = federation.launch_split().await;
+
+    assert_clock_mismatch_refused(
+        &federation,
+        launch,
+        &federation.cloud_core_node,
+        "--clock-source=sim",
+    )
+    .await;
+}
+
+/// The mirror, and the one a coordinator cannot see on its own: the
+/// coordinator serves wall time and the peer serves simulated time. Every
+/// instance placed on that peer would wait forever on a tick this launch never
+/// publishes, so the launch is refused rather than started into a hang.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_wall_launch_is_refused_when_a_peer_serves_simulated_time() {
+    let federation =
+        start_federation_with_clocks("peppy-clock-sim-peer", ClockSource::Wall, ClockSource::Sim)
+            .await;
+
+    let launch = federation.launch_split().await;
+
+    assert_clock_mismatch_refused(
+        &federation,
+        launch,
+        &federation.cloud_core_node,
+        "clock not ready",
+    )
+    .await;
+}
+
+/// The samples a probe's run log reports, in order: each ordinal with the
+/// value served, or `None` while the clock was not ready. Reads complete
+/// lines only: the log is read while the node writes it, and a tick value
+/// truncated mid-line must not be mistaken for a smaller instant.
+fn probe_samples(log: &str) -> Vec<(u64, Option<u64>)> {
+    let complete = match log.rfind('\n') {
+        Some(last_newline) => &log[..last_newline],
+        None => "",
+    };
+    complete
+        .lines()
+        .filter_map(|line| {
+            // Anywhere in the line, not a line prefix: the daemon may stamp
+            // its own prefix onto every captured stdout line.
+            let (_, rest) = line.split_once("[clock-probe] sample=")?;
+            let (sample, tail) = rest.split_once(' ')?;
+            let sample = sample.parse().ok()?;
+            let value = tail
+                .strip_prefix("now_ns=")
+                .map(|value| value.parse().expect("probe values are integers"));
+            Some((sample, value))
+        })
+        .collect()
+}
+
+/// How many samples past a reference ordinal the probe must report before a
+/// held-cap claim is judged: a hold cannot be asserted on the sample that
+/// just arrived.
+const SETTLE_SAMPLES: u64 = 20;
+
+/// Waits until `probe_instance`'s parsed history satisfies `satisfied`, using
+/// `marker` as the raw-log wait. `wait_for_node_log` matches the raw log,
+/// which can end mid-write, so a marker can be present while the complete
+/// lines do not carry it yet; the parse decides, the marker only paces.
+async fn wait_for_parsed_samples(
+    daemon: &Daemon,
+    probe_instance: &str,
+    marker: &str,
+    satisfied: impl Fn(&[(u64, Option<u64>)]) -> bool,
+) -> Vec<(u64, Option<u64>)> {
+    let started = Instant::now();
+    loop {
+        let log = daemon.wait_for_node_log(probe_instance, marker).await;
+        let samples = probe_samples(&log);
+        if satisfied(&samples) {
+            return samples;
+        }
+        assert!(
+            started.elapsed() < TIMEOUT,
+            "`{probe_instance}` never satisfied the parsed wait for `{marker}`:\n{log}"
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+/// Asserts one machine's whole clock history: nothing but scripted instants,
+/// never a regression, never unready again once a tick was served, and every
+/// sample past `capped_after` holding exactly the final instant.
+///
+/// The held tail is deterministic because no instant past the final one is
+/// ever published: any advance is a machine keeping its own time (a wall
+/// value would be nineteen digits) and any regression is a stale tick
+/// overtaking the ramp.
+fn assert_scripted_history(
+    daemon: &Daemon,
+    probe_instance: &str,
+    samples: &[(u64, Option<u64>)],
+    capped_after: u64,
+) {
+    let mut previous = None;
+    for (sample, value) in samples {
+        match value {
+            Some(value) => {
+                let tick = value / SCRIPTED_TICK_STEP_NS;
+                assert!(
+                    value % SCRIPTED_TICK_STEP_NS == 0 && (1..=SCRIPTED_TICK_COUNT).contains(&tick),
+                    "{}'s `{probe_instance}` served {value}, which no scripted tick ever was; \
+                     its machine is keeping its own time",
+                    daemon.name
+                );
+                if let Some(previous) = previous {
+                    assert!(
+                        *value >= previous,
+                        "{}'s `{probe_instance}` regressed from {previous} to {value} (sample \
+                         {sample}); a stale tick overtook the ramp",
+                        daemon.name
+                    );
+                }
+                previous = Some(*value);
+                if *sample > capped_after {
+                    assert_eq!(
+                        *value, SCRIPTED_FINAL_NS,
+                        "{}'s `{probe_instance}` moved after the ramp topped out (sample \
+                         {sample}); a capped source must hold every machine",
+                        daemon.name
+                    );
+                }
+            }
+            None => assert!(
+                previous.is_none(),
+                "{}'s `{probe_instance}` went unready after serving ticks (sample {sample})",
+                daemon.name
+            ),
+        }
+    }
+}
+
+/// Waits for the final scripted instant on one machine, lets the probe sample
+/// well past it, and asserts the whole history. Returns the last sample
+/// ordinal seen, so a later phase can anchor "still holding" after it.
+async fn assert_probe_capped_at_final(daemon: &Daemon, probe_instance: &str) -> u64 {
+    let final_marker = format!("now_ns={SCRIPTED_FINAL_NS}");
+    let samples = wait_for_parsed_samples(daemon, probe_instance, &final_marker, |samples| {
+        samples
+            .iter()
+            .any(|(_, value)| *value == Some(SCRIPTED_FINAL_NS))
+    })
+    .await;
+    let first_final = samples
+        .iter()
+        .find(|(_, value)| *value == Some(SCRIPTED_FINAL_NS))
+        .map(|(sample, _)| *sample)
+        .expect("the wait returned only once the final instant parsed");
+    assert_probe_holds_past(daemon, probe_instance, first_final).await
+}
+
+/// Waits for [`SETTLE_SAMPLES`] more samples past `after`, asserts the whole
+/// history with its cap anchored at `after`, and returns the last sample
+/// ordinal seen.
+async fn assert_probe_holds_past(daemon: &Daemon, probe_instance: &str, after: u64) -> u64 {
+    let settle = after + SETTLE_SAMPLES;
+    let settle_marker = format!("sample={settle} ");
+    let samples = wait_for_parsed_samples(daemon, probe_instance, &settle_marker, |samples| {
+        samples.iter().any(|(sample, _)| *sample >= settle)
+    })
+    .await;
+    assert_scripted_history(daemon, probe_instance, &samples, after);
+    samples
+        .last()
+        .map(|(sample, _)| *sample)
+        .expect("a satisfied wait returns a non-empty history")
+}
+
+/// The ticket's testable shape, positive path: a launch spanning the simulator
+/// machine and two more, every daemon serving simulated time. One scripted
+/// source on the coordinator feeds the whole launch; a probe on each machine
+/// reports what its resolved clock serves. Every machine serves nothing but
+/// scripted instants, never regressing, reaches the same final instant, and
+/// holds there once the ramp tops out; then the source is stopped outright
+/// and, with no tick arriving at all, every machine still holds the same
+/// instant rather than drifting anywhere. Exact values, not cross-container
+/// timestamp comparison, which the header of this file rules out for good
+/// reason.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_fleet_of_three_machines_shares_one_scripted_clock_and_holds_its_cap() {
+    let fleet = start_sim_fleet("peppy-fleet-clock").await;
+
+    let launch = fleet
+        .coordinator
+        .peppy(&[
+            "stack",
+            "launch",
+            "--place",
+            &format!("station_a@{FLEET_STATION_A_CORE_NODE}"),
+            "--place",
+            &format!("station_b@{FLEET_STATION_B_CORE_NODE}"),
+            &container_launcher(FLEET_CLOCK_LAUNCHER_FILE),
+        ])
+        .await;
+    assert!(
+        launch.success(),
+        "a fully simulated fleet launch must succeed:\n{}",
+        launch.text
+    );
+    assert!(
+        launch
+            .text
+            .contains("`clock_source_inst` is this launch's source of simulated time"),
+        "the launch names its time source:\n{}",
+        launch.text
+    );
+
+    // The launch, not the launcher, named the machines: the source's own log
+    // says which machines the daemon handed it, and it must be all three.
+    let source_log = fleet
+        .coordinator
+        .wait_for_node_log(FLEET_CLOCK_SOURCE_INSTANCE, "publishing to")
+        .await;
+    for core_node in [
+        FLEET_COORDINATOR_CORE_NODE,
+        FLEET_STATION_A_CORE_NODE,
+        FLEET_STATION_B_CORE_NODE,
+    ] {
+        assert!(
+            source_log.contains(core_node),
+            "the source must be handed `{core_node}` as a participant:\n{source_log}"
+        );
+    }
+    fleet
+        .coordinator
+        .wait_for_node_log(
+            FLEET_CLOCK_SOURCE_INSTANCE,
+            &format!("final tick {SCRIPTED_FINAL_NS} published"),
+        )
+        .await;
+
+    let probes = [
+        (&fleet.coordinator, FLEET_PROBE_COORD_INSTANCE),
+        (&fleet.station_a, FLEET_PROBE_STATION_A_INSTANCE),
+        (&fleet.station_b, FLEET_PROBE_STATION_B_INSTANCE),
+    ];
+    let mut held_through = Vec::with_capacity(probes.len());
+    for &(daemon, probe_instance) in &probes {
+        held_through.push(assert_probe_capped_at_final(daemon, probe_instance).await);
+    }
+
+    // The cap above held under a source still republishing its final instant.
+    // Now make the loss real: stop the source, and with no tick arriving at
+    // all every machine must keep the very same instant. Frozen, never
+    // drifting back to wall time: today's single-robot staleness behavior,
+    // fleet-wide.
+    let stopped = fleet
+        .coordinator
+        .peppy(&["node", "stop", FLEET_CLOCK_SOURCE_INSTANCE])
+        .await;
+    assert!(
+        stopped.success(),
+        "stopping the source must succeed:\n{}",
+        stopped.text
+    );
+    for (&(daemon, probe_instance), seen) in probes.iter().zip(held_through) {
+        assert_probe_holds_past(daemon, probe_instance, seen).await;
+    }
+}
+
+/// A launch typed from a machine that hosts none of it takes its clock from
+/// the machines that do. The coordinator serves wall time and hosts nothing;
+/// both stations serve simulated time and host everything. The launch
+/// succeeds, the source is handed exactly the two stations (never the
+/// bystander coordinator), and both stations read the scripted instants to
+/// their cap.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_fully_placed_launch_takes_its_clock_from_the_machines_that_host_it() {
+    let fleet = start_fleet("peppy-fleet-hosts", ClockSource::Wall).await;
+
+    let launch = fleet
+        .coordinator
+        .peppy(&[
+            "stack",
+            "launch",
+            "--place",
+            &format!("station_a@{FLEET_STATION_A_CORE_NODE}"),
+            "--place",
+            &format!("station_b@{FLEET_STATION_B_CORE_NODE}"),
+            &container_launcher(FULLY_PLACED_CLOCK_LAUNCHER_FILE),
+        ])
+        .await;
+    assert!(
+        launch.success(),
+        "a wall bystander coordinator must not refuse a coherent simulated launch:\n{}",
+        launch.text
+    );
+    assert!(
+        launch
+            .text
+            .contains("`clock_source_inst` is this launch's source of simulated time"),
+        "the launch names its time source:\n{}",
+        launch.text
+    );
+
+    let source_log = fleet
+        .station_a
+        .wait_for_node_log(FLEET_CLOCK_SOURCE_INSTANCE, "publishing to")
+        .await;
+    for core_node in [FLEET_STATION_A_CORE_NODE, FLEET_STATION_B_CORE_NODE] {
+        assert!(
+            source_log.contains(core_node),
+            "the source must be handed `{core_node}` as a participant:\n{source_log}"
+        );
+    }
+    assert!(
+        !source_log.contains(FLEET_COORDINATOR_CORE_NODE),
+        "a machine hosting nothing gets no tick:\n{source_log}"
+    );
+
+    for (daemon, probe_instance) in [
+        (&fleet.station_a, FLEET_PROBE_STATION_A_INSTANCE),
+        (&fleet.station_b, FLEET_PROBE_STATION_B_INSTANCE),
+    ] {
+        assert_probe_capped_at_final(daemon, probe_instance).await;
+    }
 }
 
 /// A phase that fails on a machine the operator cannot see must still name the

--- a/docs/src/content/docs/advanced_guides/system_clock.mdx
+++ b/docs/src/content/docs/advanced_guides/system_clock.mdx
@@ -242,6 +242,8 @@ Every machine of a simulated launch must serve simulated time, since a wall-mode
 <Tabs>
   <TabItem label="Python">
     ```python title="src/my_simulator/__main__.py"
+    import asyncio
+
     from peppylib.clock import SimTimePublisher
 
 
@@ -257,6 +259,8 @@ Every machine of a simulated launch must serve simulated time, since a wall-mode
     # running its physics on its own thread schedules it onto the node loop
     # rather than awaiting it there.
     def on_step(engine) -> None:
+        if engine.clock_publisher is None:
+            return
         loop.call_soon_threadsafe(
             lambda: asyncio.ensure_future(
                 engine.clock_publisher.publish(engine.time_ns())

--- a/docs/src/content/docs/advanced_guides/system_clock.mdx
+++ b/docs/src/content/docs/advanced_guides/system_clock.mdx
@@ -108,7 +108,7 @@ Call `on_next_tick` in a loop to receive each tick; it returns `None` when the s
 
 The core node publishes ticks at **10 Hz** (every 100 ms) by default: high enough to correlate logs across nodes, low enough not to flood the bus. The rate is set on the core node side via `CoreNodeArguments.clock_publish_interval`.
 
-Each `ClockTick` carries a single field, `time` (`u64` in Rust, `int` in Python): nanoseconds since the Unix epoch, stamped by the core node at emission. Because the tick is one-way, the value is stale by roughly one one-way network delay on receipt; there is no RTT correction. Use `synchronize` if you need bounded staleness.
+Each `ClockTick` carries a single instant, read with `time()` in Rust and the `time` attribute in Python: nanoseconds on the core node's timeline, stamped at emission. In wall mode that is the Unix epoch; under a simulator it is whatever origin the simulator counts from. The value is never `0`, which every sim-time cache reserves for "no tick observed yet". Because the tick is one-way, the value is stale by roughly one one-way network delay on receipt; there is no RTT correction. Use `synchronize` if you need bounded staleness.
 
 <Tabs>
   <TabItem label="Python">
@@ -159,7 +159,7 @@ Each `ClockTick` carries a single field, `time` (`u64` in Rust, `int` in Python)
                     .await
                     .expect("on_next_tick should not error")
                 {
-                    println!("core node wall time: {} ns", tick.time);
+                    println!("core node wall time: {} ns", tick.time());
                 }
                 // Subscription closed; core node went away.
             });
@@ -189,6 +189,8 @@ Resolution order, applied once in the daemon before each spawned node receives i
 1. The instance's `framework.use_sim_time` if it is set.
 2. The daemon's `--clock-source` flag (`wall` is the default).
 
+A daemon serving wall time publishes its own ticks on the `clock` topic, which is the same key a sim-time node on that machine reads. So reading simulated time needs a daemon that serves it: an instance whose `use_sim_time` resolves to `true` on a wall-mode daemon is refused as it starts, naming the instance and the flag that fixes it. Forcing the other direction (`use_sim_time: false` on a sim-mode daemon) is legal, since that node reads its OS clock and touches no topic.
+
 Standalone (daemon-less) runs resolve the same field from `StandaloneConfig`: `.with_use_sim_time(true)` in Rust, `.with_use_sim_time(True)` in Python (`false`, wall mode, is the default). Under the generated test harness the knob is `use_sim_time` on the harness config, and the harness serves the clock in either mode, with the test playing the external simulator in sim mode; see [the testing guide](/advanced_guides/testing/#the-clock).
 
 The wire format does not change. `ClockTick` and `ClockResponse` carry only timestamps; the daemon decides internally which source feeds them. In wall mode the daemon stamps every `t1`/`t2` and every published tick from its own OS clock. In sim mode the daemon stops publishing, subscribes to the `clock` topic, and answers `synchronize` from a cache populated by an external publisher. 
@@ -215,6 +217,72 @@ Subscribers see the same shape either way. Until that external publisher lands i
 ```
 
 Omit `framework` (or omit `use_sim_time` inside it) to fall through to the daemon default. Setting `use_sim_time: false` on an instance forces wall mode even when the daemon flag is `--clock-source=sim`.
+
+## One clock across a fleet
+
+The `clock` topic is keyed by the core node it belongs to, so a daemon and every sim-time node on its machine read that machine's key and nothing else. Reaching a second machine means publishing to a second key. A launch spanning several machines therefore names one instance its source of simulated time, and the daemon hands that instance every machine of the launch:
+
+```json5 title="peppy_launcher.json5"
+{
+  instance_id: "sim_inst",
+  framework: { publishes_sim_time: true },
+}
+```
+
+That instance builds a `SimTimePublisher`, and each `publish` lands one tick on every machine's `clock` topic, so the whole fleet reads one instant. Which machines those are comes from the launch's own placement, never from the launcher or the node: nothing in a simulator names a machine, and adding a robot changes no clock configuration.
+
+How often the source publishes is how finely the fleet can read time: `now_ns` returns the last tick observed, so a source ticking at 100 Hz gives every machine a 10 ms grid. Publish on the cadence the fleet needs to compare against, not on the physics step, which is usually far finer than anything reads.
+
+A launch runs on simulated time when the coordinating daemon serves it (`--clock-source=sim`), or when any instance names `framework: { use_sim_time: true }` outright, which commits the launch wherever that instance lands. Declaring a source does neither: on a wall-time launch the declaration resolves to no source at all and the instance publishes nothing, with an advisory line in the launch feedback saying so. One launcher describes the robot either way.
+
+At most one instance per launch may declare it. A second is refused when the launcher is checked (`peppy stack resolve` runs the same check), before anything starts, because two sources feeding the same keys are two timelines. `SimTimePublisher::for_node` returns `None` on a node the launch did not declare, so holding a publisher is the same fact as being the source, and an undeclared node cannot drive fleet time. Every simulated launch names its declared source in the launch feedback, so a source that never publishes leaves a named suspect rather than a silent hang.
+
+Every machine of a simulated launch must serve simulated time, since a wall-mode daemon there would flood the key the fleet's ticks land on, and every machine of a wall launch must serve wall time, since instances on a sim-mode machine would wait forever on a tick the launch never publishes. Both directions are refused at preflight, before any stack is touched, naming the machine, what committed the launch to its clock, and the flag that fixes it. A launch typed from a machine that hosts none of it takes its clock from the machines that do: they must agree among themselves, in either mode, and a split is refused naming one machine of each side. The bystander coordinator's own clock never commits such a launch.
+
+<Tabs>
+  <TabItem label="Python">
+    ```python title="src/my_simulator/__main__.py"
+    from peppylib.clock import SimTimePublisher
+
+
+    async def setup(_params, node_runner) -> None:
+        # None on a wall-time launch, which runs on the daemons' own ticks
+        # and needs no source. Build the publisher once and keep the handle.
+        engine.clock_publisher = await SimTimePublisher.for_node(node_runner)
+        if engine.clock_publisher is None:
+            return
+
+
+    # Called from the engine's step callback. `publish` is async, so an engine
+    # running its physics on its own thread schedules it onto the node loop
+    # rather than awaiting it there.
+    def on_step(engine) -> None:
+        loop.call_soon_threadsafe(
+            lambda: asyncio.ensure_future(
+                engine.clock_publisher.publish(engine.time_ns())
+            )
+        )
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust title="src/main.rs"
+    use peppylib::clock::SimTimePublisher;
+
+    // None on a wall-time launch, which runs on the daemons' own ticks and
+    // needs no source. Build the publisher once and keep the handle.
+    if let Some(publisher) = SimTimePublisher::for_node(&node_runner).await? {
+        // Then publish the engine's own clock from each step. Every machine
+        // of the launch reads this instant.
+        loop {
+            engine.step();
+            publisher.publish(engine.time_ns()).await?;
+        }
+    }
+    ```
+  </TabItem>
+</Tabs>
+
+A time source stamps its own data from its engine clock directly rather than from `now_ns()`: reading its own tick back off the wire would round-trip through its own subscription and report not-ready until the first tick it published came back. Every follower reads the published tick, which is the point.
 
 ### `PeppyClock` and the generated `clock` module
 

--- a/docs/src/content/docs/guides/launch_files.mdx
+++ b/docs/src/content/docs/guides/launch_files.mdx
@@ -247,9 +247,10 @@ The name and value rules exist because a container node receives its environment
 
 ### `framework` (optional)
 
-Framework knobs owned by peppylib rather than by the node author, so they mean the same thing for every node. The block holds one knob:
+Framework knobs owned by peppylib rather than by the node author, so they mean the same thing for every node. The block holds two knobs:
 
-- `use_sim_time`: read the clock from a simulator or bag replay instead of the daemon's wall clock. Setting it here wins over the daemon's `--clock-source` flag; omitting it falls through to that flag (which defaults to `wall`). See [System clock](/advanced_guides/system_clock/#sim-and-replay-clocks).
+- `use_sim_time`: read the clock from a simulator or bag replay instead of the daemon's wall clock. Omitting it falls through to the daemon's `--clock-source` flag (which defaults to `wall`). The two directions are not symmetric: `false` forces wall time on a daemon serving simulated time, while `true` needs a daemon started with `--clock-source=sim` and is refused on one serving wall time, because that daemon's own ticks land on the key the instance would read. See [System clock](/advanced_guides/system_clock/#sim-and-replay-clocks).
+- `publishes_sim_time`: this instance is the launch's source of simulated time. On a simulated launch it is handed every machine the launch runs on, and its `SimTimePublisher` feeds each machine's `clock` topic so a fleet shares one instant; on a wall-time launch it publishes nothing, so the same launcher works either way. At most one instance per launch may declare it, refused otherwise, and a simulated launch names its declared source in the launch feedback. See [One clock across a fleet](/advanced_guides/system_clock/#one-clock-across-a-fleet).
 
 An unknown key inside `framework` is an error rather than a no-op, so a typo like `use_simulation_time` fails the launch instead of silently leaving the instance on wall time.
 


### PR DESCRIPTION
> [!NOTE]
> Draft until Peppy-bot/public-peppy-libs#124 merges: this branch builds on that library surface, so the lockfile pin bumps and CI goes green once it lands. The diff is final and ready for review now.

A launcher entry can declare `framework: { publishes_sim_time: true }`, and the launch stamps that instance with every core node it places an instance on, as one parsed participant set derived from the flattened plan before anything is torn down. Nothing in a launcher or a node names a machine, so adding a robot changes no clock configuration, and the follow-on fleet instancing work lands on this untouched.

The declaration is held to one rule on the flattened plan: at most one source per launch, refused naming both instances, and `peppy stack resolve` runs the same check so a bad launcher fails before any launch is attempted.

A launch commits to simulated time through the clock its coordinator serves while hosting part of it, or through an instance's `use_sim_time: true`; the clock refusals carry that origin, naming the machine, what committed the launch, and every way out. A launch typed from a machine that hosts none of it takes its clock from the machines that do: they must agree among themselves, checked when their reservations come back, and a split is refused naming one machine of each side. The launch feedback says what was accepted: every launch that may run on simulated time names its declared source, so a source that never publishes leaves a named suspect instead of a silent hang at clock-not-ready; a declared source on a wall launch announces it will publish nothing; and a simulated launch with no declared source warns that its instances will wait at clock-not-ready.

The second commit is the ticket's testable shape in the containerised multi-daemon e2e suite: three daemons sharing one scripted clock through ramp, capped hold, and true tick silence, a fully placed launch taking its clock from the machines that host it past a wall-clock bystander coordinator, and both mixed-clock directions refused by name before teardown.

Second of four PRs for FRAMEWORK-202: public-peppy-libs #124, then this, then nodes-hub (the engines publish their own clock), then launchers-hub (the engine fragments declare themselves the source).

Verified against the local library branch: 2164 workspace unit tests, clippy clean, and the full 14-test multi-daemon e2e suite green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Peppy-bot/codesmith/peppy/pr/423"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790873197&installation_model_id=433186&pr_number=423&repository=Peppy-bot%2Fpeppy&return_to=https%3A%2F%2Fgithub.com%2FPeppy-bot%2Fpeppy%2Fpull%2F423&signature=91c4ff9837e1aefd04770a8aff6b2663af70769a461b69ee70950a627b973e3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added fleet-wide simulated-time support, including designated time publishers and clock probes.
  * Launch configurations can declare which instance publishes simulated time.
  * Federation responses report simulated-time capability.

* **Bug Fixes**
  * Launches now reject multiple time sources, incompatible clock modes, and clock mismatches across machines.
  * Improved clock tick handling and runtime configuration error reporting.

* **Documentation**
  * Expanded guidance for simulated clocks, fleet-wide time propagation, and launch configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->