### PR TITLE
git: clone repositories over ssh, authenticating like ssh itself does

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2816,6 +2816,7 @@ checksum = "7f7c568b25d7489bc3fb2988ed69ab111d2944d2f5fec3d5c987fe545ea97b50"
 dependencies = [
  "cc",
  "libc",
+ "libssh2-sys",
  "libz-sys",
  "openssl-sys",
  "pkg-config",
@@ -2844,6 +2845,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7955dfc218a8afb29dfeffd540e3a6e96baeb94fe7138228dd7cc6937fbbf96"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c04141a07bb0c0bc461cb657808764de571702a59bc5c726c400ac9a7625e3ab"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]

--- a/crates/core-node-internal/Cargo.toml
+++ b/crates/core-node-internal/Cargo.toml
@@ -45,7 +45,7 @@ tracing = "0.1"
 askama = "0.16"
 rust-embed = { version = "8", features = ["include-exclude"] }
 gix-url = "0.38"
-git2 = { version = "0.21", features = ["https", "vendored-openssl"] }
+git2 = { version = "0.21", features = ["https", "ssh", "vendored-openssl"] }
 url = "2"
 ureq = "3.1"
 tar = "0.4"

--- a/crates/core-node-internal/src/services/node/add.rs
+++ b/crates/core-node-internal/src/services/node/add.rs
@@ -1,6 +1,7 @@
 use super::super::action_loop::{GoalHandler, accept_goal, reject_goal, run_action_loop};
 use super::super::stack::STACK_LAUNCH_GIT_HASH;
 use super::gate::ConcurrencyGate;
