### PR TITLE
generator: let a harness declare the node the launch's source of simulated time

### DIFF
--- a/crates/generator-internal/src/generator/python/fixtures.rs
+++ b/crates/generator-internal/src/generator/python/fixtures.rs
@@ -1187,7 +1187,7 @@ async def __aexit__(self, exc_type, exc, tb) -> None:
     builder.block(
         &format!(
             "def start(setup, *, parameters=None, instance_id=None, node_dir=None, \
-             use_sim_time=False{kwarg_params}):"
+             use_sim_time=False, sim_time_participants=(){kwarg_params}):"
         ),
         |builder| {
             builder.py(r#"
@@ -1209,7 +1209,12 @@ peppy.json5 when neither the working directory nor the sync-time path
 resolves it; `use_sim_time=True` boots the node in sim time, as a
 launcher's `framework: { use_sim_time: true }` would, with the harness
 clock in sim mode so no time exists until the test advances it with
-`await harness.clock.tick(...)`.
+`await harness.clock.tick(...)`; `sim_time_participants` makes the node
+the launch's source of simulated time, as a launcher's
+`framework: { publishes_sim_time: true }` would: the core nodes it
+publishes its clock to (under the harness the fleet is one machine,
+`peppylib.testing.STANDALONE_CORE_NODE`), meaningful with
+`use_sim_time=True`, and then the test never ticks `harness.clock`.
 "#);
             // One paragraph per slot the deployment lets a test vary.
             if !slot_kwargs.is_empty() {
@@ -1219,7 +1224,7 @@ clock in sim mode so no time exists until the test advances it with
             builder.line("\"\"\"");
             builder.line(&format!(
                 "return _HarnessStart(_start(setup, parameters, instance_id, node_dir, \
-                 use_sim_time{kwarg_args}))"
+                 use_sim_time, sim_time_participants{kwarg_args}))"
             ));
         },
     );
