### PR TITLE
docs: sync with the code being released (f404bfd57684)

### DIFF
--- a/docs/src/content/docs/advanced_guides/repositories.mdx
+++ b/docs/src/content/docs/advanced_guides/repositories.mdx
@@ -245,7 +245,7 @@ A machine that has **never** read a repository successfully has nothing to fall 
 ### Add a repository
 
 ```sh
-peppy repo add <source> [--ref <tag-or-branch>] [--top]
+peppy repo add <source> [--ref <tag-or-branch>] [--top | --id <id>]
 ```
 
 Adds a new repository to `repositories.json5`. The source format is auto-detected:
@@ -262,9 +262,14 @@ peppy repo add https://github.com/org/repo.git --ref v2.0
 
 # Give the new repo top priority (lower `id` than every existing entry)
 peppy repo add /path/to/my/nodes --top
+
+# Pin the repo under an exact id from the reserved band (>= 2000)
+peppy repo add /path/to/my/nodes --id 2000
 ```
 
 The `--ref` flag is only valid for git sources. By default the new repository is appended with `id = max(existing ids) + 1`, so it has the lowest priority among configured repositories; pass `--top` to assign it an `id` just below the current minimum, giving it the highest priority. The priority `id` decides which repository wins when several of them provide the same `name:tag` (see [Refresh the index](#refresh-the-index)).
+
+Pass `--id <id>` to pin the new repository under that exact id instead of a derived one. Take ids from the reserved band `>= 2000`: Peppy's bundled defaults stay below 2000, so a pinned id never collides with a default. `--id` conflicts with `--top`, since both decide which id the entry takes. Pinning an id another entry already holds is refused, naming the id (for example `repository id 2000 is already in use`).
 
 ### Remove a repository
 


### PR DESCRIPTION
Automated docs update produced by the release script (`scripts/functions/docs.py`), which found `docs/` lagging the code at the commit the release was being cut from.

Release commit: f404bfd57684f62112f1baa9b5bf55ccdb1d32a7

Gaps the check reported:

- `docs/src/content/docs/advanced_guides/repositories.mdx`: In the "Add a repository" section, document the new `peppy repo add --id <id>` flag: add it to the synopsis, explain it pins the repository under an exact id from the reserved band >= 2000 (bundled defaults stay below 2000 so pinned ids never collide), that it conflicts with `--top`, and that pinning an already-used id is refused naming the id.

Merge this into `dev`, then re-run the release.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Peppy-bot/codesmith/peppy/pr/425"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790943756&installation_model_id=433186&pr_number=425&repository=Peppy-bot%2Fpeppy&return_to=https%3A%2F%2Fgithub.com%2FPeppy-bot%2Fpeppy%2Fpull%2F425&signature=04b4187329f63f292013608214d73002e9aa1e393d4c17362c9e3f2ca2fda715"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->