### PR TITLE
docs: sync with the code being released (1446bb4398f9)

### DIFF
--- a/docs/src/content/docs/advanced_guides/repositories.mdx
+++ b/docs/src/content/docs/advanced_guides/repositories.mdx
@@ -55,13 +55,29 @@ The two `conf/` files are JSON5 arrays. Each entry has an `id` (auto-assigned if
 | Type | Fields | Description |
 |------|--------|-------------|
 | `fs` | `path` | A local directory, read through its committed [`peppy_repository.json5`](#the-repository-index). |
-| `git` | `url`, `ref` (optional) | A git repository. Peppy shallow-clones it and reads the same committed index. Use `ref` to pin a branch, tag, or commit. |
+| `git` | `url`, `ref` (optional) | A git repository. Peppy shallow-clones it and reads the same committed index. Use `ref` to pin a branch, tag, or commit. The `url` is HTTPS or an SSH URL (see [Private git repositories over SSH](#private-git-repositories-over-ssh)). |
 
 These are the only two source types. An entry with any other `type` fails its read as `unreachable` with an "unrecognized repository entry" detail.
 
 An `fs` repository is a path only this machine can read, so a deployment resolved from one must keep
 all of its instances on this daemon in a federated launch; serve the nodes from a `git` repository
 to place them on other machines (see [Federation limits](/advanced_guides/federation/#limits)).
+
+### Private git repositories over SSH
+
+A `git` repository's `url` may be HTTPS or SSH, so a private repository is reachable without embedding a
+credential in `repositories.json5`. Give it either the scp-style `git@host:owner/repo.git` or an
+`ssh://` URL, and Peppy authenticates the way `ssh` itself does:
+
+- The ssh-agent's key is offered first, as the URL's user (`git` when the URL names none).
+- The default identity files under `~/.ssh` follow, in the order `id_ed25519`, `id_ecdsa`, `id_rsa`,
+  each offered only when it exists as a file.
+- The host key is checked against `~/.ssh/known_hosts` before any key is offered, so a host missing
+  from that file, or one whose key has changed, is refused.
+
+Load a key the remote accepts into the ssh-agent, or keep an unencrypted default identity under
+`~/.ssh`, and both [`peppy repo add`](#add-a-repository) and `peppy node add` reach the repository
+over SSH.
 
 ## Commands
 
@@ -257,6 +273,9 @@ peppy repo add /path/to/my/nodes
 # Git repository
 peppy repo add https://github.com/org/repo.git
 
+# Private git repository over SSH (see "Private git repositories over SSH" above)
+peppy repo add git@github.com:org/private-repo.git
+
 # Git repository pinned to a branch or tag
 peppy repo add https://github.com/org/repo.git --ref v2.0
 
@@ -439,7 +458,7 @@ One constraint applies to this source shape:
 
 - `--ref` is rejected. The git ref (if any) is pinned once in `repositories.json5` when you register the repo, not per-add.
 
-If the node you want to add lives in a repository that is **not** in `repositories.json5`, keep using the full git URL or HTTP archive form shown in [Sharing nodes](/guides/sharing_nodes/).
+If the node you want to add lives in a repository that is **not** in `repositories.json5`, keep using the full git URL or HTTP archive form shown in [Sharing nodes](/guides/sharing_nodes/). That git URL may be HTTPS or SSH; an SSH URL (`git@host:owner/repo.git`) reaches a private repository under the same authentication described in [Private git repositories over SSH](#private-git-repositories-over-ssh).
 
 A manifest can also pin the exact content of a contract or pairing document it references with a `sha256` fingerprint, independent of which repository provides it; see [Content pins](/advanced_guides/lockfiles/).
 


### PR DESCRIPTION
Automated docs update produced by the release script (`scripts/functions/docs.py`), which found `docs/` lagging the code at the commit the release was being cut from.

Release commit: 1446bb4398f9f5f5ad841fe5a49932541ce53649

Gaps the check reported:

- `docs/src/content/docs/advanced_guides/repositories.mdx`: Document that `git` repository sources (the `git` source type, `peppy repo add`, and `peppy node add <url>`) accept SSH URLs (`git@host:owner/repo.git` / `ssh://`) for private repositories, and describe the authentication model: ssh-agent key then default identity files (`~/.ssh/id_ed25519`, `id_ecdsa`, `id_rsa`), with the host key checked against `~/.ssh/known_hosts`.

Merge this into `dev`, then re-run the release.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Peppy-bot/codesmith/peppy/pr/427"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790951971&installation_model_id=433186&pr_number=427&repository=Peppy-bot%2Fpeppy&return_to=https%3A%2F%2Fgithub.com%2FPeppy-bot%2Fpeppy%2Fpull%2F427&signature=9326fc64423ca4187d11802992f9fbd1a0b52b02ece9f0909c998509652c984a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->