@@ -1228,7 +1233,7 @@ clock in sim mode so no time exists until the test advances it with
     builder.block(
         &format!(
             "async def _start(setup, parameters, instance_id, node_dir, \
-             use_sim_time{kwarg_args}) -> Harness:"
+             use_sim_time, sim_time_participants{kwarg_args}) -> Harness:"
         ),
         |builder| {
             builder.py(r#"
@@ -1262,6 +1267,7 @@ standalone = (
     .with_messaging(router.host, router.port)
     .with_instance_id(instance_id)
     .with_use_sim_time(use_sim_time)
+    .with_sim_time_participants(list(sim_time_participants))
 )
 if parameters is not None:
     standalone = standalone.with_parameters(parameters)

--- a/crates/generator-internal/src/generator/python/tests/golden/python_renderers.txt
+++ b/crates/generator-internal/src/generator/python/tests/golden/python_renderers.txt
@@ -5229,7 +5229,7 @@ class _HarnessStart:
         if harness is not None:
             await harness.shutdown()
 
-def start(setup, *, parameters=None, instance_id=None, node_dir=None, use_sim_time=False, spare_camera_vacant=False, camera_bank_instances=1, camera_bank_instance_ids=None, camera_pool_instances=0, camera_pool_instance_ids=None, spare_controller_vacant=False, spare_watcher_vacant=False, watcher_bank_instances=1, watcher_bank_instance_ids=None, watcher_pool_instances=0, watcher_pool_instance_ids=None):
+def start(setup, *, parameters=None, instance_id=None, node_dir=None, use_sim_time=False, sim_time_participants=(), spare_camera_vacant=False, camera_bank_instances=1, camera_bank_instance_ids=None, camera_pool_instances=0, camera_pool_instance_ids=None, spare_controller_vacant=False, spare_watcher_vacant=False, watcher_bank_instances=1, watcher_bank_instance_ids=None, watcher_pool_instances=0, watcher_pool_instance_ids=None):
     """Boots the full fixture: ephemeral router + started mocks + seeded
     StandaloneConfig + the node running in-process behind the readiness
     barriers. `setup` is the node's real entry point (the exact
@@ -5248,7 +5248,12 @@ def start(setup, *, parameters=None, instance_id=None, node_dir=None, use_sim_ti
     resolves it; `use_sim_time=True` boots the node in sim time, as a
     launcher's `framework: { use_sim_time: true }` would, with the harness
     clock in sim mode so no time exists until the test advances it with
-    `await harness.clock.tick(...)`.
+    `await harness.clock.tick(...)`; `sim_time_participants` makes the node
+    the launch's source of simulated time, as a launcher's
+    `framework: { publishes_sim_time: true }` would: the core nodes it
+    publishes its clock to (under the harness the fleet is one machine,
+    `peppylib.testing.STANDALONE_CORE_NODE`), meaningful with
+    `use_sim_time=True`, and then the test never ticks `harness.clock`.
 
     spare_camera_vacant: leave the `spare_camera` dependency slot vacant (its cardinality admits an empty binding).
     camera_bank_instances: how many mock producer instances to start and bind for the `camera_bank` dependency slot.
@@ -5262,9 +5267,9 @@ def start(setup, *, parameters=None, instance_id=None, node_dir=None, use_sim_ti
     watcher_pool_instances: how many mock sources to start for the `watcher_pool` observer slot.
     watcher_pool_instance_ids: explicit instance ids for the `watcher_pool` mock sources, overriding `watcher_pool_instances` when given. For nodes that classify sources by instance name.
     """
-    return _HarnessStart(_start(setup, parameters, instance_id, node_dir, use_sim_time, spare_camera_vacant, camera_bank_instances, camera_bank_instance_ids, camera_pool_instances, camera_pool_instance_ids, spare_controller_vacant, spare_watcher_vacant, watcher_bank_instances, watcher_bank_instance_ids, watcher_pool_instances, watcher_pool_instance_ids))
+    return _HarnessStart(_start(setup, parameters, instance_id, node_dir, use_sim_time, sim_time_participants, spare_camera_vacant, camera_bank_instances, camera_bank_instance_ids, camera_pool_instances, camera_pool_instance_ids, spare_controller_vacant, spare_watcher_vacant, watcher_bank_instances, watcher_bank_instance_ids, watcher_pool_instances, watcher_pool_instance_ids))
 
-async def _start(setup, parameters, instance_id, node_dir, use_sim_time, spare_camera_vacant, camera_bank_instances, camera_bank_instance_ids, camera_pool_instances, camera_pool_instance_ids, spare_controller_vacant, spare_watcher_vacant, watcher_bank_instances, watcher_bank_instance_ids, watcher_pool_instances, watcher_pool_instance_ids) -> Harness:
+async def _start(setup, parameters, instance_id, node_dir, use_sim_time, sim_time_participants, spare_camera_vacant, camera_bank_instances, camera_bank_instance_ids, camera_pool_instances, camera_pool_instance_ids, spare_controller_vacant, spare_watcher_vacant, watcher_bank_instances, watcher_bank_instance_ids, watcher_pool_instances, watcher_pool_instance_ids) -> Harness:
     node_dir = peppylib.testing.resolve_node_dir(node_dir, _SYNC_TIME_NODE_DIR, _NODE_CONFIG_FILE)
     if instance_id is None:
         instance_id = peppylib.testing.unique_test_instance_id()
@@ -5322,6 +5327,7 @@ async def _start(setup, parameters, instance_id, node_dir, use_sim_time, spare_c
             .with_messaging(router.host, router.port)
             .with_instance_id(instance_id)
             .with_use_sim_time(use_sim_time)
+            .with_sim_time_participants(list(sim_time_participants))
         )
         if parameters is not None:
             standalone = standalone.with_parameters(parameters)
@@ -5839,7 +5845,7 @@ class _HarnessStart:
         if harness is not None:
             await harness.shutdown()
 
-def start(setup, *, parameters=None, instance_id=None, node_dir=None, use_sim_time=False):
+def start(setup, *, parameters=None, instance_id=None, node_dir=None, use_sim_time=False, sim_time_participants=()):
     """Boots the full fixture: ephemeral router + started mocks + seeded
     StandaloneConfig + the node running in-process behind the readiness
     barriers. `setup` is the node's real entry point (the exact
@@ -5858,11 +5864,16 @@ def start(setup, *, parameters=None, instance_id=None, node_dir=None, use_sim_ti
     resolves it; `use_sim_time=True` boots the node in sim time, as a
     launcher's `framework: { use_sim_time: true }` would, with the harness
     clock in sim mode so no time exists until the test advances it with
-    `await harness.clock.tick(...)`.
+    `await harness.clock.tick(...)`; `sim_time_participants` makes the node
+    the launch's source of simulated time, as a launcher's
+    `framework: { publishes_sim_time: true }` would: the core nodes it
+    publishes its clock to (under the harness the fleet is one machine,
+    `peppylib.testing.STANDALONE_CORE_NODE`), meaningful with
+    `use_sim_time=True`, and then the test never ticks `harness.clock`.
     """
-    return _HarnessStart(_start(setup, parameters, instance_id, node_dir, use_sim_time))
+    return _HarnessStart(_start(setup, parameters, instance_id, node_dir, use_sim_time, sim_time_participants))
 
-async def _start(setup, parameters, instance_id, node_dir, use_sim_time) -> Harness:
+async def _start(setup, parameters, instance_id, node_dir, use_sim_time, sim_time_participants) -> Harness:
     node_dir = peppylib.testing.resolve_node_dir(node_dir, _SYNC_TIME_NODE_DIR, _NODE_CONFIG_FILE)
     if instance_id is None:
         instance_id = peppylib.testing.unique_test_instance_id()
@@ -5890,6 +5901,7 @@ async def _start(setup, parameters, instance_id, node_dir, use_sim_time) -> Harn
             .with_messaging(router.host, router.port)
             .with_instance_id(instance_id)
             .with_use_sim_time(use_sim_time)
+            .with_sim_time_participants(list(sim_time_participants))
         )
         if parameters is not None:
             standalone = standalone.with_parameters(parameters)
@@ -6047,7 +6059,7 @@ class _HarnessStart:
         if harness is not None:
             await harness.shutdown()
 
-def start(setup, *, parameters=None, instance_id=None, node_dir=None, use_sim_time=False):
+def start(setup, *, parameters=None, instance_id=None, node_dir=None, use_sim_time=False, sim_time_participants=()):
     """Boots the full fixture: ephemeral router + started mocks + seeded
     StandaloneConfig + the node running in-process behind the readiness
     barriers. `setup` is the node's real entry point (the exact
@@ -6066,11 +6078,16 @@ def start(setup, *, parameters=None, instance_id=None, node_dir=None, use_sim_ti
     resolves it; `use_sim_time=True` boots the node in sim time, as a
     launcher's `framework: { use_sim_time: true }` would, with the harness
     clock in sim mode so no time exists until the test advances it with
-    `await harness.clock.tick(...)`.
+    `await harness.clock.tick(...)`; `sim_time_participants` makes the node
+    the launch's source of simulated time, as a launcher's
+    `framework: { publishes_sim_time: true }` would: the core nodes it
+    publishes its clock to (under the harness the fleet is one machine,
+    `peppylib.testing.STANDALONE_CORE_NODE`), meaningful with
+    `use_sim_time=True`, and then the test never ticks `harness.clock`.
     """
-    return _HarnessStart(_start(setup, parameters, instance_id, node_dir, use_sim_time))
+    return _HarnessStart(_start(setup, parameters, instance_id, node_dir, use_sim_time, sim_time_participants))
 
-async def _start(setup, parameters, instance_id, node_dir, use_sim_time) -> Harness:
+async def _start(setup, parameters, instance_id, node_dir, use_sim_time, sim_time_participants) -> Harness:
     node_dir = peppylib.testing.resolve_node_dir(node_dir, _SYNC_TIME_NODE_DIR, _NODE_CONFIG_FILE)
     if instance_id is None:
         instance_id = peppylib.testing.unique_test_instance_id()
@@ -6097,6 +6114,7 @@ async def _start(setup, parameters, instance_id, node_dir, use_sim_time) -> Harn
             .with_messaging(router.host, router.port)
             .with_instance_id(instance_id)
             .with_use_sim_time(use_sim_time)
+            .with_sim_time_participants(list(sim_time_participants))
         )
         if parameters is not None:
             standalone = standalone.with_parameters(parameters)
