### PR TITLE
docs: minor polish (a56d3eaa35e4)

### DIFF
--- a/docs/src/content/docs/guides/sharing_nodes.mdx
+++ b/docs/src/content/docs/guides/sharing_nodes.mdx
@@ -27,6 +27,8 @@ or
 peppy node add --ref main https://github.com/some-user/custom_nodes.git/uvc_camera
 ```
 
+The URL may be HTTPS or an SSH URL (`git@host:owner/repo.git`); an SSH URL reaches a private repository under the authentication described in [Private git repositories over SSH](/advanced_guides/repositories/#private-git-repositories-over-ssh).
+
 :::note
 When `--ref` is used during `peppy node add`, it corresponds to the git tag/release or hash of the repo. On the other hand, the tag in `peppy node run uvc_camera:v1` corresponds to the tag found in `peppy.json5`. `--ref` is only accepted with a full git URL; for `name:tag` sources the ref is pinned once in `repositories.json5` when the repo is registered.
 :::


### PR DESCRIPTION
Optional docs polish produced by the release script (`scripts/functions/docs.py`): the docs check reported only minor suggestions, and the user chose to apply them anyway.

Release commit: a56d3eaa35e49a48d69568d5cb2252353041db72

Suggestions applied:

- `docs/src/content/docs/guides/sharing_nodes.mdx`: In the "Adding a node from an unindexed repository" section, note that the by-URL `peppy node add` form also accepts an SSH URL (`git@host:owner/repo.git`) for private repos and cross-reference the "Private git repositories over SSH" section in repositories.mdx.

This pull request does not block the release it was cut from; merge or close it on its own schedule.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Peppy-bot/codesmith/peppy/pr/428"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790952770&installation_model_id=433186&pr_number=428&repository=Peppy-bot%2Fpeppy&return_to=https%3A%2F%2Fgithub.com%2FPeppy-bot%2Fpeppy%2Fpull%2F428&signature=78430714849890d25abbdbbfc3755fb2f0b2ff1576e6f36a761273784c2877b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->