### PR TITLE
generator: key consumed-topic capnp schemas per slot (breaking peppygen internals)

### DIFF
--- a/crates/generator-internal/src/error.rs
+++ b/crates/generator-internal/src/error.rs
@@ -96,4 +96,19 @@ sanitize to the module name `{sanitized}`"
         second: String,
         sanitized: String,
     },
+    /// Two schema registrations with different message formats resolved to
+    /// the same capnp file stem. Schema keys are built to make this
+    /// unrepresentable (consumed topics and pairings carry the slot's
+    /// link_id, services and actions the producer name), so this is a hard
+    /// error naming both keys rather than a silent reuse or overwrite of the
+    /// first file.
+    #[error(
+        "capnp schema file collision on `{file_stem}.capnp`: schema keys `{first_key}` and \
+`{second_key}` resolve to the same file but describe different message formats"
+    )]
+    SchemaFileStemCollision {
+        file_stem: String,
+        first_key: String,
+        second_key: String,
+    },
 }

--- a/crates/generator-internal/src/generator/naming.rs
+++ b/crates/generator-internal/src/generator/naming.rs
@@ -255,24 +255,25 @@ pub(crate) fn sanitize_or(raw: &str, fallback: &str) -> String {
     }
 }
 
-/// Schema key for the cap'n proto message backing a consumed topic.
+/// Schema key for the cap'n proto message backing a consumed topic:
+/// `on_next_<link_id>_<topic>`, one file per slot.
 ///
-/// Same output in both generators so a Rust node and a Python node that
-/// consume identical topics produce matching capnp file_stems. The producer
-/// node is intentionally NOT part of the key: two consumers of the same
-/// topic name from different producers share one capnp file, and the
-/// per-language `register_schema` collision check makes the dedup safe by
-/// reusing the first registration's struct identity for any later one.
-pub(crate) fn consumed_topic_schema_key(producer_name: &str, topic_name: &str) -> String {
-    let topic = sanitize_component(topic_name);
-    let producer = sanitize_component(producer_name);
-    if !topic.is_empty() {
-        format!("on_next_{topic}")
-    } else if !producer.is_empty() {
-        format!("on_next_{producer}")
-    } else {
-        String::from("on_next_topic")
-    }
+/// The slot's `link_id` is part of the key because a topic name says nothing
+/// about its format: `rgb_camera:v1` and `rgbd_camera:v1` both emit
+/// `video_stream`, and only the rgbd header carries `align_mode`. Sharing one
+/// file across slots by topic name would hand one of those consumers a schema
+/// its decode code does not match. Two slots consuming the same producer topic
+/// therefore write two identical schema files, the price pairing topics
+/// already pay (see [`peer_schema_key`]).
+///
+/// Shared by the Rust and Python generators and by both mock generators, so
+/// the consumer of a slot and the mock of that same slot resolve one file,
+/// and a Rust node and a Python node consuming identical slots produce
+/// matching capnp file_stems.
+pub(crate) fn consumed_topic_schema_key(link_id: &str, topic_name: &str) -> String {
+    let link = sanitize_or(link_id, "slot");
+    let topic = sanitize_or(topic_name, "topic");
+    format!("on_next_{link}_{topic}")
 }
 
 /// Request-message schema key for a consumed service. Includes the producer
@@ -334,10 +335,11 @@ pub(crate) fn consumed_action_schema_keys(
     }
 }
 
-/// Schema key for a pairing topic: `peer_<link_id>_<topic>`. Per-slot capnp
-/// duplication is accepted (same policy as consumed topics): two slots of the
-/// same pairing each get their own schema entry so the nested
-/// `paired_topics.<link_id>.<topic>` namespace stays unambiguous.
+/// Schema key for a pairing topic: `peer_<link_id>_<topic>`, one file per
+/// slot, the same policy [`consumed_topic_schema_key`] applies to consumed
+/// topics. Two slots of the same pairing each get their own schema entry so
+/// the nested `paired_topics.<link_id>.<topic>` namespace stays unambiguous;
+/// the duplicated few hundred bytes of schema are accepted.
 pub fn peer_schema_key(link_id: &str, topic_name: &str) -> String {
     format!("peer_{link_id}_{topic_name}")
 }
@@ -453,6 +455,37 @@ mod tests {
         assert_eq!(
             peer_schema_key("arm", "joint_states"),
             "peer_arm_joint_states"
+        );
+    }
+
+    #[test]
+    fn consumed_topic_schema_key_is_link_id_keyed() {
+        // One schema file per slot: two slots consuming a same-named topic
+        // never resolve to the same file, whatever producer backs them.
+        assert_eq!(
+            consumed_topic_schema_key("wrist_left", "video_stream"),
+            "on_next_wrist_left_video_stream"
+        );
+        assert_ne!(
+            consumed_topic_schema_key("chest", "video_stream"),
+            consumed_topic_schema_key("wrist_left", "video_stream")
+        );
+    }
+
+    #[test]
+    fn consumed_topic_schema_key_sanitizes_and_falls_back() {
+        assert_eq!(
+            consumed_topic_schema_key("Wrist-Left", "Video Stream"),
+            "on_next_wrist_left_video_stream"
+        );
+        assert_eq!(consumed_topic_schema_key("", ""), "on_next_slot_topic");
+        assert_eq!(
+            consumed_topic_schema_key("--", "video_stream"),
+            "on_next_slot_video_stream"
+        );
+        assert_eq!(
+            consumed_topic_schema_key("wrist", "   "),
+            "on_next_wrist_topic"
         );
     }
 }