@@ -6248,7 +6266,7 @@ class _HarnessStart:
         if harness is not None:
             await harness.shutdown()
 
-def start(setup, *, parameters=None, instance_id=None, node_dir=None, use_sim_time=False):
+def start(setup, *, parameters=None, instance_id=None, node_dir=None, use_sim_time=False, sim_time_participants=()):
     """Boots the full fixture: ephemeral router + started mocks + seeded
     StandaloneConfig + the node running in-process behind the readiness
     barriers. `setup` is the node's real entry point (the exact
@@ -6267,11 +6285,16 @@ def start(setup, *, parameters=None, instance_id=None, node_dir=None, use_sim_ti
     resolves it; `use_sim_time=True` boots the node in sim time, as a
     launcher's `framework: { use_sim_time: true }` would, with the harness
     clock in sim mode so no time exists until the test advances it with
-    `await harness.clock.tick(...)`.
+    `await harness.clock.tick(...)`; `sim_time_participants` makes the node
+    the launch's source of simulated time, as a launcher's
+    `framework: { publishes_sim_time: true }` would: the core nodes it
+    publishes its clock to (under the harness the fleet is one machine,
+    `peppylib.testing.STANDALONE_CORE_NODE`), meaningful with
+    `use_sim_time=True`, and then the test never ticks `harness.clock`.
     """