+use super::git_utils::install_credentials;
 use super::sync::{
     self, AutoSyncParams, DepClosure, collect_all_deployment_interfaces,
     generate_peppygen_for_node, materialize_repo_deps, stack_resolver, stack_then_repo_resolver,
@@ -179,7 +180,10 @@ fn shallow_validate_config(
 
     let mut last_err = None;
     for refspec in &refspecs {
+        let mut callbacks = git2::RemoteCallbacks::new();
+        install_credentials(&mut callbacks);
         let mut fetch_opts = git2::FetchOptions::new();
+        fetch_opts.remote_callbacks(callbacks);
         fetch_opts.depth(1);
         fetch_opts.download_tags(git2::AutotagOption::None);
 

--- a/crates/core-node-internal/src/services/node/git_utils.rs
+++ b/crates/core-node-internal/src/services/node/git_utils.rs
@@ -1,6 +1,12 @@
 //! Git utilities shared by the node command handlers: repo-path
 //! sanitization, ref checkout, reading the commit a working tree sits on,
-//! and a clone that honors a deadline on the network transfer.
+//! and a clone that honors a deadline on the network transfer. Remote
+//! repositories are read over HTTPS or SSH; the SSH ones authenticate the
+//! way `ssh` itself would — the ssh-agent's key, then the default identity
+//! files — and have their host key checked against `~/.ssh/known_hosts`
+//! (see [`install_credentials`]), so a private repository is a
+//! `git@host:owner/repo.git` URL away rather than a local checkout this
+//! machine must register instead.
 
 use daemon_config::repository::GitCommit;
 use git2::Repository;
@@ -176,6 +182,7 @@ fn progress_callbacks<'cb>(
         .checked_sub(PROGRESS_REPORT_INTERVAL)
         .unwrap_or_else(Instant::now);
     let mut callbacks = git2::RemoteCallbacks::new();
+    install_credentials(&mut callbacks);
     callbacks.transfer_progress(move |progress| {
         if last_report.elapsed() >= PROGRESS_REPORT_INTERVAL {
             last_report = Instant::now();
@@ -190,4 +197,223 @@ fn progress_callbacks<'cb>(
         true
     });
     callbacks
+}
+
+/// The answer to libgit2's nth request for credentials on one connection.
+#[derive(Debug, PartialEq, Eq)]
+enum CredentialAnswer {
+    /// The ssh-agent's key, authing as this user.
+    AgentKey(String),
+    /// A default identity file, authing as this user.
+    KeyFile { user: String, key: PathBuf },
+    /// Just a username, for the username-only probe libgit2 makes on an
+    /// `ssh://` URL that carries no user.
+    Username(String),
+    /// Nothing left to offer, and why.
+    Refuse(&'static str),
+}
+
+/// The default identity files OpenSSH itself tries, in the order a modern
+/// host realistically holds them. The `*-sk` kinds are absent on purpose:
+/// they live on FIDO tokens, which no unattended libssh2 client can tap.
+const DEFAULT_SSH_IDENTITIES: [&str; 3] = ["id_ed25519", "id_ecdsa", "id_rsa"];
+
+/// Resolves [`DEFAULT_SSH_IDENTITIES`] against `home`, skipping names that
+/// exist as directories (an `~/.ssh/id_ed25519/` is not a key).
+fn ssh_key_candidates(home: Option<&Path>) -> Vec<PathBuf> {
+    let Some(home) = home else {
+        return Vec::new();
+    };
+    DEFAULT_SSH_IDENTITIES
+        .iter()
+        .map(|name| home.join(".ssh").join(name))
+        .filter(|path| path.is_file())
+        .collect()
+}
+
+/// What peppy answers when a remote asks for credentials.
+///
+/// A public HTTPS repository never asks, so libgit2 never calls back and the
+/// answer here is irrelevant to it. A private one asks for a username and
+/// password peppy does not hold; refusing keeps that a named failure that
+/// names the fix (credentials embedded in the URL, which libgit2 uses
+/// without asking). SSH always authenticates the client, and the answer
+/// mirrors what `ssh` itself would try: the ssh-agent's key for the URL's
+/// user — `git` for the scp-style `git@host:owner/repo.git` URLs the hub
+/// repositories use, and also for an `ssh://` URL that spells no user — and
+/// then the default identity files under `~/.ssh`. Each candidate is offered
+/// at most once: a repeated request means the remote refused it, and
+/// replaying would loop libgit2's auth retry until the server hangs up.
+///
+/// The host side of SSH is not peppy's to answer: libgit2 checks the host
+/// key against `~/.ssh/known_hosts` itself and refuses an unknown or
+/// mismatched one before any credentials are requested.
+fn credential_answer(
+    username: Option<&str>,
+    allowed: git2::CredentialType,
+    attempt: usize,
+    key_candidates: &[PathBuf],
+) -> CredentialAnswer {
+    let user = username.unwrap_or("git").to_owned();
+    if allowed.contains(git2::CredentialType::SSH_KEY) {
+        if attempt == 0 {
+            return CredentialAnswer::AgentKey(user);
+        }
+        let key = key_candidates.get(attempt - 1).cloned();
+        if let Some(key) = key {
+            return CredentialAnswer::KeyFile { user, key };
+        }
+        return CredentialAnswer::Refuse(
+            "the remote refused the ssh-agent's keys and the default identity files \
+             (~/.ssh/id_ed25519, id_ecdsa, id_rsa); load a key the remote accepts into the \
+             agent, or point the repository at an unencrypted default identity",
+        );
+    }
+    if allowed.contains(git2::CredentialType::USERNAME)
+        && !allowed
+            .intersects(git2::CredentialType::SSH_KEY | git2::CredentialType::USER_PASS_PLAINTEXT)
+    {
+        return CredentialAnswer::Username(user);
+    }
+    CredentialAnswer::Refuse(
+        "peppy authenticates git over ssh through the ssh-agent and the default identity \
+         files, and offers no other credentials; embed them in the repository URL instead",
+    )
+}
+
+/// Installs the credentials callback every peppy fetch of a remote goes
+/// through, so no two call sites can drift apart on what authentication a
+/// clone or fetch offers. See [`credential_answer`] for what is offered.
+///
+/// A candidate that fails to load — an agent with no keys, an encrypted
+/// identity file — advances to the next within the same request rather than
+/// failing the connection, exactly as `ssh` moves on from an identity it
+/// cannot use.
+pub(crate) fn install_credentials(callbacks: &mut git2::RemoteCallbacks<'_>) {
+    let mut attempt = 0usize;
+    let key_candidates = ssh_key_candidates(dirs::home_dir().as_deref());
+    callbacks.credentials(move |_url, username, allowed| {
+        loop {
+            match credential_answer(username, allowed, attempt, &key_candidates) {
+                CredentialAnswer::AgentKey(user) => {
+                    attempt += 1;
+                    if let Ok(cred) = git2::Cred::ssh_key_from_agent(&user) {
+                        return Ok(cred);
+                    }
+                }
+                CredentialAnswer::KeyFile { user, key } => {
+                    attempt += 1;
+                    if let Ok(cred) = git2::Cred::ssh_key(user.as_str(), None, &key, None) {
+                        return Ok(cred);
+                    }
+                }
+                CredentialAnswer::Username(user) => return git2::Cred::username(&user),
+                CredentialAnswer::Refuse(message) => return Err(git2::Error::from_str(message)),
+            }
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ssh_only() -> git2::CredentialType {
+        git2::CredentialType::SSH_KEY
+    }
+
+    #[test]
+    fn the_first_ssh_request_gets_the_agent_key_for_the_url_user() {
+        assert_eq!(
+            credential_answer(Some("git"), ssh_only(), 0, &[]),
+            CredentialAnswer::AgentKey("git".to_owned())
+        );
+    }
+
+    #[test]
+    fn ssh_requests_default_the_user_to_git() {
+        assert_eq!(
+            credential_answer(None, ssh_only(), 0, &[]),
+            CredentialAnswer::AgentKey("git".to_owned())
+        );
+    }
+
+    #[test]
+    fn later_ssh_requests_walk_the_default_identity_files_in_order() {
+        let keys = vec![
+            PathBuf::from("/home/peppy/.ssh/id_ed25519"),
+            PathBuf::from("/home/peppy/.ssh/id_ecdsa"),
+        ];
+        assert_eq!(
+            credential_answer(Some("git"), ssh_only(), 1, &keys),
+            CredentialAnswer::KeyFile {
+                user: "git".to_owned(),
+                key: PathBuf::from("/home/peppy/.ssh/id_ed25519")
+            }
+        );
+        assert_eq!(
+            credential_answer(Some("git"), ssh_only(), 2, &keys),
+            CredentialAnswer::KeyFile {
+                user: "git".to_owned(),
+                key: PathBuf::from("/home/peppy/.ssh/id_ecdsa")
+            }
+        );
+    }
+
+    #[test]
+    fn exhausting_the_candidates_refuses_instead_of_replaying_one() {
+        assert_eq!(
+            credential_answer(Some("git"), ssh_only(), 1, &[]),
+            CredentialAnswer::Refuse(
+                "the remote refused the ssh-agent's keys and the default identity files \
+                 (~/.ssh/id_ed25519, id_ecdsa, id_rsa); load a key the remote accepts into \
+                 the agent, or point the repository at an unencrypted default identity"
+            )
+        );
+    }
+
+    #[test]
+    fn username_only_requests_answer_the_user_git_would_auth_as() {
+        let username_only = git2::CredentialType::USERNAME;
+        assert_eq!(
+            credential_answer(Some("peppy"), username_only, 0, &[]),
+            CredentialAnswer::Username("peppy".to_owned())
+        );
+        assert_eq!(
+            credential_answer(None, username_only, 0, &[]),
+            CredentialAnswer::Username("git".to_owned())
+        );
+    }
+
+    #[test]
+    fn password_requests_refuse_with_the_embedded_url_hint() {
+        assert_eq!(
+            credential_answer(
+                Some("peppy"),
+                git2::CredentialType::USER_PASS_PLAINTEXT,
+                0,
+                &[]
+            ),
+            CredentialAnswer::Refuse(
+                "peppy authenticates git over ssh through the ssh-agent and the default \
+                 identity files, and offers no other credentials; embed them in the \
+                 repository URL instead"
+            )
+        );
+    }
+
+    #[test]
+    fn key_candidates_list_the_default_identities_that_exist_as_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ssh_dir = tmp.path().join(".ssh");
+        std::fs::create_dir_all(&ssh_dir).unwrap();
+        std::fs::write(ssh_dir.join("id_rsa"), b"key").unwrap();
+        std::fs::create_dir_all(ssh_dir.join("id_ed25519")).unwrap();
+
+        assert_eq!(
+            ssh_key_candidates(Some(tmp.path())),
+            vec![ssh_dir.join("id_rsa")]
+        );
+        assert!(ssh_key_candidates(None).is_empty());
+    }
 }


### PR DESCRIPTION
## What

libgit2's ssh transport was compiled out of peppy, so a git repository over an ssh url — the scp-style `git@host:owner/repo.git` a private hub naturally lives at — failed before any authentication was even attempted. This enables the transport and gives every clone and fetch peppy makes the credentials callback libgit2 asks for:

- the ssh-agent's key for the url's user (`git`, for scp-style and user-less `ssh://` urls alike), then
- the default identity files under `~/.ssh` (`id_ed25519`, `id_ecdsa`, `id_rsa`),

each offered at most once, mirroring what `ssh` itself tries. A candidate that fails to load (an agent with no keys, an encrypted identity file) advances to the next within the same request rather than failing the connection. The one place the callback is installed (`git_utils::install_credentials`) is shared by `repo refresh`, the commit-keyed checkout cache, and `peppy node add`'s shallow probe, so no two fetch paths can drift apart on what authentication they offer.

An unauthenticated https remote never asks and is unaffected; a private https remote gets a named refusal pointing at credentials embedded in the url, which libgit2 uses without asking. The host side needs no callback: libgit2 checks the host key against `~/.ssh/known_hosts` and refuses an unknown or mismatched one before any credentials are requested.

This is what retires the local-checkout workaround for private hubs: a machine registers `git@github.com:Peppy-bot/private-nodes-hub.git` as an ordinary git repository under the reserved id band and peppy clones it on `repo refresh`, with no fs entry pointing at a superproject checkout. The peppy-superproject PR follows up on its side of that switch.

## Test plan

- `cargo test --locked -p core-node` — the full crate suite, including 7 new unit tests for the credential decision (`agent first, then default identities, each once`, `username-only probe`, `password refusal`) and for `~/.ssh` candidate resolution.
- End to end against GitHub, with an empty ssh-agent and an unencrypted `~/.ssh/id_ed25519`: a daemon seeded with `{ id: 2000, type: "git", url: "git@github.com:Peppy-bot/private-nodes-hub.git", ref: "main" }` clones the hub over ssh on `peppy repo refresh` (progress lines show the ssh url), `peppy repo list` reports `waldo v1` under it, and `peppy repo show waldo:v1` resolves the node with its pairing analysis. The public https defaults refresh unchanged in the same run.
- With the agent socket unset, the same refresh fails with the refusal message naming the agent and the default identity files rather than a libgit2 auth loop.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Peppy-bot/codesmith/peppy/pr/426"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790947739&installation_model_id=433186&pr_number=426&repository=Peppy-bot%2Fpeppy&return_to=https%3A%2F%2Fgithub.com%2FPeppy-bot%2Fpeppy%2Fpull%2F426&signature=4393acd94684d181f44a070f48d2496e6534251f4c29905bba3deed28195531d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->