### PR TITLE
repo: add --id to repo add for pinned repository ids

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -587,7 +587,7 @@ dependencies = [
 [[package]]
 name = "build-helpers"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#acc4fa7a2723b7b321ef0e683076291f82ee2c3f"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#98874c01d6c4a39d8b0b2f6e693d53265951c7cd"
 dependencies = [
  "sha2",
 ]
@@ -785,7 +785,7 @@ dependencies = [
 [[package]]
 name = "config-test-support"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#acc4fa7a2723b7b321ef0e683076291f82ee2c3f"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#98874c01d6c4a39d8b0b2f6e693d53265951c7cd"
 dependencies = [
  "askama",
  "git2",
@@ -931,7 +931,7 @@ dependencies = [
 [[package]]
 name = "core-node-api"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#acc4fa7a2723b7b321ef0e683076291f82ee2c3f"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#98874c01d6c4a39d8b0b2f6e693d53265951c7cd"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -2696,7 +2696,7 @@ dependencies = [
 [[package]]
 name = "json5-pretty"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#acc4fa7a2723b7b321ef0e683076291f82ee2c3f"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#98874c01d6c4a39d8b0b2f6e693d53265951c7cd"
 dependencies = [
  "serde",
  "serde_json",
@@ -3572,7 +3572,7 @@ dependencies = [
 [[package]]
 name = "peppy-config-model"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#acc4fa7a2723b7b321ef0e683076291f82ee2c3f"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#98874c01d6c4a39d8b0b2f6e693d53265951c7cd"
 dependencies = [
  "capnp",
  "clap",
@@ -3591,7 +3591,7 @@ dependencies = [
 [[package]]
 name = "peppy-mcp-catalog"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#acc4fa7a2723b7b321ef0e683076291f82ee2c3f"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#98874c01d6c4a39d8b0b2f6e693d53265951c7cd"
 dependencies = [
  "indexmap 2.14.1",
  "peppy-config-model",
@@ -3603,7 +3603,7 @@ dependencies = [
 [[package]]
 name = "peppy-mcp-runtime"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#acc4fa7a2723b7b321ef0e683076291f82ee2c3f"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#98874c01d6c4a39d8b0b2f6e693d53265951c7cd"
 dependencies = [
  "axum",
  "base64 0.23.1",
@@ -3625,7 +3625,7 @@ version = "0.0.1"
 [[package]]
 name = "peppylib-rs"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#acc4fa7a2723b7b321ef0e683076291f82ee2c3f"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#98874c01d6c4a39d8b0b2f6e693d53265951c7cd"
 dependencies = [
  "build-helpers",
  "bytes",
@@ -3822,7 +3822,7 @@ dependencies = [
 [[package]]
 name = "pmi"
 version = "0.1.0"
-source = "git+https://github.com/Peppy-bot/public-peppy-libs#acc4fa7a2723b7b321ef0e683076291f82ee2c3f"
+source = "git+https://github.com/Peppy-bot/public-peppy-libs#98874c01d6c4a39d8b0b2f6e693d53265951c7cd"
 dependencies = [
  "build-helpers",
  "bytes",

--- a/crates/core-node-internal/assets/default_repositories.json5
+++ b/crates/core-node-internal/assets/default_repositories.json5
@@ -1,3 +1,13 @@
+// Default repositories peppy bundles and appends to the user's
+// `~/.peppy/conf/repositories.json5` (by id, on daemon startup and
+// `peppy repo init`).
+//
+// ID BANDS: entries here stay below 2000, and ids are never reused. Ids
+// >= 2000 are reserved for repositories pinned explicitly (`peppy repo add
+// --id`, e.g. organization setups registering a private collection), so a
+// pinned id can never collide with a default a future release ships — a
+// collision would silently skip that default, since defaults are only
+// appended for ids not already taken.
 [
   {
     id: 1000,

--- a/crates/core-node-internal/src/services/repo/add.rs
+++ b/crates/core-node-internal/src/services/repo/add.rs
@@ -60,9 +60,20 @@ fn handle_repo_add_request_inner(
     let request = RepoAddRequest::decode(payload.as_ref())?;
 
     debug!(
-        "Received `repo_add` request from {sender_instance_id}, source={:?}",
-        request.source
+        "Received `repo_add` request from {sender_instance_id}, source={:?}, id={:?}",
+        request.source, request.id
     );
+
+    // An explicit id and top priority answer the same question (which id the
+    // new entry takes) in incompatible ways; deriving one while pinning the
+    // other would silently ignore half the request.
+    if request.id.is_some() && request.top {
+        return RepoAddResponse::failure(
+            "cannot combine an explicit id with top priority: --id pins the id, --top derives one",
+        )
+        .encode()
+        .map_err(Into::into);
+    }
 
     let identity = source_identity(&request.source);
     if identity.trim().is_empty() {
@@ -95,7 +106,26 @@ fn handle_repo_add_request_inner(
             .map_err(Into::into);
     }
 
-    let next_id = if request.top {
+    let next_id = if let Some(id) = request.id {
+        // The caller pinned this id (typically from the >= 2000 band
+        // reserved for organization-added repositories) so it stays stable
+        // across re-runs of whatever setup registered it. Claiming an id
+        // another entry already holds would merge two repositories' entries
+        // under one owner, so it is a refusal naming the id.
+        if repos
+            .iter()
+            .filter_map(|e| e.get("id").and_then(|v| v.as_u64()))
+            .any(|existing| existing == id)
+        {
+            return RepoAddResponse::failure(format!(
+                "repository id {id} is already in use; pick another (ids >= 2000 are reserved \
+                 for manually pinned repositories)"
+            ))
+            .encode()
+            .map_err(Into::into);
+        }
+        id
+    } else if request.top {
         match repos
             .iter()
             .filter_map(|e| e.get("id").and_then(|v| v.as_u64()))

--- a/crates/core-node-internal/tests/listen_for_repo_add.rs
+++ b/crates/core-node-internal/tests/listen_for_repo_add.rs
@@ -448,3 +448,79 @@ async fn listen_for_repo_add_same_git_url_different_refs_are_distinct() {
     assert!(refs.contains(&"main"));
     assert!(refs.contains(&"dev"));
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn listen_for_repo_add_explicit_id_succeed() {
+    let started = start_core_node_with_mock_messenger().await;
+
+    let resp = send_repo_add(
+        &started,
+        &RepoAddRequest::new_fs("/tmp/private-hub").with_id(2000),
+    )
+    .await;
+    assert!(resp.success, "repo_add with explicit id should succeed");
+
+    let repos_path = repositories_list_path(&started.peppy_dirs);
+    let content = std::fs::read_to_string(&repos_path).expect("read repos file");
+    let repos: Vec<serde_json::Value> =
+        serde_json5::from_str(&content).expect("parse repos as JSON5");
+
+    let added = repos
+        .iter()
+        .find(|e| e["path"] == "/tmp/private-hub")
+        .expect("added entry should be persisted");
+    assert_eq!(added["id"], 2000, "entry must carry the pinned id");
+    assert_eq!(
+        repos.iter().filter(|e| e["id"] == 2000).count(),
+        1,
+        "exactly one entry may hold the pinned id"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn listen_for_repo_add_explicit_id_collision_fails() {
+    let started = start_core_node_with_mock_messenger().await;
+
+    // 1000 is the id of the first bundled default; claiming it would merge
+    // the new repository's entries under that default's owner.
+    let resp = send_repo_add(
+        &started,
+        &RepoAddRequest::new_fs("/tmp/private-hub").with_id(1000),
+    )
+    .await;
+    assert!(!resp.success, "add pinning a taken id should fail");
+    assert!(
+        resp.error_message.contains("id 1000 is already in use"),
+        "error should name the taken id, got: {}",
+        resp.error_message
+    );
+
+    let repos_path = repositories_list_path(&started.peppy_dirs);
+    let content = std::fs::read_to_string(&repos_path).expect("read repos file");
+    let repos: Vec<serde_json::Value> =
+        serde_json5::from_str(&content).expect("parse repos as JSON5");
+    assert!(
+        repos.iter().all(|e| e["path"] != "/tmp/private-hub"),
+        "refused entry must not be persisted"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn listen_for_repo_add_explicit_id_with_top_fails() {
+    let started = start_core_node_with_mock_messenger().await;
+
+    let resp = send_repo_add(
+        &started,
+        &RepoAddRequest::new_fs("/tmp/private-hub")
+            .with_id(2000)
+            .with_top(true),
+    )
+    .await;
+    assert!(!resp.success, "id + top should fail");
+    assert!(
+        resp.error_message
+            .contains("cannot combine an explicit id with top priority"),
+        "error should explain the conflict, got: {}",
+        resp.error_message
+    );
+}

--- a/crates/peppy/src/commands/repo.rs
+++ b/crates/peppy/src/commands/repo.rs
@@ -132,6 +132,14 @@ pub enum RepoCommands {
         /// Give the new repo top priority (assigns an id below the current min).
         #[arg(long)]
         top: bool,
+        /// Register the repository under this exact id instead of the next
+        /// free one. Take ids from the reserved band >= 2000: peppy's
+        /// bundled defaults (see its `assets/default_repositories.json5`)
+        /// stay below 2000, so a pinned id can never collide with a default
+        /// a future peppy release ships — which would silently skip that
+        /// default, since defaults are only appended for ids not taken.
+        #[arg(long, conflicts_with = "top")]
+        id: Option<u64>,
     },
     /// Remove a repository
     Remove {
@@ -182,7 +190,8 @@ impl Command for RepoCommand {
                 source,
                 git_ref,
                 top,
-            } => add::add_repo(ctx, &source, git_ref, top),
+                id,
+            } => add::add_repo(ctx, &source, git_ref, top, id),
             RepoCommands::Remove { id } => remove::remove_repo(ctx, id),
             RepoCommands::Exclude { source, git_ref } => {
                 exclude::exclude_repo(ctx, &source, git_ref)

--- a/crates/peppy/src/commands/repo/add.rs
+++ b/crates/peppy/src/commands/repo/add.rs
@@ -18,12 +18,17 @@ pub(super) fn add_repo(
     source_str: &str,
     git_ref: Option<String>,
     top: bool,
+    id: Option<u64>,
 ) -> Result<()> {
     let repo_source = parse_repo_source(source_str, git_ref)?;
     let label = repo_source_label(&repo_source);
-    info!("Adding repository {label}");
+    let id_label = match id {
+        Some(n) => n.to_string(),
+        None => "auto".to_string(),
+    };
+    info!("Adding repository {label} (id: {id_label})");
 
-    crate::commands::block_on(add_repo_async(ctx, repo_source, label, top))
+    crate::commands::block_on(add_repo_async(ctx, repo_source, label, top, id))
 }
 
 async fn add_repo_async(
@@ -31,6 +36,7 @@ async fn add_repo_async(
     repo_source: RepoSource,
     label: String,
     top: bool,
+    id: Option<u64>,
 ) -> Result<()> {
     let conn = ctx.connect_to_daemon().await?;
 
@@ -44,6 +50,7 @@ async fn add_repo_async(
     let request = RepoAddRequest {
         source: repo_source,
         top,
+        id,
     };
     let response = poll(
         &request,

--- a/crates/peppy/src/main.rs
+++ b/crates/peppy/src/main.rs
@@ -272,6 +272,29 @@ mod tests {
         );
     }
 
+    /// `--id` pins the repository id (the reserved >= 2000 band); it answers
+    /// the same question `--top` does, so the parser refuses the pair rather
+    /// than silently honoring one half.
+    #[test]
+    fn repo_add_id_flag_parses_and_conflicts_with_top() {
+        let cli = Cli::try_parse_from(["peppy", "repo", "add", "/hub", "--id", "2000"])
+            .expect("repo add --id parses");
+        assert!(matches!(
+            cli.command,
+            Commands::Repo {
+                command: repo::RepoCommands::Add {
+                    id: Some(2000),
+                    top: false,
+                    ..
+                }
+            }
+        ));
+        assert!(
+            Cli::try_parse_from(["peppy", "repo", "add", "/hub", "--id", "2000", "--top"]).is_err(),
+            "--id with --top is refused"
+        );
+    }
+
     /// Exposures are published by writing the document and listing it in a
     /// launcher; there is no publication command, and the parser knows no
     /// such word.

--- a/crates/peppy/tests/repo_add.rs
+++ b/crates/peppy/tests/repo_add.rs
@@ -11,6 +11,7 @@ fn repo_add_git_url_succeeds() {
             source: "https://github.com/org/repo.git".to_string(),
             git_ref: None,
             top: false,
+            id: None,
         },
     }
     .execute(&ctx);
@@ -31,6 +32,7 @@ fn repo_add_with_git_ref_succeeds() {
             source: "https://github.com/org/repo.git".to_string(),
             git_ref: Some("v1.0.0".to_string()),
             top: false,
+            id: None,
         },
     }
     .execute(&ctx);
@@ -56,6 +58,7 @@ fn repo_add_fs_path_succeeds() {
                 .to_string(),
             git_ref: None,
             top: false,
+            id: None,
         },
     }
     .execute(&ctx);
@@ -79,6 +82,7 @@ fn repo_add_refuses_a_url_that_is_not_a_git_clone_url() {
             source: "https://example.com/packages".to_string(),
             git_ref: None,
             top: false,
+            id: None,
         },
     }
     .execute(&ctx);
@@ -105,6 +109,7 @@ fn repo_add_duplicate_fails() {
             source: source.clone(),
             git_ref: None,
             top: false,
+            id: None,
         },
     }
     .execute(&ctx)
@@ -116,6 +121,7 @@ fn repo_add_duplicate_fails() {
             source,
             git_ref: None,
             top: false,
+            id: None,
         },
     }
     .execute(&ctx);
@@ -142,6 +148,7 @@ fn repo_add_fs_path_with_ref_fails() {
                 .to_string(),
             git_ref: Some("main".to_string()),
             top: false,
+            id: None,
         },
     }
     .execute(&ctx);
@@ -164,6 +171,7 @@ fn repo_add_top_assigns_id_below_current_min() {
             source: "https://example.com/first.git".to_string(),
             git_ref: None,
             top: false,
+            id: None,
         },
     }
     .execute(&ctx)
@@ -175,6 +183,7 @@ fn repo_add_top_assigns_id_below_current_min() {
             source: "https://example.com/second.git".to_string(),
             git_ref: None,
             top: true,
+            id: None,
         },
     }
     .execute(&ctx)
@@ -205,6 +214,54 @@ fn repo_add_top_assigns_id_below_current_min() {
 }
 
 #[test]
+fn repo_add_explicit_id_assigns_given_id() {
+    let (_rt, serve, ctx, _work_dir) = setup();
+
+    // An explicit id from the reserved >= 2000 band lands verbatim, not at
+    // the next free slot — organization setups rely on that stability.
+    RepoCommand {
+        command: RepoCommands::Add {
+            source: "/tmp/private-hub".to_string(),
+            git_ref: None,
+            top: false,
+            id: Some(2000),
+        },
+    }
+    .execute(&ctx)
+    .expect("explicit-id add should succeed");
+
+    let repos_path = serve.temp_dir().join("conf/repositories.json5");
+    let content = std::fs::read_to_string(&repos_path).expect("read repos file");
+    let repos: Vec<serde_json::Value> = serde_json5::from_str(&content).expect("parse repos");
+
+    let added = repos
+        .iter()
+        .find(|e| e["path"] == "/tmp/private-hub")
+        .expect("added entry missing");
+    assert_eq!(
+        added["id"], 2000,
+        "--id must assign exactly the given id, not the next free one"
+    );
+
+    // A second add claiming the same id is a refusal naming it.
+    let err = RepoCommand {
+        command: RepoCommands::Add {
+            source: "/tmp/other-hub".to_string(),
+            git_ref: None,
+            top: false,
+            id: Some(2000),
+        },
+    }
+    .execute(&ctx)
+    .expect_err("claiming a taken id should fail");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("id 2000 is already in use"),
+        "error should name the taken id, got: {msg}"
+    );
+}
+
+#[test]
 fn repo_add_https_url_with_ref_treated_as_git() {
     // When --ref is provided, a parseable HTTPS URL (without `.git` suffix)
     // should be treated as a git clone URL rather than rejected.
@@ -215,6 +272,7 @@ fn repo_add_https_url_with_ref_treated_as_git() {
             source: "https://github.com/org/repo".to_string(),
             git_ref: Some("main".to_string()),
             top: false,
+            id: None,
         },
     }
     .execute(&ctx);

--- a/crates/peppy/tests/repo_remove.rs
+++ b/crates/peppy/tests/repo_remove.rs
@@ -44,6 +44,7 @@ fn repo_remove_after_add_succeeds() {
             source: source.to_string(),
             git_ref: None,
             top: false,
+            id: None,
         },
     }
     .execute(&ctx)
@@ -92,6 +93,7 @@ fn repo_remove_after_add_git_succeeds() {
             source: source.to_string(),
             git_ref: None,
             top: false,
+            id: None,
         },
     }
     .execute(&ctx)


### PR DESCRIPTION
## What

`peppy repo add --id <n>` registers a repository under an exact id instead of the next free one. Ids come from a reserved band **>= 2000** (bundled defaults stay below 2000), so a pinned id can never collide with a default a future release ships — a collision would silently skip that default, since `ensure_default_repos` only appends defaults for ids not already taken.

Semantics:
- `--id` conflicts with `--top` (both answer which id the entry takes); the daemon also refuses the combination over the wire.
- Claiming an id another entry already holds is a refusal naming the id; nothing is persisted.
- The band convention is documented in `crates/core-node-internal/assets/default_repositories.json5`.

Enables the superproject's `scripts/setup-repositories.sh`, which registers the private `private-nodes-hub` checkout as an `fs` repository under id 2000 on internal machines — public installs are unaffected.

## Test plan

- `cargo test -p core-node --test listen_for_repo_add`: 17 passed, including new tests for explicit-id success, id-collision refusal (asserting the entry is not persisted), and `--id`+`--top` rejection.
- `cargo test -p peppy --bin peppy`: 14 passed, including the `--id` parse/conflict test.
- `cargo check --locked -p peppy` against the merged public-peppy-libs main tip.

## Dependencies

- ~~Peppy-bot/public-peppy-libs#125~~ **merged** — `Cargo.lock` now pins the merged main tip (`98874c0`).