-    return _HarnessStart(_start(setup, parameters, instance_id, node_dir, use_sim_time))
+    return _HarnessStart(_start(setup, parameters, instance_id, node_dir, use_sim_time, sim_time_participants))
 
-async def _start(setup, parameters, instance_id, node_dir, use_sim_time) -> Harness:
+async def _start(setup, parameters, instance_id, node_dir, use_sim_time, sim_time_participants) -> Harness:
     node_dir = peppylib.testing.resolve_node_dir(node_dir, _SYNC_TIME_NODE_DIR, _NODE_CONFIG_FILE)
     if instance_id is None:
         instance_id = peppylib.testing.unique_test_instance_id()
@@ -6298,6 +6321,7 @@ async def _start(setup, parameters, instance_id, node_dir, use_sim_time) -> Harn
             .with_messaging(router.host, router.port)
             .with_instance_id(instance_id)
             .with_use_sim_time(use_sim_time)
+            .with_sim_time_participants(list(sim_time_participants))
         )
         if parameters is not None:
             standalone = standalone.with_parameters(parameters)

--- a/crates/generator-internal/src/generator/python/tests/testing.rs
+++ b/crates/generator-internal/src/generator/python/tests/testing.rs
@@ -96,11 +96,13 @@ fn every_harness_carries_the_daemon_clock_stand_in() {
         &rendered,
         &[
             "use_sim_time=False",
+            "sim_time_participants=()",
             "if use_sim_time:",
             "MockClock.start_sim(",
             "MockClock.start_wall(",
             "MOCK_CLOCK_INSTANCE_ID",
             ".with_use_sim_time(use_sim_time)",
+            ".with_sim_time_participants(list(sim_time_participants))",
             "service_readiness = [clock.readiness()]",
             "clock=clock,",
         ],

--- a/crates/generator-internal/src/generator/rust/fixtures.rs
+++ b/crates/generator-internal/src/generator/rust/fixtures.rs
@@ -1029,6 +1029,17 @@ fn render_harness(
             /// default) is wall mode: the harness clock serves and ticks OS
             /// wall time like a wall-mode daemon.
             pub use_sim_time: bool,
+            /// Make the node the launch's source of simulated time, as a
+            /// launcher's `framework: { publishes_sim_time: true }` would:
+            /// the core nodes it publishes its clock to, one `clock` topic
+            /// each, which is what `SimTimePublisher::for_node` hands it a
+            /// publisher for. Under the harness the fleet is one machine,
+            /// `peppylib::testing::STANDALONE_CORE_NODE`, so a subscription
+            /// on the node runner (`peppylib::clock::subscribe`) sees every
+            /// tick the node publishes. Meaningful with `use_sim_time`, and
+            /// then the test never ticks [`Harness::clock`]: the node is the
+            /// simulator. Empty (the default) leaves the node a follower.
+            pub sim_time_participants: Vec<String>,
             #( #config_fields ),*
         }
 
@@ -1041,6 +1052,7 @@ fn render_harness(
                     parameters: None,
                     instance_id: None,
                     use_sim_time: false,
+                    sim_time_participants: Vec::new(),
                     #( #config_defaults ),*
                 }
             }