--- a/crates/generator-internal/src/generator/python.rs
+++ b/crates/generator-internal/src/generator/python.rs
@@ -119,13 +119,39 @@ impl PythonGenerator {
 
         let resolved = resolve_schema_file_stem(schema_key);
         let struct_name = format!("{}Message", to_camel_case(&resolved.base_name));
+
+        // A file stem registered twice is the consumer of a slot and the mock
+        // publisher of that slot resolving the slot's key for one and the
+        // same message: keep the first entry. Two different formats on one
+        // stem is a schema-key naming bug; overwriting would silently decode
+        // one caller's payloads through the other's schema, so fail instead.
+        if let Some(existing) = self.schemas.get(&resolved.file_stem) {
+            if existing.source() != schema_source {
+                return Err(crate::error::Error::SchemaFileStemCollision {
+                    file_stem: resolved.file_stem,
+                    first_key: existing.schema_key().to_string(),
+                    second_key: schema_key.to_string(),
+                });
+            }
+            return Ok(PythonSchemaInfo {
+                file_stem: resolved.file_stem,
+                struct_name,
+            });
+        }
+
         let schema_text =
             schema_source.replacen("struct Message", &format!("struct {struct_name}"), 1);
 
         let struct_module = crate::generator::naming::normalize_snake_case(&struct_name);
         self.schemas.insert(
             resolved.file_stem.clone(),
-            CapnpSchema::new(resolved.file_stem.clone(), struct_module, schema_text),
+            CapnpSchema::new(
+                schema_key.to_string(),
+                resolved.file_stem.clone(),
+                struct_module,
+                schema_source,
+                schema_text,
+            ),
         );
 
         Ok(PythonSchemaInfo {

--- a/crates/generator-internal/src/generator/python/mock.rs
+++ b/crates/generator-internal/src/generator/python/mock.rs
@@ -427,6 +427,10 @@ fn render_dep_topic(
     let alias = format!("_{attr}");
     builder.add_import(&production_import_line(&production, &alias));
     let camel = to_camel_case(&attr);
+    // `module_link` is the slot's consumer-side link_id, the same value
+    // `add_consumed_topic` keys the schema on. The mock must pass exactly what
+    // the consumer passes so both resolve one per-slot capnp file (and the
+    // `register_schema` mismatch guard sees identical text, not a collision).
     let schema_key =
         crate::generator::naming::consumed_topic_schema_key(&spec.module_link, topic_name);
     let serialize_fn = format!("_serialize_{attr}_message");

--- a/crates/generator-internal/src/generator/python/tests/golden/python_renderers.txt
+++ b/crates/generator-internal/src/generator/python/tests/golden/python_renderers.txt
@@ -933,8 +933,8 @@ import peppylib
 import types
 
 @lru_cache(maxsize=1)
-def _on_next_video_stream_message_capnp() -> types.ModuleType:
-    return capnp.load(str(files("peppygen") / "capnp" / "on_next_video_stream_message.capnp"))
+def _on_next_uvc_camera_video_stream_message_capnp() -> types.ModuleType:
+    return capnp.load(str(files("peppygen") / "capnp" / "on_next_uvc_camera_video_stream_message.capnp"))
 
 @dataclass
 class MessageHeader:
@@ -948,7 +948,7 @@ class Message:
 
 
 def _deserialize_payload(payload: bytes) -> Message:
-    with _on_next_video_stream_message_capnp().OnNextVideoStreamMessage.from_bytes(payload) as capnp_msg:
+    with _on_next_uvc_camera_video_stream_message_capnp().OnNextUvcCameraVideoStreamMessage.from_bytes(payload) as capnp_msg:
         reader_0 = capnp_msg.header
         timestamp_1 = reader_0.stamp
         stamp_2 = peppylib.encoding.convert_time_from_capnp(timestamp_1.sec, timestamp_1.nsec)
@@ -1104,8 +1104,8 @@ import peppylib
 import types
 
 @lru_cache(maxsize=1)
-def _on_next_video_stream_message_capnp() -> types.ModuleType:
-    return capnp.load(str(files("peppygen") / "capnp" / "on_next_video_stream_message.capnp"))
+def _on_next_spare_camera_video_stream_message_capnp() -> types.ModuleType:
+    return capnp.load(str(files("peppygen") / "capnp" / "on_next_spare_camera_video_stream_message.capnp"))
 
 @dataclass
 class MessageHeader:
@@ -1119,7 +1119,7 @@ class Message:
 
 
 def _deserialize_payload(payload: bytes) -> Message:
-    with _on_next_video_stream_message_capnp().OnNextVideoStreamMessage.from_bytes(payload) as capnp_msg:
+    with _on_next_spare_camera_video_stream_message_capnp().OnNextSpareCameraVideoStreamMessage.from_bytes(payload) as capnp_msg:
         reader_0 = capnp_msg.header
         timestamp_1 = reader_0.stamp
         stamp_2 = peppylib.encoding.convert_time_from_capnp(timestamp_1.sec, timestamp_1.nsec)
@@ -1278,8 +1278,8 @@ import peppylib
 import types
 
 @lru_cache(maxsize=1)
-def _on_next_video_stream_message_capnp() -> types.ModuleType:
-    return capnp.load(str(files("peppygen") / "capnp" / "on_next_video_stream_message.capnp"))
+def _on_next_camera_bank_video_stream_message_capnp() -> types.ModuleType:
+    return capnp.load(str(files("peppygen") / "capnp" / "on_next_camera_bank_video_stream_message.capnp"))
 
 @dataclass
 class MessageHeader:
@@ -1293,7 +1293,7 @@ class Message:
 
 
 def _deserialize_payload(payload: bytes) -> Message:
-    with _on_next_video_stream_message_capnp().OnNextVideoStreamMessage.from_bytes(payload) as capnp_msg:
+    with _on_next_camera_bank_video_stream_message_capnp().OnNextCameraBankVideoStreamMessage.from_bytes(payload) as capnp_msg:
         reader_0 = capnp_msg.header
         timestamp_1 = reader_0.stamp
         stamp_2 = peppylib.encoding.convert_time_from_capnp(timestamp_1.sec, timestamp_1.nsec)
@@ -1451,8 +1451,8 @@ import peppylib
 import types
 
 @lru_cache(maxsize=1)
-def _on_next_video_stream_message_capnp() -> types.ModuleType:
-    return capnp.load(str(files("peppygen") / "capnp" / "on_next_video_stream_message.capnp"))
+def _on_next_camera_pool_video_stream_message_capnp() -> types.ModuleType:
+    return capnp.load(str(files("peppygen") / "capnp" / "on_next_camera_pool_video_stream_message.capnp"))
 
 @dataclass
 class MessageHeader:
@@ -1466,7 +1466,7 @@ class Message:
 
 
 def _deserialize_payload(payload: bytes) -> Message:
-    with _on_next_video_stream_message_capnp().OnNextVideoStreamMessage.from_bytes(payload) as capnp_msg:
+    with _on_next_camera_pool_video_stream_message_capnp().OnNextCameraPoolVideoStreamMessage.from_bytes(payload) as capnp_msg:
         reader_0 = capnp_msg.header
         timestamp_1 = reader_0.stamp
         stamp_2 = peppylib.encoding.convert_time_from_capnp(timestamp_1.sec, timestamp_1.nsec)
@@ -2326,11 +2326,11 @@ def producer_ref_for(instance_id: str) -> peppylib.ProducerRef:
     return peppylib.ProducerRef(MOCK_CORE_NODE, instance_id)
 
 @lru_cache(maxsize=1)
-def _on_next_video_stream_message_capnp() -> types.ModuleType:
-    return capnp.load(str(files("peppygen") / "capnp" / "on_next_video_stream_message.capnp"))
+def _on_next_uvc_camera_video_stream_message_capnp() -> types.ModuleType:
+    return capnp.load(str(files("peppygen") / "capnp" / "on_next_uvc_camera_video_stream_message.capnp"))
 
 def _serialize_video_stream_message(value: _video_stream.Message) -> bytes:
-    capnp_msg = _on_next_video_stream_message_capnp().OnNextVideoStreamMessage.new_message()
+    capnp_msg = _on_next_uvc_camera_video_stream_message_capnp().OnNextUvcCameraVideoStreamMessage.new_message()
     builder_0 = capnp_msg.init("header")
     timestamp_1 = peppylib.encoding.convert_time(value.header.stamp)
     builder_2 = builder_0.init("stamp")
@@ -2504,11 +2504,11 @@ def producer_ref_for(instance_id: str) -> peppylib.ProducerRef:
     return peppylib.ProducerRef(MOCK_CORE_NODE, instance_id)
 
 @lru_cache(maxsize=1)
-def _on_next_video_stream_message_capnp() -> types.ModuleType:
-    return capnp.load(str(files("peppygen") / "capnp" / "on_next_video_stream_message.capnp"))
+def _on_next_spare_camera_video_stream_message_capnp() -> types.ModuleType:
+    return capnp.load(str(files("peppygen") / "capnp" / "on_next_spare_camera_video_stream_message.capnp"))
 
 def _serialize_video_stream_message(value: _video_stream.Message) -> bytes:
-    capnp_msg = _on_next_video_stream_message_capnp().OnNextVideoStreamMessage.new_message()
+    capnp_msg = _on_next_spare_camera_video_stream_message_capnp().OnNextSpareCameraVideoStreamMessage.new_message()
     builder_0 = capnp_msg.init("header")
     timestamp_1 = peppylib.encoding.convert_time(value.header.stamp)
     builder_2 = builder_0.init("stamp")
@@ -2682,11 +2682,11 @@ def producer_ref_for(instance_id: str) -> peppylib.ProducerRef:
     return peppylib.ProducerRef(MOCK_CORE_NODE, instance_id)
 
 @lru_cache(maxsize=1)
-def _on_next_video_stream_message_capnp() -> types.ModuleType:
-    return capnp.load(str(files("peppygen") / "capnp" / "on_next_video_stream_message.capnp"))
+def _on_next_camera_bank_video_stream_message_capnp() -> types.ModuleType:
+    return capnp.load(str(files("peppygen") / "capnp" / "on_next_camera_bank_video_stream_message.capnp"))
 
 def _serialize_video_stream_message(value: _video_stream.Message) -> bytes:
-    capnp_msg = _on_next_video_stream_message_capnp().OnNextVideoStreamMessage.new_message()
+    capnp_msg = _on_next_camera_bank_video_stream_message_capnp().OnNextCameraBankVideoStreamMessage.new_message()
     builder_0 = capnp_msg.init("header")
     timestamp_1 = peppylib.encoding.convert_time(value.header.stamp)
     builder_2 = builder_0.init("stamp")
@@ -2860,11 +2860,11 @@ def producer_ref_for(instance_id: str) -> peppylib.ProducerRef:
     return peppylib.ProducerRef(MOCK_CORE_NODE, instance_id)
 
 @lru_cache(maxsize=1)
-def _on_next_video_stream_message_capnp() -> types.ModuleType:
-    return capnp.load(str(files("peppygen") / "capnp" / "on_next_video_stream_message.capnp"))
+def _on_next_camera_pool_video_stream_message_capnp() -> types.ModuleType:
+    return capnp.load(str(files("peppygen") / "capnp" / "on_next_camera_pool_video_stream_message.capnp"))
 
 def _serialize_video_stream_message(value: _video_stream.Message) -> bytes:
-    capnp_msg = _on_next_video_stream_message_capnp().OnNextVideoStreamMessage.new_message()
+    capnp_msg = _on_next_camera_pool_video_stream_message_capnp().OnNextCameraPoolVideoStreamMessage.new_message()
     builder_0 = capnp_msg.init("header")
     timestamp_1 = peppylib.encoding.convert_time(value.header.stamp)
     builder_2 = builder_0.init("stamp")

--- a/crates/generator-internal/src/generator/python/tests/topics.rs
+++ b/crates/generator-internal/src/generator/python/tests/topics.rs
@@ -584,16 +584,16 @@ fn consumed_topic() {
         ],
     );
 
-    // Lazy cached schema loader using `importlib.resources`. The
-    // `on_next_` prefix on the file_stem comes from the shared
-    // `consumed_topic_schema_key` helper in `naming.rs`, matching the Rust
-    // generator's output.
+    // Lazy cached schema loader using `importlib.resources`. The file_stem
+    // comes from the shared `consumed_topic_schema_key` helper in
+    // `naming.rs` (matching the Rust generator's output) and is keyed per
+    // slot: `on_next_<link_id>_<topic>`, here the `uvc_camera` slot.
     assert_contains_all(
         &rendered,
         &[
             "@lru_cache(maxsize=1)",
-            "def _on_next_video_stream_message_capnp() -> types.ModuleType:",
-            "return capnp.load(str(files(\"peppygen\") / \"capnp\" / \"on_next_video_stream_message.capnp\"))",
+            "def _on_next_uvc_camera_video_stream_message_capnp() -> types.ModuleType:",
+            "return capnp.load(str(files(\"peppygen\") / \"capnp\" / \"on_next_uvc_camera_video_stream_message.capnp\"))",
         ],
     );
 
@@ -614,7 +614,7 @@ fn consumed_topic() {
         &rendered,
         &[
             "def _deserialize_payload(payload: bytes) -> Message:",
-            "with _on_next_video_stream_message_capnp().OnNextVideoStreamMessage.from_bytes(payload) as capnp_msg:",
+            "with _on_next_uvc_camera_video_stream_message_capnp().OnNextUvcCameraVideoStreamMessage.from_bytes(payload) as capnp_msg:",
         ],
     );
 

--- a/crates/generator-internal/src/generator/rust.rs
+++ b/crates/generator-internal/src/generator/rust.rs
@@ -115,26 +115,42 @@ impl RustGenerator {
         artifacts: &CapnpSchemaArtifacts,
     ) -> Result<SchemaInfo> {
         let resolved = resolve_schema_file_stem(schema_key);
+        let schema_source = artifacts.encoding_schema();
 
-        // When multiple callers (e.g. two consumed topics sharing producer+topic
-        // with different link_ids) resolve to the same capnp file, the schema
-        // file is written once but every caller still needs a Rust-side
-        // reference to a struct that actually exists in it. Reuse the first
-        // registration's struct identity for every subsequent collision.
+        // The same file stem is registered more than once only when two
+        // callers describe the very same message: the consumer of a slot and
+        // the mock publisher of that slot both resolve the slot's key. The
+        // file is written once and every caller gets a Rust-side reference to
+        // the struct that actually exists in it, so reuse the first
+        // registration's struct identity. Any other collision means two
+        // different formats want one file; that is a schema-key naming bug
+        // and must fail here rather than hand a caller a schema its decode
+        // code does not match.
         if let Some(existing) = self.schemas.get(&resolved.file_stem) {
+            if existing.source() != schema_source {
+                return Err(Error::SchemaFileStemCollision {
+                    file_stem: resolved.file_stem,
+                    first_key: existing.schema_key().to_string(),
+                    second_key: schema_key.to_string(),
+                });
+            }
             return Ok(SchemaInfo {
                 file_stem: resolved.file_stem,
                 struct_module: existing.struct_module().to_string(),
             });
         }
 
-        let schema_source = artifacts.encoding_schema();
         let struct_name = format!("{struct_prefix}Message");
         let struct_module = crate::generator::naming::normalize_snake_case(&struct_name);
         let schema = schema_source.replacen("struct Message", &format!("struct {struct_name}"), 1);
 
-        let capnp_schema =
-            CapnpSchema::new(resolved.file_stem.clone(), struct_module.clone(), schema);
+        let capnp_schema = CapnpSchema::new(
+            schema_key.to_string(),
+            resolved.file_stem.clone(),
+            struct_module.clone(),
+            schema_source.to_string(),
+            schema,
+        );
         self.schemas
             .insert(resolved.file_stem.clone(), capnp_schema);
 
@@ -177,8 +193,10 @@ impl RustGenerator {
         schema_key: &str,
         dependency: &DependencyContext,
     ) -> Result<(TokenStream, Vec<TokenStream>, bool)> {
-        let request_artifacts =
-            map_message_format(&format!("{schema_key}_request"), request_format)?;
+        // Each format is mapped under the exact key it is registered under so
+        // the rendered schema (file id included) is identical to what the mock
+        // and fixture generators produce for the same key.
+        let request_artifacts = map_message_format(schema_key, request_format)?;
         let response_artifacts =
             map_message_format(&format!("{schema_key}_response"), response_format)?;
 
@@ -781,7 +799,8 @@ impl LanguageGenerator for RustGenerator {
         let struct_prefix = String::from("Message");
 
         let mut context = GenerationContext::default();
-        let format_artifacts = map_message_format(&fn_name_str, topic.message_format.as_ref())?;
+        let scoped_key = scoped_schema_key(origin, &fn_name_str);
+        let format_artifacts = map_message_format(&scoped_key, topic.message_format.as_ref())?;
         let params = collect_function_params(
             format_artifacts.as_ref(),
             None,
@@ -789,7 +808,6 @@ impl LanguageGenerator for RustGenerator {
             &mut context,
             None,
         )?;
-        let scoped_key = scoped_schema_key(origin, &fn_name_str);
         let encoding = self.prepare_message_encoding(
             &scoped_key,
             &schema_prefix,
@@ -836,10 +854,11 @@ impl LanguageGenerator for RustGenerator {
 
         let mut context = GenerationContext::default();
         let request_format = non_empty_message_format(service.request_message_format.as_ref());
-        let request_wire_artifacts =
-            map_message_format(&format!("{fn_name_str}_request"), request_format)?;
+        let scoped_request_key = scoped_schema_key(origin, &fn_name_str);
+        let scoped_response_key = scoped_schema_key(origin, &format!("{fn_name_str}_response"));
+        let request_wire_artifacts = map_message_format(&scoped_request_key, request_format)?;
         let response_artifacts = map_message_format(
-            &format!("{fn_name_str}_response"),
+            &scoped_response_key,
             service.response_message_format.as_ref(),
         )?;
         let wire_params = collect_function_params(
@@ -849,7 +868,6 @@ impl LanguageGenerator for RustGenerator {
             &mut context,
             Some(&generic_response_ident),
         )?;
-        let scoped_request_key = scoped_schema_key(origin, &fn_name_str);
         let encoding = self.prepare_message_encoding(
             &scoped_request_key,
             &struct_prefix,
@@ -879,9 +897,8 @@ impl LanguageGenerator for RustGenerator {
 
         let response_spec = if let Some(return_artifacts) = response_artifacts.as_ref() {
             let response_prefix = format!("{struct_prefix}Response");
-            let schema_key = scoped_schema_key(origin, &format!("{fn_name_str}_response"));
             let schema_info =
-                self.register_schema(&schema_key, &response_prefix, return_artifacts)?;
+                self.register_schema(&scoped_response_key, &response_prefix, return_artifacts)?;
             Some(ServiceResponseSpec {
                 format: return_artifacts.message_format(),
                 struct_ident: generic_response_ident.clone(),
@@ -974,13 +991,15 @@ impl LanguageGenerator for RustGenerator {
             let goal_service = action.goal_service.as_ref();
             let label = format!("{base_name}_goal");
             let schema_struct_prefix = format!("{action_prefix}Goal");
+            let scoped_goal_key = scoped_schema_key(origin, &label);
+            let scoped_goal_response_key = scoped_schema_key(origin, &format!("{label}_response"));
 
             let request_artifacts = map_message_format(
-                &format!("{label}_request"),
+                &scoped_goal_key,
                 goal_service.and_then(|goal| goal.request_message_format.as_ref()),
             )?;
             let response_artifacts = map_message_format(
-                &format!("{label}_response"),
+                &scoped_goal_response_key,
                 goal_service.and_then(|goal| goal.response_message_format.as_ref()),
             )?;
 
@@ -1010,7 +1029,6 @@ impl LanguageGenerator for RustGenerator {
                 goal_request_data_struct.as_ref(),
             );
 
-            let scoped_goal_key = scoped_schema_key(origin, &label);
             let encoding = self.prepare_message_encoding(
                 &scoped_goal_key,
                 &schema_struct_prefix,
@@ -1044,9 +1062,11 @@ impl LanguageGenerator for RustGenerator {
             let response_serialization = if let Some(return_artifacts) = response_artifacts.as_ref()
             {
                 let response_schema_prefix = format!("{schema_struct_prefix}Response");
-                let schema_key = scoped_schema_key(origin, &format!("{label}_response"));
-                let schema_info =
-                    self.register_schema(&schema_key, &response_schema_prefix, return_artifacts)?;
+                let schema_info = self.register_schema(
+                    &scoped_goal_response_key,
+                    &response_schema_prefix,
+                    return_artifacts,
+                )?;
                 let spec = ServiceResponseSpec {
                     format: return_artifacts.message_format(),
                     struct_ident: Ident::new("GoalResponse", Span::call_site()),
@@ -1079,9 +1099,10 @@ impl LanguageGenerator for RustGenerator {
         if let Some(feedback) = action.feedback_topic.as_ref() {
             let label = format!("publish_feedback {}", action.name);
             let struct_prefix = format!("{action_prefix}Feedback");
-            let feedback_schema_name = format!("{base_name}_feedback");
+            let feedback_schema_key =
+                scoped_schema_key(origin, &format!("emit_{base_name}_feedback"));
             let format_artifacts =
-                map_message_format(&feedback_schema_name, Some(&feedback.message_format))?;
+                map_message_format(&feedback_schema_key, Some(&feedback.message_format))?;
             let params = collect_function_params(
                 format_artifacts.as_ref(),
                 None,
@@ -1091,7 +1112,7 @@ impl LanguageGenerator for RustGenerator {
             )?;
             let encoding = self
                 .prepare_message_encoding(
-                    &scoped_schema_key(origin, &format!("emit_{base_name}_feedback")),
+                    &feedback_schema_key,
                     &struct_prefix,
                     format_artifacts.as_ref(),
                     &params,
@@ -1112,11 +1133,10 @@ impl LanguageGenerator for RustGenerator {
         if let Some(result) = action.result_service.as_ref() {
             let label = format!("{base_name}_result");
             let schema_struct_prefix = format!("{action_prefix}Result");
+            let scoped_result_key = scoped_schema_key(origin, &format!("{label}_response"));
 
-            let response_artifacts = map_message_format(
-                &format!("{label}_response"),
-                result.response_message_format.as_ref(),
-            )?;
+            let response_artifacts =
+                map_message_format(&scoped_result_key, result.response_message_format.as_ref())?;
 
             // The result-response fields become `complete(fields…)` parameters.
             let result_params = collect_function_params(
@@ -1127,7 +1147,7 @@ impl LanguageGenerator for RustGenerator {
                 None,
             )?;
             let encoding = self.prepare_message_encoding(
-                &scoped_schema_key(origin, &format!("{label}_response")),
+                &scoped_result_key,
                 &schema_struct_prefix,
                 response_artifacts.as_ref(),
                 &result_params,
@@ -1293,23 +1313,20 @@ impl LanguageGenerator for RustGenerator {
         let request_arguments = non_empty_message_format(Some(request_arguments));
         let response_arguments = non_empty_message_format(Some(response_arguments));
 
-        let service_ident = prefixed_ident("", non_empty_str(service.name.as_str()), "service");
-        let service_name_component = service_ident.to_string();
-
-        let request_artifacts = map_message_format(
-            &format!("{service_name_component}_request"),
-            request_arguments,
-        )?;
-        let response_artifacts = map_message_format(
-            &format!("{service_name_component}_response"),
-            response_arguments,
-        )?;
-        let struct_prefix = identifiers::consumed_service_struct_prefix(service.name.as_str());
-
         let method_label = crate::generator::naming::consumed_service_request_schema_key(
             dependency_node_name,
             service.name.as_str(),
         );
+        let response_schema_key = crate::generator::naming::consumed_service_response_schema_key(
+            dependency_node_name,
+            service.name.as_str(),
+        );
+
+        // Mapped under the exact keys they are registered under so the
+        // rendered schemas (file ids included) match the mock's for this slot.
+        let request_artifacts = map_message_format(&method_label, request_arguments)?;
+        let response_artifacts = map_message_format(&response_schema_key, response_arguments)?;
+        let struct_prefix = identifiers::consumed_service_struct_prefix(service.name.as_str());
         let method_ident = Ident::new("poll", Span::call_site());
 
         let mut context = GenerationContext::default();
@@ -1427,11 +1444,6 @@ impl LanguageGenerator for RustGenerator {
             if let Some(response_artifacts) = response_artifacts.as_ref() {
                 let response_struct_name = format!("{struct_prefix}Response");
 
-                let response_schema_key =
-                    crate::generator::naming::consumed_service_response_schema_key(
-                        dependency_node_name,
-                        service.name.as_str(),
-                    );
                 let response_schema = self.register_schema(
                     &response_schema_key,
                     &response_struct_name,

--- a/crates/generator-internal/src/generator/rust/mock.rs
+++ b/crates/generator-internal/src/generator/rust/mock.rs
@@ -404,6 +404,10 @@ fn render_dep_topic(
 ) -> Result<MemberModule> {
     let topic_name = spec.name.as_str();
     let production = production_module("consumed_topics", &[&spec.module_link, topic_name]);
+    // `module_link` is the slot's consumer-side link_id, the same value
+    // `add_consumed_topic` keys the schema on. The mock must pass exactly what
+    // the consumer passes so both resolve one per-slot capnp file (and the
+    // `register_schema` mismatch guard sees identical text, not a collision).
     let schema_key =
         crate::generator::naming::consumed_topic_schema_key(&spec.module_link, topic_name);
     let struct_prefix = format!(

--- a/crates/generator-internal/src/generator/types.rs
+++ b/crates/generator-internal/src/generator/types.rs
@@ -1209,20 +1209,44 @@ mod tests {
     }
 }
 
+/// One generated Cap'n Proto schema file, keyed by its file stem.
+///
+/// `source` is the schema text exactly as the message-format mapper rendered
+/// it (root struct still named `Message`); `schema` is what gets written to
+/// disk, with the root struct renamed to the generator's chosen identity.
+/// The unsubstituted `source` is what `register_schema` compares when a
+/// second registration lands on the same file stem: identical text is the
+/// consumer and the mock of one slot sharing a file, anything else is a
+/// naming collision that must fail loudly.
 #[derive(Clone)]
 pub struct CapnpSchema {
+    schema_key: String,
     file_stem: String,
     struct_module: String,
+    source: String,
     schema: String,
 }
 
 impl CapnpSchema {
-    pub fn new(file_stem: String, struct_module: String, schema: String) -> Self {
+    pub fn new(
+        schema_key: String,
+        file_stem: String,
+        struct_module: String,
+        source: String,
+        schema: String,
+    ) -> Self {
         Self {
+            schema_key,
             file_stem,
             struct_module,
+            source,
             schema,
         }
+    }
+
+    /// The raw schema key the first registration used for this file.
+    pub fn schema_key(&self) -> &str {
+        &self.schema_key
     }
 
     pub fn file_stem(&self) -> &str {
@@ -1233,6 +1257,12 @@ impl CapnpSchema {
         &self.struct_module
     }
 
+    /// The mapper's schema text before the root-struct rename.
+    pub fn source(&self) -> &str {
+        &self.source
+    }
+
+    /// The schema text written to disk.
     pub fn schema(&self) -> &str {
         &self.schema
     }

--- a/crates/generator-internal/tests/python.rs
+++ b/crates/generator-internal/tests/python.rs
@@ -9,6 +9,8 @@ mod actions_implements;
 mod consumed_services_dedup;
 #[path = "python/consumed_topics_dedup.rs"]
 mod consumed_topics_dedup;
+#[path = "python/consumed_topics_distinct_formats.rs"]
+mod consumed_topics_distinct_formats;
 #[path = "python/generate_lib.rs"]
 mod generate_lib;
 #[path = "python/pairing_lib.rs"]

--- a/crates/generator-internal/tests/python/consumed_topics_dedup.rs
+++ b/crates/generator-internal/tests/python/consumed_topics_dedup.rs
@@ -1,20 +1,19 @@
-//! Regression guard for the case where two consumed topics share the same
-//! producer node + topic name but use different `link_id`s. The generator
-//! deduplicates the cap'n proto schema by `file_stem`; before the fix on the
-//! Rust path, the per-link Rust module would reference a struct name that had
-//! been overwritten in the deduplicated capnp source. Python's
-//! `register_schema` already derives the struct identity from the file_stem,
-//! so this test passes both before and after the fix, but it acts as a
-//! forward-looking guardrail so the Python generator can't regress into the
-//! same divergence.
+//! Guard for two consumed topics that share one producer node and one topic
+//! name on two different `link_id`s. Consumed-topic cap'n proto schemas are
+//! keyed per slot (`on_next_<link_id>_<topic>`), so each slot gets its own
+//! schema file and its own struct identity; this test checks that two
+//! same-named consumers on one producer still generate side by side and
+//! import together, with each per-link module's `_deserialize_payload`
+//! resolving a struct that exists in the file that module loads.
 //!
 //! This is the Python equivalent of the Rust test
-//! `compile_lib_with_two_consumed_topics_sharing_topic_name` in
-//! `src/generator/rust/tests/topics.rs`. The Rust test compiles the generated
-//! crate via `cargo build`; here we install the generated package with
-//! `uv sync` and execute Python that imports both per-link modules and
-//! force-resolves the cap'n proto struct each module's `_deserialize_payload`
-//! references.
+//! `rust_handles_two_consumed_topics_sharing_topic_name` in
+//! `tests/rust/consumed_topics_dedup.rs`. The Rust test compiles the
+//! generated crate via `cargo build`; here we install the generated package
+//! with `uv sync` and execute Python that imports both per-link modules and
+//! force-resolves the cap'n proto struct each module references. The
+//! distinct-formats case (same topic name, different `message_format`) lives
+//! in `consumed_topics_distinct_formats.rs`.
 
 use crate::helpers::TOPIC_DEDUP_SHARED_FORMAT as SHARED_FORMAT;
 use crate::helpers::{
@@ -50,8 +49,8 @@ const RIGHT_CONSUMER: &str = r#"{ link_id: "right_arm", name: "joint_states" }"#
 
 /// Probes the generated Python modules by importing both per-link consumers
 /// and accessing the cap'n proto struct each one's `_deserialize_payload`
-/// references. If the dedup logic ever drifts so that a consumer module
-/// references a struct name not present in the shared capnp file, the
+/// references. If the per-slot keying ever drifts so that a consumer module
+/// references a struct name not present in the capnp file it loads, the
 /// `getattr` call here raises `AttributeError` and the subprocess exits
 /// non-zero.
 const PYTHON_PROBE: &str = r#"
@@ -83,8 +82,8 @@ left_struct_name = referenced_struct(left)
 right_struct_name = referenced_struct(right)
 
 # Force-resolve each referenced struct. AttributeError here means the per-link
-# Python module references a struct that doesn't exist in the deduplicated
-# cap'n proto file, the same class of bug that bit the Rust generator.
+# Python module references a struct that doesn't exist in the per-slot
+# cap'n proto file it loads.
 getattr(left_schema, left_struct_name)
 getattr(right_schema, right_struct_name)
 

--- a/crates/generator-internal/tests/python/consumed_topics_distinct_formats.rs
+++ b/crates/generator-internal/tests/python/consumed_topics_distinct_formats.rs
@@ -1,0 +1,233 @@
+//! Regression guard for two consumed topics that share a topic name but carry
+//! different message formats: `rgb_camera:v1` and `rgbd_camera:v1` both emit
+//! `video_stream`, and only the rgbd header carries `align_mode`. Consumed
+//! topic cap'n proto schemas are keyed per slot (`on_next_<link_id>_<topic>`),
+//! so each slot writes its own file from its own format and each per-slot
+//! `_deserialize_payload` decodes through the schema it was generated from.
+//!
+//! Before per-slot keying both slots resolved `on_next_video_stream_message`
+//! and the last registration overwrote the file, so every consumer decoded
+//! through whichever format was declared last: rgb declared last made every
+//! rgbd frame raise on `alignMode`, rgbd declared last silently read an empty
+//! `align_mode` on rgb frames. Both declaration orders are covered.
+//!
+//! This is the Python counterpart of `tests/rust/consumed_topics_distinct_formats.rs`.
+
+use crate::helpers::{
+    contract_dep, init_python_project_venv, init_python_user_node, run_uv, test_peppy_dirs,
+};
+use config::consts::{NODE_CONFIG_FILE, PEPPYGEN_OUTPUT_PATH};
+use config::node::{ConsumedTopic, MessageFormat, PeppygenLanguage};
+use generator::{DeploymentInterface, InterfaceVariant, NodeTree, generate_peppygen_lib};
+use std::fs;
+use std::path::Path;
+use tempfile::TempDir;
+
+const NODE_CONFIG: &str = r#"{
+  peppy_schema: "node/v1",
+  manifest: {
+    name: "camera_consumer",
+    tag: "v1",
+    depends_on: {
+      contracts: [
+        { name: "rgb_camera", tag: "v1", link_id: "wrist" },
+        { name: "rgbd_camera", tag: "v1", link_id: "chest" }
+      ]
+    }
+  },
+  interfaces: {
+    topics: {
+      consumes: [
+        { link_id: "wrist", name: "video_stream" },
+        { link_id: "chest", name: "video_stream" }
+      ]
+    }
+  },
+  execution: {
+    language: "python",
+    build_cmd: ["uv", "sync"],
+    run_cmd: ["uv", "run", "camera_consumer"]
+  }
+}"#;
+
+const WRIST_CONSUMER: &str = r#"{ link_id: "wrist", name: "video_stream" }"#;
+const CHEST_CONSUMER: &str = r#"{ link_id: "chest", name: "video_stream" }"#;
+
+/// `rgb_camera:v1` `video_stream`, trimmed to the fields that matter.
+const RGB_FORMAT: &str = r#"{
+  header: { $type: "object", timestamp: "time", frame_id: "u32" },
+  encoding: "string",
+  width: "u32",
+  height: "u32",
+  frame: { $type: "array", $items: "u8" }
+}"#;
+
+/// `rgbd_camera:v1` `video_stream`: one more header field than the rgb one.
+const RGBD_FORMAT: &str = r#"{
+  header: { $type: "object", timestamp: "time", frame_id: "u32", align_mode: "string" },
+  encoding: "string",
+  width: "u32",
+  height: "u32",
+  frame: { $type: "array", $items: "u8" }
+}"#;
+
+/// Round-trips one message per slot through that slot's own cap'n proto
+/// loader and `_deserialize_payload`. The chest (rgbd) frame must come back
+/// with its `align_mode`; the wrist (rgb) frame must decode to a dataclass
+/// with no such attribute, and its builder must reject the field outright.
+const PYTHON_PROBE: &str = r#"
+import importlib
+import sys
+
+def capnp_loader(mod):
+    for name in dir(mod):
+        if name.endswith("_capnp") and name.startswith("_") and callable(getattr(mod, name)):
+            return getattr(mod, name)
+    sys.exit(f"no capnp loader found in {mod.__name__}")
+
+def fill_common(msg, frame_id):
+    header = msg.init("header")
+    timestamp = header.init("timestamp")
+    timestamp.sec = 12
+    timestamp.nsec = 34
+    header.frameId = frame_id
+    msg.encoding = "rgb8"
+    msg.width = 640
+    msg.height = 480
+    msg.frame = b"\x01\x02\x03"
+    return header
+
+wrist = importlib.import_module("peppygen.consumed_topics.wrist.video_stream")
+chest = importlib.import_module("peppygen.consumed_topics.chest.video_stream")
+
+chest_schema = capnp_loader(chest)()
+chest_msg = chest_schema.OnNextChestVideoStreamMessage.new_message()
+chest_header = fill_common(chest_msg, 2)
+chest_header.alignMode = "depth_to_color"
+chest_decoded = chest._deserialize_payload(chest_msg.to_bytes())
+assert chest_decoded.header.frame_id == 2, chest_decoded
+assert chest_decoded.header.align_mode == "depth_to_color", chest_decoded
+assert chest_decoded.frame == b"\x01\x02\x03", chest_decoded
+
+wrist_schema = capnp_loader(wrist)()
+wrist_msg = wrist_schema.OnNextWristVideoStreamMessage.new_message()
+wrist_header = fill_common(wrist_msg, 1)
+try:
+    wrist_header.alignMode = "depth_to_color"
+except Exception:
+    pass
+else:
+    sys.exit("the wrist (rgb) schema must not carry alignMode")
+wrist_decoded = wrist._deserialize_payload(wrist_msg.to_bytes())
+assert wrist_decoded.header.frame_id == 1, wrist_decoded
+assert not hasattr(wrist_decoded.header, "align_mode"), wrist_decoded
+assert wrist_decoded.frame == b"\x01\x02\x03", wrist_decoded
+
+print("wrist and chest video_stream decode through their own per-slot schemas")
+"#;
+
+#[derive(Clone, Copy)]
+enum Slot {
+    Wrist,
+    Chest,
+}
+
+fn consumed_topic(slot: Slot) -> DeploymentInterface {
+    let (consumer, format, dependency) = match slot {
+        Slot::Wrist => (
+            WRIST_CONSUMER,
+            RGB_FORMAT,
+            contract_dep("rgb_camera", "v1", "wrist"),
+        ),
+        Slot::Chest => (
+            CHEST_CONSUMER,
+            RGBD_FORMAT,
+            contract_dep("rgbd_camera", "v1", "chest"),
+        ),
+    };
+    let topic: ConsumedTopic =
+        serde_json5::from_str(consumer).expect("failed to parse consumed topic");
+    let message_format: MessageFormat =
+        serde_json5::from_str(format).expect("failed to parse message format");
+    DeploymentInterface::new(InterfaceVariant::ConsumedTopic {
+        topic,
+        message_format,
+        dependency,
+    })
+}
+
+fn read_schema(capnp_dir: &Path, file_stem: &str) -> String {
+    let path = capnp_dir.join(format!("{file_stem}.capnp"));
+    fs::read_to_string(&path)
+        .unwrap_or_else(|err| panic!("schema missing at {}: {err}", path.display()))
+}
+
+fn generate_and_probe(order: [Slot; 2]) {
+    let temp_dir =
+        TempDir::new_in(crate::helpers::test_tmp_root()).expect("failed to create temp directory");
+    let user_node_dir = temp_dir.path().join("user_node");
+    fs::create_dir_all(&user_node_dir).expect("failed to create user_node directory");
+
+    fs::write(user_node_dir.join(NODE_CONFIG_FILE), NODE_CONFIG)
+        .expect("failed to write peppy.json5");
+
+    let interfaces = order.into_iter().map(consumed_topic).collect();
+
+    generate_peppygen_lib(
+        PeppygenLanguage::Python,
+        &user_node_dir,
+        interfaces,
+        "test-hash",
+        &test_peppy_dirs(),
+        Default::default(),
+        None,
+        NodeTree::Source,
+    )
+    .expect("failed to generate peppygen lib");
+
+    let peppygen_dir = user_node_dir.join(PEPPYGEN_OUTPUT_PATH);
+    let capnp_dir = peppygen_dir.join("peppygen/capnp");
+
+    let wrist_schema = read_schema(&capnp_dir, "on_next_wrist_video_stream_message");
+    let chest_schema = read_schema(&capnp_dir, "on_next_chest_video_stream_message");
+    assert!(
+        !wrist_schema.contains("alignMode"),
+        "the wrist (rgb) schema must not carry alignMode:\n{wrist_schema}"
+    );
+    assert!(
+        chest_schema.contains("alignMode"),
+        "the chest (rgbd) schema must carry alignMode:\n{chest_schema}"
+    );
+    assert_ne!(wrist_schema, chest_schema);
+
+    let shared_stem = capnp_dir.join("on_next_video_stream_message.capnp");
+    assert!(
+        !shared_stem.exists(),
+        "a topic-name-keyed schema file must not be generated: {}",
+        shared_stem.display()
+    );
+
+    init_python_user_node(&user_node_dir);
+    init_python_project_venv(&user_node_dir);
+
+    let output = run_uv(&user_node_dir, &["run", "python", "-c", PYTHON_PROBE]);
+
+    assert!(
+        output.status.success(),
+        "Python probe failed for same-named consumed topics with distinct formats.\n\
+         stdout:\n{}\n\
+         stderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn python_decodes_same_named_consumed_topics_with_distinct_formats() {
+    generate_and_probe([Slot::Wrist, Slot::Chest]);
+}
+
+#[test]
+fn python_decodes_same_named_consumed_topics_with_distinct_formats_reversed_order() {
+    generate_and_probe([Slot::Chest, Slot::Wrist]);
+}

--- a/crates/generator-internal/tests/rust.rs
+++ b/crates/generator-internal/tests/rust.rs
@@ -11,6 +11,8 @@ mod codec_wire;
 mod consumed_services_dedup;
 #[path = "rust/consumed_topics_dedup.rs"]
 mod consumed_topics_dedup;
+#[path = "rust/consumed_topics_distinct_formats.rs"]
+mod consumed_topics_distinct_formats;
 #[path = "rust/generate_lib.rs"]
 mod generate_lib;
 #[path = "rust/multi_binding_communication.rs"]

--- a/crates/generator-internal/tests/rust/consumed_topics_dedup.rs
+++ b/crates/generator-internal/tests/rust/consumed_topics_dedup.rs
@@ -1,18 +1,19 @@
-//! Regression guard for the case where two consumed topics share the same
-//! producer node + topic name but use different `link_id`s. The generator
-//! deduplicates the cap'n proto schema by `file_stem`; before the fix, the
-//! second consumer's `register_schema` call overwrote the capnp struct name
-//! while the first consumer's already-emitted per-link Rust module still
-//! referenced the now-dead earlier name, producing
-//! `error[E0433]: cannot find <link>_<topic>_message in <topic>_message_capnp`
-//! at compile time.
+//! Guard for two consumed topics that share one producer node and one topic
+//! name on two different `link_id`s. Consumed-topic cap'n proto schemas are
+//! keyed per slot (`on_next_<link_id>_<topic>`), so each slot gets its own
+//! schema file and its own struct identity; this test checks that two
+//! same-named consumers on one producer still generate side by side and
+//! build together, with neither per-link Rust module referencing a struct
+//! that lives in the other slot's file.
 //!
 //! This is the Rust counterpart of the Python integration test
 //! `python_handles_two_consumed_topics_sharing_topic_name` in
 //! `tests/python/consumed_topics_dedup.rs`. The Python test installs the
 //! generated package with `uv sync` and runs Python that imports both modules;
 //! here we generate a peppygen lib, wire it into a user crate, and invoke
-//! `cargo build` against the result.
+//! `cargo build` against the result. The distinct-formats case (same topic
+//! name, different `message_format`) lives in
+//! `consumed_topics_distinct_formats.rs`.
 
 use crate::helpers::TOPIC_DEDUP_SHARED_FORMAT as SHARED_FORMAT;
 use config::consts::{NODE_CONFIG_FILE, PEPPYGEN_OUTPUT_PATH};

--- a/crates/generator-internal/tests/rust/consumed_topics_distinct_formats.rs
+++ b/crates/generator-internal/tests/rust/consumed_topics_distinct_formats.rs
@@ -1,0 +1,206 @@
+//! Regression guard for two consumed topics that share a topic name but carry
+//! different message formats: `rgb_camera:v1` and `rgbd_camera:v1` both emit
+//! `video_stream`, and only the rgbd header carries `align_mode`. Consumed
+//! topic cap'n proto schemas are keyed per slot (`on_next_<link_id>_<topic>`),
+//! so each slot writes its own file from its own format and the per-slot
+//! decode code always matches the schema it reads.
+//!
+//! Before per-slot keying both slots resolved `on_next_video_stream_message`;
+//! the first registration owned the file and every later slot was handed the
+//! first struct while its decode code was still generated from its own
+//! format. Declaring the rgbd slot after the rgb one produced
+//! `error[E0599]: no method named get_align_mode` on the shared reader and the
+//! node did not build; the other order built but read the rgb slot through a
+//! schema with a field it never sets. Both declaration orders are covered.
+//!
+//! This is the Rust counterpart of `tests/python/consumed_topics_distinct_formats.rs`.
+
+use config::consts::{NODE_CONFIG_FILE, PEPPYGEN_OUTPUT_PATH};
+use config::node::{ConsumedTopic, MessageFormat, PeppygenLanguage};
+use generator::{DeploymentInterface, InterfaceVariant, NodeTree, generate_peppygen_lib};
+use std::fs;
+use std::path::Path;
+use tempfile::TempDir;
+
+use crate::helpers;
+
+const NODE_CONFIG: &str = r#"{
+  peppy_schema: "node/v1",
+  manifest: {
+    name: "camera_consumer",
+    tag: "v1",
+    depends_on: {
+      contracts: [
+        { name: "rgb_camera", tag: "v1", link_id: "wrist" },
+        { name: "rgbd_camera", tag: "v1", link_id: "chest" }
+      ]
+    }
+  },
+  interfaces: {
+    topics: {
+      consumes: [
+        { link_id: "wrist", name: "video_stream" },
+        { link_id: "chest", name: "video_stream" }
+      ]
+    }
+  },
+  execution: {
+    language: "rust",
+    run_cmd: ["./target/debug/camera_consumer"]
+  }
+}"#;
+
+const WRIST_CONSUMER: &str = r#"{ link_id: "wrist", name: "video_stream" }"#;
+const CHEST_CONSUMER: &str = r#"{ link_id: "chest", name: "video_stream" }"#;
+
+/// `rgb_camera:v1` `video_stream`, trimmed to the fields that matter.
+const RGB_FORMAT: &str = r#"{
+  header: { $type: "object", timestamp: "time", frame_id: "u32" },
+  encoding: "string",
+  width: "u32",
+  height: "u32",
+  frame: { $type: "array", $items: "u8" }
+}"#;
+
+/// `rgbd_camera:v1` `video_stream`: one more header field than the rgb one.
+const RGBD_FORMAT: &str = r#"{
+  header: { $type: "object", timestamp: "time", frame_id: "u32", align_mode: "string" },
+  encoding: "string",
+  width: "u32",
+  height: "u32",
+  frame: { $type: "array", $items: "u8" }
+}"#;
+
+/// User crate `main.rs` that constructs both per-slot messages: the chest
+/// header carries `align_mode`, the wrist header is built without it (so the
+/// build fails if the wrist slot ever picks up the rgbd schema, or the chest
+/// slot the rgb one).
+const USER_MAIN: &str = r#"
+use peppygen::consumed_topics::chest::video_stream as chest_video_stream;
+use peppygen::consumed_topics::wrist::video_stream as wrist_video_stream;
+
+fn main() {
+    let wrist = wrist_video_stream::Message {
+        header: wrist_video_stream::MessageHeader {
+            timestamp: std::time::SystemTime::UNIX_EPOCH,
+            frame_id: 1,
+        },
+        encoding: String::from("rgb8"),
+        width: 640,
+        height: 480,
+        frame: Vec::new(),
+    };
+    let chest = chest_video_stream::Message {
+        header: chest_video_stream::MessageHeader {
+            timestamp: std::time::SystemTime::UNIX_EPOCH,
+            frame_id: 2,
+            align_mode: String::from("depth_to_color"),
+        },
+        encoding: String::from("rgb8"),
+        width: 640,
+        height: 480,
+        frame: Vec::new(),
+    };
+    assert_eq!(wrist.header.frame_id, 1);
+    assert_eq!(chest.header.align_mode, "depth_to_color");
+}
+"#;
+
+#[derive(Clone, Copy)]
+enum Slot {
+    Wrist,
+    Chest,
+}
+
+fn consumed_topic(slot: Slot) -> DeploymentInterface {
+    let (consumer, format, dependency) = match slot {
+        Slot::Wrist => (
+            WRIST_CONSUMER,
+            RGB_FORMAT,
+            helpers::contract_dep("rgb_camera", "v1", "wrist"),
+        ),
+        Slot::Chest => (
+            CHEST_CONSUMER,
+            RGBD_FORMAT,
+            helpers::contract_dep("rgbd_camera", "v1", "chest"),
+        ),
+    };
+    let topic: ConsumedTopic =
+        serde_json5::from_str(consumer).expect("failed to parse consumed topic");
+    let message_format: MessageFormat =
+        serde_json5::from_str(format).expect("failed to parse message format");
+    DeploymentInterface::new(InterfaceVariant::ConsumedTopic {
+        topic,
+        message_format,
+        dependency,
+    })
+}
+
+fn read_schema(capnp_dir: &Path, file_stem: &str) -> String {
+    let path = capnp_dir.join(format!("{file_stem}.capnp"));
+    fs::read_to_string(&path)
+        .unwrap_or_else(|err| panic!("schema missing at {}: {err}", path.display()))
+}
+
+fn generate_and_build(order: [Slot; 2]) {
+    let temp_dir =
+        TempDir::new_in(crate::helpers::test_tmp_root()).expect("failed to create temp directory");
+    let user_node_dir = temp_dir.path().join("user_node");
+    fs::create_dir_all(&user_node_dir).expect("failed to create user_node directory");
+
+    fs::write(user_node_dir.join(NODE_CONFIG_FILE), NODE_CONFIG)
+        .expect("failed to write peppy.json5");
+
+    let interfaces = order.into_iter().map(consumed_topic).collect();
+
+    generate_peppygen_lib(
+        PeppygenLanguage::Rust,
+        &user_node_dir,
+        interfaces,
+        "test-hash",
+        &helpers::test_peppy_dirs(),
+        Default::default(),
+        None,
+        NodeTree::Source,
+    )
+    .expect("failed to generate peppygen lib");
+
+    let peppygen_dir = user_node_dir.join(PEPPYGEN_OUTPUT_PATH);
+    let capnp_dir = peppygen_dir.join("src/capnp");
+
+    let wrist_schema = read_schema(&capnp_dir, "on_next_wrist_video_stream_message");
+    let chest_schema = read_schema(&capnp_dir, "on_next_chest_video_stream_message");
+    assert!(
+        !wrist_schema.contains("alignMode"),
+        "the wrist (rgb) schema must not carry alignMode:\n{wrist_schema}"
+    );
+    assert!(
+        chest_schema.contains("alignMode"),
+        "the chest (rgbd) schema must carry alignMode:\n{chest_schema}"
+    );
+    assert_ne!(wrist_schema, chest_schema);
+
+    let shared_stem = capnp_dir.join("on_next_video_stream_message.capnp");
+    assert!(
+        !shared_stem.exists(),
+        "a topic-name-keyed schema file must not be generated: {}",
+        shared_stem.display()
+    );
+
+    helpers::init_cargo_user_node(&user_node_dir);
+    let src_dir = user_node_dir.join("src");
+    fs::create_dir_all(&src_dir).expect("failed to create src dir");
+    fs::write(src_dir.join("main.rs"), USER_MAIN).expect("failed to write user main.rs");
+
+    helpers::compile_project(&user_node_dir);
+}
+
+#[test]
+fn rust_builds_same_named_consumed_topics_with_distinct_formats() {
+    generate_and_build([Slot::Wrist, Slot::Chest]);
+}
+
+#[test]
+fn rust_builds_same_named_consumed_topics_with_distinct_formats_reversed_order() {
+    generate_and_build([Slot::Chest, Slot::Wrist]);
+}


### PR DESCRIPTION
## Summary

Breaking change of the generated peppygen internals: consumed-topic Cap'n Proto schemas are now **one file per slot**, `on_next_<link_id>_<topic>`, in both the Rust and Python generators and in the per-slot mocks. The shared `on_next_<topic>` schema files are gone; nodes that named them directly must use the per-slot stems (no hub node does). Wire format unchanged.

## Defect

`consumed_topic_schema_key` dropped the slot, so every consumed topic named `video_stream` resolved to one file whatever its format. `rgb_camera:v1` and `rgbd_camera:v1` both emit `video_stream`, and only the rgbd header carries `align_mode`:

- Rust: the first registration owned the file, every later slot was handed the first struct while its decode code was generated from its own format. rgbd declared after rgb: `error[E0599]: no method named get_align_mode`, node does not build. The other order built and read the rgb slot through a schema with a field it never sets.
- Python: `register_schema` overwrote, so every consumer decoded through whichever slot registered last. `nodes-hub/lerobot_recorder` only worked by manifest order.

## Changes

- `naming.rs`: `consumed_topic_schema_key(link_id, topic)` = `on_next_<link_id>_<topic>` with `sanitize_or` fallbacks; dead branches removed; pairing doc reworded; two unit tests.
- `register_schema` (Rust and Python): identical text on an existing stem is reused (consumer and mock of one slot); different text is a new `Error::SchemaFileStemCollision` naming the stem and both keys. `CapnpSchema` now carries the schema key and the unsubstituted source for that comparison.
- Rust production paths now map each message format under the exact key they register (consumed action goal, consumed service request/response, emitted topic, exposed service, exposed action goal/feedback/result). The mocks, fixtures and the Python generator already did; the previous `<name>_request` style mapper names only changed the generated file id, which the old silent reuse hid and the new guard rejects.
- Mock generators: comment at both `consumed_topic_schema_key` sites that the mock must pass the same link id as `add_consumed_topic`.
- Tests: Python renderer expectations and golden regenerated (only the consumed-topic stems and struct names gain the slot); dedup e2e doc comments rewritten; new `tests/{rust,python}/consumed_topics_distinct_formats.rs` (same topic name, rgb vs rgbd formats, both declaration orders).

## Verification

- `cargo fmt -p generator`
- `cargo test -p generator --lib`: 201 passed
- `cargo test -p generator --test rust --test python`: 48 + 49 passed
- Against the rebuilt daemon (isolated `PEPPY_HOME`): `peppy node sync` of `nodes-hub/lerobot_recorder` gives `on_next_color_cameras_video_stream_message.capnp` (no `alignMode`) and `on_next_rgbd_cameras_video_stream_message.capnp` (with it), each slot module loading its own file; a three-slot Rust node (`wrist_left`, `wrist_right` on `rgb_camera`, `chest` on `rgbd_camera`, the node that fails on `dev` today) syncs and builds in release; `example_robot/my_rust_robot_brain` and `openarm/web_commander` sync and build.

## Hub-wide check

Every node manifest under `nodes-hub` and `private-nodes-hub` (37 nodes, waldo included) syncs against the rebuilt daemon, so the collision guard fires for none of them. No hub source references the generated capnp internals (file stems, `peppygen.capnp` / `peppygen::capnp` paths, loaders, or the `OnNext<...>Message` class names), and no hub checks in `.peppy/libs`. Two hub nodes consume `video_stream` on both an rgb and an rgbd slot and were silently dependent on manifest order before this change: `lerobot_recorder` and `xr_commander`. Both need no source change. `xr_commander` installs and its full test suite passes (316 tests, including the publish test that drives the node through the generated color-camera mock over the wire); `lerobot_recorder`'s generated package round-trips a frame through each slot's own schema in a minimal venv.

## Release notes line (for the maintainer to place at release time)

> Generated consumed-topic Cap'n Proto schemas are now one file per slot (`on_next_<link_id>_<topic>`); the shared `on_next_<topic>` schema files are gone and nodes that named them directly must use the per-slot stems. A node consuming same-named topics with different formats, such as `rgb_camera` and `rgbd_camera` `video_stream`, now generates and builds in both languages. Wire format unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Peppy-bot/codesmith/peppy/pr/434"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791368186&installation_model_id=433186&pr_number=434&repository=Peppy-bot%2Fpeppy&return_to=https%3A%2F%2Fgithub.com%2FPeppy-bot%2Fpeppy%2Fpull%2F434&signature=c5b5cde645ff532f44abf6b4830f7a5137b2e1c5388bb3707f29322be02f8efc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
