### PR TITLE
build_release: make the release-scripts suite pass on any host

### DIFF
--- a/scripts/functions/build_release.py
+++ b/scripts/functions/build_release.py
@@ -854,8 +854,10 @@ def _offer_pending_upload(
         f"\nA previous run built the archives for [bold]{pending.tag}[/bold] "
         f"({pending.content.title}) at {built_from} but did not publish them:"
     )
+    # Paths print whole: rich would otherwise fold one longer than the console
+    # over several lines, and a path broken mid-word cannot be copied.
     for artifact in pending.artifacts:
-        console.print(f"  {artifact.asset_path}")
+        console.print(f"  {artifact.asset_path}", soft_wrap=True)
     if prompt_yn(
         "Upload and publish them now instead of rebuilding?", default_yes=True
     ):
@@ -1039,7 +1041,7 @@ def _run_local() -> None:
 
     console.print()
     for artifact in artifacts:
-        console.print(f"[green]Built:[/green] {artifact.asset_path}")
+        console.print(f"[green]Built:[/green] {artifact.asset_path}", soft_wrap=True)
 
 
 def _run_full(

--- a/scripts/tests/test_build_release.py
+++ b/scripts/tests/test_build_release.py
@@ -364,6 +364,7 @@ def _setup_run_full_mocks(
     )
 
 
+@patch("functions.build_release.need_cmd")
 @patch("functions.build_release._verify_docs_up_to_date")
 @patch("functions.build_release._commit_notes_and_align_main")
 @patch("functions.build_release._prepare_release_content")
@@ -407,6 +408,7 @@ def test_run_full_uploads_all_artifacts(
     mock_prepare: MagicMock,
     mock_align: MagicMock,
     mock_docs_gate: MagicMock,
+    mock_need_cmd: MagicMock,
     tmp_path: Path,
     capfd: pytest.CaptureFixture[str],
 ) -> None:
@@ -462,6 +464,7 @@ def test_run_full_uploads_all_artifacts(
     assert "untagged" not in captured.err
 
 
+@patch("functions.build_release.need_cmd")
 @patch("functions.build_release._verify_docs_up_to_date")
 @patch("functions.build_release._prepare_release_content")
 @patch("functions.build_release.delete_release")
@@ -501,6 +504,7 @@ def test_run_full_cleans_up_draft_on_upload_failure(
     mock_delete_release: MagicMock,
     mock_prepare: MagicMock,
     mock_docs_gate: MagicMock,
+    mock_need_cmd: MagicMock,
     tmp_path: Path,
     capfd: pytest.CaptureFixture[str],
 ) -> None:
@@ -540,6 +544,7 @@ def test_run_full_cleans_up_draft_on_upload_failure(
     assert f"checkout of 'dev' at {DEV_COMMIT[:12]} on another machine" in output
 
 
+@patch("functions.build_release.need_cmd")
 @patch("functions.build_release._verify_docs_up_to_date")
 @patch("functions.build_release._prepare_release_content")
 @patch("functions.build_release.delete_release")
@@ -579,6 +584,7 @@ def test_run_full_warns_on_cleanup_failure(
     mock_delete_release: MagicMock,
     mock_prepare: MagicMock,
     mock_docs_gate: MagicMock,
+    mock_need_cmd: MagicMock,
     tmp_path: Path,
 ) -> None:
     _setup_run_full_mocks(
@@ -605,6 +611,7 @@ def test_run_full_warns_on_cleanup_failure(
     mock_publish.assert_not_called()
 
 
+@patch("functions.build_release.need_cmd")
 @patch("functions.build_release._verify_docs_up_to_date")
 @patch(
     "functions.build_release._commit_notes_and_align_main",
@@ -651,6 +658,7 @@ def test_run_full_reports_manual_steps_when_git_align_fails(
     mock_prepare: MagicMock,
     mock_align: MagicMock,
     mock_docs_gate: MagicMock,
+    mock_need_cmd: MagicMock,
     tmp_path: Path,
 ) -> None:
     _setup_run_full_mocks(
@@ -1569,6 +1577,7 @@ def test_find_open_docs_sync_pr_returns_none_when_there_is_no_pr(
     )
 
 
+@patch("functions.build_release.need_cmd")
 @patch("functions.build_release._verify_docs_up_to_date")
 @patch("functions.build_release.build_github_client")
 @patch("functions.build_release.github_repo_slug")
@@ -1590,6 +1599,7 @@ def test_run_full_skips_the_docs_gate_when_asked(
     mock_slug: MagicMock,
     mock_client: MagicMock,
     mock_docs_gate: MagicMock,
+    mock_need_cmd: MagicMock,
     tmp_path: Path,
     capfd: pytest.CaptureFixture[str],
 ) -> None:

--- a/scripts/tests/test_build_release.py
+++ b/scripts/tests/test_build_release.py
@@ -859,6 +859,28 @@ def test_offer_pending_upload_returns_the_manifest_when_accepted(
     assert manifest_path.exists()
 
 
+@patch("functions.build_release.prompt_yn", return_value=True)
+def test_offer_pending_upload_prints_every_archive_path_whole(
+    mock_prompt_yn: MagicMock,
+    tmp_path: Path,
+    capfd: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A console narrower than any archive path. Rich folds an over-long word
+    # across lines, and a path split mid-word can neither be read back by this
+    # suite nor copied by the user: each one has to come out on a line of its own.
+    monkeypatch.setenv("COLUMNS", "40")
+    manifest_path = _record_pending(tmp_path)
+
+    pending = _offer_pending_upload(manifest_path, DEV_COMMIT)
+
+    assert pending is not None
+    printed = [line.strip() for line in capfd.readouterr().err.splitlines()]
+    for artifact in pending.artifacts:
+        assert len(str(artifact.asset_path)) > 40
+        assert str(artifact.asset_path) in printed
+
+
 @patch("functions.build_release.prompt_yn", return_value=False)
 def test_offer_pending_upload_keeps_the_manifest_when_refused(
     mock_prompt_yn: MagicMock, tmp_path: Path, capfd: pytest.CaptureFixture[str]


### PR DESCRIPTION
## Summary

The `release-scripts` CI job has been red on `dev` since 26b7e880 ("build_release: resume publishing from a previously built pending upload", 2026-09-07). Six tests in `scripts/tests/test_build_release.py` fail on any host that is not the author's machine. This PR fixes both root causes and adds a regression test.

## Root causes

**1. The run-full tests probed the real host's PATH.** They fake a capable build host by stubbing `is_macos_arm64`, but 26b7e880 moved the `cargo`/`rustc`/`claude` checks out of the mocked `validate_release_environment` call and into `_verify_build_host`, which calls `need_cmd` directly. Five tests therefore failed with `missing required command: claude` wherever `claude` is not installed, such as the CI runner. Fix: stub `need_cmd` alongside the platform probe, as `test_run_full_requires_the_build_tools_before_building` already did.

**2. The pending-upload offer let rich fold archive paths mid-word.** At the 80-column default of a non-terminal stderr, a path such as `/tmp/pytest-of-runner/pytest-0/test_offer_pending_upload_retu0/dist/peppy-a.tgz` came out as `peppy-a.tg` / `z`. A user cannot copy that, and `test_offer_pending_upload_returns_the_manifest_when_accepted` could not find the archive names whenever the tmp directory was long enough. Fix: print the archive paths of the offer and of `build-release --local` with `soft_wrap=True`, and pin it with `test_offer_pending_upload_prints_every_archive_path_whole` on a 40-column console.

## Why it went unnoticed

26b7e880 was pushed straight to `dev`, and the `Tests` workflow only runs on pull requests (and pushes to `main`). The `release-scripts` job is also gated on `scripts/**` or the shared build inputs, so every PR since skipped it until #435 bumped `Cargo.lock` and surfaced the failures. The last green run of the job was 2026-09-03.

## Verification

- Reproduced all six failures locally on `dev` with `~/.local/bin` (where `claude` lives) removed from PATH.
- With this branch, `tests/test_build_release.py` + `tests/test_pending_upload.py`: 83 passed with `claude` hidden.
- The new regression test fails against the old printer and passes with the fix.
- Every non-VM file in `scripts/tests` (all but `test_install*.py` and `test_lima.py`): 297 passed with `claude` hidden.

Possible follow-up, not in this PR: running `Tests` on pushes to `dev` would have caught a direct-to-dev commit like 26b7e880.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Peppy-bot/codesmith/peppy/pr/436"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791750582&installation_model_id=433186&pr_number=436&repository=Peppy-bot%2Fpeppy&return_to=https%3A%2F%2Fgithub.com%2FPeppy-bot%2Fpeppy%2Fpull%2F436&signature=5fae3c56c1a3b0eb7f394b2270d519d85235878a6f5e192a8d0461b9d871373c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->