@@ -1147,7 +1159,8 @@ fn render_harness(
                 let mut standalone = peppylib::runtime::StandaloneConfig::new()
                     .with_messaging(router.host(), router.port())
                     .with_instance_id(instance_id.clone())
-                    .with_use_sim_time(config.use_sim_time);
+                    .with_use_sim_time(config.use_sim_time)
+                    .with_sim_time_participants(config.sim_time_participants.clone());
                 #parameters_seed
                 #( #seeding )*
 

--- a/crates/generator-internal/src/generator/rust/tests/testing.rs
+++ b/crates/generator-internal/src/generator/rust/tests/testing.rs
@@ -98,10 +98,13 @@ fn every_harness_carries_the_daemon_clock_stand_in() {
         &[
             "pub use_sim_time: bool",
             "use_sim_time: false",
+            "pub sim_time_participants: Vec<String>",
+            "sim_time_participants: Vec::new()",
             "MockClock::start_sim(",
             "MockClock::start_wall(",
             "MOCK_CLOCK_INSTANCE_ID",
             ".with_use_sim_time(config.use_sim_time)",
+            ".with_sim_time_participants(config.sim_time_participants.clone())",
             "service_readiness.push(clock.readiness()?);",
             "pub clock: peppylib::testing::MockClock",
         ],

--- a/crates/generator-internal/tests/rust/testing_lib.rs
+++ b/crates/generator-internal/tests/rust/testing_lib.rs
@@ -9,13 +9,17 @@
 //! `ActionFeedbackProducerGone`, never a hang or clean close). A second test
 //! boots the same node in sim time (`Config::use_sim_time`) and drives the
 //! harness clock: every `harness.clock.tick(..)` instant is what the node's
-//! `peppygen::clock::now_ns` observes.
+//! `peppygen::clock::now_ns` observes. A third declares the node the
+//! launch's source of simulated time (`Config::sim_time_participants`): the
+//! node holds the fleet's publisher and the ticks it publishes are read
+//! back on the `clock` topic, with the test never ticking.
 
 use config::consts::PEPPYGEN_OUTPUT_PATH;
 use config::node::{
     Cardinality, ConsumedAction, ConsumedService, ConsumedTopic, MessageFormat, NativeEmittedTopic,
     NativeExposedService,
 };
+use daemon_config::consts::PEPPYLIB_OUTPUT_PATH;
 use generator::{ConsumedActionMessage, DependencyContext, LanguageGenerator, PeerContext};
 use std::fs;
 
@@ -195,6 +199,36 @@ pub async fn setup_sim_clock(
         }
     }
 }
