### PR TITLE
Authenticate git over ssh with the agent and identities ~/.ssh/config selects

### DIFF
--- a/crates/core-node-internal/src/lib.rs
+++ b/crates/core-node-internal/src/lib.rs
@@ -3,6 +3,7 @@
 
 mod error;
 mod services;
+mod ssh_config;
 #[cfg(any(test, feature = "test-support"))]
 pub mod test_support;
 
@@ -31,3 +32,4 @@ pub use services::{
     check_runtime_prerequisites, force_kill_deadline, idle_timeout_flag, slow_connection_hint,
     teardown_all_instances,
 };
+pub use ssh_config::{IdentityAgent, SshHostConfig, SshTarget, resolve_host_config};

--- a/crates/core-node-internal/src/services/node/git_utils.rs
+++ b/crates/core-node-internal/src/services/node/git_utils.rs
@@ -2,17 +2,19 @@
 //! sanitization, ref checkout, reading the commit a working tree sits on,
 //! and a clone that honors a deadline on the network transfer. Remote
 //! repositories are read over HTTPS or SSH; the SSH ones authenticate the
-//! way `ssh` itself would — the ssh-agent's key, then the default identity
-//! files — and have their host key checked against `~/.ssh/known_hosts`
-//! (see [`install_credentials`]), so a private repository is a
-//! `git@host:owner/repo.git` URL away rather than a local checkout this
-//! machine must register instead.
+//! way `ssh` itself would for the host, with the agent and identity files
+//! `~/.ssh/config` selects, and have their host key checked against
+//! `~/.ssh/known_hosts` (see [`install_credentials`]), so a private
+//! repository is a `git@host:owner/repo.git` URL away rather than a local
+//! checkout this machine must register instead.
 
+use crate::ssh_config::{IdentityAgent, SshHostConfig, SshTarget, resolve_host_config};
 use daemon_config::repository::GitCommit;
 use git2::Repository;
 use git2::build::{CheckoutBuilder, RepoBuilder};
 use std::path::{Component, Path, PathBuf};
 use std::time::{Duration, Instant};
+use tracing::debug;
 
 /// Throttle window between consecutive `transfer_progress` reports surfaced
 /// to the user: fast enough to feel live, slow enough to avoid flooding