+
+/// Time-source entry point: the launch (here the harness config) declared
+/// this node the source of simulated time, so it holds the fleet's
+/// publisher and drives the clock itself, reporting who it publishes to on
+/// the status topic and then ticking on until shutdown. A source stamps
+/// from its own clock, never from `now_ns`, so nothing here reads time.
+pub async fn setup_sim_source(
+    _parameters: peppygen::Parameters,
+    node_runner: Arc<peppygen::NodeRunner>,
+) -> peppygen::Result<()> {
+    peppygen::clock::init(&node_runner).await?;
+    let publisher = peppylib::clock::SimTimePublisher::for_node(&node_runner)
+        .await?
+        .expect("the harness declared this node the launch's time source");
+    let status =
+        peppygen::emitted_topics::status::declare_publisher(&node_runner).await?;
+    let participants: Vec<&str> = publisher.participants().collect();
+    status
+        .publish(peppygen::emitted_topics::status::build_message(format!(
+            "source of {}",
+            participants.join(",")
+        ))?)
+        .await?;
+    let mut time_ns = 1_000u64;
+    loop {
+        publisher.publish(time_ns).await?;
+        time_ns += 1_000;
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+}
 "#;
 
 #[test]
@@ -275,6 +309,7 @@ path = "src/lib.rs"
 
 [dependencies]
 tokio = {{ version = "1", features = ["macros", "rt-multi-thread", "time"] }}
+peppylib = {{ path = "{PEPPYLIB_OUTPUT_PATH}" }}
 {main_dep}
 {dev_dep}
 "#,
@@ -455,6 +490,52 @@ async fn sim_time_is_test_driven_under_the_harness() {{
         .clock
         .set_offset_ns(1)
         .expect_err("sim time has no wall offset to skew");
+
+    harness.shutdown().await.expect("clean shutdown");
+}}
+
+// The node as the launch's source of simulated time: `sim_time_participants`
+// names the harness's one machine, the node builds its publisher onto it,
+// and every tick it publishes is read back on that machine's `clock` topic
+// in order, without the test ever ticking the harness clock.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_declared_time_source_ticks_the_fleet_under_the_harness() {{
+    let (mut harness, _mocks) = Harness::start_with(
+        peppygen::fixtures::harness::Config {{
+            use_sim_time: true,
+            sim_time_participants: vec![peppylib::testing::STANDALONE_CORE_NODE.to_owned()],
+            ..Default::default()
+        }},
+        {crate_name}::setup_sim_source,
+    )
+    .await
+    .expect("harness should start with the node as the time source");
+
+    let status = tokio::time::timeout(Duration::from_secs(10), harness.emitted.status.next())
+        .await
+        .expect("the node should report being the source")
+        .expect("status should decode")
+        .expect("status subscription should be open");
+    assert_eq!(
+        status.outcome,
+        format!("source of {{}}", peppylib::testing::STANDALONE_CORE_NODE)
+    );
+
+    let mut ticks = peppylib::clock::subscribe(harness.node_runner())
+        .await
+        .expect("clock subscription on the node's machine");
+    let mut next_tick = async || {{
+        tokio::time::timeout(Duration::from_secs(10), ticks.on_next_tick())
+            .await
+            .expect("the node should tick the fleet")
+            .expect("tick should decode")
+            .expect("clock subscription should be open")
+            .time()
+    }};
+    let first = next_tick().await;
+    assert!(first >= 1_000, "ticks are the node's own instants: {{first}}");
+    assert_eq!(next_tick().await, first + 1_000);
+    assert_eq!(next_tick().await, first + 2_000);
 
     harness.shutdown().await.expect("clean shutdown");
 }}

--- a/docs/src/content/docs/advanced_guides/testing.mdx
+++ b/docs/src/content/docs/advanced_guides/testing.mdx
@@ -595,6 +595,8 @@ async with harness.start(
     parameters=Parameters(gain=2.5),  # typed override; None uses schema defaults
     instance_id="my_test_node",       # explicit instead of generated
     use_sim_time=True,                # boot in sim time; see "The clock"
+    # ...and be the launch's source of it; see "The clock"
+    sim_time_participants=[peppylib.testing.STANDALONE_CORE_NODE],
     fleet_arms_instances=2,           # per multi-cardinality slot: mock count
     # per zero_or_one dependency or observer slot: boot the slot
     # empty, no mock started
@@ -613,6 +615,8 @@ let (mut harness, mut mocks) = Harness::start_with(
         parameters: Some(peppygen::Parameters { gain: 2.5 }),
         instance_id: Some("my_test_node".to_string()),
         use_sim_time: true, // boot in sim time; see "The clock"
+        // ...and be the launch's source of it; see "The clock"
+        sim_time_participants: vec![peppylib::testing::STANDALONE_CORE_NODE.to_owned()],
         fleet_arms_instances: 2,
         // per zero_or_one dependency or observer slot: boot the
         // slot empty, no mock started
@@ -629,6 +633,7 @@ let (mut harness, mut mocks) = Harness::start_with(
 - **`parameters`** is the node's typed `Parameters`; leaving it unset hydrates the schema defaults exactly as a launch would (a required parameter without a default is then an error at boot, as in production).
 - **`instance_id`** replaces the generated unique id (`test-<pid>-<counter>`). The node's wire identity under the harness is `("standalone-core", <instance_id>)`, returned by `harness.node_producer_ref()`.
 - **`use_sim_time`** boots the node in sim time, exactly as a launcher's `framework: { use_sim_time: true }` would, with the harness clock in sim mode: the test is the simulator, and no time exists until it calls `harness.clock.tick(...)`. See [The clock](#the-clock).
+- **`sim_time_participants`** makes the node the launch's source of simulated time, exactly as a launcher's `framework: { publishes_sim_time: true }` would: the core nodes it publishes its clock to. Under the harness the fleet is one machine, `peppylib::testing::STANDALONE_CORE_NODE`. Meaningful with `use_sim_time`, and then the node is the simulator, not the test. See [The clock](#the-clock).
 - **`<link_id>_vacant`** (per `zero_or_one` dependency or observer slot) boots the slot [written vacant](/advanced_guides/topics/#dependency-cardinality): no mock is started (the mock field is `None`), and the node's `bound_producer()` / `source()` accessor answers `None`, the branch this cardinality exists for.
 - **`<link_id>_instances`** (per multi-cardinality dependency or observer slot) sets how many mock instances to start, each under its own instance identity, delivered as a list. The default is 1 for `one_or_more` and 0 for `zero_or_more`.
 - **`<link_id>_instance_ids`** (same slots) names those instances explicitly, overriding the count when set. Reach for it when the node classifies producers by instance name (a health monitor keying reports on `left_arm`/`right_gripper` identities, a recorder naming limbs after its sources), so the mocks wear identities the node's classifier accepts.
@@ -684,6 +689,39 @@ harness.clock.tick(2_500_000_000).await?; // time advances only when the test sa
 </Tabs>
 
 The first `tick` waits until the node's clock subscription is visible (the subscription `peppygen::clock::init` opens in sim mode), so it cannot be dropped by discovery; ticking a node that never reads sim time is surfaced as a loud error, not a silent drop. Mode and knob agree or fail fast: `tick` on a wall-mode clock and `set_offset_ns` on a sim-mode clock are errors.
+
+**Source mode** (`sim_time_participants` alongside `use_sim_time`) mirrors the launch that declared the node its [source of simulated time](/advanced_guides/system_clock/#one-clock-across-a-fleet): `SimTimePublisher::for_node` hands the node a publisher onto each listed core node's `clock` topic, and the test never calls `tick`, since the node is the simulator. The harness's own sim clock stays silent, so a clock subscription on the node runner sees exactly what the node published, in the order it published it, and the node's stamps can be checked against those ticks. What the harness's clock *service* answers stays "clock not ready" in this mode: a source stamps from its own clock and never synchronizes against the wire.
+
+<Tabs>
+  <TabItem label="Python">
+```python
+async with harness.start(
+    setup,
+    use_sim_time=True,
+    sim_time_participants=[peppylib.testing.STANDALONE_CORE_NODE],
+) as h:
+    ticks = await peppylib.clock.subscribe(h.node_runner)
+    first = await ticks.on_next_tick()   # published by the node, not the test
+    assert first.time >= 1               # 0 is the wire's "no tick yet"
+```
+  </TabItem>
+  <TabItem label="Rust">
+```rust
+let (harness, mocks) = Harness::start_with(
+    Config {
+        use_sim_time: true,
+        sim_time_participants: vec![peppylib::testing::STANDALONE_CORE_NODE.to_owned()],
+        ..Config::default()
+    },
+    my_simulator::setup,
+)
+.await?;
+let mut ticks = peppylib::clock::subscribe(harness.node_runner()).await?;
+let first = ticks.on_next_tick().await?.expect("the node publishes its clock");
+assert!(first.time() >= 1); // 0 is the wire's "no tick yet"
+```
+  </TabItem>
+</Tabs>
 
 ## Caveats
 


### PR DESCRIPTION
## What

The generated test harness (Rust `Config`, Python `start(...)` kwargs) gains `sim_time_participants`: the daemon-less spelling of a launcher's `framework: { publishes_sim_time: true }`, chained onto `StandaloneConfig::with_sim_time_participants` after `use_sim_time`. Empty by default, so every existing harness boot is unchanged (a follower).

## Why

`StandaloneConfig` has had the knob (`runtime/builder.rs`) but neither harness surfaced it, so a node that is a time source (the sim engines: `openarm_sim_mujoco`, Isaac, and now waldo) could only be tested as a follower: `SimTimePublisher::for_node` was always `None` under the harness. With the knob the node holds its publisher onto `peppylib::testing::STANDALONE_CORE_NODE`'s `clock` topic, a `peppylib::clock::subscribe` on the node runner reads exactly what it published, and the test never ticks `harness.clock`.

First consumer: waldo's source-path harness test (Peppy-bot/private-nodes-hub, branch `waldo/sim-time-source-harness`), which lands after this is released and `peppy node sync .` rerun.

## Changes

- `generator/rust/fixtures.rs`, `generator/python/fixtures.rs`: the field / kwarg, its default, the chaining, docs on both.
- `generator/{rust,python}/tests/testing.rs`: the rendered-surface test pins the new strings.
- `tests/rust/testing_lib.rs`: the e2e node gains `setup_sim_source` (holds the publisher, reports its participants, ticks on) and a test booting it as the source, asserting the participants and three consecutive ticks read back off the `clock` topic. The e2e node manifest now depends on `peppylib` (for `SimTimePublisher`).
- `docs/.../testing.mdx`: configuration list entry and a "Source mode" paragraph with both languages under "The clock".

## Verified locally (Jetson, aarch64)

```
cargo test -p generator --lib -- every_harness_carries_the_daemon_clock_stand_in   # 2 passed
cargo test -p generator --test rust -- generated_mocks_and_fixtures_drive_a_node_end_to_end   # 1 passed (110 s, runs the 3 in-node tests incl. the new source one)
```

Not run locally: the Python e2e suite (its harness kwarg is exercised only through the rendered-surface test here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Peppy-bot/codesmith/peppy/pr/433"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791242508&installation_model_id=433186&pr_number=433&repository=Peppy-bot%2Fpeppy&return_to=https%3A%2F%2Fgithub.com%2FPeppy-bot%2Fpeppy%2Fpull%2F433&signature=1f86a109410751e75768432fc0b5ec6a0f0f5bd78736e6a939615add06430a6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->