@@ -202,99 +204,278 @@ fn progress_callbacks<'cb>(
 /// The answer to libgit2's nth request for credentials on one connection.
 #[derive(Debug, PartialEq, Eq)]
 enum CredentialAnswer {
-    /// The ssh-agent's key, authing as this user.
+    /// The ssh agent's keys, authing as this user.
     AgentKey(String),
-    /// A default identity file, authing as this user.
+    /// An identity file, authing as this user.
     KeyFile { user: String, key: PathBuf },
     /// Just a username, for the username-only probe libgit2 makes on an
     /// `ssh://` URL that carries no user.
     Username(String),
     /// Nothing left to offer, and why.
-    Refuse(&'static str),
+    Refuse(String),
 }
 
-/// The default identity files OpenSSH itself tries, in the order a modern
-/// host realistically holds them. The `*-sk` kinds are absent on purpose:
-/// they live on FIDO tokens, which no unattended libssh2 client can tap.
+/// The identity files `ssh` itself tries when its configuration names none,
+/// in the order a modern host realistically holds them. Offered only when
+/// no `ssh` is installed to resolve the configured list; the `*-sk` kinds
+/// are absent on purpose: they live on FIDO tokens, which no unattended
+/// libssh2 client can tap.
 const DEFAULT_SSH_IDENTITIES: [&str; 3] = ["id_ed25519", "id_ecdsa", "id_rsa"];
 
-/// Resolves [`DEFAULT_SSH_IDENTITIES`] against `home`, skipping names that
-/// exist as directories (an `~/.ssh/id_ed25519/` is not a key).
-fn ssh_key_candidates(home: Option<&Path>) -> Vec<PathBuf> {
+/// Resolves [`DEFAULT_SSH_IDENTITIES`] against `home`.
+fn default_identity_files(home: Option<&Path>) -> Vec<PathBuf> {
     let Some(home) = home else {
         return Vec::new();
     };
     DEFAULT_SSH_IDENTITIES
         .iter()
         .map(|name| home.join(".ssh").join(name))
-        .filter(|path| path.is_file())
         .collect()
 }
 
-/// What peppy answers when a remote asks for credentials.
-///
-/// A public HTTPS repository never asks, so libgit2 never calls back and the
-/// answer here is irrelevant to it. A private one asks for a username and
-/// password peppy does not hold; refusing keeps that a named failure that
-/// names the fix (credentials embedded in the URL, which libgit2 uses
-/// without asking). SSH always authenticates the client, and the answer
-/// mirrors what `ssh` itself would try: the ssh-agent's key for the URL's
-/// user — `git` for the scp-style `git@host:owner/repo.git` URLs the hub
-/// repositories use, and also for an `ssh://` URL that spells no user — and
-/// then the default identity files under `~/.ssh`. Each candidate is offered
-/// at most once: a repeated request means the remote refused it, and
-/// replaying would loop libgit2's auth retry until the server hangs up.
-///
-/// The host side of SSH is not peppy's to answer: libgit2 checks the host
-/// key against `~/.ssh/known_hosts` itself and refuses an unknown or
-/// mismatched one before any credentials are requested.
-fn credential_answer(
-    username: Option<&str>,
-    allowed: git2::CredentialType,
-    attempt: usize,
-    key_candidates: &[PathBuf],
-) -> CredentialAnswer {
-    let user = username.unwrap_or("git").to_owned();
-    if allowed.contains(git2::CredentialType::SSH_KEY) {
-        if attempt == 0 {
-            return CredentialAnswer::AgentKey(user);
-        }
-        let key = key_candidates.get(attempt - 1).cloned();
-        if let Some(key) = key {
-            return CredentialAnswer::KeyFile { user, key };
-        }
-        return CredentialAnswer::Refuse(
-            "the remote refused the ssh-agent's keys and the default identity files \
-             (~/.ssh/id_ed25519, id_ecdsa, id_rsa); load a key the remote accepts into the \
-             agent, or point the repository at an unencrypted default identity",
-        );
+/// The agent whose keys open one ssh connection, or why none does.
+#[derive(Debug, PartialEq, Eq)]
+enum OfferedAgent {
+    /// The agent at this socket, which `SSH_AUTH_SOCK` names in this process.
+    Socket(PathBuf),
+    /// `SSH_AUTH_SOCK` is unset and the host's configuration names no agent.
+    Unset,
+    /// The host's configuration disables the agent (`IdentityAgent none`).
+    Disabled,
+}
+
+/// The credentials peppy offers on one ssh connection, in order: the
+/// agent's keys, then each identity file. Built once per connection from
+/// what `ssh` selects for the host.
+#[derive(Debug, PartialEq, Eq)]
+struct SshCredentialPlan {
+    user: String,
+    host: String,
+    agent: OfferedAgent,
+    /// The identity files that exist, offered after the agent.
+    key_files: Vec<PathBuf>,
+    /// The identity files the configuration names that are not files on
+    /// disk, named in the refusal so a typo in `~/.ssh/config` is visible.
+    absent_key_files: Vec<PathBuf>,
+}
+
+impl SshCredentialPlan {
+    /// The credentials in the order they are offered.
+    fn offers(&self) -> impl Iterator<Item = CredentialAnswer> + '_ {
+        let agent = matches!(self.agent, OfferedAgent::Socket(_))
+            .then(|| CredentialAnswer::AgentKey(self.user.clone()));
+        agent
+            .into_iter()
+            .chain(self.key_files.iter().map(|key| CredentialAnswer::KeyFile {
+                user: self.user.clone(),
+                key: key.clone(),
+            }))
     }
+
+    /// The answer to the nth credential request: each offer exactly once,
+    /// then a refusal naming everything the connection had.
+    fn answer(&self, attempt: usize) -> CredentialAnswer {
+        self.offers()
+            .nth(attempt)
+            .unwrap_or_else(|| CredentialAnswer::Refuse(self.refusal()))
+    }
+
+    fn refusal(&self) -> String {
+        let outcome = if self.offers().next().is_some() {
+            "the remote refused every credential peppy holds for"
+        } else {
+            "peppy holds no credential for"
+        };
+        format!(
+            "{outcome} {}@{}: {}, and {}; load a key the remote accepts into the agent, or keep \
+             an unencrypted identity file at one of those paths",
+            self.user,
+            self.host,
+            self.agent_description(),
+            self.identity_files_description()
+        )
+    }
+
+    fn agent_description(&self) -> String {
+        match &self.agent {
+            OfferedAgent::Socket(socket) if socket.exists() => {
+                format!("the keys in the ssh agent at {}", socket.display())
+            }
+            OfferedAgent::Socket(socket) => format!(
+                "the ssh agent at {}, whose socket does not exist",
+                socket.display()
+            ),
+            OfferedAgent::Unset => "no ssh agent (SSH_AUTH_SOCK is unset)".to_owned(),
+            OfferedAgent::Disabled => "no ssh agent (IdentityAgent none)".to_owned(),
+        }
+    }
+
+    fn identity_files_description(&self) -> String {
+        let absent = || {
+            format!(
+                "{} do not exist as files",
+                list_paths(&self.absent_key_files)
+            )
+        };
+        match (self.key_files.is_empty(), self.absent_key_files.is_empty()) {
+            (false, true) => format!("the identity files {}", list_paths(&self.key_files)),
+            (false, false) => format!(
+                "the identity files {} ({})",
+                list_paths(&self.key_files),
+                absent()
+            ),
+            (true, false) => format!("no identity file ({})", absent()),
+            (true, true) => "no identity file (the configuration names none)".to_owned(),
+        }
+    }
+}
+
+fn list_paths(paths: &[PathBuf]) -> String {
+    paths
+        .iter()
+        .map(|path| path.display().to_string())
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Builds the plan for one connection from what `ssh` selects for the
+/// host. `host_config` is `None` when no `ssh` is installed to ask, in
+/// which case the agent `SSH_AUTH_SOCK` names and the default identity
+/// files stand in. `process_agent` is the socket `SSH_AUTH_SOCK` names in
+/// this process, the only agent libssh2 can reach; a host whose
+/// configuration selects a different one is refused by name, since the
+/// daemon binds its agent once at startup.
+fn plan_ssh_credentials(
+    user: String,
+    target: &SshTarget,
+    host_config: Option<SshHostConfig>,
+    process_agent: Option<PathBuf>,
+    default_identity_files: Vec<PathBuf>,
+) -> Result<SshCredentialPlan, String> {
+    let process_agent_offer = || match process_agent.clone() {
+        Some(socket) => OfferedAgent::Socket(socket),
+        None => OfferedAgent::Unset,
+    };
+    let (agent, identity_files) = match host_config {
+        None => (process_agent_offer(), default_identity_files),
+        Some(config) => {
+            let agent = match config.identity_agent {
+                IdentityAgent::FromEnvironment => process_agent_offer(),
+                IdentityAgent::Disabled => OfferedAgent::Disabled,
+                IdentityAgent::Socket(selected) if process_agent.as_ref() == Some(&selected) => {
+                    OfferedAgent::Socket(selected)
+                }
+                IdentityAgent::Socket(selected) => {
+                    return Err(agent_mismatch(target, &selected, process_agent.as_deref()));
+                }
+            };
+            (agent, config.identity_files)
+        }
+    };
+    let (key_files, absent_key_files) = identity_files.into_iter().partition(|path| path.is_file());
+    Ok(SshCredentialPlan {
+        user,
+        host: target.host.clone(),
+        agent,
+        key_files,
+        absent_key_files,
+    })
+}
+
+fn agent_mismatch(target: &SshTarget, selected: &Path, bound: Option<&Path>) -> String {
+    let bound = match bound {
+        Some(bound) => format!("the agent at {}", bound.display()),
+        None => "no agent (SSH_AUTH_SOCK is unset)".to_owned(),
+    };
+    format!(
+        "~/.ssh/config selects the ssh agent at {} for {} (IdentityAgent), but this daemon is \
+         bound to {bound} for its lifetime: when it starts it binds the agent ssh selects for a \
+         host with no host-specific configuration. Give every host that IdentityAgent (a \
+         `Host *` block) and restart the daemon",
+        selected.display(),
+        target.host
+    )
+}
+
+/// The plan for the connection libgit2 opened to `url`, authing as `user`.
+fn plan_for_url(url: &str, user: String) -> Result<SshCredentialPlan, String> {
+    let target = SshTarget::from_git_url(url)
+        .ok_or_else(|| format!("{url} is not an ssh URL peppy can read a host from"))?;
+    let host_config = resolve_host_config(&target)?;
+    let process_agent = std::env::var_os("SSH_AUTH_SOCK")
+        .filter(|socket| !socket.is_empty())
+        .map(PathBuf::from);
+    let plan = plan_ssh_credentials(
+        user,
+        &target,
+        host_config,
+        process_agent,
+        default_identity_files(dirs::home_dir().as_deref()),
+    )?;
+    debug!(
+        "git over ssh to {}@{}: offering {}, then {}",
+        plan.user,
+        plan.host,
+        plan.agent_description(),
+        plan.identity_files_description()
+    );
+    Ok(plan)
+}
+
+/// What peppy answers when a remote asks for something other than an ssh
+/// key. A public HTTPS repository never asks, so libgit2 never calls back
+/// and the answer here is irrelevant to it. A private one asks for a
+/// username and password peppy does not hold; refusing keeps that a named
+/// failure that names the fix (credentials embedded in the URL, which
+/// libgit2 uses without asking).
+fn non_ssh_answer(username: Option<&str>, allowed: git2::CredentialType) -> CredentialAnswer {
     if allowed.contains(git2::CredentialType::USERNAME)
-        && !allowed
-            .intersects(git2::CredentialType::SSH_KEY | git2::CredentialType::USER_PASS_PLAINTEXT)
+        && !allowed.intersects(git2::CredentialType::USER_PASS_PLAINTEXT)
     {
-        return CredentialAnswer::Username(user);
+        return CredentialAnswer::Username(username.unwrap_or("git").to_owned());
     }
     CredentialAnswer::Refuse(
-        "peppy authenticates git over ssh through the ssh-agent and the default identity \
-         files, and offers no other credentials; embed them in the repository URL instead",
+        "peppy authenticates git over ssh through the ssh agent and identity files, and offers \
+         no other credentials; embed them in the repository URL instead"
+            .to_owned(),
     )
 }
 
 /// Installs the credentials callback every peppy fetch of a remote goes
 /// through, so no two call sites can drift apart on what authentication a
-/// clone or fetch offers. See [`credential_answer`] for what is offered.
+/// clone or fetch offers.
 ///
-/// A candidate that fails to load — an agent with no keys, an encrypted
-/// identity file — advances to the next within the same request rather than
+/// SSH always authenticates the client, and the answer mirrors what `ssh`
+/// itself would try for the URL's host: the keys of the agent
+/// `~/.ssh/config` selects for it (`IdentityAgent`, else the one
+/// `SSH_AUTH_SOCK` names), then its `IdentityFile` list, each as the URL's
+/// user (`git` when the URL names none). See [`plan_ssh_credentials`] for
+/// how the plan is built and [`SshCredentialPlan::answer`] for the order.
+/// Each candidate is offered at most once: a repeated request means the
+/// remote refused it, and replaying would loop libgit2's auth retry until
+/// the server hangs up. A candidate that fails to load (an encrypted
+/// identity file) advances to the next within the same request rather than
 /// failing the connection, exactly as `ssh` moves on from an identity it
 /// cannot use.
+///
+/// The host side of SSH is not peppy's to answer: libgit2 checks the host
+/// key against `~/.ssh/known_hosts` itself and refuses an unknown or
+/// mismatched one before any credentials are requested.
 pub(crate) fn install_credentials(callbacks: &mut git2::RemoteCallbacks<'_>) {
     let mut attempt = 0usize;
-    let key_candidates = ssh_key_candidates(dirs::home_dir().as_deref());
-    callbacks.credentials(move |_url, username, allowed| {
+    let mut plan: Option<Result<SshCredentialPlan, String>> = None;
+    callbacks.credentials(move |url, username, allowed| {
         loop {
-            match credential_answer(username, allowed, attempt, &key_candidates) {
+            let answer = if allowed.contains(git2::CredentialType::SSH_KEY) {
+                let user = username.unwrap_or("git").to_owned();
+                match plan.get_or_insert_with(|| plan_for_url(url, user)) {
+                    Ok(plan) => plan.answer(attempt),
+                    Err(message) => CredentialAnswer::Refuse(message.clone()),
+                }
+            } else {
+                non_ssh_answer(username, allowed)
+            };
+            match answer {
                 CredentialAnswer::AgentKey(user) => {
                     attempt += 1;
                     if let Ok(cred) = git2::Cred::ssh_key_from_agent(&user) {
@@ -308,7 +489,7 @@ pub(crate) fn install_credentials(callbacks: &mut git2::RemoteCallbacks<'_>) {
                     }
                 }
                 CredentialAnswer::Username(user) => return git2::Cred::username(&user),
-                CredentialAnswer::Refuse(message) => return Err(git2::Error::from_str(message)),
+                CredentialAnswer::Refuse(message) => return Err(git2::Error::from_str(&message)),
             }
         }
     });
@@ -318,57 +499,221 @@ pub(crate) fn install_credentials(callbacks: &mut git2::RemoteCallbacks<'_>) {
 mod tests {
     use super::*;
 
-    fn ssh_only() -> git2::CredentialType {
-        git2::CredentialType::SSH_KEY
+    fn github() -> SshTarget {
+        SshTarget {
+            user: Some("git".to_owned()),
+            host: "github.com".to_owned(),
+            port: None,
+        }
+    }
+
+    fn agent_key() -> CredentialAnswer {
+        CredentialAnswer::AgentKey("git".to_owned())
+    }
+
+    fn key_file(key: &Path) -> CredentialAnswer {
+        CredentialAnswer::KeyFile {
+            user: "git".to_owned(),
+            key: key.to_path_buf(),
+        }
+    }
+
+    /// A `.ssh` directory holding `existing` as key files, plus a directory
+    /// at `id_ed25519`, which is not a key.
+    fn ssh_dir(existing: &[&str]) -> (tempfile::TempDir, PathBuf) {
+        let tmp = tempfile::tempdir().unwrap();
+        let ssh_dir = tmp.path().join(".ssh");
+        std::fs::create_dir_all(&ssh_dir).unwrap();
+        for name in existing {
+            std::fs::write(ssh_dir.join(name), b"key").unwrap();
+        }
+        std::fs::create_dir_all(ssh_dir.join("id_ed25519")).unwrap();
+        (tmp, ssh_dir)
+    }
+
+    fn plan_without_ssh(
+        process_agent: Option<PathBuf>,
+        home: &Path,
+    ) -> Result<SshCredentialPlan, String> {
+        plan_ssh_credentials(
+            "git".to_owned(),
+            &github(),
+            None,
+            process_agent,
+            default_identity_files(Some(home)),
+        )
+    }
+
+    fn plan_with_config(
+        identity_agent: IdentityAgent,
+        identity_files: Vec<PathBuf>,
+        process_agent: Option<PathBuf>,
+    ) -> Result<SshCredentialPlan, String> {
+        plan_ssh_credentials(
+            "git".to_owned(),
+            &github(),
+            Some(SshHostConfig {
+                identity_agent,
+                identity_files,
+            }),
+            process_agent,
+            vec![PathBuf::from("/never/offered")],
+        )
     }
 
     #[test]
-    fn the_first_ssh_request_gets_the_agent_key_for_the_url_user() {
+    fn without_ssh_the_environment_agent_leads_and_the_default_identities_follow() {
+        let (tmp, ssh_dir) = ssh_dir(&["id_rsa"]);
+        let socket = tmp.path().join("agent.sock");
+        let plan = plan_without_ssh(Some(socket.clone()), tmp.path()).unwrap();
+
+        assert_eq!(plan.agent, OfferedAgent::Socket(socket));
+        assert_eq!(plan.key_files, vec![ssh_dir.join("id_rsa")]);
         assert_eq!(
-            credential_answer(Some("git"), ssh_only(), 0, &[]),
-            CredentialAnswer::AgentKey("git".to_owned())
+            plan.absent_key_files,
+            vec![ssh_dir.join("id_ed25519"), ssh_dir.join("id_ecdsa")]
         );
+        assert_eq!(plan.answer(0), agent_key());
+        assert_eq!(plan.answer(1), key_file(&ssh_dir.join("id_rsa")));
+        assert!(matches!(plan.answer(2), CredentialAnswer::Refuse(_)));
     }
 
     #[test]
-    fn ssh_requests_default_the_user_to_git() {
-        assert_eq!(
-            credential_answer(None, ssh_only(), 0, &[]),
-            CredentialAnswer::AgentKey("git".to_owned())
-        );
-    }
-
-    #[test]
-    fn later_ssh_requests_walk_the_default_identity_files_in_order() {
-        let keys = vec![
-            PathBuf::from("/home/peppy/.ssh/id_ed25519"),
-            PathBuf::from("/home/peppy/.ssh/id_ecdsa"),
+    fn the_configured_identity_files_replace_the_defaults_in_their_order() {
+        let (_tmp, ssh_dir) = ssh_dir(&["work", "home"]);
+        let files = vec![
+            ssh_dir.join("work"),
+            ssh_dir.join("typo"),
+            ssh_dir.join("home"),
         ];
+        let plan = plan_with_config(IdentityAgent::FromEnvironment, files, None).unwrap();
+
+        assert_eq!(plan.agent, OfferedAgent::Unset);
         assert_eq!(
-            credential_answer(Some("git"), ssh_only(), 1, &keys),
-            CredentialAnswer::KeyFile {
-                user: "git".to_owned(),
-                key: PathBuf::from("/home/peppy/.ssh/id_ed25519")
-            }
+            plan.key_files,
+            vec![ssh_dir.join("work"), ssh_dir.join("home")]
         );
+        assert_eq!(plan.absent_key_files, vec![ssh_dir.join("typo")]);
+        assert_eq!(plan.answer(0), key_file(&ssh_dir.join("work")));
+        assert_eq!(plan.answer(1), key_file(&ssh_dir.join("home")));
+    }
+
+    #[test]
+    fn the_agent_the_configuration_selects_is_offered_when_the_process_is_bound_to_it() {
+        let socket = PathBuf::from("/run/agent.sock");
+        let plan = plan_with_config(
+            IdentityAgent::Socket(socket.clone()),
+            Vec::new(),
+            Some(socket.clone()),
+        )
+        .unwrap();
+        assert_eq!(plan.agent, OfferedAgent::Socket(socket));
+        assert_eq!(plan.answer(0), agent_key());
+    }
+
+    #[test]
+    fn an_agent_the_process_is_not_bound_to_is_refused_by_name() {
+        let selected = PathBuf::from("/run/1password.sock");
+        let refusal = plan_with_config(
+            IdentityAgent::Socket(selected.clone()),
+            Vec::new(),
+            Some(PathBuf::from("/run/launchd.sock")),
+        )
+        .unwrap_err();
         assert_eq!(
-            credential_answer(Some("git"), ssh_only(), 2, &keys),
-            CredentialAnswer::KeyFile {
-                user: "git".to_owned(),
-                key: PathBuf::from("/home/peppy/.ssh/id_ecdsa")
-            }
+            refusal,
+            "~/.ssh/config selects the ssh agent at /run/1password.sock for github.com \
+             (IdentityAgent), but this daemon is bound to the agent at /run/launchd.sock for its \
+             lifetime: when it starts it binds the agent ssh selects for a host with no \
+             host-specific configuration. Give every host that IdentityAgent (a `Host *` block) \
+             and restart the daemon"
+        );
+
+        let refusal =
+            plan_with_config(IdentityAgent::Socket(selected), Vec::new(), None).unwrap_err();
+        assert!(
+            refusal.contains("bound to no agent (SSH_AUTH_SOCK is unset)"),
+            "{refusal}"
         );
     }
 
     #[test]
-    fn exhausting_the_candidates_refuses_instead_of_replaying_one() {
+    fn a_disabled_agent_is_never_offered() {
+        let (tmp, ssh_dir) = ssh_dir(&["id_rsa"]);
+        let plan = plan_with_config(
+            IdentityAgent::Disabled,
+            vec![ssh_dir.join("id_rsa")],
+            Some(tmp.path().join("agent.sock")),
+        )
+        .unwrap();
+        assert_eq!(plan.agent, OfferedAgent::Disabled);
+        assert_eq!(plan.answer(0), key_file(&ssh_dir.join("id_rsa")));
+    }
+
+    #[test]
+    fn the_refusal_names_what_was_offered_and_what_was_not() {
+        let (tmp, ssh_dir) = ssh_dir(&["id_rsa"]);
+        let socket = tmp.path().join("agent.sock");
+        std::fs::write(&socket, b"").unwrap();
+        let plan = plan_without_ssh(Some(socket.clone()), tmp.path()).unwrap();
+
         assert_eq!(
-            credential_answer(Some("git"), ssh_only(), 1, &[]),
+            plan.answer(2),
+            CredentialAnswer::Refuse(format!(
+                "the remote refused every credential peppy holds for git@github.com: the keys \
+                 in the ssh agent at {}, and the identity files {} ({}, {} do not exist as \
+                 files); load a key the remote accepts into the agent, or keep an unencrypted \
+                 identity file at one of those paths",
+                socket.display(),
+                ssh_dir.join("id_rsa").display(),
+                ssh_dir.join("id_ed25519").display(),
+                ssh_dir.join("id_ecdsa").display(),
+            ))
+        );
+    }
+
+    #[test]
+    fn a_missing_agent_socket_is_named_as_such() {
+        let (tmp, _ssh_dir) = ssh_dir(&[]);
+        let socket = tmp.path().join("gone.sock");
+        let plan = plan_without_ssh(Some(socket.clone()), tmp.path()).unwrap();
+        let CredentialAnswer::Refuse(refusal) = plan.answer(1) else {
+            panic!("the second request has nothing left to offer");
+        };
+        assert!(
+            refusal.starts_with(&format!(
+                "the remote refused every credential peppy holds for git@github.com: the ssh \
+                 agent at {}, whose socket does not exist, and no identity file (",
+                socket.display()
+            )),
+            "{refusal}"
+        );
+    }
+
+    #[test]
+    fn a_connection_with_nothing_to_offer_refuses_the_first_request() {
+        let plan = plan_with_config(IdentityAgent::Disabled, Vec::new(), None).unwrap();
+        assert_eq!(
+            plan.answer(0),
             CredentialAnswer::Refuse(
-                "the remote refused the ssh-agent's keys and the default identity files \
-                 (~/.ssh/id_ed25519, id_ecdsa, id_rsa); load a key the remote accepts into \
-                 the agent, or point the repository at an unencrypted default identity"
+                "peppy holds no credential for git@github.com: no ssh agent (IdentityAgent \
+                 none), and no identity file (the configuration names none); load a key the \
+                 remote accepts into the agent, or keep an unencrypted identity file at one of \
+                 those paths"
+                    .to_owned()
             )
+        );
+
+        let plan = plan_without_ssh(None, Path::new("/nonexistent")).unwrap();
+        let CredentialAnswer::Refuse(refusal) = plan.answer(0) else {
+            panic!("nothing to offer");
+        };
+        assert!(
+            refusal.starts_with(
+                "peppy holds no credential for git@github.com: no ssh agent (SSH_AUTH_SOCK is \
+                 unset), and no identity file (/nonexistent/.ssh/id_ed25519, "
+            ),
+            "{refusal}"
         );
     }
 
@@ -376,11 +721,11 @@ mod tests {
     fn username_only_requests_answer_the_user_git_would_auth_as() {
         let username_only = git2::CredentialType::USERNAME;
         assert_eq!(
-            credential_answer(Some("peppy"), username_only, 0, &[]),
+            non_ssh_answer(Some("peppy"), username_only),
             CredentialAnswer::Username("peppy".to_owned())
         );
         assert_eq!(
-            credential_answer(None, username_only, 0, &[]),
+            non_ssh_answer(None, username_only),
             CredentialAnswer::Username("git".to_owned())
         );
     }
@@ -388,32 +733,26 @@ mod tests {
     #[test]
     fn password_requests_refuse_with_the_embedded_url_hint() {
         assert_eq!(
-            credential_answer(
-                Some("peppy"),
-                git2::CredentialType::USER_PASS_PLAINTEXT,
-                0,
-                &[]
-            ),
+            non_ssh_answer(Some("peppy"), git2::CredentialType::USER_PASS_PLAINTEXT),
             CredentialAnswer::Refuse(
-                "peppy authenticates git over ssh through the ssh-agent and the default \
-                 identity files, and offers no other credentials; embed them in the \
-                 repository URL instead"
+                "peppy authenticates git over ssh through the ssh agent and identity files, \
+                 and offers no other credentials; embed them in the repository URL instead"
+                    .to_owned()
             )
         );
     }
 
     #[test]
-    fn key_candidates_list_the_default_identities_that_exist_as_files() {
-        let tmp = tempfile::tempdir().unwrap();
-        let ssh_dir = tmp.path().join(".ssh");
-        std::fs::create_dir_all(&ssh_dir).unwrap();
-        std::fs::write(ssh_dir.join("id_rsa"), b"key").unwrap();
-        std::fs::create_dir_all(ssh_dir.join("id_ed25519")).unwrap();
-
+    fn plans_are_built_for_ssh_urls_only() {
+        let refusal = plan_for_url(
+            "https://github.com/Peppy-bot/nodes-hub.git",
+            "git".to_owned(),
+        )
+        .unwrap_err();
         assert_eq!(
-            ssh_key_candidates(Some(tmp.path())),
-            vec![ssh_dir.join("id_rsa")]
+            refusal,
+            "https://github.com/Peppy-bot/nodes-hub.git is not an ssh URL peppy can read a host \
+             from"
         );
-        assert!(ssh_key_candidates(None).is_empty());
     }
 }

--- a/crates/core-node-internal/src/ssh_config.rs
+++ b/crates/core-node-internal/src/ssh_config.rs
@@ -1,0 +1,485 @@
+//! What `~/.ssh/config` selects for a host, read the way `ssh` itself reads
+//! it. `ssh -G <host>` prints the configuration `ssh` would connect with
+//! after every `Host` and `Match` block, `Include` file and system default
+//! has been applied, so peppy never parses the file on its own and cannot
+//! disagree with `ssh` about which agent socket and identity files apply to
+//! a host. Two directives are read: `IdentityAgent`, and the `IdentityFile`
+//! list.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+/// The host, user and port a git ssh URL connects to: what `ssh` matches
+/// its configuration against.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SshTarget {
+    pub user: Option<String>,
+    pub host: String,
+    pub port: Option<u16>,
+}
+
+impl SshTarget {
+    /// Parses the URL forms libgit2 connects over ssh: `ssh://`, `git+ssh://`
+    /// and `ssh+git://` URLs, and the scp-style `[user@]host:path`. Any other
+    /// URL is not an ssh target.
+    pub fn from_git_url(url: &str) -> Option<Self> {
+        if let Some((scheme, rest)) = url.split_once("://") {
+            if !matches!(scheme, "ssh" | "git+ssh" | "ssh+git") {
+                return None;
+            }
+            let parsed = url::Url::parse(&format!("ssh://{rest}")).ok()?;
+            let host = match parsed.host()? {
+                url::Host::Domain(domain) => domain.to_owned(),
+                url::Host::Ipv4(address) => address.to_string(),
+                url::Host::Ipv6(address) => address.to_string(),
+            };
+            let user = (!parsed.username().is_empty()).then(|| parsed.username().to_owned());
+            return Some(Self {
+                user,
+                host,
+                port: parsed.port(),
+            });
+        }
+        let (authority, _path) = url.split_once(':')?;
+        if authority.is_empty() || authority.contains('/') {
+            return None;
+        }
+        let (user, host) = match authority.rsplit_once('@') {
+            Some((user, host)) => (Some(user).filter(|user| !user.is_empty()), host),
+            None => (None, authority),
+        };
+        if host.is_empty() {
+            return None;
+        }
+        Some(Self {
+            user: user.map(str::to_owned),
+            host: host.to_owned(),
+            port: None,
+        })
+    }
+
+    /// A host no `Host` or `Match` block names, so what `ssh -G` resolves for
+    /// it is the configuration every host shares: the `Host *` blocks and
+    /// the defaults.
+    pub fn without_host_specific_configuration() -> Self {
+        Self {
+            user: None,
+            host: "host.invalid".to_owned(),
+            port: None,
+        }
+    }
+}
+
+/// The agent `ssh` uses for a host.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IdentityAgent {
+    /// No `IdentityAgent` directive, or `IdentityAgent SSH_AUTH_SOCK`: the
+    /// agent `SSH_AUTH_SOCK` names.
+    FromEnvironment,
+    /// `IdentityAgent none`, or `IdentityAgent $NAME` with `NAME` unset: no
+    /// agent at all.
+    Disabled,
+    /// `IdentityAgent <path>`, or `IdentityAgent $NAME` with `NAME` set: the
+    /// agent at this socket.
+    Socket(PathBuf),
+}
+
+/// What `ssh` selects for one host.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SshHostConfig {
+    pub identity_agent: IdentityAgent,
+    /// The `IdentityFile` paths in the order `ssh` offers them, with `~` and
+    /// the tokens `%d`, `%h`, `%n`, `%p`, `%r` and `%%` expanded. Whether a
+    /// path exists is not checked here.
+    pub identity_files: Vec<PathBuf>,
+}
+
+/// Reads what `ssh` selects for `target`. `Ok(None)` when no `ssh` is on the
+/// PATH; `Err` when `ssh -G` fails, which is what `ssh` itself does with that
+/// configuration (a bad directive, an unreadable `Include`).
+pub fn resolve_host_config(target: &SshTarget) -> Result<Option<SshHostConfig>, String> {
+    let output = match resolve_command(target, None).output() {
+        Ok(output) => output,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => return Err(format!("could not run ssh -G {}: {err}", target.host)),
+    };
+    if !output.status.success() {
+        return Err(format!(
+            "ssh -G {} failed, so what ~/.ssh/config selects for that host is unknown: {}",
+            target.host,
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let home = dirs::home_dir();
+    Ok(Some(parse_resolved_config(
+        &stdout,
+        target,
+        home.as_deref(),
+        &|name| std::env::var(name).ok(),
+    )))
+}
+
+/// The `ssh -G` invocation that resolves `target`. `config_file` replaces the
+/// user's and the system's configuration files, which the tests use to keep
+/// the machine's `~/.ssh/config` out of the resolution.
+fn resolve_command(target: &SshTarget, config_file: Option<&Path>) -> Command {
+    let mut command = Command::new("ssh");
+    command.arg("-G");
+    if let Some(config_file) = config_file {
+        command.arg("-F").arg(config_file);
+    }
+    if let Some(user) = &target.user {
+        command.arg("-l").arg(user);
+    }
+    if let Some(port) = target.port {
+        command.arg("-p").arg(port.to_string());
+    }
+    command.arg("--").arg(&target.host);
+    command.stdin(Stdio::null());
+    command
+}
+
+/// The values `ssh` substitutes for the tokens an `IdentityFile` may carry.
+struct TokenValues<'a> {
+    home: Option<&'a Path>,
+    /// `%h`: the host name after `HostName` rewriting.
+    hostname: &'a str,
+    /// `%n`: the host name as the URL spelled it.
+    original_host: &'a str,
+    /// `%p`: the resolved port.
+    port: Option<&'a str>,
+    /// `%r`: the resolved remote user.
+    user: Option<&'a str>,
+}
+
+/// Parses the `key value` lines `ssh -G` prints. `env` answers the
+/// `IdentityAgent $NAME` form, which `ssh -G` prints unexpanded.
+fn parse_resolved_config(
+    stdout: &str,
+    target: &SshTarget,
+    home: Option<&Path>,
+    env: &dyn Fn(&str) -> Option<String>,
+) -> SshHostConfig {
+    let directives: Vec<(&str, &str)> = stdout
+        .lines()
+        .filter_map(|line| line.split_once(' '))
+        .map(|(key, value)| (key, value.trim()))
+        .collect();
+    let value_of = |key: &str| {
+        directives
+            .iter()
+            .find(|(candidate, _)| *candidate == key)
+            .map(|(_, value)| *value)
+    };
+    let identity_agent = match value_of("identityagent") {
+        None => IdentityAgent::FromEnvironment,
+        Some(value) => parse_identity_agent(value, env),
+    };
+    let tokens = TokenValues {
+        home,
+        hostname: value_of("hostname").unwrap_or(&target.host),
+        original_host: &target.host,
+        port: value_of("port"),
+        user: value_of("user"),
+    };
+    let identity_files = directives
+        .iter()
+        .filter(|(key, _)| *key == "identityfile")
+        .map(|(_, value)| expand_identity_file(value, &tokens))
+        .collect();
+    SshHostConfig {
+        identity_agent,
+        identity_files,
+    }
+}
+
+fn parse_identity_agent(value: &str, env: &dyn Fn(&str) -> Option<String>) -> IdentityAgent {
+    match value {
+        "none" => IdentityAgent::Disabled,
+        "SSH_AUTH_SOCK" => IdentityAgent::FromEnvironment,
+        variable if variable.starts_with('$') => match env(&variable[1..]) {
+            Some(path) if !path.is_empty() => IdentityAgent::Socket(PathBuf::from(path)),
+            _ => IdentityAgent::Disabled,
+        },
+        path => IdentityAgent::Socket(PathBuf::from(path)),
+    }
+}
+
+/// Expands the tokens and the leading `~` of an `IdentityFile` value, which
+/// `ssh -G` prints as written. A token peppy does not know the value of is
+/// left as printed, so the path names a file that does not exist.
+fn expand_identity_file(value: &str, tokens: &TokenValues<'_>) -> PathBuf {
+    let mut expanded = String::with_capacity(value.len());
+    let mut chars = value.chars();
+    while let Some(character) = chars.next() {
+        if character != '%' {
+            expanded.push(character);
+            continue;
+        }
+        let token = chars.next();
+        let substitution = match token {
+            Some('%') => Some("%".to_owned()),
+            Some('d') => tokens.home.map(|home| home.to_string_lossy().into_owned()),
+            Some('h') => Some(tokens.hostname.to_owned()),
+            Some('n') => Some(tokens.original_host.to_owned()),
+            Some('p') => tokens.port.map(str::to_owned),
+            Some('r') => tokens.user.map(str::to_owned),
+            _ => None,
+        };
+        match (substitution, token) {
+            (Some(substitution), _) => expanded.push_str(&substitution),
+            (None, Some(token)) => {
+                expanded.push('%');
+                expanded.push(token);
+            }
+            (None, None) => expanded.push('%'),
+        }
+    }
+    expand_tilde(&expanded, tokens.home)
+}
+
+fn expand_tilde(value: &str, home: Option<&Path>) -> PathBuf {
+    match (value.strip_prefix('~'), home) {
+        (Some(""), Some(home)) => home.to_path_buf(),
+        (Some(rest), Some(home)) if rest.starts_with('/') => home.join(&rest[1..]),
+        _ => PathBuf::from(value),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn no_env(_: &str) -> Option<String> {
+        None
+    }
+
+    fn github() -> SshTarget {
+        SshTarget {
+            user: Some("git".to_owned()),
+            host: "github.com".to_owned(),
+            port: None,
+        }
+    }
+
+    #[test]
+    fn scp_style_urls_name_their_user_and_host() {
+        assert_eq!(
+            SshTarget::from_git_url("git@github.com:Peppy-bot/private-nodes-hub.git"),
+            Some(github())
+        );
+        for url in [
+            "github.com:Peppy-bot/private-nodes-hub.git",
+            "@github.com:Peppy-bot/private-nodes-hub.git",
+        ] {
+            assert_eq!(
+                SshTarget::from_git_url(url),
+                Some(SshTarget {
+                    user: None,
+                    host: "github.com".to_owned(),
+                    port: None,
+                }),
+                "{url}"
+            );
+        }
+    }
+
+    #[test]
+    fn ssh_scheme_urls_name_their_user_host_and_port() {
+        for url in [
+            "ssh://git@github.com:2222/Peppy-bot/private-nodes-hub.git",
+            "git+ssh://git@github.com:2222/Peppy-bot/private-nodes-hub.git",
+            "ssh+git://git@github.com:2222/Peppy-bot/private-nodes-hub.git",
+        ] {
+            assert_eq!(
+                SshTarget::from_git_url(url),
+                Some(SshTarget {
+                    user: Some("git".to_owned()),
+                    host: "github.com".to_owned(),
+                    port: Some(2222),
+                }),
+                "{url}"
+            );
+        }
+        assert_eq!(
+            SshTarget::from_git_url("ssh://[::1]/repo.git"),
+            Some(SshTarget {
+                user: None,
+                host: "::1".to_owned(),
+                port: None,
+            })
+        );
+    }
+
+    #[test]
+    fn urls_that_do_not_connect_over_ssh_are_not_targets() {
+        for url in [
+            "https://github.com/Peppy-bot/nodes-hub.git",
+            "git://github.com/Peppy-bot/nodes-hub.git",
+            "file:///srv/repo.git",
+            "/srv/repo.git",
+            "./relative/path",
+            ":no-host",
+            "@:no-host",
+        ] {
+            assert_eq!(SshTarget::from_git_url(url), None, "{url}");
+        }
+    }
+
+    #[test]
+    fn an_absent_identity_agent_directive_means_the_environment_agent() {
+        let config = parse_resolved_config(
+            "user git\nhostname github.com\nport 22\n",
+            &github(),
+            None,
+            &no_env,
+        );
+        assert_eq!(config.identity_agent, IdentityAgent::FromEnvironment);
+        assert!(config.identity_files.is_empty());
+    }
+
+    #[test]
+    fn identity_agent_values_follow_the_ssh_config_forms() {
+        let parse = |line: &str, env: &dyn Fn(&str) -> Option<String>| {
+            parse_resolved_config(&format!("{line}\n"), &github(), None, env).identity_agent
+        };
+        assert_eq!(
+            parse(
+                "identityagent /Users/me/Library/Group Containers/1password/agent.sock",
+                &no_env
+            ),
+            IdentityAgent::Socket(PathBuf::from(
+                "/Users/me/Library/Group Containers/1password/agent.sock"
+            ))
+        );
+        assert_eq!(
+            parse("identityagent none", &no_env),
+            IdentityAgent::Disabled
+        );
+        assert_eq!(
+            parse("identityagent SSH_AUTH_SOCK", &no_env),
+            IdentityAgent::FromEnvironment
+        );
+        let agent_var = |name: &str| (name == "MY_AGENT").then(|| "/run/my.sock".to_owned());
+        assert_eq!(
+            parse("identityagent $MY_AGENT", &agent_var),
+            IdentityAgent::Socket(PathBuf::from("/run/my.sock"))
+        );
+        assert_eq!(
+            parse("identityagent $UNSET_AGENT", &agent_var),
+            IdentityAgent::Disabled
+        );
+    }
+
+    #[test]
+    fn identity_files_keep_their_order_and_expand_tilde_and_tokens() {
+        let stdout = "user git\nhostname ssh.github.com\nport 443\n\
+                      identityfile ~/.ssh/id_rsa\n\
+                      identityfile %d/.ssh/%r_at_%h_%p\n\
+                      identityfile /keys/%n_%%\n\
+                      identityfile ~\n\
+                      identityfile /keys/%u_unknown\n";
+        let config = parse_resolved_config(stdout, &github(), Some(Path::new("/home/me")), &no_env);
+        assert_eq!(
+            config.identity_files,
+            vec![
+                PathBuf::from("/home/me/.ssh/id_rsa"),
+                PathBuf::from("/home/me/.ssh/git_at_ssh.github.com_443"),
+                PathBuf::from("/keys/github.com_%"),
+                PathBuf::from("/home/me"),
+                PathBuf::from("/keys/%u_unknown"),
+            ]
+        );
+    }
+
+    #[test]
+    fn without_a_home_directory_tilde_and_home_tokens_stay_as_printed() {
+        let config = parse_resolved_config(
+            "identityfile ~/.ssh/id_rsa\nidentityfile %d/.ssh/id_rsa\n",
+            &github(),
+            None,
+            &no_env,
+        );
+        assert_eq!(
+            config.identity_files,
+            vec![
+                PathBuf::from("~/.ssh/id_rsa"),
+                PathBuf::from("%d/.ssh/id_rsa")
+            ]
+        );
+    }
+
+    #[test]
+    fn the_resolve_command_passes_the_target_the_way_ssh_expects_it() {
+        let target = SshTarget {
+            user: Some("git".to_owned()),
+            host: "github.com".to_owned(),
+            port: Some(2222),
+        };
+        let command = resolve_command(&target, Some(Path::new("/tmp/ssh_config")));
+        let args: Vec<_> = command
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(
+            args,
+            [
+                "-G",
+                "-F",
+                "/tmp/ssh_config",
+                "-l",
+                "git",
+                "-p",
+                "2222",
+                "--",
+                "github.com"
+            ]
+        );
+    }
+
+    /// Runs the real `ssh -G` against a configuration file written for the
+    /// test, so the parser sees output the installed `ssh` produces. The
+    /// test passes vacuously on a host without `ssh`.
+    #[test]
+    fn ssh_g_output_resolves_host_blocks_the_way_ssh_does() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_file = dir.path().join("ssh_config");
+        let socket = dir.path().join("agent.sock");
+        std::fs::write(
+            &config_file,
+            format!(
+                "Host github.com\n  IdentityFile ~/.ssh/github_only\n\
+                 Host *\n  IdentityAgent \"{}\"\n  IdentityFile ~/.ssh/everywhere\n",
+                socket.display()
+            ),
+        )
+        .unwrap();
+
+        let output = match resolve_command(&github(), Some(&config_file)).output() {
+            Ok(output) => output,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return,
+            Err(err) => panic!("ssh -G could not run: {err}"),
+        };
+        assert!(
+            output.status.success(),
+            "ssh -G failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let config = parse_resolved_config(
+            &String::from_utf8_lossy(&output.stdout),
+            &github(),
+            Some(Path::new("/home/me")),
+            &no_env,
+        );
+
+        assert_eq!(config.identity_agent, IdentityAgent::Socket(socket));
+        assert_eq!(
+            config.identity_files,
+            vec![
+                PathBuf::from("/home/me/.ssh/github_only"),
+                PathBuf::from("/home/me/.ssh/everywhere"),
+            ]
+        );
+    }
+}

--- a/crates/peppy/src/commands/service.rs
+++ b/crates/peppy/src/commands/service.rs
@@ -1,5 +1,6 @@
 pub mod install;
 pub mod serve;
+mod ssh_agent;
 
 use super::Command;
 use crate::{context::AppContext, error::Error as CommandError};
@@ -72,14 +73,17 @@ impl Command for ServiceCommand {
                 messaging_engine,
                 core_node_name,
                 clock_source,
-            } => serve::ServeCommand {
-                messaging_engine,
-                core_node_name,
-                clock_source,
-                shutdown_token: None,
-                peppy_dirs: daemon_config::consts::PeppyDirs::default(),
+            } => {
+                ssh_agent::bind_ssh_agent_from_config();
+                serve::ServeCommand {
+                    messaging_engine,
+                    core_node_name,
+                    clock_source,
+                    shutdown_token: None,
+                    peppy_dirs: daemon_config::consts::PeppyDirs::default(),
+                }
+                .execute(app_ctx)
             }
-            .execute(app_ctx),
             ServiceCommands::Install {} => install::InstallCommand {}.execute(app_ctx),
             ServiceCommands::Stop {} => install::StopCommand {}.execute(app_ctx),
             ServiceCommands::Uninstall {} => install::UninstallCommand {}.execute(app_ctx),

--- a/crates/peppy/src/commands/service/install.rs
+++ b/crates/peppy/src/commands/service/install.rs
@@ -288,14 +288,14 @@ fn is_root() -> bool {
 /// On SSH sessions and minimal installs, `XDG_RUNTIME_DIR` and
 /// `DBUS_SESSION_BUS_ADDRESS` may be missing, causing
 /// "Failed to connect to bus: No medium found".
-// This is the one function in the crate that keeps `unsafe`: `env::set_var` has
-// no safe equivalent in edition 2024, and `service-manager` shells out to
-// `systemctl --user` with the inherited environment, giving no hook to pass
-// these values to the child explicitly. The mutation is sound here because it
-// runs during synchronous, single-threaded CLI startup, before any tokio
-// runtime or other thread exists (see the SAFETY notes on each call). The rest
-// of the crate is `#![deny(unsafe_code)]`; this function carries the only
-// allowance, scoped and documented.
+// This function and `ssh_agent::bind_ssh_agent_from_config` are the two
+// `unsafe` allowances in the crate: `env::set_var` has no safe equivalent in
+// edition 2024, and `service-manager` shells out to `systemctl --user` with
+// the inherited environment, giving no hook to pass these values to the child
+// explicitly. The mutation is sound here because it runs during synchronous,
+// single-threaded CLI startup, before any tokio runtime or other thread exists
+// (see the SAFETY notes on each call). The rest of the crate is
+// `#![deny(unsafe_code)]`.
 #[cfg(target_os = "linux")]
 #[allow(unsafe_code)]
 fn ensure_systemd_user_env() -> Result<()> {

--- a/crates/peppy/src/commands/service/ssh_agent.rs
+++ b/crates/peppy/src/commands/service/ssh_agent.rs
@@ -1,0 +1,59 @@
+//! Binds the daemon process to the ssh agent `ssh` selects for hosts in
+//! general, so git over ssh inside the daemon reaches the agent `ssh` would.
+//! libssh2 connects to the agent `SSH_AUTH_SOCK` names and reads no ssh
+//! configuration, so an `IdentityAgent` directive in `~/.ssh/config` (how
+//! 1Password, Secretive and gpg-agent are wired in) only reaches it through
+//! that variable. The binding happens once, before any other thread exists,
+//! and holds for the daemon's lifetime; a host whose configuration selects a
+//! different agent is refused by name when it is cloned.
+
+use std::env;
+use std::path::PathBuf;
+
+use core_node::{IdentityAgent, SshTarget, resolve_host_config};
+use tracing::{info, warn};
+
+/// The environment variable libssh2 reads the agent socket from.
+const SSH_AUTH_SOCK: &str = "SSH_AUTH_SOCK";
+
+/// Points `SSH_AUTH_SOCK` at the agent `~/.ssh/config` selects for a host
+/// with no host-specific configuration, when it selects one. Without `ssh`
+/// on the PATH, or without an `IdentityAgent` directive that applies, the
+/// inherited environment stands. A configuration `ssh -G` rejects is
+/// reported and the inherited environment stands too, since a daemon that
+/// cannot clone over ssh still serves everything else.
+// This function and `install::ensure_systemd_user_env` are the two `unsafe`
+// allowances in the crate: `env::set_var` has no safe equivalent in edition
+// 2024, and libssh2 reads the socket path from the process environment,
+// giving no hook to pass it explicitly. The mutation is sound here because
+// it runs during synchronous, single-threaded CLI startup, before the daemon
+// runtime or any other thread exists (see the SAFETY note on the call). The
+// rest of the crate is `#![deny(unsafe_code)]`.
+#[allow(unsafe_code)]
+pub(super) fn bind_ssh_agent_from_config() {
+    let selected = match resolve_host_config(&SshTarget::without_host_specific_configuration()) {
+        Ok(Some(config)) => config.identity_agent,
+        Ok(None) => return,
+        Err(message) => {
+            warn!("{message}; git over ssh uses the agent SSH_AUTH_SOCK names");
+            return;
+        }
+    };
+    let IdentityAgent::Socket(socket) = selected else {
+        return;
+    };
+    let bound = env::var_os(SSH_AUTH_SOCK)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from);
+    if bound.as_ref() != Some(&socket) {
+        // SAFETY: called during single-threaded CLI startup, before the
+        // daemon runtime and before any other thread exists.
+        unsafe {
+            env::set_var(SSH_AUTH_SOCK, &socket);
+        }
+    }
+    info!(
+        "git over ssh uses the agent at {} (IdentityAgent in ~/.ssh/config)",
+        socket.display()
+    );
+}

--- a/docs/src/content/docs/advanced_guides/repositories.mdx
+++ b/docs/src/content/docs/advanced_guides/repositories.mdx
@@ -67,17 +67,33 @@ to place them on other machines (see [Federation limits](/advanced_guides/federa
 
 A `git` repository's `url` may be HTTPS or SSH, so a private repository is reachable without embedding a
 credential in `repositories.json5`. Give it either the scp-style `git@host:owner/repo.git` or an
-`ssh://` URL, and Peppy authenticates the way `ssh` itself does:
+`ssh://` URL, and Peppy authenticates the way `ssh` itself does for that host. It reads what
+`~/.ssh/config` selects for the URL's host, user and port through `ssh -G`, so every `Host` and
+`Match` block, `Include` file and system default applies exactly as it does to `ssh`:
 
-- The ssh-agent's key is offered first, as the URL's user (`git` when the URL names none).
-- The default identity files under `~/.ssh` follow, in the order `id_ed25519`, `id_ecdsa`, `id_rsa`,
-  each offered only when it exists as a file.
+- The keys of the agent the host's `IdentityAgent` names are offered first, as the URL's user (`git`
+  when the URL names none). Without that directive the agent is the one `SSH_AUTH_SOCK` names;
+  `IdentityAgent none` offers no agent.
+- The host's `IdentityFile` list follows, in `ssh`'s order, each path offered when it exists as a
+  file. That list is `ssh`'s own defaults under `~/.ssh` unless the configuration names others.
 - The host key is checked against `~/.ssh/known_hosts` before any key is offered, so a host missing
   from that file, or one whose key has changed, is refused.
 
-Load a key the remote accepts into the ssh-agent, or keep an unencrypted default identity under
-`~/.ssh`, and both [`peppy repo add`](#add-a-repository) and `peppy node add` reach the repository
-over SSH.
+A refusal names everything that was offered: the agent socket, the identity files that exist, and
+the configured paths that do not, so a typo in `~/.ssh/config` is visible in the message. Without
+`ssh` on the PATH, Peppy offers the agent `SSH_AUTH_SOCK` names and the default identity files
+`id_ed25519`, `id_ecdsa` and `id_rsa` under `~/.ssh`.
+
+The daemon binds one agent for its lifetime. When it starts, it points `SSH_AUTH_SOCK` at the agent
+`~/.ssh/config` selects for a host with no host-specific configuration (a `Host *` block, the way
+1Password, Secretive and gpg-agent are wired in), and logs which one. That is what makes those agents
+reachable from a daemon installed with `peppy service install`, which starts with a clean environment,
+and from a shell whose `SSH_AUTH_SOCK` names another agent. A host whose own block selects a different
+agent is refused by name; give every host the same `IdentityAgent` and restart the daemon.
+
+Load a key the remote accepts into the agent `ssh` uses, or keep an unencrypted identity file at one
+of the configured paths, and both [`peppy repo add`](#add-a-repository) and `peppy node add` reach the
+repository over SSH.
 
 ## Commands
 


### PR DESCRIPTION
## Problem

`peppy repo update` could not clone the private hub over ssh on a machine whose keys live in the 1Password agent, while `ssh -T git@github.com` on the same machine authenticated fine. libgit2 authenticates through libssh2, which connects to the agent `SSH_AUTH_SOCK` names and reads no ssh configuration, so the `IdentityAgent` directive that wires 1Password (or Secretive, gpg-agent, KeePassXC) into `ssh` never reached the daemon. The clone ran inside `peppy service serve`, whose `SSH_AUTH_SOCK` was the launchd agent with no identities, and the refusal told the user to load a key into an agent that already held it.

The same gap hit every daemon installed with `peppy service install`: systemd and launchd start it with `PATH` and `PEPPY_HOME` only, so no agent was ever reachable and a private ssh hub needed an unencrypted default key file.

## What changes

**`ssh -G` is the source of truth for a host** (`crates/core-node-internal/src/ssh_config.rs`). Before offering credentials for an ssh URL, peppy runs `ssh -G [-l user] [-p port] -- host` and reads what `ssh` itself resolved after every `Host` and `Match` block, `Include` file and default: the `IdentityAgent` (`none`, `SSH_AUTH_SOCK`, `$NAME`, or a socket path) and the `IdentityFile` list in `ssh`'s order, with `~` and the `%d %h %n %p %r %%` tokens expanded (`ssh -G` prints identity files unexpanded, agent paths expanded). No `ssh` on the PATH keeps the previous behaviour: the agent `SSH_AUTH_SOCK` names and the default identity files. A configuration `ssh -G` rejects fails the connection with ssh's own diagnostic. `SshTarget::from_git_url` parses the forms libgit2 connects over ssh: `ssh://`, `git+ssh://`, `ssh+git://` and scp-style `[user@]host:path`.

**One credential plan per connection** (`git_utils.rs`). `install_credentials` builds an `SshCredentialPlan` on the first ssh key request from the URL libgit2 passes: the agent's keys when the host's agent is the one this process is bound to, then each configured identity file that exists, each offered once. The refusal names what was offered and what was not: the agent socket (and whether it exists), the identity files that exist, and the configured paths that do not, so a typo in `~/.ssh/config` shows up in the message. A host whose `IdentityAgent` differs from the socket the process is bound to is refused by name with the fix (a `Host *` block and a restart).

**The daemon binds the agent `ssh` selects** (`crates/peppy/src/commands/service/ssh_agent.rs`). Before the runtime starts, `peppy service serve` resolves `ssh -G` for a host no block names (`host.invalid`), points `SSH_AUTH_SOCK` at the `IdentityAgent` that applies to every host, and logs it:

```
INFO peppy::commands::service::ssh_agent: git over ssh uses the agent at /Users/me/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock (IdentityAgent in ~/.ssh/config)
```

This is the second `unsafe` allowance in the `peppy` crate, next to `ensure_systemd_user_env`, sound for the same reason: single-threaded CLI startup, before any tokio runtime. It sits in `ServiceCommand::execute` rather than `ServeCommand::execute` so the serve integration test, which runs inside a threaded test process, never touches the environment.

**Docs**: `repositories.mdx` "Private git repositories over SSH" describes the resolution, the refusal contents, the startup binding and the `Host *` requirement.

Rejected: detecting 1Password's socket paths (differ per OS and install channel, and a socket existing is not a request to use it), and shelling out to `git` for ssh URLs (peppy has no git-binary dependency and would lose the progress callbacks and the single credentials chokepoint).

## Tests

- `ssh_config.rs`: URL parsing for every ssh form and the non-ssh rejections; `IdentityAgent` forms (`none`, `SSH_AUTH_SOCK`, `$NAME` set and unset, path); identity file order, `~` and token expansion, missing home; the exact argv `ssh -G` gets; and one test that runs the installed `ssh -G -F <temp config>` so the parser sees real output (vacuous where `ssh` is absent, isolated from the machine's `~/.ssh/config` by `-F`).
- `git_utils.rs`: plan construction with and without `ssh`, configured files replacing the defaults in order, the bound/unbound/disabled agent cases, the mismatch refusal text, the refusal listing existing and absent files and a missing socket, the nothing-to-offer refusal, and the non-ssh answers.
- Verified by hand against `git@github.com:Peppy-bot/private-nodes-hub.git`: the clone succeeds when the process is bound to the 1Password socket; bound to the launchd socket or to nothing it fails with the mismatch refusal naming both sockets. `peppy service serve` under a throwaway `PEPPY_HOME` logs the binding line above.

Run locally: `cargo test -p core-node --lib` (452), `cargo test -p peppy --lib` (239), `cargo test -p peppy --test integration -- service_serve`, `cargo clippy -p core-node -p peppy --all-targets` (clean), `npm run check && npm run build` in `docs/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HXqd76ri9vZm8v4uGW3D7f

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Peppy-bot/codesmith/peppy/pr/431"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791055080&installation_model_id=433186&pr_number=431&repository=Peppy-bot%2Fpeppy&return_to=https%3A%2F%2Fgithub.com%2FPeppy-bot%2Fpeppy%2Fpull%2F431&signature=855497557456e9d390f5f79b7701d0e4d51c6dab8c740b78de25887fb2eaf021"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->